### PR TITLE
Adding case_insensitive to yaml parsing

### DIFF
--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -139,6 +139,7 @@ impl<'a, 'b> Arg<'a, 'b> {
                 "conflicts_with" => yaml_vec_or_str!(v, a, conflicts_with),
                 "overrides_with" => yaml_vec_or_str!(v, a, overrides_with),
                 "possible_values" => yaml_vec_or_str!(v, a, possible_value),
+                "case_insensitive" => yaml_to_bool!(a, v, case_insensitive),
                 "required_unless_one" => yaml_vec_or_str!(v, a, required_unless),
                 "required_unless_all" => {
                     a = yaml_vec_or_str!(v, a, required_unless);

--- a/tests/app.yml
+++ b/tests/app.yml
@@ -90,6 +90,11 @@ args:
         multiple: true
         help: Tests 3 max vals
         max_values: 3
+    - case_insensitive:
+        help: Test case_insensitive
+        possible_values: [test123, test321]
+        case_insensitive: true
+
 arg_groups:
     - test:
         args:


### PR DESCRIPTION
There's a missing of setting [case_insensitive](https://github.com/clap-rs/clap/commit/27ecd0d76b331d36d7e1672d20f5a0b6511e3f12) in YAML.