### PR TITLE
[WIP] Fix release tests

### DIFF
--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -53,20 +53,21 @@ fn non_existing_arg() {
         .get_matches_from_safe(vec![""]);
 }
 
-// ### TEST FAIL ###
-// #[test]
-// #[should_panic(expected = "The group 'c' contains the arg 'd' that doesn't actually exist.")]
-// fn non_existing_arg_in_subcommand_help() {
-//     let _ = App::new("a")
-//         .subcommand(
-//             SubCommand::with_name("b")
-//                 .group(
-//                     ArgGroup::with_name("c")
-//                         .args(&["d"])
-//                         .required(true),
-//                 )
-//         ).get_matches_from_safe(vec!["a", "help", "b"]);
-// }
+// This tests a programmer error and will only succeed with debug_assertions enabled
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "The group 'c' contains the arg 'd' that doesn't actually exist.")]
+fn non_existing_arg_in_subcommand_help() {
+    let _ = App::new("a")
+        .subcommand(
+            SubCommand::with_name("b")
+                .group(
+                    ArgGroup::with_name("c")
+                        .args(&["d"])
+                        .required(true),
+                )
+        ).get_matches_from_safe(vec!["a", "help", "b"]);
+}
 
 #[test]
 fn group_single_value() {

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -41,8 +41,10 @@ fn required_group_missing_arg() {
     assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
 }
 
+// This tests a programmer error and will only succeed with debug_assertions
+#[cfg(debug_assertions)]
 #[test]
-#[should_panic]
+#[should_panic(expected = "The group 'req' contains the arg 'flg' that doesn't actually exist.")]
 fn non_existing_arg() {
     let _ = App::new("group")
         .args_from_usage("-f, --flag 'some flag'
@@ -53,7 +55,7 @@ fn non_existing_arg() {
         .get_matches_from_safe(vec![""]);
 }
 
-// This tests a programmer error and will only succeed with debug_assertions enabled
+// This tests a programmer error and will only succeed with debug_assertions
 #[cfg(debug_assertions)]
 #[test]
 #[should_panic(expected = "The group 'c' contains the arg 'd' that doesn't actually exist.")]
@@ -66,7 +68,8 @@ fn non_existing_arg_in_subcommand_help() {
                         .args(&["d"])
                         .required(true),
                 )
-        ).get_matches_from_safe(vec!["a", "help", "b"]);
+        // Error is only caught if subcommand is provided
+        ).get_matches_from_safe(vec!["a", "b"]);
 }
 
 #[test]

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -53,19 +53,20 @@ fn non_existing_arg() {
         .get_matches_from_safe(vec![""]);
 }
 
-#[test]
-#[should_panic(expected = "The group 'c' contains the arg 'd' that doesn't actually exist.")]
-fn non_existing_arg_in_subcommand_help() {
-    let _ = App::new("a")
-        .subcommand(
-            SubCommand::with_name("b")
-                .group(
-                    ArgGroup::with_name("c")
-                        .args(&["d"])
-                        .required(true),
-                )
-        ).get_matches_from_safe(vec!["a", "help", "b"]);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic(expected = "The group 'c' contains the arg 'd' that doesn't actually exist.")]
+// fn non_existing_arg_in_subcommand_help() {
+//     let _ = App::new("a")
+//         .subcommand(
+//             SubCommand::with_name("b")
+//                 .group(
+//                     ArgGroup::with_name("c")
+//                         .args(&["d"])
+//                         .required(true),
+//                 )
+//         ).get_matches_from_safe(vec!["a", "help", "b"]);
+// }
 
 #[test]
 fn group_single_value() {

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -877,11 +877,13 @@ fn req_delimiter_complex() {
           "val20", "val23", "val26"]);
 }
 
-// ### WTF ###
-// This tests a programmer error and will only succeed with debug_assertions enabled
+// This tests a programmer error and will only succeed with debug_assertions
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic]
+#[should_panic(expected = "When using a positional argument with \
+.multiple(true) that is *not the last* positional argument, the last \
+positional argument (i.e the one with the highest index) *must* have \
+.required(true) or .last(true) set.")]
 fn low_index_positional_not_required() {
     let _ = App::new("lip")
         .arg(Arg::with_name("files")
@@ -889,62 +891,47 @@ fn low_index_positional_not_required() {
             .required(true)
             .multiple(true))
         .arg(Arg::with_name("target")
-            .index(2));
-// Release passes (panics) just building App,
-// however Debug only passes if .get_matches... is called
-// wtf?
-        // .get_matches_from_safe(vec![
-        //     "lip",
-        //     "file1", "file2",
-        //     "file3", "target",
-        // ]);
+            .index(2))
+        .get_matches_from_safe(vec![""]);
 }
 
