### PR TITLE
Avoid panicking on invalid UTF-8 in DYM args

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -14,7 +14,6 @@ use std::cell::Cell;
 
 // Internal
 use INTERNAL_ERROR_MSG;
-use INVALID_UTF8;
 use SubCommand;
 use app::App;
 use app::help::Help;
@@ -1626,10 +1625,10 @@ where
 
         debugln!("Parser::parse_long_arg: Didn't match anything");
 
-        let args_rest: Vec<_> = it.map(|x| x.clone().into()).collect();
-        let args_rest2: Vec<_> = args_rest.iter().map(|x| x.to_str().expect(INVALID_UTF8)).collect();
+        let args_rest: Vec<_> = it.map(|x| x.into().to_string_lossy().to_string()).collect();
+        let args_rest2: Vec<_> = args_rest.iter().map(|x| x.as_str()).collect();
         self.did_you_mean_error(
-            arg.to_str().expect(INVALID_UTF8),
+            &arg.to_string_lossy(),
             matcher,
             &args_rest2[..]
         ).map(|_| ParseResult::NotFound)


### PR DESCRIPTION
```bash
cargo --help`printf "\\x8d00"`
```

panics, because "did you mean?" tries to use the arg with an invalid codepoint. It's an invalid user input, not a programmer bug, so IMHO it shouldn't cause a panic. 

This fix uses `to_string_lossy`, so this case displays as:

> error: Found argument '--help�00' which wasn't expected, or isn't valid in this context
>	Did you mean --help?

Since that's an error case, the lossiness shouldn't be an issue, and the correction is still useful.

Related to #751