### PR TITLE
Use `$crate` prepend to make importing the `_clap_count_exprs` macro unnecessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: rust
 cache: cargo
 rust:
   - nightly
-  - nightly-2018-06-19
+  - nightly-2018-08-06
   - beta
   - stable
-  - 1.21.0
+  - 1.30.0
 matrix:
     allow_failures:
         - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Minimum Required Rust
+
+* As of this release, `clap` requires `rustc 1.30.0` or greater.
+
 <a name="v2.32.0"></a>
 ## v2.32.0 (2018-06-26)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 
 Here's whats new in 2.32.0:
 
-* `clap` requires `rustc 1.21.0` or greater.
+* `clap` requires `rustc 1.30.0` or greater.
 * **Completions:**  adds completion support for Elvish. ([e9d0562a](https://github.com/kbknapp/clap-rs/commit/e9d0562a1dc5dfe731ed7c767e6cee0af08f0cf9))
 * **ArgGroup and macros:**  Support shorthand syntax for ArgGroups ([df9095e7](https://github.com/kbknapp/clap-rs/commit/df9095e75bb1e7896415251d0d4ffd8a0ebcd559))
 * **OsValues:**  Add `ExactSizeIterator` implementation ([356c69e5](https://github.com/kbknapp/clap-rs/commit/356c69e508fd25a9f0ea2d27bf80ae1d9a8d88f4))
@@ -488,9 +488,9 @@ This is inherently an unresolvable crate graph in Cargo right now. Cargo require
 
 #### Minimum Version of Rust
 
-`clap` will officially support current stable Rust, minus two releases, but may work with prior releases as well. For example, current stable Rust at the time of this writing is 1.21.0, meaning `clap` is guaranteed to compile with 1.19.0 and beyond.
+`clap` will officially support current stable Rust, minus two releases, but may work with prior releases as well. For example, current stable Rust at the time of this writing is 1.32.0, meaning `clap` is guaranteed to compile with 1.30.0 and beyond.
 
-At the 1.22.0 stable release, `clap` will be guaranteed to compile with 1.20.0 and beyond, etc.
+At the 1.33.0 stable release, `clap` will be guaranteed to compile with 1.31.0 and beyond, etc.
 
 Upon bumping the minimum version of Rust (assuming it's within the stable-2 range), it *must* be clearly annotated in the `CHANGELOG.md`
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -254,7 +254,7 @@ macro_rules! values_t_or_exit {
 macro_rules! _clap_count_exprs {
     () => { 0 };
     ($e:expr) => { 1 };
-    ($e:expr, $($es:expr),+) => { 1 + _clap_count_exprs!($($es),*) };
+    ($e:expr, $($es:expr),+) => { 1 + $crate::_clap_count_exprs!($($es),*) };
 }
 
 /// Convenience macro to generate more complete enums with variants to be used as a type when
@@ -338,7 +338,7 @@ macro_rules! arg_enum {
         }
         impl $e {
             #[allow(dead_code)]
-            pub fn variants() -> [&'static str; _clap_count_exprs!($(stringify!($v)),+)] {
+            pub fn variants() -> [&'static str; $crate::_clap_count_exprs!($(stringify!($v)),+)] {
                 [
                     $(stringify!($v),)+
                 ]


### PR DESCRIPTION
Resolves #1329, using the `$crate::` keyword that was [stabilized with Rust 1.30.0](https://rust-lang-nursery.github.io/edition-guide/rust-2018/macros/macro-changes.html#local-helper-macros).

**NOTE: This should be merged on or after the day of the Rust 1.32** (probably 2019-01-21, 6 weeks after 1.31.0 released) release in order to maintain the `supports($LATEST - 2)` minimum Rust compiler policy.