### PR TITLE
Revert "Upgrading yaml-rust to 0.4.2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,12 @@ maintenance = {status = "actively-developed"}
 bitflags              = "1.0"
 unicode-width         = "0.1.4"
 textwrap              = "0.10.0"
-strsim                = { version = "0.8",  optional = true }
-yaml-rust             = { version = "0.4.2",  optional = true }
-linked-hash-map       = { version = ">=0.0.9, <0.6", optional = true }
-clippy                = { version = "~0.0.166", optional = true }
-atty                  = { version = "0.2.2",  optional = true }
-vec_map               = { version = "0.8", optional = true }
-term_size             = { version = "0.3.0", optional = true }
+strsim    = { version = "0.8",  optional = true }
+yaml-rust = { version = "0.3.5",  optional = true }
+clippy    = { version = "~0.0.166", optional = true }
+atty      = { version = "0.2.2",  optional = true }
+vec_map   = { version = "0.8", optional = true }
+term_size = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 ansi_term = { version = "0.11",  optional = true }
@@ -49,7 +48,7 @@ default     = ["suggestions", "color", "vec_map"]
 suggestions = ["strsim"]
 color       = ["ansi_term", "atty"]
 wrap_help   = ["term_size", "textwrap/term_size"]
-yaml        = ["yaml-rust", "linked-hash-map"]
+yaml        = ["yaml-rust"]
 unstable    = [] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 nightly     = [] # for building with unstable Rust features (currently none)
 lints       = ["clippy"] # Requires nightly Rust

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "yaml")]
-use linked_hash_map::LinkedHashMap;
+use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::ffi::{OsStr, OsString};
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
@@ -91,7 +91,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// ```
     /// [`Arg`]: ./struct.Arg.html
     #[cfg(feature = "yaml")]
-    pub fn from_yaml(y: &LinkedHashMap<Yaml, Yaml>) -> Arg {
+    pub fn from_yaml(y: &BTreeMap<Yaml, Yaml>) -> Arg {
         // We WANT this to panic on error...so expect() is good.
         let name_yml = y.keys().nth(0).unwrap();
         let name_str = name_yml.as_str().unwrap();

--- a/src/args/group.rs
+++ b/src/args/group.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "yaml")]
-use linked_hash_map::LinkedHashMap;
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter, Result};
 
 #[cfg(feature = "yaml")]
@@ -454,8 +454,8 @@ impl<'a, 'z> From<&'z ArgGroup<'a>> for ArgGroup<'a> {
 }
 
 #[cfg(feature = "yaml")]
-impl<'a> From<&'a LinkedHashMap<Yaml, Yaml>> for ArgGroup<'a> {
-    fn from(b: &'a LinkedHashMap<Yaml, Yaml>) -> Self {
+impl<'a> From<&'a BTreeMap<Yaml, Yaml>> for ArgGroup<'a> {
+    fn from(b: &'a BTreeMap<Yaml, Yaml>) -> Self {
         // We WANT this to panic on error...so expect() is good.
         let mut a = ArgGroup::default();
         let group_settings = if b.len() == 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -548,8 +548,6 @@ extern crate unicode_width;
 extern crate vec_map;
 #[cfg(feature = "yaml")]
 extern crate yaml_rust;
-#[cfg(feature = "yaml")]
-extern crate linked_hash_map;
 
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;


### PR DESCRIPTION
Reverts clap-rs/clap#1415

## Reasoning

I merged this PR yesterday, not fully aware of how the public API would be changed.
Committing to this change would _require_ us to release a `clap 3.0` for it which seems very unreasonable.

After merging the idea was to re-work the function signatures to preserve the `clap 2.0` API while bumping to a new yaml version. This doesn't seem to be possible though because `arg_yaml.as_hash()` now hands out ownership of a tree, instead of just borrowing it.

The only reasonable choice at this time is to revert this PR.

## Alternatives

This is not to say that `clap` should depend on code that has known security vulnerabilities, small as they might be.
Because of this I feel it would be more appropriate to try to fix the recursion issue on the `0.3` branch of `yaml_rust` instead of bumping to a breaking change.

Apologies for the carfuffle!

**cc/** @gedigi 
