### PR TITLE
fix(src/fmt.rs): Respect ColorAlways

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -62,11 +62,11 @@ impl Colorizer {
         let is_a_tty = is_a_tty(option.use_stderr);
         let is_term_dumb = is_term_dumb();
         Colorizer {
-            when: if is_a_tty && !is_term_dumb {
-                option.when
-            } else {
-                ColorWhen::Never
-            },
+            when: match option.when {
+                ColorWhen::Auto if is_a_tty && !is_term_dumb => ColorWhen::Auto,
+                ColorWhen::Auto => ColorWhen::Never,
+                when => when,
+            }
         }
     }
 


### PR DESCRIPTION
Currently, `AppSettings::ColorAlways` doesn't do anything (see #1400). This is because the requested colorizer is changed to `ColorWhen::Never` if `TERM=dumb` or the destination stream is not a TTY.

https://github.com/clap-rs/clap/blob/47edd1c1e686fd679f14915e00cda07ddcd313c4/src/fmt.rs#L65-L69

This pull request changes the behavior for `ColorAlways` so that it ignores `atty::is()` and `TERM=dumb`.