### PR TITLE
fix(arg_enum!): Fix comma position for valid values.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -324,7 +324,7 @@ macro_rules! arg_enum {
                             $(stringify!($v),)+
                         ];
                         format!("valid values: {}",
-                            v.join(" ,"))
+                            v.join(", "))
                     }),
                 }
             }


### PR DESCRIPTION
It should be `a, b, c` instead of `a ,b ,c`.