### PR TITLE
chore: removes pinned nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: rust
 cache: cargo
 rust:
   - nightly
-  - nightly-2018-08-06
   - beta
   - stable
   - 1.30.0


### PR DESCRIPTION
The pinned nightly doesn't make as much sense anymore since clippy is
part of the build system. At some point we'll add clippy back into our
travis workflow, but for now I'm OK without clippy being run on every
PR.