### PR TITLE
imp(YAML): supports setting Arg::hide_env_values from YAML

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -209,6 +209,7 @@ impl<'help> Arg<'help> {
                 "default_value_if" => yaml_tuple3!(a, v, default_value_if),
                 "default_value_ifs" => yaml_tuple3!(a, v, default_value_if),
                 "env" => yaml_to_str!(a, v, env),
+                "hide_env_values" => yaml_to_bool!(a, v, hide_env_values),
                 "value_names" => yaml_vec_or_str!(v, a, value_name),
                 "groups" => yaml_vec_or_str!(v, a, group),
                 "requires" => yaml_vec_or_str!(v, a, requires),

--- a/tests/app.yml
+++ b/tests/app.yml
@@ -93,6 +93,14 @@ args:
         multiple: true
         help: Tests 3 max vals
         max_values: 3
+    - env:
+        help: Test env
+        env: "TEST_ENV_VAR"
+    - env_hide_values:
+        help: Test env
+        env: "TEST_ENV_VAR"
+        hide_env_values: true
+
 arg_groups:
     - test:
         args:


### PR DESCRIPTION
Looks like this was missing from fb41d062eedf37cb4f805c90adca29909bd197d7