### PR TITLE
[RFC/WIP] fix missing optional values (feature?)

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1773,6 +1773,14 @@ where
             ));
         } else {
             sdebugln!("None");
+            if needs_eq && min_vals_zero { // OPTION with missing optional value?
+                let default_missing_val = opt.v.default_missing_val;
+                debugln!("default_missing_val = {:?}", default_missing_val);
+                if let Some(ref value) = default_missing_val {
+                    debugln!("setting value from default_missing_val = {:?}", value);
+                    self.add_val_to_arg(opt, value, matcher)?;
+                    };
+            }
         }
 
         matcher.inc_occurrence_of(opt.b.name);

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -3239,6 +3239,16 @@ impl<'a, 'b> Arg<'a, 'b> {
         self.default_value_os(OsStr::from_bytes(val.as_bytes()))
     }
 
+    /// ... docs ...
+    pub fn default_missing_value(self, val: &'a str) -> Self {
+        self.default_missing_value_os(OsStr::from_bytes(val.as_bytes()))
+    }
+    /// ... docs ...
+    pub fn default_missing_value_os(mut self, val: &'a OsStr) -> Self {
+        self.v.default_missing_val = Some(val);
+        self
+    }
+
     /// Provides a default value in the exact same manner as [`Arg::default_value`]
     /// only using [`OsStr`]s instead.
     /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value

--- a/src/args/arg_builder/valued.rs
+++ b/src/args/arg_builder/valued.rs
@@ -21,6 +21,7 @@ where
     pub val_delim: Option<char>,
     pub default_val: Option<&'b OsStr>,
     pub default_vals_ifs: Option<VecMap<(&'a str, Option<&'b OsStr>, &'b OsStr)>>,
+    pub default_missing_val: Option<&'b OsStr>,
     pub env: Option<(&'a OsStr, Option<OsString>)>,
     pub terminator: Option<&'b str>,
 }
@@ -38,6 +39,7 @@ impl<'n, 'e> Default for Valued<'n, 'e> {
             val_delim: None,
             default_val: None,
             default_vals_ifs: None,
+            default_missing_val: None,
             env: None,
             terminator: None,
         }


### PR DESCRIPTION
RFC/WIP ~ this PR is a quick proof-of-concept, inviting commentary before being updated and fleshed out (documentation, tests, etc).

For an OPTION taking optional values (ie, `.min_values(0).require_equals(true)`), currently any time that option is encountered multiple times, `occurs` is incremented, but no entry is made into the `indices` and `vals` arrays for options with no/missing value. "None" would seem like a good entry but the `vals` array contains just that, values, not `Option`s, so that would break compatibility without any great upside. However, adding a default for missing values can be done without breaking anything else...

This PR adds support to supply a value for the "None"/missing-value case (eg, for "--OPTION") via a `default_missing_value()` method. Notably, the supplied value to `default_missing_value()` may differ from the OPTION's `default_value()`.

example use case: "--color"

``` rust
#[macro_use]
extern crate clap;

fn main() {
    let matches = clap::App::new("PR-ex")
        .version(crate_version!())
        .author(crate_authors!(", "))
        .about("PR-ex (add default_missing_value())")
        .arg(
            clap::Arg::with_name("color").long("color")
                .value_name("WHEN")
                .possible_values(&["always", "auto", "never"])
                .multiple(true)
                .overrides_with("color")
                .help(
                    r#"Specify WHEN to colorize output.
[WHEN] == ( *always* | auto | never ) ; "--color=auto" is assumed if the option is never specified
"#,
                )
                .default_value("auto")
                .hide_default_value(true)
                .min_values(0)
                .require_equals(true)
                .default_missing_value("always")
        )
        .arg(clap::Arg::with_name("arg").multiple(true))
        .get_matches();

    let color_when = if let Some(v) = matches.values_of("color") {
        v.collect::<Vec<_>>().last().unwrap()
    } else {
        matches.value_of("color").unwrap()
    };

    println!("matches: '{:?}'", matches);
    println!("color_when: '{}'", color_when);

    //...
}
```

Output *without* `.default_missing_value("always")` (ie, the current algorithm):

``` shell
$ target\debug\PR-ex.exe --color
matches: 'ArgMatches { args: {"color": MatchedArg { occurs: 1, indices: [2], vals: ["auto"] }}, subcommand: None, usage: Some("USAGE:\n    PR-ex.exe [OPTIONS] [--] [arg]...") }'
color_when: 'auto'

$ target\debug\PR-ex.exe --color=never --color
matches: 'ArgMatches { args: {"color": MatchedArg { occurs: 2, indices: [2], vals: ["never"] }}, subcommand: None, usage: Some("USAGE:\n    PR-ex.exe [OPTIONS] [--] [arg]...") }'
color_when: 'never'
```

Output *with* `.default_missing_value("always")`:

``` shell
$ target\debug\PR-ex.exe --color
matches: 'ArgMatches { args: {"color": MatchedArg { occurs: 1, indices: [2], vals: ["always"] }}, subcommand: None, usage: Some("USAGE:\n    PR-ex.exe [OPTIONS] [--] [arg]...") }'
color_when: 'always'

$ target\debug\PR-ex.exe --color=never --color
matches: 'ArgMatches { args: {"color": MatchedArg { occurs: 2, indices: [2, 4], vals: ["never", "always"] }}, subcommand: None, usage: Some("USAGE:\n    PR-ex.exe [OPTIONS] [--] [arg]...") }'
color_when: 'always'
```