-// ### WTF ###
-// // This tests a programmer error and will only succeed with debug_assertions enabled
-// #[cfg(debug_assertions)]
-// #[test]
-// #[should_panic]
-// fn low_index_positional_last_multiple_too() {
-//     let _ = App::new("lip")
-//         .arg(Arg::with_name("files")
-//             .index(1)
-//             .required(true)
-//             .multiple(true))
-//         .arg(Arg::with_name("target")
-//             .index(2)
-//             .required(true)
-//             .multiple(true));
-//         .get_matches_from_safe(vec![
-//             "lip",
-//             "file1", "file2",
-//             "file3", "target",
-//         ]);
-// }
+// This tests a programmer error and will only succeed with debug_assertions
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "Only one positional argument with .multiple(true) \
+set is allowed per command, unless the second one also has .last(true) set")]
+fn low_index_positional_last_multiple_too() {
+    let _ = App::new("lip")
+        .arg(Arg::with_name("files")
+            .index(1)
+            .required(true)
+            .multiple(true))
+        .arg(Arg::with_name("target")
+            .index(2)
+            .required(true)
+            .multiple(true))
+        .get_matches_from_safe(vec![""]);
+}
 
-// ### WTF ###
-// // This tests a programmer error and will only succeed with debug_assertions enabled
-// #[cfg(debug_assertions)]
-// #[test]
-// #[should_panic]
-// fn low_index_positional_too_far_back() {
-//     let _ = App::new("lip")
-//         .arg(Arg::with_name("files")
-//             .index(1)
-//             .required(true)
-//             .multiple(true))
-//         .arg(Arg::with_name("target")
-//             .required(true)
-//             .index(2))
-//         .arg(Arg::with_name("target2")
-//             .required(true)
-//             .index(3));
-//         .get_matches_from_safe(vec![
-//             "lip",
-//             "file1", "file2",
-//             "file3", "target",
-//         ]);
-// }
+// This tests a programmer error and will only succeed with debug_assertions
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "Only the last positional argument, or second to \
+last positional argument may be set to .multiple(true)")]
+fn low_index_positional_too_far_back() {
+    let _ = App::new("lip")
+        .arg(Arg::with_name("files")
+            .index(1)
+            .required(true)
+            .multiple(true))
+        .arg(Arg::with_name("target")
+            .required(true)
+            .index(2))
+        .arg(Arg::with_name("target2")
+            .required(true)
+            .index(3))
+        .get_matches_from_safe(vec![""]);
+}
 
 #[test]
 fn low_index_positional() {

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -877,62 +877,65 @@ fn req_delimiter_complex() {
           "val20", "val23", "val26"]);
 }
 
-#[test]
-#[should_panic]
-fn low_index_positional_not_required() {
-    let _ = App::new("lip")
-        .arg(Arg::with_name("files")
-            .index(1)
-            .required(true)
-            .multiple(true))
-        .arg(Arg::with_name("target")
-            .index(2))
-        .get_matches_from_safe(vec![
-            "lip",
-            "file1", "file2",
-            "file3", "target",
-        ]);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic]
+// fn low_index_positional_not_required() {
+//     let _ = App::new("lip")
+//         .arg(Arg::with_name("files")
+//             .index(1)
+//             .required(true)
+//             .multiple(true))
+//         .arg(Arg::with_name("target")
+//             .index(2))
+//         .get_matches_from_safe(vec![
+//             "lip",
+//             "file1", "file2",
+//             "file3", "target",
+//         ]);
+// }
 
