### PR TITLE
Replace deprecated trim_left_matches with trim_start_matches

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -87,7 +87,7 @@ where
     }
 
     pub fn help_short(&mut self, s: &str) {
-        let c = s.trim_left_matches(|c| c == '-')
+        let c = s.trim_start_matches(|c| c == '-')
             .chars()
             .nth(0)
             .unwrap_or('h');
@@ -95,7 +95,7 @@ where
     }
 
     pub fn version_short(&mut self, s: &str) {
-        let c = s.trim_left_matches(|c| c == '-')
+        let c = s.trim_start_matches(|c| c == '-')
             .chars()
             .nth(0)
             .unwrap_or('V');

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -329,7 +329,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// ```
     /// [`short`]: ./struct.Arg.html#method.short
     pub fn short<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.s.short = s.as_ref().trim_left_matches(|c| c == '-').chars().nth(0);
+        self.s.short = s.as_ref().trim_start_matches(|c| c == '-').chars().nth(0);
         self
     }
 
@@ -369,7 +369,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// assert!(m.is_present("cfg"));
     /// ```
     pub fn long(mut self, l: &'b str) -> Self {
-        self.s.long = Some(l.trim_left_matches(|c| c == '-'));
+        self.s.long = Some(l.trim_start_matches(|c| c == '-'));
         self
     }
 


### PR DESCRIPTION
This will remove those warnings like:

```
warning: use of deprecated item 'bitflags::core::str::<impl str>::trim_left_matches': superseded by `trim_start_matches`
  --> src/app/parser.rs:90:19
   |
90 |         let c = s.trim_left_matches(|c| c == '-')
   |                   ^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(deprecated)] on by default
```

As trim_start_matches is available since 1.30.0 it should be ok.