### PR TITLE
imp: hide flags with default values in error usage

### DIFF
--- a/src/app/usage.rs
+++ b/src/app/usage.rs
@@ -29,7 +29,9 @@ pub fn create_error_usage<'a, 'b>(
         .iter()
         .filter(|n| {
             if let Some(o) = find_by_name!(p, **n, opts, iter) {
-                !o.b.is_set(ArgSettings::Required) && !o.b.is_set(ArgSettings::Hidden)
+                !o.b.is_set(ArgSettings::Required) &&
+                    !o.b.is_set(ArgSettings::Hidden) &&
+                    matcher.0.occurrences_of(n) != 0
             } else if let Some(p) = find_by_name!(p, **n, positionals, values) {
                 !p.b.is_set(ArgSettings::Required) && p.b.is_set(ArgSettings::Hidden)
             } else {


### PR DESCRIPTION
When running a program and not giving a required argument, the error
usage will contain every optional option. This is really annoying for
commands with many different optionals.

USAGE:
	bin <file> --opt-1 <arg> --opt-2 <arg> --opt-3 <arg> etc....

This is also inconsistent as if the error is triggered by an unknown
argument, the error ussage instead does not contain the optionals.

USAGE:
	bin <file>

This patch makes it so that only the flags that are actually used appear
in the error usage.