-#[test]
-#[should_panic]
-fn low_index_positional_last_multiple_too() {
-    let _ = App::new("lip")
-        .arg(Arg::with_name("files")
-            .index(1)
-            .required(true)
-            .multiple(true))
-        .arg(Arg::with_name("target")
-            .index(2)
-            .required(true)
-            .multiple(true))
-        .get_matches_from_safe(vec![
-            "lip",
-            "file1", "file2",
-            "file3", "target",
-        ]);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic]
+// fn low_index_positional_last_multiple_too() {
+//     let _ = App::new("lip")
+//         .arg(Arg::with_name("files")
+//             .index(1)
+//             .required(true)
+//             .multiple(true))
+//         .arg(Arg::with_name("target")
+//             .index(2)
+//             .required(true)
+//             .multiple(true))
+//         .get_matches_from_safe(vec![
+//             "lip",
+//             "file1", "file2",
+//             "file3", "target",
+//         ]);
+// }
 
-#[test]
-#[should_panic]
-fn low_index_positional_too_far_back() {
-    let _ = App::new("lip")
-        .arg(Arg::with_name("files")
-            .index(1)
-            .required(true)
-            .multiple(true))
-        .arg(Arg::with_name("target")
-            .required(true)
-            .index(2))
-        .arg(Arg::with_name("target2")
-            .required(true)
-            .index(3))
-        .get_matches_from_safe(vec![
-            "lip",
-            "file1", "file2",
-            "file3", "target",
-        ]);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic]
+// fn low_index_positional_too_far_back() {
+//     let _ = App::new("lip")
+//         .arg(Arg::with_name("files")
+//             .index(1)
+//             .required(true)
+//             .multiple(true))
+//         .arg(Arg::with_name("target")
+//             .required(true)
+//             .index(2))
+//         .arg(Arg::with_name("target2")
+//             .required(true)
+//             .index(3))
+//         .get_matches_from_safe(vec![
+//             "lip",
+//             "file1", "file2",
+//             "file3", "target",
+//         ]);
+// }
 
 #[test]
 fn low_index_positional() {

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -877,25 +877,32 @@ fn req_delimiter_complex() {
           "val20", "val23", "val26"]);
 }
 
-// ### TEST FAIL ###
-// #[test]
-// #[should_panic]
-// fn low_index_positional_not_required() {
-//     let _ = App::new("lip")
-//         .arg(Arg::with_name("files")
-//             .index(1)
-//             .required(true)
-//             .multiple(true))
-//         .arg(Arg::with_name("target")
-//             .index(2))
-//         .get_matches_from_safe(vec![
-//             "lip",
-//             "file1", "file2",
-//             "file3", "target",
-//         ]);
-// }
+// ### WTF ###
+// This tests a programmer error and will only succeed with debug_assertions enabled
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+fn low_index_positional_not_required() {
+    let _ = App::new("lip")
+        .arg(Arg::with_name("files")
+            .index(1)
+            .required(true)
+            .multiple(true))
+        .arg(Arg::with_name("target")
+            .index(2));
+// Release passes (panics) just building App,
+// however Debug only passes if .get_matches... is called
+// wtf?
+        // .get_matches_from_safe(vec![
+        //     "lip",
+        //     "file1", "file2",
+        //     "file3", "target",
+        // ]);
+}
 
-// ### TEST FAIL ###
+// ### WTF ###
+// // This tests a programmer error and will only succeed with debug_assertions enabled
+// #[cfg(debug_assertions)]
 // #[test]
 // #[should_panic]
 // fn low_index_positional_last_multiple_too() {
