### PR TITLE
Improve performance of formatting (both with and w/o `color` enabled).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ A simple to use, efficient, and full featured  Command Line Argument Parser
 bitflags  = "~0.7"
 vec_map   = "~0.6"
 libc      = { version = "~0.2.9",  optional = true }
-ansi_term = { version = "~0.9.0",  optional = true }
+termion   = { version = "~1.1.1",  optional = true }
 strsim    = { version = "~0.5.1",  optional = true }
 yaml-rust = { version = "~0.3.2",  optional = true }
 clippy    = { version = "~0.0.88", optional = true }
@@ -32,7 +32,7 @@ regex = "~0.1.69"
 [features]
 default     = ["suggestions", "color", "wrap_help"]
 suggestions = ["strsim"]
-color       = ["ansi_term", "libc"]
+color       = ["termion", "libc"]
 yaml        = ["yaml-rust"]
 wrap_help   = ["libc", "term_size"]
 lints       = ["clippy", "nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ A simple to use, efficient, and full featured  Command Line Argument Parser
 bitflags  = "~0.7"
 vec_map   = "~0.6"
 libc      = { version = "~0.2.9",  optional = true }
-termion   = { version = "~1.1.1",  optional = true }
 strsim    = { version = "~0.5.1",  optional = true }
 yaml-rust = { version = "~0.3.2",  optional = true }
 clippy    = { version = "~0.0.88", optional = true }
 unicode-width = "~0.1.3"
 unicode-segmentation = "~0.1.2"
 term_size = { version = "~0.2.0", optional = true }
+termion   = { version = "~1.1.1", optional = true }
 
 [dev-dependencies]
 regex = "~0.1.69"

--- a/clap_dep_graph.dot
+++ b/clap_dep_graph.dot
@@ -1,6 +1,6 @@
 digraph dependencies {
 	N0[label="clap"];
-	N1[label="ansi_term"];
+	N1[label="termion"];
 	N2[label="bitflags"];
 	N3[label="clippy",color=blue];
 	N4[label="strsim"];

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -493,7 +493,7 @@ impl<'a> Help<'a> {
                            if self.color {
                                self.cizer.good(pv)
                            } else {
-                               Format::None(pv)
+                               Format::none(pv)
                            },
                            if self.hide_pv || a.is_set(ArgSettings::HidePossibleValues) {
                                "".into()

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1615,7 +1615,7 @@ impl<'a, 'b> Parser<'a, 'b>
                 &*self.get_required_from(&*reqs, Some(matcher))
                       .iter()
                       .fold(String::new(),
-                          |acc, s| acc + &format!("\n    {}", Format::Error(s))[..]),
+                          |acc, s| acc + &format!("\n    {}", Format::error(s))[..]),
                 &*self.create_current_usage(matcher),
                 self.color())
                 };

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -181,7 +181,7 @@ impl<T: fmt::Display> fmt::Display for Format<T> {
 #[cfg(any(not(feature = "color"), target_os = "windows"))]
 impl<T: AsRef<str>> fmt::Display for Format<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, self.msg.as_ref())
+        write!(f, "{}", self.msg.as_ref())
     }
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,8 +1,5 @@
 #[cfg(all(feature = "color", not(target_os = "windows")))]
-use ansi_term::ANSIString;
-
-#[cfg(all(feature = "color", not(target_os = "windows")))]
-use ansi_term::Colour::{Green, Red, Yellow};
+use termion::{color, style};
 
 #[cfg(feature = "color")]
 use libc;
@@ -52,10 +49,10 @@ macro_rules! color {
             ColorWhen::Auto => if is_a_tty($_self.use_stderr) {
                 Format::$c($m)
             } else {
-                Format::None($m)
+                Format::none($m)
             },
             ColorWhen::Always => Format::$c($m),
-            ColorWhen::Never => Format::None($m),
+            ColorWhen::Never => Format::none($m),
         }
     };
 }
@@ -65,28 +62,28 @@ impl Colorizer {
         where T: fmt::Display + AsRef<str>
     {
         debugln!("fn=good;");
-        color!(self, Good, msg)
+        color!(self, good, msg)
     }
 
     pub fn warning<T>(&self, msg: T) -> Format<T>
         where T: fmt::Display + AsRef<str>
     {
         debugln!("fn=warning;");
-        color!(self, Warning, msg)
+        color!(self, warning, msg)
     }
 
     pub fn error<T>(&self, msg: T) -> Format<T>
         where T: fmt::Display + AsRef<str>
     {
         debugln!("fn=error;");
-        color!(self, Error, msg)
+        color!(self, error, msg)
     }
 
     pub fn none<T>(&self, msg: T) -> Format<T>
         where T: fmt::Display + AsRef<str>
     {
         debugln!("fn=none;");
-        Format::None(msg)
+        Format::none(msg)
     }
 }
 
