### PR TITLE
Fix #1487 - Duplicate args in groups

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -239,7 +239,9 @@ where
             for g in grps {
                 let mut found = false;
                 if let Some(ref mut ag) = self.groups.iter_mut().find(|grp| &grp.name == g) {
-                    ag.args.push(a.b.name);
+                    if !ag.args.contains(&a.b.name) {
+                        ag.args.push(a.b.name);
+                    }
                     found = true;
                 }
                 if !found {
@@ -353,18 +355,19 @@ where
             //                self.blacklist.extend_from_slice(bl);
             //            }
         }
-        if self.groups.iter().any(|g| g.name == group.name) {
-            let grp = self.groups
-                .iter_mut()
-                .find(|g| g.name == group.name)
-                .expect(INTERNAL_ERROR_MSG);
-            grp.args.extend_from_slice(&group.args);
+        if let Some(grp) = self.groups.iter_mut().find(|g| g.name == group.name) {
+            for arg in &group.args {
+                if !grp.args.contains(arg) {
+                    grp.args.push(arg);
+                }
+            }
             grp.requires = group.requires.clone();
             grp.conflicts = group.conflicts.clone();
             grp.required = group.required;
-        } else {
+            return
+        } // else {
             self.groups.push(group);
-        }
+        // }
     }
 
     pub fn add_subcommand(&mut self, mut subcmd: App<'a, 'b>) {

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -4,7 +4,7 @@ extern crate regex;
 
 include!("../clap-test.rs");
 
-use clap::{App, AppSettings, SubCommand, ErrorKind, Arg};
+use clap::{App, AppSettings, SubCommand, ErrorKind, Arg, ArgGroup};
 
 static REQUIRE_DELIM_HELP: &'static str = "test 1.3
 Kevin K.
@@ -516,6 +516,20 @@ FLAGS:
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -p, --pos <VAL>      Some vals [possible values: fast, slow]";
+
+static ISSUE_1487: &'static str = "test 
+
+USAGE:
+    ctest <arg1|arg2>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <arg1>    
+    <arg2>    
+";
 
 fn setup() -> App<'static, 'static> {
     App::new("test")
@@ -1202,4 +1216,17 @@ fn show_short_about_issue_897() {
             .about("About foo")
             .long_about("Long about foo"));
     assert!(test::compare_output(app, "ctest foo -h", ISSUE_897_SHORT, false));
+}
+
+#[test]
+fn issue_1487() {
+    let app = App::new("test")
+        .arg(Arg::with_name("arg1")
+            .group("group1"))
+        .arg(Arg::with_name("arg2")
+            .group("group1"))
+        .group(ArgGroup::with_name("group1")
+            .args(&["arg1", "arg2"])
+            .required(true));
+    assert!(test::compare_output(app, "ctest -h", ISSUE_1487, false));
 }


### PR DESCRIPTION
Fixed 1487 by preventing duplicate args from ever being in the same group. Added a test for regression.

I also slightly rewrote the `Parser::add_group` fn, as it was needlessly iterating over `self.groups` twice. I suspect it was done this way because of the borrow checker, which I got around with an "early" return and removed "else" (although if this isn't desired, I think it can be done in a way that keeps the if/else structure in-tact, but might get a bit more verbose)