@@ -907,7 +914,7 @@ fn req_delimiter_complex() {
 //         .arg(Arg::with_name("target")
 //             .index(2)
 //             .required(true)
-//             .multiple(true))
+//             .multiple(true));
 //         .get_matches_from_safe(vec![
 //             "lip",
 //             "file1", "file2",
@@ -915,7 +922,9 @@ fn req_delimiter_complex() {
 //         ]);
 // }
 
-// ### TEST FAIL ###
+// ### WTF ###
+// // This tests a programmer error and will only succeed with debug_assertions enabled
+// #[cfg(debug_assertions)]
 // #[test]
 // #[should_panic]
 // fn low_index_positional_too_far_back() {
@@ -929,7 +938,7 @@ fn req_delimiter_complex() {
 //             .index(2))
 //         .arg(Arg::with_name("target2")
 //             .required(true)
-//             .index(3))
+//             .index(3));
 //         .get_matches_from_safe(vec![
 //             "lip",
 //             "file1", "file2",

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -219,16 +219,17 @@ fn single_positional_required_usage_string() {
     assert_eq!(m.usage(), "USAGE:\n    test <FILE>");
 }
 
-// ### WTF ###
-// // This tests a programmer error and will only succeed with debug_assertions enabled
-// #[cfg(debug_assertions)]
-// #[test]
-// #[should_panic]
-// fn missing_required() {
-//     let r = App::new("test")
-//         .arg_from_usage("[FILE1] 'some file'")
-//         .arg_from_usage("<FILE2> 'some file'");
-// }
+// This tests a programmer error and will only succeed with debug_assertions
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic(expected = "Found positional argument which is not required \
+with a lower index than a required positional argument")]
+fn missing_required() {
+    let _ = App::new("test")
+        .arg_from_usage("[FILE1] 'some file'")
+        .arg_from_usage("<FILE2> 'some file'")
+        .get_matches_from_safe(vec![""]);
+}
 
 #[test]
 fn missing_required_2() {

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -219,16 +219,17 @@ fn single_positional_required_usage_string() {
     assert_eq!(m.usage(), "USAGE:\n    test <FILE>");
 }
 
-#[test]
-#[should_panic]
-fn missing_required() {
-    let r = App::new("test")
-        .arg_from_usage("[FILE1] 'some file'")
-        .arg_from_usage("<FILE2> 'some file'")
-        .get_matches_from_safe(vec!["test", "file"]);
-    assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic]
+// fn missing_required() {
+//     let r = App::new("test")
+//         .arg_from_usage("[FILE1] 'some file'")
+//         .arg_from_usage("<FILE2> 'some file'")
+//         .get_matches_from_safe(vec!["test", "file"]);
+//     assert!(r.is_err());
+//     assert_eq!(r.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+// }
 
 #[test]
 fn missing_required_2() {

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -219,16 +219,15 @@ fn single_positional_required_usage_string() {
     assert_eq!(m.usage(), "USAGE:\n    test <FILE>");
 }
 
-// ### TEST FAIL ###
+// ### WTF ###
+// // This tests a programmer error and will only succeed with debug_assertions enabled
+// #[cfg(debug_assertions)]
 // #[test]
 // #[should_panic]
 // fn missing_required() {
 //     let r = App::new("test")
 //         .arg_from_usage("[FILE1] 'some file'")
-//         .arg_from_usage("<FILE2> 'some file'")
-//         .get_matches_from_safe(vec!["test", "file"]);
-//     assert!(r.is_err());
-//     assert_eq!(r.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+//         .arg_from_usage("<FILE2> 'some file'");
 // }
 
 #[test]

--- a/tests/unique_args.rs
+++ b/tests/unique_args.rs
@@ -2,24 +2,27 @@ extern crate clap;
 
 use clap::{App, Arg};
 
-// ### TEST FAIL ###
-// #[test]
-// #[should_panic]
-// fn unique_arg_names() {
-//     App::new("some").args(&[Arg::with_name("arg").short("a"), Arg::with_name("arg").short("b")]);
-// }
+// This tests a programmer error and will only succeed with debug_assertions enabled
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+fn unique_arg_names() {
+    App::new("some").args(&[Arg::with_name("arg").short("a"), Arg::with_name("arg").short("b")]);
+}
 
-// ### TEST FAIL ###
-// #[test]
-// #[should_panic]
-// fn unique_arg_shorts() {
-//     App::new("some").args(&[Arg::with_name("arg1").short("a"), Arg::with_name("arg2").short("a")]);
-// }
+// This tests a programmer error and will only succeed with debug_assertions enabled
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+fn unique_arg_shorts() {
+    App::new("some").args(&[Arg::with_name("arg1").short("a"), Arg::with_name("arg2").short("a")]);
+}
 
-// ### TEST FAIL ###
-// #[test]
-// #[should_panic]
-// fn unique_arg_longs() {
-//     App::new("some")
-//         .args(&[Arg::with_name("arg1").long("long"), Arg::with_name("arg2").long("long")]);
-// }
+// This tests a programmer error and will only succeed with debug_assertions enabled
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic]
+fn unique_arg_longs() {
+    App::new("some")
+        .args(&[Arg::with_name("arg1").long("long"), Arg::with_name("arg2").long("long")]);
+}

--- a/tests/unique_args.rs
+++ b/tests/unique_args.rs
@@ -5,15 +5,15 @@ use clap::{App, Arg};
 // This tests a programmer error and will only succeed with debug_assertions enabled
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic]
+#[should_panic(expected = "Non-unique argument name: arg1 is already in use")]
 fn unique_arg_names() {
-    App::new("some").args(&[Arg::with_name("arg").short("a"), Arg::with_name("arg").short("b")]);
+    App::new("some").args(&[Arg::with_name("arg1").short("a"), Arg::with_name("arg1").short("b")]);
 }
 
 // This tests a programmer error and will only succeed with debug_assertions enabled
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic]
+#[should_panic(expected = "Argument short must be unique")]
 fn unique_arg_shorts() {
     App::new("some").args(&[Arg::with_name("arg1").short("a"), Arg::with_name("arg2").short("a")]);
 }
@@ -21,7 +21,7 @@ fn unique_arg_shorts() {
 // This tests a programmer error and will only succeed with debug_assertions enabled
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic]
+#[should_panic(expected = "Argument long must be unique")]
 fn unique_arg_longs() {
     App::new("some")
         .args(&[Arg::with_name("arg1").long("long"), Arg::with_name("arg2").long("long")]);

--- a/tests/unique_args.rs
+++ b/tests/unique_args.rs
@@ -2,21 +2,24 @@ extern crate clap;
 
 use clap::{App, Arg};
 
-#[test]
-#[should_panic]
-fn unique_arg_names() {
-    App::new("some").args(&[Arg::with_name("arg").short("a"), Arg::with_name("arg").short("b")]);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic]
+// fn unique_arg_names() {
+//     App::new("some").args(&[Arg::with_name("arg").short("a"), Arg::with_name("arg").short("b")]);
+// }
 
-#[test]
-#[should_panic]
-fn unique_arg_shorts() {
-    App::new("some").args(&[Arg::with_name("arg1").short("a"), Arg::with_name("arg2").short("a")]);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic]
+// fn unique_arg_shorts() {
+//     App::new("some").args(&[Arg::with_name("arg1").short("a"), Arg::with_name("arg2").short("a")]);
+// }
 
-#[test]
-#[should_panic]
-fn unique_arg_longs() {
-    App::new("some")
-        .args(&[Arg::with_name("arg1").long("long"), Arg::with_name("arg2").long("long")]);
-}
+// ### TEST FAIL ###
+// #[test]
+// #[should_panic]
+// fn unique_arg_longs() {
+//     App::new("some")
+//         .args(&[Arg::with_name("arg1").long("long"), Arg::with_name("arg2").long("long")]);
+// }


### PR DESCRIPTION
[WIP] Fix #1489 

The goal of this PR is to get all tests passing with `cargo test --release`

I've found a total of 8 failing tests using default features.

* low_index_positional_last_multiple_too
* low_index_positional_not_required
* low_index_positional_too_far_back
* missing_required
* non_existing_arg_in_subcommand_help
* unique_arg_longs
* unique_arg_names
* unique_arg_shorts

~The latter 4 tests were failing because they are testing programmer errors (as apposed to user errors) which only fail with `debug_assertions` enabled and fail when building the App. To fix these, I've added the `#[cfg(debug_assertions)]` line so they simply do not run with `cargo test --release`. These tests DO pass in release if debug_assertions are enabled (`RUSTFLAGS="-C debug-assertions" cargo test --release`)~

~The former 4 tests also pass, as originally written, with `debug_assertions`. However I've found inconsistencies in the way these panic (panic is considered passing). When built in release, they panic while building App, however in debug they panic in `get_matches` but NOT while building the App.~

~These tests seem to also be programmer errors, not user errors (although I am not 100% sure of this). Assuming they are programmer errors, I feel they should always fail at building App. If they do not fail until `get_matches` then there is a potential for a programmer error to go unnoticed until certain arguments are provided (or not provided) at run-time. As such I intend to investigate these and find out why the behave the way they do.~

My previous analysis appears to be incorrect. I believe I must have had `#[should_panic]` commented out on some tests. All tests are now working in both debug and release. All 8 tests I found require `debug_assertions`. I also cleaned up some of the `should_panic` tests by removing unnecessary code (code which might panic even if the expected panic does not happen) and adding panic messages to the tests.

I also have not yet ran `cargo test --features "yaml unstable" --release` so there may be additional tests to fix.