### PR TITLE
WIP: Clippy cleanups

### DIFF
--- a/benches/06_rustup.rs
+++ b/benches/06_rustup.rs
@@ -186,7 +186,7 @@ pub fn build_cli() -> App<'static, 'static> {
             .setting(AppSettings::TrailingVarArg)
             .arg(Arg::with_name("toolchain").setting(ArgSettings::Required))
             .arg(Arg::with_name("command")
-                .settings(&[ArgSettings::Required, ArgSettings::MultipleValues, ArgSettings::MutlipleOccurrences])))
+                .settings(&[ArgSettings::Required, ArgSettings::MultipleValues, ArgSettings::MultipleOccurrences])))
         .subcommand(SubCommand::with_name("which")
             .about("Display which binary will be run for a given command")
             .arg(Arg::with_name("command").setting(ArgSettings::Required)))

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -28,7 +28,7 @@ mod term_size {
 
 fn str_width(s: &str) -> usize { UnicodeWidthStr::width(s) }
 
-const TAB: &'static str = "    ";
+const TAB: &str = "    ";
 
 // trait ArgWithOrder<'b, 'c>: Display + DispOrder {
 //     fn as_base(&self) -> &Arg<'b, 'c>;

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -90,8 +90,8 @@ impl<'w> Help<'w> {
         debugln!("Help::new;");
         Help {
             writer: w,
-            next_line_help: next_line_help,
-            hide_pv: hide_pv,
+            next_line_help,
+            hide_pv,
             term_w: match term_w {
                 Some(width) => if width == 0 {
                     usize::MAX
@@ -106,11 +106,11 @@ impl<'w> Help<'w> {
                     },
                 ),
             },
-            color: color,
-            cizer: cizer,
+            color,
+            cizer,
             longest: 0,
             force_next_line: false,
-            use_long: use_long,
+            use_long,
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1398,7 +1398,7 @@ impl<'a, 'b> App<'a, 'b> {
             }
         }
 
-        let global_arg_vec: Vec<&str> = (&self)
+        let global_arg_vec: Vec<&str> = self
             .args
             .iter()
             .filter(|a| a.is_set(ArgSettings::Global))

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -557,8 +557,9 @@ where
                 let _ = self.add_val_to_arg(p, &arg_os, matcher)?;
 
                 matcher.inc_occurrence_of(p.name);
-                let _ = self.groups_for_arg(p.name)
-                    .and_then(|vec| Some(matcher.inc_occurrences_of(&*vec)));
+                if let Some(grps) = self.groups_for_arg(p.name) {
+                    matcher.inc_occurrences_of(&*grps);
+                }
 
                 self.app.settings.set(AS::ValidArgFound);
                 // Only increment the positional counter if it doesn't allow multiples
@@ -1180,8 +1181,9 @@ where
 
         matcher.inc_occurrence_of(opt.name);
         // Increment or create the group "args"
-        self.groups_for_arg(opt.name)
-            .and_then(|vec| Some(matcher.inc_occurrences_of(&*vec)));
+        if let Some(grps) = self.groups_for_arg(opt.name) {
+            matcher.inc_occurrences_of(&*grps)
+        }
 
         let needs_delim = opt.is_set(ArgSettings::RequireDelimiter);
         let mult = opt.is_set(ArgSettings::MultipleValues);
@@ -1483,12 +1485,14 @@ where
         // Add the arg to the matches to build a proper usage string
         if let Some(name) = suffix.1 {
             if let Some(opt) = find_by_long!(self.app, name) {
-                self.groups_for_arg(&*opt.name)
-                    .and_then(|grps| Some(matcher.inc_occurrences_of(&*grps)));
+                if let Some(grps) = self.groups_for_arg(&*opt.name) {
+                    Some(matcher.inc_occurrences_of(&*grps));
+                }
                 matcher.insert(&*opt.name);
             } else if let Some(flg) = find_by_long!(self.app, name) {
-                self.groups_for_arg(&*flg.name)
-                    .and_then(|grps| Some(matcher.inc_occurrences_of(&*grps)));
+                if let Some(grps) = self.groups_for_arg(&*flg.name) {
+                    matcher.inc_occurrences_of(&*grps);
+                }
                 matcher.insert(&*flg.name);
             }
         }

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -469,8 +469,9 @@ where
                 }
             }
 
