### PR TITLE
fix(macros): fixes broken pattern

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -775,9 +775,13 @@ macro_rules! clap_app {
     (@arg ($arg:expr) $modes:tt $ident:ident[$($target:ident)*] $($tail:tt)*) => {
         clap_app!{ @arg ($arg $( .$ident(stringify!($target)) )*) $modes $($tail)* }
     };
-// Inherit builder's functions
-    (@arg ($arg:expr) $modes:tt $ident:ident($($expr:expr)*) $($tail:tt)*) => {
-        clap_app!{ @arg ($arg.$ident($($expr)*)) $modes $($tail)* }
+// Inherit builder's functions, e.g. `index(2)`, `requires_if("val", "arg")`
+    (@arg ($arg:expr) $modes:tt $ident:ident($($expr:expr),*) $($tail:tt)*) => {
+        clap_app!{ @arg ($arg.$ident($($expr),*)) $modes $($tail)* }
+    };
+// Inherit builder's functions with trailing comma, e.g. `index(2,)`, `requires_if("val", "arg",)`
+    (@arg ($arg:expr) $modes:tt $ident:ident($($expr:expr,)*) $($tail:tt)*) => {
+        clap_app!{ @arg ($arg.$ident($($expr),*)) $modes $($tail)* }
     };
 
 // Build a subcommand outside of an app.

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -250,6 +250,32 @@ fn group_macro_set_not_required() {
 }
 
 #[test]
+fn multiarg() {
+    let app = || clap_app!(
+        claptests =>
+            (@arg flag: --flag "value")
+            (@arg multiarg: --multiarg
+             default_value("flag-unset") default_value_if("flag", None, "flag-set")
+             "multiarg")
+            (@arg multiarg2: --multiarg2
+             default_value("flag-unset") default_value_if("flag", None, "flag-set",)
+             "multiarg2")
+    );
+
+    let matches = app()
+        .get_matches_from_safe(vec!["bin_name"])
+        .expect("match failed");
+    assert_eq!(matches.value_of("multiarg"), Some("flag-unset"));
+    assert_eq!(matches.value_of("multiarg2"), Some("flag-unset"));
+
+    let matches = app()
+        .get_matches_from_safe(vec!["bin_name", "--flag"])
+        .expect("match failed");
+    assert_eq!(matches.value_of("multiarg"), Some("flag-set"));
+    assert_eq!(matches.value_of("multiarg2"), Some("flag-set"));
+}
+
+#[test]
 fn arg_enum() {
     // Helper macros to avoid repetition
     macro_rules! test_greek {


### PR DESCRIPTION
I discovered that `default_value_if` cannot be used inside a `clap_app!` macro. The root cause was a bad pattern which did not handle comma-separated arguments. It was probably not spotted before because almost all `Arg` methods take zero or one argument and thus don't need a comma.

This pull request contains a fix for this bug, an extra pattern to handle the unusual but valid case of a trailing comma in the parameters (which can sometimes be inserted by rustfmt), and some tests.