@@ -101,75 +98,120 @@ impl Default for Colorizer {
 
 /// Defines styles for different types of error messages. Defaults to Error=Red, Warning=Yellow,
 /// and Good=Green
-#[derive(Debug)]
-#[doc(hidden)]
-pub enum Format<T> {
+#[derive(Debug, Copy, Clone)]
+pub enum Kind {
     /// Defines the style used for errors, defaults to Red
-    Error(T),
+    Error,
     /// Defines the style used for warnings, defaults to Yellow
-    Warning(T),
+    Warning,
     /// Defines the style used for good values, defaults to Green
-    Good(T),
+    Good,
     /// Defines no formatting style
-    None(T),
+    None,
 }
 
-#[cfg(all(feature = "color", not(target_os = "windows")))]
-impl<T: AsRef<str>> Format<T> {
-    fn format(&self) -> ANSIString {
-        match *self {
-            Format::Error(ref e) => Red.bold().paint(e.as_ref()),
-            Format::Warning(ref e) => Yellow.paint(e.as_ref()),
-            Format::Good(ref e) => Green.paint(e.as_ref()),
-            Format::None(ref e) => ANSIString::from(e.as_ref()),
+/// An log message.
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct Format<T> {
+    kind: Kind,
+    msg: T,
+}
+
+impl<T> Format<T> {
+    /// An error message.
+    pub fn error(msg: T) -> Format<T> {
+        Format {
+            kind: Kind::Error,
+            msg: msg,
+        }
+    }
+
+    /// A warning message.
+    pub fn warning(msg: T) -> Format<T> {
+        Format {
+            kind: Kind::Warning,
+            msg: msg,
+        }
+    }
+
+    /// A "good" message.
+    ///
+    /// That is, it went well.
+    pub fn good(msg: T) -> Format<T> {
+        Format {
+            kind: Kind::Good,
+            msg: msg,
+        }
+    }
+
+    /// A "neutral" message.
+    ///
+    /// That is, it is simply a log message.
+    pub fn none(msg: T) -> Format<T> {
+        Format {
+            kind: Kind::None,
+            msg: msg,
         }
     }
 }
 
-#[cfg(any(not(feature = "color"), target_os = "windows"))]
-impl<T: fmt::Display> Format<T> {
-    fn format(&self) -> &T {
-        match *self {
-            Format::Error(ref e) => e,
-            Format::Warning(ref e) => e,
-            Format::Good(ref e) => e,
-            Format::None(ref e) => e,
-        }
-    }
-}
-
-
 #[cfg(all(feature = "color", not(target_os = "windows")))]
-impl<T: AsRef<str>> fmt::Display for Format<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", &self.format())
-    }
-}
-
-#[cfg(any(not(feature = "color"), target_os = "windows"))]
 impl<T: fmt::Display> fmt::Display for Format<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", &self.format())
+        match self.kind {
+            Kind::Error => write!(f, "{color}{style}{msg}{reset}",
+                                    color = color::Fg(color::Red),
+                                    style = style::Bold,
+                                    msg   = self.msg,
+                                    reset = style::Reset),
+            Kind::Warning => write!(f, "{color}{msg}{reset}",
+                                      color = color::Fg(color::Yellow),
+                                      msg   = self.msg,
+                                      reset = style::Reset),
+            Kind::Good => write!(f, "{color}{msg}{reset}",
+                                   color = color::Fg(color::Green),
+                                   msg   = self.msg,
+                                   reset = style::Reset),
+            Kind::None => write!(f, "{}", self.msg),
+        }
+    }
+}
+
+#[cfg(any(not(feature = "color"), target_os = "windows"))]
+impl<T: AsRef<str>> fmt::Display for Format<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, self.msg.as_ref())
     }
 }
 
 #[cfg(all(test, feature = "color", not(target_os = "windows")))]
 mod test {
-    use ansi_term::ANSIString;
-    use ansi_term::Colour::{Green, Red, Yellow};
-    use super::Format;
+    use termion::{color, style};
+    use super::*;
 
     #[test]
     fn colored_output() {
-        let err = Format::Error("error");
-        assert_eq!(&*format!("{}", err),
-                   &*format!("{}", Red.bold().paint("error")));
-        let good = Format::Good("good");
-        assert_eq!(&*format!("{}", good), &*format!("{}", Green.paint("good")));
-        let warn = Format::Warning("warn");
-        assert_eq!(&*format!("{}", warn), &*format!("{}", Yellow.paint("warn")));
-        let none = Format::None("none");
+        let err = Format {
+            kind: Kind::Error,
+            msg: "error",
+        };
+        assert_eq!(&*format!("{}", err), &*format!("{}{}error{}", color::Fg(color::Red), style::Bold, style::Reset));
+        let good = Format {
+            kind: Kind::Good,
+            msg: "good",
+        };
+        assert_eq!(&*format!("{}", good), &*format!("{}good{}", color::Fg(color::Green), style::Reset));
+        let warn = Format {
+            kind: Kind::Warning,
+            msg: "warn",
+        };
+        assert_eq!(&*format!("{}", warn), &*format!("{}warn{}", color::Fg(color::Yellow), style::Reset));
+        let none = Format {
+            kind: Kind::None,
+            msg: "none",
+        };
         assert_eq!(&*format!("{}", none),
-                   &*format!("{}", ANSIString::from("none")));
+                   "none");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@
 #[cfg(feature = "suggestions")]
 extern crate strsim;
 #[cfg(feature = "color")]
-extern crate ansi_term;
+extern crate termion;
 #[cfg(feature = "yaml")]
 extern crate yaml_rust;
 #[cfg(any(feature = "wrap_help", feature = "color"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@
 
 #[cfg(feature = "suggestions")]
 extern crate strsim;
-#[cfg(feature = "color")]
+#[cfg(all(feature = "color", not(target_os = "windows")))]
 extern crate termion;
 #[cfg(feature = "yaml")]
 extern crate yaml_rust;

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -52,11 +52,11 @@ pub fn did_you_mean_suffix<'z, T, I>(arg: &str,
             let mut suffix = "\n\tDid you mean ".to_owned();
             match style {
                 DidYouMeanMessageStyle::LongFlag => {
-                    suffix.push_str(&Format::Good("--").to_string())
+                    suffix.push_str(&Format::good("--").to_string())
                 }
                 DidYouMeanMessageStyle::EnumValue => suffix.push('\''),
             }
-            suffix.push_str(&Format::Good(candidate).to_string()[..]);
+            suffix.push_str(&Format::good(candidate).to_string()[..]);
             if let DidYouMeanMessageStyle::EnumValue = style {
                 suffix.push('\'');
             }


### PR DESCRIPTION
Instead of using `ansi_term`, we change clap to use `termion`, which
does not encode colors as an enum, but instead as distinct types
implementing `Display` (and hence avoids branches).

Old:

```
running 10 tests
test example1          ... bench:      20,448 ns/iter (+/- 384)
test example10         ... bench:       7,646 ns/iter (+/- 2,363)
test example2          ... bench:         811 ns/iter (+/- 18)
test example3          ... bench:      18,206 ns/iter (+/- 602)
test example4          ... bench:       9,876 ns/iter (+/- 5,241)
test example4_template ... bench:      10,651 ns/iter (+/- 7,594)
test example5          ... bench:       6,994 ns/iter (+/- 1,411)
test example6          ... bench:       3,542 ns/iter (+/- 3,261)
test example7          ... bench:      13,315 ns/iter (+/- 6,517)
test example8          ... bench:       8,056 ns/iter (+/- 394)
```

New:

```
running 10 tests
test example1          ... bench:      19,681 ns/iter (+/- 3,156)
test example10         ... bench:       7,147 ns/iter (+/- 2,121)
test example2          ... bench:         825 ns/iter (+/- 76)
test example3          ... bench:      17,180 ns/iter (+/- 1,065)
test example4          ... bench:       9,075 ns/iter (+/- 993)
test example4_template ... bench:       9,828 ns/iter (+/- 266)
test example5          ... bench:       6,336 ns/iter (+/- 723)
test example6          ... bench:       3,485 ns/iter (+/- 217)
test example7          ... bench:       7,626 ns/iter (+/- 375)
test example8          ... bench:       7,592 ns/iter (+/- 396)
```

(both compiled with --opt-level=3 and panic=abort)

Further optimization can perhaps be done by eliminating the virtual
calls in `fmt::Formatter`, which, for some strange reason, holds a
`fmt::Write` trait object. Fortunately, most of it is eliminated in the
LLVM devirtualization pass.
