### PR TITLE
fix(suggestions): Dont mention unused subcommands

### DIFF
--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -71,8 +71,14 @@ where
                 .filter_map(|f| f.s.long)
                 .chain(subcommand.p.opts.iter().filter_map(|o| o.s.long));
 
-            let candidate = did_you_mean(arg, opts)?;
-            let score = args_rest.iter().position(|x| *x == subcommand.get_name())?;
+            let candidate = match did_you_mean(arg, opts) {
+                Some(candidate) => candidate,
+                None => return None
+            };
+            let score = match args_rest.iter().position(|x| *x == subcommand.get_name()) {
+                Some(score) => score,
+                None => return None
+            };
 
             let suffix = format!(
                 "\n\tDid you mean to put '{}{}' after the subcommand '{}'?",

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -44,6 +44,7 @@ where
 #[cfg_attr(feature = "lints", allow(needless_lifetimes))]
 pub fn did_you_mean_flag_suffix<'z, T, I>(
     arg: &str,
+    args_rest: &'z [&str],
     longs: I,
     subcommands: &'z [App],
 ) -> (String, Option<&'z str>)
@@ -51,16 +52,18 @@ where
     T: AsRef<str> + 'z,
     I: IntoIterator<Item = &'z T>,
 {
-    match did_you_mean(arg, longs) {
-        Some(candidate) => {
-            let suffix = format!(
-                "\n\tDid you mean {}{}?",
-                Format::Good("--"),
-                Format::Good(candidate)
+    if let Some(candidate) = did_you_mean(arg, longs) {
+        let suffix = format!(
+            "\n\tDid you mean {}{}?",
+            Format::Good("--"),
+            Format::Good(candidate)
             );
-            return (suffix, Some(candidate));
-        }
-        None => for subcommand in subcommands {
+        return (suffix, Some(candidate));
+    }
+
+    subcommands
+        .into_iter()
+        .filter_map(|subcommand| {
             let opts = subcommand
                 .p
                 .flags
@@ -68,18 +71,21 @@ where
                 .filter_map(|f| f.s.long)
                 .chain(subcommand.p.opts.iter().filter_map(|o| o.s.long));
 
-            if let Some(candidate) = did_you_mean(arg, opts) {
-                let suffix = format!(
-                    "\n\tDid you mean to put '{}{}' after the subcommand '{}'?",
-                    Format::Good("--"),
-                    Format::Good(candidate),
-                    Format::Good(subcommand.get_name())
-                );
-                return (suffix, Some(candidate));
-            }
-        },
-    }
-    (String::new(), None)
+            let candidate = did_you_mean(arg, opts)?;
+            let score = args_rest.iter().position(|x| *x == subcommand.get_name())?;
+
+            let suffix = format!(
+                "\n\tDid you mean to put '{}{}' after the subcommand '{}'?",
+                Format::Good("--"),
+                Format::Good(candidate),
+                Format::Good(subcommand.get_name())
+            );
+
+            Some((score, (suffix, Some(candidate))))
+        })
+        .min_by_key(|&(score, _)| score)
+        .map(|(_, suggestion)| suggestion)
+        .unwrap_or_else(|| (String::new(), None))
 }
 
 /// Returns a suffix that can be empty, or is the standard 'did you mean' phrase

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -42,15 +42,6 @@ USAGE:
 
 For more information try --help";
 
-#[cfg(feature = "suggestions")]
-static DYM_ARG: &'static str = "error: Found argument '--subcm' which wasn't expected, or isn't valid in this context
-\tDid you mean to put '--subcmdarg' after the subcommand 'subcmd'?
-
-USAGE:
-    dym [SUBCOMMAND]
-
-For more information try --help";
-
 #[test]
 fn subcommand() {
     let m = App::new("test")
@@ -137,10 +128,34 @@ fn subcmd_did_you_mean_output() {
 #[test]
 #[cfg(feature="suggestions")]
 fn subcmd_did_you_mean_output_arg() {
+    static EXPECTED: &'static str = "error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
+\tDid you mean to put '--subcmdarg' after the subcommand 'subcmd'?
+
+USAGE:
+    dym [SUBCOMMAND]
+
+For more information try --help";
+
     let app = App::new("dym")
         .subcommand(SubCommand::with_name("subcmd")
             .arg_from_usage("-s --subcmdarg [subcmdarg] 'tests'") );
-    assert!(test::compare_output(app, "dym --subcm foo", DYM_ARG, true));
+    assert!(test::compare_output(app, "dym --subcmarg subcmd", EXPECTED, true));
+}
+
+#[test]
+#[cfg(feature="suggestions")]
+fn subcmd_did_you_mean_output_arg_false_positives() {
+    static EXPECTED: &'static str = "error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
+
+USAGE:
+    dym [SUBCOMMAND]
+
+For more information try --help";
+
+    let app = App::new("dym")
+        .subcommand(SubCommand::with_name("subcmd")
+            .arg_from_usage("-s --subcmdarg [subcmdarg] 'tests'") );
+    assert!(test::compare_output(app, "dym --subcmarg foo", EXPECTED, true));
 }
 
 #[test]


### PR DESCRIPTION
Let's say I have a CLI app like this: 
```
foo bar --baz
foo bam --baz
```

And a user invokes it as: `foo --baz bar`

We would currently suggest something like `"Did you mean to put '--baz' after the subcommand 'bam'"`, even though the user clearly didn't show the intent to invoke `bam`, but wanted to invoke `bar`.

This PR fixes this by reading the entire argument line and checking for potential occurences of all subcommands. Of course this is super fuzzy because we have no idea what is supposed to be a value of an option, and what is part of the subcommand, but it's slightly better than just taking the first subcommand that happens to have the option.