### PR TITLE
Remove all values from previous occurrences on self-override

### DIFF
--- a/src/args/arg_matcher.rs
+++ b/src/args/arg_matcher.rs
@@ -10,6 +10,8 @@ use args::{ArgMatches, MatchedArg, SubCommand};
 use args::AnyArg;
 use args::settings::ArgSettings;
 
+use INTERNAL_ERROR_MSG;
+
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
 pub struct ArgMatcher<'a>(pub ArgMatches<'a>);
@@ -68,9 +70,15 @@ impl<'a> ArgMatcher<'a> {
                     if aa.takes_value() {
                         // Only keep values for the last occurrence
                         let len = ma.vals.len();
-                        let keep = len - ma.occurrences.pop().unwrap_or(len);
+                        let occurrence_start = ma.occurrences.pop().expect(INTERNAL_ERROR_MSG);
 
-                        ma.vals.rotate_right(keep);
+                        // 1.26 has `rotate_left`, but we can't use it.
+                        // ma.vals.rotate_left(occurrence_start);
+                        let keep = len - occurrence_start;
+                        for i in 0..keep {
+                            ma.vals.swap(i, occurrence_start + i);
+                        }
+
                         ma.vals.truncate(keep);
                     }
 

--- a/src/args/matched_arg.rs
+++ b/src/args/matched_arg.rs
@@ -7,6 +7,10 @@ pub struct MatchedArg {
     #[doc(hidden)] pub occurs: u64,
     #[doc(hidden)] pub indices: Vec<usize>,
     #[doc(hidden)] pub vals: Vec<OsString>,
+    // This contains the positions in `vals` at which each occurrence starts.  The first occurrence
+    // is implicitely starting at position `0` so that `occurrences` is empty in the common case of
+    // a single occurrence.
+    #[doc(hidden)] pub occurrences: Vec<usize>,
 }
 
 impl Default for MatchedArg {
@@ -15,6 +19,7 @@ impl Default for MatchedArg {
             occurs: 1,
             indices: Vec::new(),
             vals: Vec::new(),
+            occurrences: Vec::new(),
         }
     }
 }

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -827,6 +827,64 @@ fn aaos_opts() {
 }
 
 #[test]
+fn aaos_opts_two_values() {
+    // opts with two values
+    let res = App::new("posix")
+        .setting(AppSettings::AllArgsOverrideSelf)
+        .arg(Arg::from_usage("--opt [val1] [val2] 'some option'"))
+        .get_matches_from_safe(vec![
+            "", "--opt", "some", "thing", "--opt", "other", "stuff",
+        ]);
+    assert!(res.is_ok());
+    let m = res.unwrap();
+    assert!(m.is_present("opt"));
+    assert_eq!(m.occurrences_of("opt"), 1);
+    assert_eq!(
+        m.values_of("opt").unwrap().collect::<Vec<_>>(),
+        &["other", "stuff"]
+    );
+}
+
+#[test]
+fn aaos_opts_two_values_delimiter() {
+    // opts with two values and a delimiter
+    let res = App::new("posix")
+        .setting(AppSettings::AllArgsOverrideSelf)
+        .arg(Arg::from_usage("--opt [val1] [val2] 'some option'").require_delimiter(true))
+        .get_matches_from_safe(vec!["", "--opt=some,thing", "--opt=other,stuff"]);
+    assert!(res.is_ok());
+    let m = res.unwrap();
+    assert!(m.is_present("opt"));
+    assert_eq!(m.occurrences_of("opt"), 1);
+    assert_eq!(
+        m.values_of("opt").unwrap().collect::<Vec<_>>(),
+        &["other", "stuff"]
+    );
+}
+
+#[test]
+fn aaos_opts_min_value() {
+    // opts with min_value
+    let res = App::new("posix")
+        .setting(AppSettings::AllArgsOverrideSelf)
+        .arg(
+            Arg::from_usage("--opt [val] 'some option'")
+                .require_delimiter(true)
+                .min_values(0),
+        )
+        .get_matches_from_safe(vec!["", "--opt", "--opt=val1,val2"]);
+    assert!(res.is_ok());
+    let m = res.unwrap();
+    assert!(m.is_present("opt"));
+    assert_eq!(m.occurrences_of("opt"), 1);
+    assert_eq!(
+        m.values_of("opt").unwrap().collect::<Vec<_>>(),
+        &["val1", "val2"]
+    );
+}
+
+
+#[test]
 fn aaos_opts_w_other_overrides() {
     // opts with other overrides
     let res = App::new("posix")


### PR DESCRIPTION
When an argument gets self-overriden, at most a single value[1] gets removed from the existing values list.  This is incorrect when the argument has multiple values per occurrence, and makes for "funny" bugs such as `--input --input a b` being parsed as `--input b` and `--input a b c --input d` being parsed as `--input c d`.

This patch fixes the issue by keeping track of how many values were already present when we started parsing each occurrence, and removing all the values but the ones for the last occurrence when a self-override occurs.

Fixes #1374 
    
[1]: Actually at most two values due to clap handling the overrides twice, which is a separate bug fixed in v3.