### PR TITLE
Change the return type of ArgMatches::subcommand.

### DIFF
--- a/examples/16_app_settings.rs
+++ b/examples/16_app_settings.rs
@@ -35,7 +35,7 @@ fn main() {
     }
 
     match matches.subcommand() {
-        ("test", _) => println!("The 'test' subcommand was used"),
+        Some(("test", _)) => println!("The 'test' subcommand was used"),
         _           => unreachable!()
     }
 }

--- a/examples/20_subcommands.rs
+++ b/examples/20_subcommands.rs
@@ -114,28 +114,28 @@ fn main() {
     // The most common way to handle subcommands is via a combined approach using
     // `ArgMatches::subcommand` which returns a tuple of both the name and matches
     match matches.subcommand() {
-        ("clone", Some(clone_matches)) =>{
+        Some(("clone", clone_matches)) =>{
             // Now we have a reference to clone's matches
             println!("Cloning {}", clone_matches.value_of("repo").unwrap());
         },
-        ("push", Some(push_matches)) =>{
+        Some(("push", push_matches)) =>{
             // Now we have a reference to push's matches
             match push_matches.subcommand() {
-                ("remote", Some(remote_matches)) =>{
+                Some(("remote", remote_matches)) =>{
                     // Now we have a reference to remote's matches
                     println!("Pushing to {}", remote_matches.value_of("repo").unwrap());
                 },
-                ("local", Some(_)) =>{
+                Some(("local", _)) =>{
                     println!("'git push local' was used");
                 },
                 _            => unreachable!(),
             }
         },
-        ("add", Some(add_matches)) =>{
+        Some(("add", add_matches)) =>{
             // Now we have a reference to add's matches
             println!("Adding {}", add_matches.values_of("stuff").unwrap().collect::<Vec<_>>().join(", "));
         },
-        ("", None)   => println!("No subcommand was used"), // If no subcommand was usd it'll match the tuple ("", None)
+        None => println!("No subcommand was used"), // If no subcommand was usd it'll match the tuple ("", None)
         _            => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
     }
 

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -262,7 +262,7 @@ pub enum AppSettings {
     /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
     /// // string argument name
     /// match m.subcommand() {
-    ///     (external, Some(ext_m)) => {
+    ///     Some((external, ext_m)) => {
     ///          let ext_args: Vec<&str> = ext_m.values_of("").unwrap().collect();
     ///          assert_eq!(external, "subcmd");
     ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);

--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -473,9 +473,9 @@ impl<'a> ArgMatches<'a> {
     ///      .get_matches();
     ///
     /// match app_m.subcommand() {
-    ///     ("clone",  Some(sub_m)) => {}, // clone was used
-    ///     ("push",   Some(sub_m)) => {}, // push was used
-    ///     ("commit", Some(sub_m)) => {}, // commit was used
+    ///     Some(("clone",  sub_m)) => {}, // clone was used
+    ///     Some(("push",   sub_m)) => {}, // push was used
+    ///     Some(("commit", sub_m)) => {}, // commit was used
     ///     _                       => {}, // Either no subcommand or one not tested for...
     /// }
     /// ```
@@ -496,7 +496,7 @@ impl<'a> ArgMatches<'a> {
     /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
     /// // string argument name
     /// match app_m.subcommand() {
-    ///     (external, Some(sub_m)) => {
+    ///     Some((external, sub_m)) => {
     ///          let ext_args: Vec<&str> = sub_m.values_of("").unwrap().collect();
     ///          assert_eq!(external, "subcmd");
     ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);
@@ -506,8 +506,8 @@ impl<'a> ArgMatches<'a> {
     /// ```
     /// [`ArgMatches::subcommand_matches`]: ./struct.ArgMatches.html#method.subcommand_matches
     /// [`ArgMatches::subcommand_name`]: ./struct.ArgMatches.html#method.subcommand_name
-    pub fn subcommand(&self) -> (&str, Option<&ArgMatches<'a>>) {
-        self.subcommand.as_ref().map_or(("", None), |sc| (&sc.name[..], Some(&sc.matches)))
+    pub fn subcommand(&self) -> Option<(&str, &ArgMatches<'a>)> {
+        self.subcommand.as_ref().map_or(None, |sc| Some((&sc.name[..], &sc.matches)))
     }
 
     /// Returns a string slice of the usage statement for the [`App`] or [`SubCommand`]


### PR DESCRIPTION
Make the return type of `ArgMatches::subcommand` consistent with the other
`ArgMatches::subcommand_*` methods. In particular, `subcommand_name` returns
an `Option<&str>`, but when the subcommand is missing `subcommand` returns `("", None)` instead of `None`.

This is a breaking change, so I understand you'd have to wait until the next major version bump to merge this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1074)
<!-- Reviewable:end -->
