### PR TITLE
Remove bitflags dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ is-it-maintained-open-issues = { repository = "clap-rs/clap" }
 maintenance = {status = "actively-developed"}
 
 [dependencies]
-bitflags              = "1.0"
 unicode-width         = "0.1.4"
 textwrap              = "0.10.0"
 indexmap              = "1.0.1"

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1404,7 +1404,7 @@ impl<'a, 'b> App<'a, 'b> {
     pub fn _build(&mut self, prop: Propagation) {
         debugln!("App::_build;");
         // Make sure all the globally set flags apply to us as well
-        self.settings = self.settings | self.g_settings;
+        self.settings.update(&self.g_settings);
 
         // Depending on if DeriveDisplayOrder is set or not, we need to determine when we build
         // the help and version flags, otherwise help message orders get screwed up
@@ -1507,8 +1507,8 @@ impl<'a, 'b> App<'a, 'b> {
                     sc.set(AppSettings::GlobalVersion);
                     sc.version = Some(self.version.unwrap());
                 }
-                sc.settings = sc.settings | self.g_settings;
-                sc.g_settings = sc.g_settings | self.g_settings;
+                sc.settings.update(&self.g_settings);
+                sc.g_settings.update(&self.g_settings);
                 sc.term_w = self.term_w;
                 sc.max_w = self.max_w;
             }

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -1,113 +1,117 @@
 // Std
+use std::collections::HashSet;
 #[allow(unused_imports)]
 use std::ascii::AsciiExt;
-use std::ops::BitOr;
 use std::str::FromStr;
 
-bitflags! {
-    struct Flags: u64 {
-        const SC_NEGATE_REQS       = 1;
-        const SC_REQUIRED          = 1 << 1;
-        const A_REQUIRED_ELSE_HELP = 1 << 2;
-        const GLOBAL_VERSION       = 1 << 3;
-        const VERSIONLESS_SC       = 1 << 4;
-        const UNIFIED_HELP         = 1 << 5;
-        const WAIT_ON_ERROR        = 1 << 6;
-        const SC_REQUIRED_ELSE_HELP= 1 << 7;
-        const NO_AUTO_HELP         = 1 << 8;
-        const NO_AUTO_VERSION      = 1 << 9;
-        const DISABLE_VERSION      = 1 << 10;
-        const HIDDEN               = 1 << 11;
-        const TRAILING_VARARG      = 1 << 12;
-        const NO_BIN_NAME          = 1 << 13;
-        const ALLOW_UNK_SC         = 1 << 14;
-        const UTF8_STRICT          = 1 << 15;
-        const UTF8_NONE            = 1 << 16;
-        const LEADING_HYPHEN       = 1 << 17;
-        const NO_POS_VALUES        = 1 << 18;
-        const NEXT_LINE_HELP       = 1 << 19;
-        const DERIVE_DISP_ORDER    = 1 << 20;
-        const COLORED_HELP         = 1 << 21;
-        const COLOR_ALWAYS         = 1 << 22;
-        const COLOR_AUTO           = 1 << 23;
-        const COLOR_NEVER          = 1 << 24;
-        const DONT_DELIM_TRAIL     = 1 << 25;
-        const ALLOW_NEG_NUMS       = 1 << 26;
-        const LOW_INDEX_MUL_POS    = 1 << 27;
-        const DISABLE_HELP_SC      = 1 << 28;
-        const DONT_COLLAPSE_ARGS   = 1 << 29;
-        const ARGS_NEGATE_SCS      = 1 << 30;
-        const PROPAGATE_VALS_DOWN  = 1 << 31;
-        const ALLOW_MISSING_POS    = 1 << 32;
-        const TRAILING_VALUES      = 1 << 33;
-        const VALID_NEG_NUM_FOUND  = 1 << 34;
-        const PROPAGATED           = 1 << 35;
-        const VALID_ARG_FOUND      = 1 << 36;
-        const INFER_SUBCOMMANDS    = 1 << 37;
-        const CONTAINS_LAST        = 1 << 38;
-        const ARGS_OVERRIDE_SELF   = 1 << 39;
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Flags {
+    ScNegateReqs,
+    ScRequired,
+    ARequiredElseHelp,
+    GlobalVersion,
+    VersionlessSc,
+    UnifiedHelp,
+    WaitOnError,
+    ScRequiredElseHelp,
+    NoAutoHelp,
+    NoAutoVersion,
+    DisableVersion,
+    Hidden,
+    TrailingVarArg,
+    NoBinName,
+    AllowUnkSc,
+    Utf8Strict,
+    Utf8None,
+    LeadingHyphen,
+    NoPosValues,
+    NextLineHelp,
+    DeriveDispOrder,
+    ColoredHelp,
+    ColorAlways,
+    ColorAuto,
+    ColorNever,
+    DontDelimTrail,
+    AllowNegNums,
+    LowIndexMulPos,
+    DisableHelpSc,
+    DontCollapseArgs,
+    ArgsNegateScs,
+    PropagateValsDown,
+    AllowMissingPos,
+    TrailingValues,
+    ValidNegNumFound,
+    Propagated,
+    ValidArgFound,
+    InferSubcommands,
+    ContainsLast,
+    ArgsOverrideSelf,
 }
 
 #[doc(hidden)]
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub struct AppFlags(Flags);
-
-impl BitOr for AppFlags {
-    type Output = Self;
-    fn bitor(self, rhs: Self) -> Self { AppFlags(self.0 | rhs.0) }
-}
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppFlags(HashSet<Flags>);
 
 impl Default for AppFlags {
-    fn default() -> Self { AppFlags(Flags::UTF8_NONE | Flags::COLOR_AUTO) }
+    fn default() -> Self {
+        let mut set = HashSet::new();
+        set.insert(Flags::Utf8None);
+        set.insert(Flags::ColorAuto);
+        AppFlags(set)
+    }
 }
 
 #[allow(deprecated)]
 impl AppFlags {
     pub fn new() -> Self { AppFlags::default() }
-    pub fn zeroed() -> Self { AppFlags(Flags::empty()) }
+    pub fn zeroed() -> Self { AppFlags(HashSet::new()) }
+    pub fn update(&mut self, other: &Self) {
+        for flag in other.0.iter() {
+            self.0.insert(*flag);
+        }
+    }
 
     impl_settings! { AppSettings,
-        ArgRequiredElseHelp => Flags::A_REQUIRED_ELSE_HELP,
-        ArgsNegateSubcommands => Flags::ARGS_NEGATE_SCS,
-        AllowExternalSubcommands => Flags::ALLOW_UNK_SC,
-        AllowInvalidUtf8 => Flags::UTF8_NONE,
-        AllowLeadingHyphen => Flags::LEADING_HYPHEN,
-        AllowNegativeNumbers => Flags::ALLOW_NEG_NUMS,
-        AllowMissingPositional => Flags::ALLOW_MISSING_POS,
-        ColoredHelp => Flags::COLORED_HELP,
-        ColorAlways => Flags::COLOR_ALWAYS,
-        ColorAuto => Flags::COLOR_AUTO,
-        ColorNever => Flags::COLOR_NEVER,
-        DontDelimitTrailingValues => Flags::DONT_DELIM_TRAIL,
-        DontCollapseArgsInUsage => Flags::DONT_COLLAPSE_ARGS,
-        DeriveDisplayOrder => Flags::DERIVE_DISP_ORDER,
-        DisableHelpSubcommand => Flags::DISABLE_HELP_SC,
-        DisableVersion => Flags::DISABLE_VERSION,
-        GlobalVersion => Flags::GLOBAL_VERSION,
-        HidePossibleValuesInHelp => Flags::NO_POS_VALUES,
-        Hidden => Flags::HIDDEN,
-        LowIndexMultiplePositional => Flags::LOW_INDEX_MUL_POS,
-        NoAutoHelp => Flags::NO_AUTO_HELP,
-        NoAutoVersion => Flags::NO_AUTO_VERSION,
-        NoBinaryName => Flags::NO_BIN_NAME,
-        PropagateGlobalValuesDown=> Flags::PROPAGATE_VALS_DOWN,
-        StrictUtf8 => Flags::UTF8_STRICT,
-        SubcommandsNegateReqs => Flags::SC_NEGATE_REQS,
-        SubcommandRequired => Flags::SC_REQUIRED,
-        SubcommandRequiredElseHelp => Flags::SC_REQUIRED_ELSE_HELP,
-        TrailingVarArg => Flags::TRAILING_VARARG,
-        UnifiedHelpMessage => Flags::UNIFIED_HELP,
-        NextLineHelp => Flags::NEXT_LINE_HELP,
-        VersionlessSubcommands => Flags::VERSIONLESS_SC,
-        WaitOnError => Flags::WAIT_ON_ERROR,
-        TrailingValues => Flags::TRAILING_VALUES,
-        ValidNegNumFound => Flags::VALID_NEG_NUM_FOUND,
-        Propagated => Flags::PROPAGATED,
-        ValidArgFound => Flags::VALID_ARG_FOUND,
-        InferSubcommands => Flags::INFER_SUBCOMMANDS,
-        AllArgsOverrideSelf => Flags::ARGS_OVERRIDE_SELF,
-        ContainsLast => Flags::CONTAINS_LAST
+        ArgRequiredElseHelp => Flags::ARequiredElseHelp,
+        ArgsNegateSubcommands => Flags::ArgsNegateScs,
+        AllowExternalSubcommands => Flags::AllowUnkSc,
+        AllowInvalidUtf8 => Flags::Utf8None,
+        AllowLeadingHyphen => Flags::LeadingHyphen,
+        AllowNegativeNumbers => Flags::AllowNegNums,
+        AllowMissingPositional => Flags::AllowMissingPos,
+        ColoredHelp => Flags::ColoredHelp,
+        ColorAlways => Flags::ColorAlways,
+        ColorAuto => Flags::ColorAuto,
+        ColorNever => Flags::ColorNever,
+        DontDelimitTrailingValues => Flags::DontDelimTrail,
+        DontCollapseArgsInUsage => Flags::DontCollapseArgs,
+        DeriveDisplayOrder => Flags::DeriveDispOrder,
+        DisableHelpSubcommand => Flags::DisableHelpSc,
+        DisableVersion => Flags::DisableVersion,
+        GlobalVersion => Flags::GlobalVersion,
+        HidePossibleValuesInHelp => Flags::NoPosValues,
+        Hidden => Flags::Hidden,
+        LowIndexMultiplePositional => Flags::LowIndexMulPos,
+        NoAutoHelp => Flags::NoAutoHelp,
+        NoAutoVersion => Flags::NoAutoVersion,
+        NoBinaryName => Flags::NoBinName,
+        PropagateGlobalValuesDown=> Flags::PropagateValsDown,
+        StrictUtf8 => Flags::Utf8Strict,
+        SubcommandsNegateReqs => Flags::ScNegateReqs,
+        SubcommandRequired => Flags::ScRequired,
+        SubcommandRequiredElseHelp => Flags::ScRequiredElseHelp,
+        TrailingVarArg => Flags::TrailingVarArg,
+        UnifiedHelpMessage => Flags::UnifiedHelp,
+        NextLineHelp => Flags::NextLineHelp,
+        VersionlessSubcommands => Flags::VersionlessSc,
+        WaitOnError => Flags::WaitOnError,
+        TrailingValues => Flags::TrailingValues,
+        ValidNegNumFound => Flags::ValidNegNumFound,
+        Propagated => Flags::Propagated,
+        ValidArgFound => Flags::ValidArgFound,
+        InferSubcommands => Flags::InferSubcommands,
+        AllArgsOverrideSelf => Flags::ArgsOverrideSelf,
+        ContainsLast => Flags::ContainsLast
     }
 }
 

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -1,69 +1,73 @@
 // Std
+use std::collections::HashSet;
 #[allow(unused_imports)]
 use std::ascii::AsciiExt;
 use std::str::FromStr;
 
-bitflags! {
-    struct Flags: u32 {
-        const REQUIRED         = 1;
-        const MULTIPLE_OCC     = 1 << 1;
-        const EMPTY_VALS       = 1 << 2 | Self::TAKES_VAL.bits;
-        const GLOBAL           = 1 << 3;
-        const HIDDEN           = 1 << 4;
-        const TAKES_VAL        = 1 << 5;
-        const USE_DELIM        = 1 << 6;
-        const NEXT_LINE_HELP   = 1 << 7;
-        const R_UNLESS_ALL     = 1 << 8;
-        const REQ_DELIM        = 1 << 9 | Self::TAKES_VAL.bits | Self::USE_DELIM.bits;
-        const DELIM_NOT_SET    = 1 << 10;
-        const HIDE_POS_VALS    = 1 << 11 | Self::TAKES_VAL.bits;
-        const ALLOW_TAC_VALS   = 1 << 12 | Self::TAKES_VAL.bits;
-        const REQUIRE_EQUALS   = 1 << 13 | Self::TAKES_VAL.bits;
-        const LAST             = 1 << 14 | Self::TAKES_VAL.bits;
-        const HIDE_DEFAULT_VAL = 1 << 15 | Self::TAKES_VAL.bits;
-        const CASE_INSENSITIVE = 1 << 16;
-        const HIDE_ENV_VALS    = 1 << 17;
-        const HIDDEN_SHORT_H   = 1 << 18;
-        const HIDDEN_LONG_H    = 1 << 19;
-        const MULTIPLE_VALS    = 1 << 20 | Self::TAKES_VAL.bits;
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Flags {
+    Required,
+    MultipleOcc,
+    EmptyVals,
+    Global,
+    Hidden,
+    TakesVal,
+    UseDelim,
+    NextLineHelp,
+    RUnlessAll,
+    ReqDelim,
+    DelimNotSet,
+    HidePosVals,
+    AllowTacVals,
+    RequireEquals,
+    Last,
+    HideDefaultVal,
+    CaseInsensitive,
+    HideEnvVals,
+    HiddenShortH,
+    HiddenLongH,
+    MultipleVals,
 }
 
 #[doc(hidden)]
-#[derive(Debug, Clone, Copy)]
-pub struct ArgFlags(Flags);
+#[derive(Debug, Clone)]
+pub struct ArgFlags(HashSet<Flags>);
 
 impl ArgFlags {
     pub fn new() -> Self { ArgFlags::default() }
 
     // @TODO @p6 @internal: Reorder alphabetically
     impl_settings!{ArgSettings,
-        Required => Flags::REQUIRED,
-        MultipleOccurrences => Flags::MULTIPLE_OCC,
-        MultipleValues => Flags::MULTIPLE_VALS,
-        AllowEmptyValues => Flags::EMPTY_VALS,
-        Global => Flags::GLOBAL,
-        Hidden => Flags::HIDDEN,
-        TakesValue => Flags::TAKES_VAL,
-        UseValueDelimiter => Flags::USE_DELIM,
-        NextLineHelp => Flags::NEXT_LINE_HELP,
-        RequiredUnlessAll => Flags::R_UNLESS_ALL,
-        RequireDelimiter => Flags::REQ_DELIM,
-        ValueDelimiterNotSet => Flags::DELIM_NOT_SET,
-        HidePossibleValues => Flags::HIDE_POS_VALS,
-        AllowHyphenValues => Flags::ALLOW_TAC_VALS,
-        RequireEquals => Flags::REQUIRE_EQUALS,
-        Last => Flags::LAST,
-        IgnoreCase => Flags::CASE_INSENSITIVE,
-        HideEnvValues => Flags::HIDE_ENV_VALS,
-        HideDefaultValue => Flags::HIDE_DEFAULT_VAL,
-        HiddenShortHelp => Flags::HIDDEN_SHORT_H,
-        HiddenLongHelp => Flags::HIDDEN_LONG_H
+        Required => Flags::Required,
+        MultipleOccurrences => Flags::MultipleOcc,
+        MultipleValues => Flags::MultipleVals | Flags::TakesVal,
+        AllowEmptyValues => Flags::EmptyVals | Flags::TakesVal,
+        Global => Flags::Global,
+        Hidden => Flags::Hidden,
+        TakesValue => Flags::TakesVal,
+        UseValueDelimiter => Flags::UseDelim,
+        NextLineHelp => Flags::NextLineHelp,
+        RequiredUnlessAll => Flags::RUnlessAll,
+        RequireDelimiter => Flags::ReqDelim | Flags::TakesVal | Flags::UseDelim,
+        ValueDelimiterNotSet => Flags::DelimNotSet,
+        HidePossibleValues => Flags::HidePosVals | Flags::TakesVal,
+        AllowHyphenValues => Flags::AllowTacVals | Flags::TakesVal,
+        RequireEquals => Flags::RequireEquals | Flags::TakesVal,
+        Last => Flags::Last | Flags::TakesVal,
+        IgnoreCase => Flags::CaseInsensitive,
+        HideEnvValues => Flags::HideEnvVals,
+        HideDefaultValue => Flags::HideDefaultVal | Flags::TakesVal,
+        HiddenShortHelp => Flags::HiddenShortH,
+        HiddenLongHelp => Flags::HiddenLongH
     }
 }
 
 impl Default for ArgFlags {
-    fn default() -> Self { ArgFlags(Flags::DELIM_NOT_SET) }
+    fn default() -> Self {
+        let mut set = HashSet::new();
+        set.insert(Flags::DelimNotSet);
+        ArgFlags(set)
+    }
 }
 
 /// Various settings that apply to arguments and may be set, unset, and checked via getter/setter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,8 +543,6 @@
 extern crate ansi_term;
 #[cfg(feature = "color")]
 extern crate atty;
-#[macro_use]
-extern crate bitflags;
 #[cfg(feature = "derive")]
 #[cfg_attr(feature = "derive", allow(unused_imports))]
 #[cfg_attr(feature = "derive", macro_use)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -804,22 +804,26 @@ macro_rules! clap_app {
 }
 
 macro_rules! impl_settings {
-    ($n:ident, $($v:ident => $c:path),+) => {
+    ($n:ident, $($v:ident => $($c:path)|+),+) => {
         pub fn set(&mut self, s: $n) {
             match s {
-                $($n::$v => self.0.insert($c)),+
+                $($n::$v => { $(self.0.insert($c);)+ }),+
             }
         }
 
         pub fn unset(&mut self, s: $n) {
             match s {
-                $($n::$v => self.0.remove($c)),+
+                $($n::$v => { $(self.0.remove(&$c);)+ }),+
             }
         }
 
         pub fn is_set(&self, s: $n) -> bool {
             match s {
-                $($n::$v => self.0.contains($c)),+
+                $($n::$v => {
+                    let mut lacking = false;
+                    $(lacking |= !self.0.contains(&$c);)+
+                    !lacking
+                }),+
             }
         }
     };

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -798,8 +798,8 @@ where
                 .help("The subcommand whose help message to display");
             pb._build();
             //parser.positionals.insert(1, pb.name);
-            parser.app.settings = parser.app.settings | self.app.g_settings;
-            parser.app.g_settings = self.app.g_settings;
+            parser.app.settings.update(&self.app.g_settings);
+            parser.app.g_settings = self.app.g_settings.clone();
         }
         if parser.app.bin_name != self.app.bin_name {
             parser.app.bin_name = Some(format!("{} {}", bin_name, parser.app.name));


### PR DESCRIPTION
The only real use of bitflags was to save a tiny bit of memory. It isn't
exposed externally and we can just use a flag enumeration combined with
a HashSet to replace it. Because of this, let's not subject this
dependency to all projects which depend on clap.