### PR TITLE
fix: add debug assertion for missing args in subcommand ArgGroup

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -135,7 +135,7 @@ where
     }
 
     #[inline]
-    fn app_debug_asserts(&mut self) -> bool {
+    fn app_debug_asserts(&self) -> bool {
         assert!(self.verify_positionals());
         let should_err = self.groups.iter().all(|g| {
             g.args.iter().all(|arg| {
@@ -512,7 +512,7 @@ where
     pub fn unset(&mut self, s: AS) { self.settings.unset(s) }
 
     #[cfg_attr(feature = "lints", allow(block_in_if_condition_stmt))]
-    pub fn verify_positionals(&mut self) -> bool {
+    pub fn verify_positionals(&self) -> bool {
         // Because you must wait until all arguments have been supplied, this is the first chance
         // to make assertions on positional argument indexes
         //
@@ -1362,6 +1362,8 @@ where
     }
 
     pub fn args_in_group(&self, group: &str) -> Vec<String> {
+        debug_assert!(self.app_debug_asserts());
+
         let mut g_vec = vec![];
         let mut args = vec![];
 

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -3,7 +3,7 @@ extern crate regex;
 
 include!("../clap-test.rs");
 
-use clap::{App, Arg, ArgGroup, ErrorKind};
+use clap::{App, Arg, ArgGroup, ErrorKind, SubCommand};
 
 static REQ_GROUP_USAGE: &'static str = "error: The following required arguments were not provided:
     <base|--delete>
@@ -51,6 +51,20 @@ fn non_existing_arg() {
             .args(&["flg", "color"])
             .required(true))
         .get_matches_from_safe(vec![""]);
+}
+
+#[test]
+#[should_panic(expected = "The group 'c' contains the arg 'd' that doesn't actually exist.")]
+fn non_existing_arg_in_subcommand_help() {
+    let _ = App::new("a")
+        .subcommand(
+            SubCommand::with_name("b")
+                .group(
+                    ArgGroup::with_name("c")
+                        .args(&["d"])
+                        .required(true),
+                )
+        ).get_matches_from_safe(vec!["a", "help", "b"]);
 }
 
 #[test]


### PR DESCRIPTION
In debug mode, assert that all arguments in a subcommand's required ArgGroup exist when printing the subcommand's help message. The previous behavior was an expectation failure with the generic INTERNAL_ERROR_MSG.

See-also: 7ad123e2c02577 (introduced relevant assertion)