### PR TITLE
tests(global_args.rs): silence unused_must_use

### DIFF
--- a/tests/global_args.rs
+++ b/tests/global_args.rs
@@ -30,8 +30,8 @@ mod tests {
     #[test]
     fn issue_1076() {
         let mut app = get_app();
-        app.get_matches_from_safe_borrow(vec!["myprog"]);
-        app.get_matches_from_safe_borrow(vec!["myprog"]);
-        app.get_matches_from_safe_borrow(vec!["myprog"]);
+        let _ = app.get_matches_from_safe_borrow(vec!["myprog"]);
+        let _ = app.get_matches_from_safe_borrow(vec!["myprog"]);
+        let _ = app.get_matches_from_safe_borrow(vec!["myprog"]);
     }
 }


### PR DESCRIPTION
This function only tests that the program does not panic, so the result need not be used.

(Silences three warnings during compilation.)