### PR TITLE
chore: bump the version for textwrap crate from 0.10 to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ maintenance = {status = "actively-developed"}
 [dependencies]
 bitflags              = "1.0"
 unicode-width         = "0.1.4"
-textwrap              = "0.10.0"
+textwrap              = "0.11"
 indexmap              = "1.0.1"
 strsim    = { version = "0.8.0",  optional = true }
 yaml-rust = { version = "0.4",  optional = true }


### PR DESCRIPTION
ran the tests, seems fine i guess since there were no major breaking changes between v0.10 and v0.11