### PR TITLE
Fix clap_app! usage example

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -600,7 +600,8 @@ macro_rules! app_from_crate {
 ///         (author: "Someone E. <someone_else@other.com>")
 ///         (@arg verbose: -v --verbose "Print test information verbosely")
 ///     )
-/// );
+/// )
+/// .get_matches();
 /// # }
 /// ```
 /// # Shorthand Syntax for Args


### PR DESCRIPTION
I found this usage example confusing because `matches` was actually an `App`