### PR TITLE
Allowing parser to continue trying in case of UnknownArgument error

### DIFF
--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -478,19 +478,6 @@ fn allow_negative_numbers() {
 }
 
 #[test]
-fn allow_negative_numbers_fail() {
-    let res = App::new("negnum")
-        .setting(AppSettings::AllowNegativeNumbers)
-        .arg(Arg::with_name("panum"))
-        .arg(Arg::with_name("onum")
-            .short("o")
-            .takes_value(true))
-        .get_matches_from_safe(vec!["negnum", "--foo", "-o", "-1.2"]);
-    assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument)
-}
-
-#[test]
 fn leading_double_hyphen_trailingvararg() {
     let m = App::new("positional")
         .setting(AppSettings::TrailingVarArg)

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -272,3 +272,25 @@ fn last_positional_second_to_last_mult() {
         .get_matches_from_safe(vec!["test", "tgt", "crp1", "crp2", "--", "arg"]);
     assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
 }
+
+#[test]
+fn last_positional_var_arg_hyphenized() {
+    let r = App::new("test")
+        .arg(Arg::from_usage("<TARGET> 'some file'"))
+        .arg(Arg::from_usage("[ARGS]... 'some corpus'").allow_hyphen_values(true))
+        .get_matches_from_safe(vec!["prog", "test", "-s", "crp2"]);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    let m = r.unwrap();
+    assert_eq!(m.values_of("ARGS").unwrap().collect::<Vec<_>>(), &["-s", "crp2"]);
+}
+
+#[test]
+fn last_positional_var_arg_double_hyphenized() {
+    let r = App::new("test")
+        .arg(Arg::from_usage("<TARGET> 'some file'"))
+        .arg(Arg::from_usage("[ARGS]... 'some corpus'").allow_hyphen_values(true))
+        .get_matches_from_safe(vec!["prog", "test", "--thing", "crp2"]);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    let m = r.unwrap();
+    assert_eq!(m.values_of("ARGS").unwrap().collect::<Vec<_>>(), &["--thing", "crp2"]);
+}


### PR DESCRIPTION
This is meant as a fix for #1287, as hyphenized arguments may still be valid positionals even if they are not a  known short or long argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kbknapp/clap-rs/1290)
<!-- Reviewable:end -->
