### PR TITLE
 setting(DisableHelpFlags): disable the automatic generation of the -h/--help flags

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1413,7 +1413,7 @@ where
     pub fn create_help_and_version(&mut self) {
         debugln!("Parser::create_help_and_version;");
         // name is "hclap_help" because flags are sorted by name
-        if !self.contains_long("help") {
+        if !self.is_set(AS::DisableHelpFlags) && !self.contains_long("help") {
             debugln!("Parser::create_help_and_version: Building --help");
             if self.help_short.is_none() && !self.contains_short('h') {
                 self.help_short = Some('h');


### PR DESCRIPTION
This commit adds an `AppSettings::DisableHelpFlags` variant, which disables the generation of the `-h`/`--help` flags similarly to how `AppSettings::DisableVersion` works.

My original use case for this (and `AppSettings::DisableVersion`) is to use `clap` to parse a "command line" of purely subcomands in a chat client, and having `/-h` or `/--help` (or `/-V`) be valid commands is a little strange.