### PR TITLE
Upgrade to yaml-rust 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,13 @@ maintenance = {status = "actively-developed"}
 bitflags              = "1.0"
 unicode-width         = "0.1.4"
 textwrap              = "0.10.0"
-strsim    = { version = "0.8",  optional = true }
-yaml-rust = { version = "0.3.5",  optional = true }
-clippy    = { version = "~0.0.166", optional = true }
-atty      = { version = "0.2.2",  optional = true }
-vec_map   = { version = "0.8", optional = true }
-term_size = { version = "0.3.0", optional = true }
+strsim          = { version = "0.8",  optional = true }
+yaml-rust       = { version = "0.4.1",  optional = true }
+linked-hash-map = { version = "0.5", optional = true }
+clippy          = { version = "~0.0.166", optional = true }
+atty            = { version = "0.2.2",  optional = true }
+vec_map         = { version = "0.8", optional = true }
+term_size       = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 ansi_term = { version = "0.11",  optional = true }
@@ -47,7 +48,7 @@ default     = ["suggestions", "color", "vec_map"]
 suggestions = ["strsim"]
 color       = ["ansi_term", "atty"]
 wrap_help   = ["term_size", "textwrap/term_size"]
-yaml        = ["yaml-rust"]
+yaml        = ["yaml-rust", "linked-hash-map"]
 unstable    = [] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 nightly     = [] # for building with unstable Rust features (currently none)
 lints       = ["clippy"] # Requires nightly Rust

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "yaml")]
-use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::ffi::{OsStr, OsString};
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
@@ -10,6 +8,8 @@ use std::env;
 
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
+#[cfg(feature = "yaml")]
+use linked_hash_map::LinkedHashMap;
 use map::VecMap;
 
 use usage_parser::UsageParser;
@@ -91,7 +91,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// ```
     /// [`Arg`]: ./struct.Arg.html
     #[cfg(feature = "yaml")]
-    pub fn from_yaml(y: &BTreeMap<Yaml, Yaml>) -> Arg {
+    pub fn from_yaml(y: &LinkedHashMap<Yaml, Yaml>) -> Arg {
         // We WANT this to panic on error...so expect() is good.
         let name_yml = y.keys().nth(0).unwrap();
         let name_str = name_yml.as_str().unwrap();

--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "yaml")]
-use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter, Result};
 
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
+#[cfg(feature = "yaml")]
+use linked_hash_map::LinkedHashMap;
 
 /// `ArgGroup`s are a family of related [arguments] and way for you to express, "Any of these
 /// arguments". By placing arguments in a logical group, you can create easier requirement and
@@ -454,8 +454,8 @@ impl<'a, 'z> From<&'z ArgGroup<'a>> for ArgGroup<'a> {
 }
 
 #[cfg(feature = "yaml")]
-impl<'a> From<&'a BTreeMap<Yaml, Yaml>> for ArgGroup<'a> {
-    fn from(b: &'a BTreeMap<Yaml, Yaml>) -> Self {
+impl<'a> From<&'a LinkedHashMap<Yaml, Yaml>> for ArgGroup<'a> {
+    fn from(b: &'a LinkedHashMap<Yaml, Yaml>) -> Self {
         // We WANT this to panic on error...so expect() is good.
         let mut a = ArgGroup::default();
         let group_settings = if b.len() == 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,6 +548,8 @@ extern crate unicode_width;
 extern crate vec_map;
 #[cfg(feature = "yaml")]
 extern crate yaml_rust;
+#[cfg(feature = "yaml")]
+extern crate linked_hash_map;
 
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;


### PR DESCRIPTION
Prevent abort when parsing yaml with deep recursion.

Introduces `linked-hash-map` as a new dependency.

Fixes #1367.