### PR TITLE
Pin lazy_static to ~1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ ansi_term = { version = "0.11",  optional = true }
 
 [dev-dependencies]
 regex = "1"
-lazy_static = "1"
+# lazy_static 1.2 requires Rust 1.24.1+
+lazy_static = "~1.1"
 version-sync = "0.5"
 
 [features]


### PR DESCRIPTION
lazy_static 1.2 requires Rust 1.24.1+ but we support 1.21+