### PR TITLE
Fix ArgMatcher consuming extra arguments when `max_values` is set

### DIFF
--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -2780,7 +2780,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooManyValues);
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
     /// [`Arg::multiple(true)`]: ./struct.Arg.html#method.multiple
     pub fn max_values(mut self, qty: u64) -> Self {

--- a/src/args/arg_matcher.rs
+++ b/src/args/arg_matcher.rs
@@ -202,7 +202,7 @@ impl<'a> ArgMatcher<'a> {
                 };
             } else if let Some(num) = o.max_vals() {
                 debugln!("ArgMatcher::needs_more_vals: max_vals...{}", num);
-                return !((ma.vals.len() as u64) > num);
+                return (ma.vals.len() as u64) < num;
             } else if o.min_vals().is_some() {
                 debugln!("ArgMatcher::needs_more_vals: min_vals...true");
                 return true;

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -1089,7 +1089,7 @@ fn multiple_value_terminator_option_other_arg() {
             .short("-F"))
         .get_matches_from_safe(vec![
             "lip",
-            "-f", "val1", "val2", 
+            "-f", "val1", "val2",
             "-F",
             "otherval"
         ]);
@@ -1119,4 +1119,56 @@ fn multiple_vals_with_hyphen() {
     let cmds: Vec<_> = m.values_of("cmds").unwrap().collect();
     assert_eq!(&cmds, &["find", "-type", "f", "-name", "special"]);
     assert_eq!(m.value_of("location"), Some("/home/clap"));
+}
+
+#[test]
+fn issue_1480_max_values_consumes_extra_arg_1() {
+    let res = App::new("prog")
+        .arg(
+            Arg::with_name("field")
+                .takes_value(true)
+                .multiple(false)
+                .max_values(1)
+                .long("field"),
+        )
+        .arg(
+            Arg::with_name("positional")
+                .required(true)
+                .index(1),
+        )
+        .get_matches_from_safe(vec!["prog", "--field", "1", "file"]);
+
+    assert!(res.is_ok());
+}
+
+#[test]
+fn issue_1480_max_values_consumes_extra_arg_2() {
+    let res = App::new("prog")
+        .arg(
+            Arg::with_name("field")
+                .takes_value(true)
+                .multiple(false)
+                .max_values(1)
+                .long("field"),
+        )
+        .get_matches_from_safe(vec!["prog", "--field", "1", "2"]);
+
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+}
+
+#[test]
+fn issue_1480_max_values_consumes_extra_arg_3() {
+    let res = App::new("prog")
+        .arg(
+            Arg::with_name("field")
+                .takes_value(true)
+                .multiple(false)
+                .max_values(1)
+                .long("field"),
+        )
+        .get_matches_from_safe(vec!["prog", "--field", "1", "2", "3"]);
+
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
 }


### PR DESCRIPTION
Closes #1480 