-            if !(self.is_set(AS::ArgsNegateSubcommands) && self.is_set(AS::ValidArgFound))
-                && !self.is_set(AS::InferSubcommands) && !self.is_set(AS::AllowExternalSubcommands)
+            if !( (self.is_set(AS::ArgsNegateSubcommands) && self.is_set(AS::ValidArgFound))
+                || self.is_set(AS::InferSubcommands)
+                || self.is_set(AS::AllowExternalSubcommands))
             {
                 if let Some(cdate) =
                     suggestions::did_you_mean(&*arg_os.to_string_lossy(), sc_names!(self.app))

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -136,12 +136,10 @@ where
 
         let num_p = self.positionals.len();
 
-        assert!(
-            highest_idx == num_p,
-            "Found positional argument whose index is {} but there \
-             are only {} positional arguments defined",
-            highest_idx,
-            num_p
+        assert_eq!(highest_idx, num_p,
+                   "Found positional argument whose index is {} but there \
+                    are only {} positional arguments defined",
+                   highest_idx, num_p
         );
 
         // Next we verify that only the highest index has a .multiple(true) (if any)

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -114,6 +114,7 @@ where
 
 
     #[cfg_attr(feature = "lints", allow(block_in_if_condition_stmt))]
+    #[cfg_attr(feature = "cargo-clippy", allow(block_in_if_condition_stmt))]
     fn _verify_positionals(&mut self) -> bool {
         debugln!("Parser::_verify_positionals;");
         // Because you must wait until all arguments have been supplied, this is the first chance
@@ -287,6 +288,8 @@ where
     }
 
     // Does all the initializing and prepares the parser
+    #[cfg_attr(feature = "lints", allow(block_in_if_condition_stmt))]
+    #[cfg_attr(feature = "cargo-clippy", allow(block_in_if_condition_stmt))]
     fn _build(&mut self) {
         debugln!("Parser::_build;");
 
@@ -353,6 +356,7 @@ where
 {
     // The actual parsing function
     #[cfg_attr(feature = "lints", allow(while_let_on_iterator, collapsible_if))]
+    #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity, collapsible_if))]
     pub fn get_matches_with<I, T>(
         &mut self,
         matcher: &mut ArgMatcher<'a>,

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -99,7 +99,7 @@ where
             .collect();
 
         Parser {
-            app: app,
+            app,
             required: reqs,
             r_ifs: Vec::new(),
             overriden: Vec::new(),
@@ -871,7 +871,7 @@ where
             let mut p = Parser::new(sc);
             p.get_matches_with(&mut sc_matcher, it)?;
             matcher.subcommand(SubCommand {
-                name: name,
+                name,
                 matches: sc_matcher.into(),
             });
         }
@@ -1434,6 +1434,7 @@ where
         Ok(())
     }
 
+    #[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
     pub(crate) fn add_env(&mut self, matcher: &mut ArgMatcher<'a>) -> ClapResult<()> {
         for a in &self.app.args {
             if let Some(ref val) = a.env {

--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -154,8 +154,8 @@ impl<'a> ArgGroup<'a> {
     /// [argument]: ./struct.Arg.html
     #[cfg_attr(feature = "lints", allow(should_assert_eq))]
     pub fn arg(mut self, n: &'a str) -> Self {
-        assert!(
-            self.name != n,
+        assert_ne!(
+            self.name, n,
             "ArgGroup '{}' can not have same name as arg inside it",
             &*self.name
         );

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -884,7 +884,7 @@ impl Error {
         });
         Error {
             message: format!("{} {}", c.error("error:"), description),
-            kind: kind,
+            kind,
             info: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,9 +569,9 @@ mod strext;
 mod completions;
 mod map;
 
-const INTERNAL_ERROR_MSG: &'static str = "Fatal internal error. Please consider filing a bug \
-                                          report at https://github.com/kbknapp/clap-rs/issues";
-const INVALID_UTF8: &'static str = "unexpected invalid UTF-8 code point";
+const INTERNAL_ERROR_MSG: &str = "Fatal internal error. Please consider filing a bug \
+                                  report at https://github.com/kbknapp/clap-rs/issues";
+const INVALID_UTF8: &str = "unexpected invalid UTF-8 code point";
 
 #[cfg(unstable)]
 pub use derive::{ArgEnum, ClapApp, FromArgMatches, IntoApp};

--- a/src/usage_parser.rs
+++ b/src/usage_parser.rs
@@ -29,7 +29,7 @@ impl<'a> UsageParser<'a> {
     fn new(usage: &'a str) -> Self {
         debugln!("UsageParser::new: usage={:?}", usage);
         UsageParser {
-            usage: usage,
+            usage,
             pos: 0,
             start: 0,
             prev: UsageToken::Unknown,

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -6,7 +6,7 @@ include!("../clap-test.rs");
 
 use clap::{App, AppSettings, Arg, ArgSettings, ErrorKind, SubCommand};
 
-static REQUIRE_DELIM_HELP: &'static str = "test 1.3
+static REQUIRE_DELIM_HELP: &str = "test 1.3
 Kevin K.
 tests stuff
 
@@ -20,7 +20,7 @@ FLAGS:
 OPTIONS:
     -f, --fake <some>:<val>    some help";
 
-static HELP: &'static str = "clap-test v1.4.8
+static HELP: &str = "clap-test v1.4.8
 Kevin K. <kbknapp@gmail.com>
 tests clap library
 
@@ -51,7 +51,7 @@ SUBCOMMANDS:
     help      Prints this message or the help of the given subcommand(s)
     subcmd    tests subcommands";
 
-static SC_NEGATES_REQS: &'static str = "prog 1.0
+static SC_NEGATES_REQS: &str = "prog 1.0
 
 USAGE:
     prog --opt <FILE> [PATH]
@@ -71,7 +71,7 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     test";
 
-static ARGS_NEGATE_SC: &'static str = "prog 1.0
+static ARGS_NEGATE_SC: &str = "prog 1.0
 
 USAGE:
     prog [FLAGS] [OPTIONS] [PATH]
@@ -92,7 +92,7 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     test";
 
-static AFTER_HELP: &'static str = "some text that comes before the help
+static AFTER_HELP: &str = "some text that comes before the help
 
 clap-test v1.4.8
 tests clap library
@@ -106,7 +106,7 @@ FLAGS:
 
 some text that comes after the help";
 
-static HIDDEN_ARGS: &'static str = "prog 1.0
+static HIDDEN_ARGS: &str = "prog 1.0
 
 USAGE:
     prog [FLAGS] [OPTIONS]
@@ -119,7 +119,7 @@ FLAGS:
 OPTIONS:
     -o, --opt <FILE>    tests options";
 
-static SC_HELP: &'static str = "clap-test-subcmd 0.1
+static SC_HELP: &str = "clap-test-subcmd 0.1
 Kevin K. <kbknapp@gmail.com>
 tests subcommands
 
@@ -138,7 +138,7 @@ OPTIONS:
     -o, --option <scoption>...     tests options
     -s, --subcmdarg <subcmdarg>    tests other args";
 
-static ISSUE_1046_HIDDEN_SCS: &'static str = "prog 1.0
+static ISSUE_1046_HIDDEN_SCS: &str = "prog 1.0
 
 USAGE:
     prog [FLAGS] [OPTIONS] [PATH]
@@ -155,7 +155,7 @@ OPTIONS:
     -o, --opt <FILE>    tests options";
 
 // Using number_of_values(1) with multiple(true) misaligns help message
-static ISSUE_760: &'static str = "ctest 0.1
+static ISSUE_760: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
@@ -168,7 +168,7 @@ OPTIONS:
     -O, --opt <opt>             tests options
     -o, --option <option>...    tests options";
 
-static RIPGREP_USAGE: &'static str = "ripgrep 0.5
+static RIPGREP_USAGE: &str = "ripgrep 0.5
 
 USAGE:
     rg [OPTIONS] <pattern> [<path> ...]
@@ -180,7 +180,7 @@ FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
-static MULTI_SC_HELP: &'static str = "ctest-subcmd-multi 0.1
+static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
 Kevin K. <kbknapp@gmail.com>
 tests subcommands
 
@@ -195,7 +195,7 @@ FLAGS:
 OPTIONS:
     -o, --option <scoption>...    tests options";
 
-static ISSUE_626_CUTOFF: &'static str = "ctest 0.1
+static ISSUE_626_CUTOFF: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
@@ -214,7 +214,7 @@ OPTIONS:
                          tea. Many cafés also serve some type of food,
                          such as light snacks, muffins, or pastries.";
 
-static ISSUE_626_PANIC: &'static str = "ctest 0.1
+static ISSUE_626_PANIC: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
@@ -233,7 +233,7 @@ OPTIONS:
             souvent une contribution majeure aux
             exportations des régions productrices.";
 
-static HIDE_POS_VALS: &'static str = "ctest 0.1
+static HIDE_POS_VALS: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
@@ -246,7 +246,7 @@ OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
     -p, --pos <VAL>      Some vals [possible values: fast, slow]";
 
-static FINAL_WORD_WRAPPING: &'static str = "ctest 0.1
+static FINAL_WORD_WRAPPING: &str = "ctest 0.1
 
 USAGE:
     ctest
@@ -260,7 +260,7 @@ FLAGS:
             version
             information";
 
-static OLD_NEWLINE_CHARS: &'static str = "ctest 0.1
+static OLD_NEWLINE_CHARS: &str = "ctest 0.1
 
 USAGE:
     ctest [FLAGS]
@@ -271,7 +271,7 @@ FLAGS:
                      (Defaults to something)
     -V, --version    Prints version information";
 
-static WRAPPING_NEWLINE_CHARS: &'static str = "ctest 0.1
+static WRAPPING_NEWLINE_CHARS: &str = "ctest 0.1
 
 USAGE:
     ctest [mode]
@@ -288,7 +288,7 @@ FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
-static ISSUE_688: &'static str = "ctest 0.1
+static ISSUE_688: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
@@ -302,7 +302,7 @@ OPTIONS:
                              images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic,
                              Gaussian, Lanczos3]";
 
-static ISSUE_702: &'static str = "myapp 1.0
+static ISSUE_702: &str = "myapp 1.0
 foo
 bar
 
@@ -322,7 +322,7 @@ OPTIONS:
     -o, --other <other>       some other option
     -s, --some <some>         some option";
 
-static ISSUE_777: &'static str = "A app with a crazy very long long
+static ISSUE_777: &str = "A app with a crazy very long long
 long name hahaha 1.0
 Some Very Long Name and crazy long
 email <email@server.com>
@@ -340,7 +340,7 @@ FLAGS:
             Prints version
             information";
 
-static CUSTOM_VERSION_AND_HELP: &'static str = "customize 0.1
+static CUSTOM_VERSION_AND_HELP: &str = "customize 0.1
 Nobody <odysseus@example.com>
 You can customize the version and help text
 
@@ -351,7 +351,7 @@ FLAGS:
     -H, --help       Print help information
     -v, --version    Print version information";
 
-static LAST_ARG: &'static str = "last 0.1
+static LAST_ARG: &str = "last 0.1
 
 USAGE:
     last <TARGET> [CORPUS] [-- <ARGS>...]
@@ -365,7 +365,7 @@ FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
-static LAST_ARG_SC: &'static str = "last 0.1
+static LAST_ARG_SC: &str = "last 0.1
 
 USAGE:
     last <TARGET> [CORPUS] [-- <ARGS>...]
@@ -384,7 +384,7 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     test    some";
 
-static LAST_ARG_REQ: &'static str = "last 0.1
+static LAST_ARG_REQ: &str = "last 0.1
 
 USAGE:
     last <TARGET> [CORPUS] -- <ARGS>...
@@ -398,7 +398,7 @@ FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
-static LAST_ARG_REQ_SC: &'static str = "last 0.1
+static LAST_ARG_REQ_SC: &str = "last 0.1
 
 USAGE:
     last <TARGET> [CORPUS] -- <ARGS>...
@@ -417,7 +417,7 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     test    some";
 
-static HIDE_DEFAULT_VAL: &'static str = "default 0.1
+static HIDE_DEFAULT_VAL: &str = "default 0.1
 
 USAGE:
     default [OPTIONS]
@@ -429,7 +429,7 @@ FLAGS:
 OPTIONS:
         --arg <argument>    Pass an argument to the program. [default: default-argument]";
 
-static LAST_ARG_USAGE: &'static str = "flamegraph 0.1
+static LAST_ARG_USAGE: &str = "flamegraph 0.1
 
 USAGE:
     flamegraph [FLAGS] [OPTIONS] [BINFILE] [-- <ARGS>...]
@@ -447,7 +447,7 @@ OPTIONS:
     -f, --frequency <HERTZ>    The sampling frequency.
     -t, --timeout <SECONDS>    Timeout in seconds.";
 
-static LAST_ARG_REQ_MULT: &'static str = "example 1.0
+static LAST_ARG_REQ_MULT: &str = "example 1.0
 
 USAGE:
     example <FIRST>... [--] <SECOND>...
@@ -460,7 +460,7 @@ FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
-static DEFAULT_HELP: &'static str = "ctest 1.0
+static DEFAULT_HELP: &str = "ctest 1.0
 
 USAGE:
     ctest
@@ -469,7 +469,7 @@ FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
-static LONG_ABOUT: &'static str = "myapp 1.0
+static LONG_ABOUT: &str = "myapp 1.0
 foo
 something really really long, with
 multiple lines of text
@@ -489,7 +489,7 @@ FLAGS:
     -V, --version    
             Prints version information";
 
-static HIDE_ENV_VALS: &'static str = "ctest 0.1
+static HIDE_ENV_VALS: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
@@ -502,7 +502,7 @@ OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR]
     -p, --pos <VAL>      Some vals [possible values: fast, slow]";
 
-static SHOW_ENV_VALS: &'static str = "ctest 0.1
+static SHOW_ENV_VALS: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
@@ -515,7 +515,7 @@ OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -p, --pos <VAL>      Some vals [possible values: fast, slow]";
 
-static CUSTOM_HELP_SECTION: &'static str = "blorp 1.4
+static CUSTOM_HELP_SECTION: &str = "blorp 1.4
 Will M.
 does stuff
 
@@ -1389,7 +1389,7 @@ fn custom_headers_headers() {
     ));
 }
 
-static MULTIPLE_CUSTOM_HELP_SECTIONS: &'static str = "blorp 1.4
+static MULTIPLE_CUSTOM_HELP_SECTIONS: &str = "blorp 1.4
 Will M.
 does stuff
 


### PR DESCRIPTION
This is part of a run-through of cleaning up the clippy lints on the v3-master branch (done as part of impl days paris). One type of lint per commit fixed per commit.

The branch is a WIP, lots of cleanups left to do. Planning to do more cleanups if it is wangted.

Note: clippy as of 2018-05-29 does not work on the v3-master branch (ICE), but with https://github.com/rust-lang-nursery/rust-clippy/pull/2819 the ICE is avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1278)
<!-- Reviewable:end -->
