### PR TITLE
Bump yaml-rust to 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bitflags              = "1.0"
 unicode-width         = "0.1.4"
 textwrap              = "0.10.0"
 strsim    = { version = "0.8",  optional = true }
-yaml-rust = { version = "0.3.5",  optional = true }
+yaml-rust = { version = "0.4.2",  optional = true }
 clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
 vec_map   = { version = "0.8", optional = true }


### PR DESCRIPTION
0.3 version is vulnerable: 

> RUSTSEC-2018-0006 Uncontrolled recursion leads to abort in deserialization

Fixes #1387