### PR TITLE
 fix(#1374): Remove all values from previous occurrences on self-override

### DIFF
--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -103,6 +103,11 @@ impl<'a> ArgMatcher<'a> {
     pub fn inc_occurrence_of(&mut self, arg: &'a str) {
         debugln!("ArgMatcher::inc_occurrence_of: arg={}", arg);
         if let Some(a) = self.get_mut(arg) {
+            if a.occurs > 0 {
+                // If not the first occurrence, we need to record the position in the vals vector
+                // at which this occurrence starts.
+                a.occurrences.push(a.vals.len());
+            }
             a.occurs += 1;
             return;
         }
@@ -115,6 +120,7 @@ impl<'a> ArgMatcher<'a> {
             occurs: 0,
             indices: Vec::with_capacity(1),
             vals: Vec::with_capacity(1),
+            occurrences: Vec::new(),
         });
         ma.vals.push(val.to_owned());
     }
@@ -124,6 +130,7 @@ impl<'a> ArgMatcher<'a> {
             occurs: 0,
             indices: Vec::with_capacity(1),
             vals: Vec::new(),
+            occurrences: Vec::new(),
         });
         ma.indices.push(idx);
     }

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -10,6 +10,11 @@ pub struct MatchedArg {
     pub indices: Vec<usize>,
     #[doc(hidden)]
     pub vals: Vec<OsString>,
+    // This contains the positions in `vals` at which each occurrence starts.  The first occurrence
+    // is implicitely starting at position `0` so that `occurrences` is empty in the common case of
+    // a single occurrence.
+    #[doc(hidden)]
+    pub occurrences: Vec<usize>,
 }
 
 impl Default for MatchedArg {
@@ -18,6 +23,7 @@ impl Default for MatchedArg {
             occurs: 1,
             indices: Vec::new(),
             vals: Vec::new(),
+            occurrences: Vec::new(),
         }
     }
 }

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -828,6 +828,64 @@ fn aaos_opts() {
 }
 
 #[test]
+fn aaos_opts_two_values() {
+    // opts with two values
+    let res = App::new("posix")
+        .setting(AppSettings::AllArgsOverrideSelf)
+        .arg(Arg::from("--opt [val1] [val2] 'some option'"))
+        .try_get_matches_from(vec![
+            "", "--opt", "some", "thing", "--opt", "other", "stuff",
+        ]);
+    assert!(res.is_ok());
+    let m = res.unwrap();
+    assert!(m.is_present("opt"));
+    assert_eq!(m.occurrences_of("opt"), 1);
+    assert_eq!(
+        m.values_of("opt").unwrap().collect::<Vec<_>>(),
+        &["other", "stuff"]
+    );
+}
+
+#[test]
+fn aaos_opts_two_values_delimiter() {
+    // opts with two values and a delimiter
+    let res = App::new("posix")
+        .setting(AppSettings::AllArgsOverrideSelf)
+        .arg(Arg::from("--opt [val1] [val2] 'some option'").require_delimiter(true))
+        .try_get_matches_from(vec!["", "--opt=some,thing", "--opt=other,stuff"]);
+    assert!(res.is_ok());
+    let m = res.unwrap();
+    assert!(m.is_present("opt"));
+    assert_eq!(m.occurrences_of("opt"), 1);
+    assert_eq!(
+        m.values_of("opt").unwrap().collect::<Vec<_>>(),
+        &["other", "stuff"]
+    );
+}
+
+#[test]
+fn aaos_opts_min_value() {
+    // opts with min_value
+    let res = App::new("posix")
+        .setting(AppSettings::AllArgsOverrideSelf)
+        .arg(
+            Arg::from("--opt [val] 'some option'")
+                .require_delimiter(true)
+                .min_values(0),
+        )
+        .try_get_matches_from(vec!["", "--opt", "--opt=val1,val2"]);
+    assert!(res.is_ok());
+    let m = res.unwrap();
+    assert!(m.is_present("opt"));
+    assert_eq!(m.occurrences_of("opt"), 1);
+    assert_eq!(
+        m.values_of("opt").unwrap().collect::<Vec<_>>(),
+        &["val1", "val2"]
+    );
+}
+
+
+#[test]
 fn aaos_opts_w_other_overrides() {
     // opts with other overrides
     let res = App::new("posix")


### PR DESCRIPTION
When an argument gets self-overriden, at most a single value gets kept
from the existing values list.  This is incorrect when the argument has
multiple values per occurrence, and makes for "funny" bugs such as
`--input a b --input c d` being parsed as `--input d`.

This patch fixes the issue by keeping track of how many values were
already present when we started parsing each occurrence, and removing
all the values but the ones for the last occurrence when a self-override
occurs.