### PR TITLE
Automatically check if README.md examples are working when running "cargo test"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ ansi_term = { version = "0.11.0",  optional = true }
 regex = "1.0"
 lazy_static = "1"
 version-sync = "0.8"
+doc-comment = "0.3"
 
 [features]
 default     = ["suggestions", "color", "vec_map", "derive"]

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The following examples show a quick example of some of the very basic functional
 
 The first example shows the simplest way to use `clap`, by defining a struct. If you're familiar with the `structopt` crate you're in luck, it's the same! (In fact it's the exact same code running under the covers!)
 
-```rust
+```rust,no_run
 // (Full example with detailed comments in examples/01d_quick_example.rs)
 //
 // This example demonstrates clap's full 'custom derive' style of creating arguments which is the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,6 +555,12 @@ extern crate unicode_width;
 extern crate vec_map;
 #[cfg(feature = "yaml")]
 extern crate yaml_rust;
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 pub use crate::build::{App, AppSettings, Arg, ArgGroup, ArgSettings, Propagation};
 pub use crate::output::fmt::Format;


### PR DESCRIPTION
Since rustdoc nightly now provides "cfg(test)" when running on test mode, we can now use this macro on test mode only to check if README.md examples are working as expected.