### PR TITLE
Update to rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-
+edition = "2018"
 name = "clap"
 version = "2.33.0"
 authors = ["Kevin K. <kbknapp@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ unicode-width         = "0.1.4"
 textwrap              = "0.11.0"
 strsim    = { version = "0.8",  optional = true }
 yaml-rust = { version = "0.3.5",  optional = true }
-clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
 vec_map   = { version = "0.8", optional = true }
 term_size = { version = "0.3.0", optional = true }
@@ -50,7 +49,7 @@ wrap_help   = ["term_size", "textwrap/term_size"]
 yaml        = ["yaml-rust"]
 unstable    = [] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 nightly     = [] # for building with unstable Rust features (currently none)
-lints       = ["clippy"] # Requires nightly Rust
+lints       = [] # Requires nightly Rust
 debug       = [] # Enables debug messages
 no_cargo    = [] # Enable if you're not using Cargo, disables Cargo-env-var-dependent macros
 doc         = ["yaml"] # All the features which add to documentation

--- a/examples/17_yaml.rs
+++ b/examples/17_yaml.rs
@@ -14,7 +14,6 @@
 
 // Using yaml requires calling a clap macro `load_yaml!()` so we must use the '#[macro_use]'
 // directive
-#[macro_use]
 extern crate clap;
 
 #[cfg(feature = "yaml")]
@@ -29,7 +28,7 @@ fn main() {
     //
     // Finally we call get_matches() to start the parsing process. We use the matches just as we
     // normally would
-    let yml = load_yaml!("17_yaml.yml");
+    let yml = clap::load_yaml!("17_yaml.yml");
     let m = App::from_yaml(yml).get_matches();
 
     // Because the example 17_yaml.yml is rather large we'll just look a single arg so you can

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ remove-nightly:
 	rustup override remove
 
 @lint: nightly
-	cargo build --features lints && just remove-nightly
+	cargo clippy --features lints && just remove-nightly
 
 clean:
 	cargo clean

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -100,7 +100,7 @@ pub struct Help<'a> {
 // Public Functions
 impl<'a> Help<'a> {
     /// Create a new `Help` instance.
-    #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::too_many_arguments))]
     pub fn new(
         w: &'a mut Write,
         next_line_help: bool,
@@ -588,8 +588,8 @@ fn should_show_arg(use_long: bool, arg: &ArgWithOrder) -> bool {
 impl<'a> Help<'a> {
     /// Writes help for all arguments (options, flags, args, subcommands)
     /// including titles of a Parser Object to the wrapped stream.
-    #[cfg_attr(feature = "lints", allow(useless_let_if_seq))]
-    #[cfg_attr(feature = "cargo-clippy", allow(useless_let_if_seq))]
+    #[cfg_attr(feature = "lints", allow(clippy::useless_let_if_seq))]
+    #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_let_if_seq))]
     pub fn write_all_args(&mut self, parser: &Parser) -> ClapResult<()> {
         debugln!("Help::write_all_args;");
         let flags = parser.has_flags();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,13 +20,13 @@ use std::result::Result as StdResult;
 use yaml_rust::Yaml;
 
 // Internal
-use app::help::Help;
-use app::parser::Parser;
-use args::{AnyArg, Arg, ArgGroup, ArgMatcher, ArgMatches, ArgSettings};
-use errors::Result as ClapResult;
+use crate::app::help::Help;
+use crate::app::parser::Parser;
+use crate::args::{AnyArg, Arg, ArgGroup, ArgMatcher, ArgMatches, ArgSettings};
+use crate::errors::Result as ClapResult;
 pub use self::settings::AppSettings;
-use completions::Shell;
-use map::{self, VecMap};
+use crate::completions::Shell;
+use crate::map::{self, VecMap};
 
 /// Used to create a representation of a command line program and all possible command line
 /// arguments. Application settings are set using the "builder pattern" with the
@@ -1640,7 +1640,7 @@ impl<'a, 'b> App<'a, 'b> {
 #[cfg(feature = "yaml")]
 impl<'a> From<&'a Yaml> for App<'a, 'a> {
     fn from(mut yaml: &'a Yaml) -> Self {
-        use args::SubCommand;
+        use crate::args::SubCommand;
         // We WANT this to panic on error...so expect() is good.
         let mut is_sc = None;
         let mut a = if let Some(name) = yaml["name"].as_str() {
@@ -1802,8 +1802,8 @@ impl<'n, 'e> AnyArg<'n, 'e> for App<'n, 'e> {
     fn max_vals(&self) -> Option<u64> { None }
     fn num_vals(&self) -> Option<u64> { None }
     fn possible_vals(&self) -> Option<&[&'e str]> { None }
-    fn validator(&self) -> Option<&Rc<Fn(String) -> StdResult<(), String>>> { None }
-    fn validator_os(&self) -> Option<&Rc<Fn(&OsStr) -> StdResult<(), OsString>>> { None }
+    fn validator(&self) -> Option<&Rc<dyn Fn(String) -> StdResult<(), String>>> { None }
+    fn validator_os(&self) -> Option<&Rc<dyn Fn(&OsStr) -> StdResult<(), OsString>>> { None }
     fn min_vals(&self) -> Option<u64> { None }
     fn short(&self) -> Option<char> { None }
     fn long(&self) -> Option<&'e str> { None }

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -6,33 +6,33 @@ use std::io::{self, BufWriter, Write};
 #[cfg(all(feature = "debug", not(any(target_os = "windows", target_arch = "wasm32"))))]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(all(feature = "debug", any(target_os = "windows", target_arch = "wasm32")))]
-use osstringext::OsStrExt3;
+use crate::osstringext::OsStrExt3;
 use std::path::PathBuf;
 use std::slice::Iter;
 use std::iter::Peekable;
 use std::cell::Cell;
 
 // Internal
-use INTERNAL_ERROR_MSG;
-use INVALID_UTF8;
-use SubCommand;
-use app::App;
-use app::help::Help;
-use app::meta::AppMeta;
-use app::settings::AppFlags;
-use args::{AnyArg, Arg, ArgGroup, ArgMatcher, Base, FlagBuilder, OptBuilder, PosBuilder, Switched};
-use args::settings::ArgSettings;
-use completions::ComplGen;
-use errors::{Error, ErrorKind};
-use errors::Result as ClapResult;
-use fmt::ColorWhen;
-use osstringext::OsStrExt2;
-use completions::Shell;
-use suggestions;
-use app::settings::AppSettings as AS;
-use app::validator::Validator;
-use app::usage;
-use map::{self, VecMap};
+use crate::INTERNAL_ERROR_MSG;
+use crate::INVALID_UTF8;
+use crate::SubCommand;
+use crate::app::App;
+use crate::app::help::Help;
+use crate::app::meta::AppMeta;
+use crate::app::settings::AppFlags;
+use crate::args::{AnyArg, Arg, ArgGroup, ArgMatcher, Base, FlagBuilder, OptBuilder, PosBuilder, Switched};
+use crate::args::settings::ArgSettings;
+use crate::completions::ComplGen;
+use crate::errors::{Error, ErrorKind};
+use crate::errors::Result as ClapResult;
+use crate::fmt::ColorWhen;
+use crate::osstringext::OsStrExt2;
+use crate::completions::Shell;
+use crate::suggestions;
+use crate::app::settings::AppSettings as AS;
+use crate::app::validator::Validator;
+use crate::app::usage;
+use crate::map::{self, VecMap};
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 #[doc(hidden)]
@@ -87,7 +87,7 @@ where
     }
 
     pub fn help_short(&mut self, s: &str) {
-        let c = s.trim_left_matches(|c| c == '-')
+        let c = s.trim_start_matches(|c| c == '-')
             .chars()
             .nth(0)
             .unwrap_or('h');
@@ -95,7 +95,7 @@ where
     }
 
     pub fn version_short(&mut self, s: &str) {
-        let c = s.trim_left_matches(|c| c == '-')
+        let c = s.trim_start_matches(|c| c == '-')
             .chars()
             .nth(0)
             .unwrap_or('V');
@@ -660,7 +660,7 @@ where
         #[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
         use std::os::unix::ffi::OsStrExt;
         #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-        use osstringext::OsStrExt3;
+        use crate::osstringext::OsStrExt3;
         debugln!("Parser::possible_subcommand: arg={:?}", arg_os);
         fn starts(h: &str, n: &OsStr) -> bool {
             let n_bytes = n.as_bytes();
@@ -2095,7 +2095,7 @@ where
         }
     }
 
-    pub fn find_any_arg(&self, name: &str) -> Option<&AnyArg<'a, 'b>> {
+    pub fn find_any_arg(&self, name: &str) -> Option<&dyn AnyArg<'a, 'b>> {
         if let Some(f) = find_by_name!(self, name, flags, iter) {
             return Some(f);
         }

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -416,7 +416,7 @@ where
         }
     }
 
-    #[cfg_attr(feature = "lints", allow(needless_borrow))]
+    #[cfg_attr(feature = "lints", allow(clippy::needless_borrow))]
     pub fn derive_display_order(&mut self) {
         if self.is_set(AS::DeriveDisplayOrder) {
             let unified = self.is_set(AS::UnifiedHelpMessage);
@@ -449,7 +449,7 @@ where
 
     pub fn required(&self) -> Iter<&str> { self.required.iter() }
 
-    #[cfg_attr(feature = "lints", allow(needless_borrow))]
+    #[cfg_attr(feature = "lints", allow(clippy::needless_borrow))]
     #[inline]
     pub fn has_args(&self) -> bool {
         !(self.flags.is_empty() && self.opts.is_empty() && self.positionals.is_empty())
@@ -511,7 +511,7 @@ where
     #[inline]
     pub fn unset(&mut self, s: AS) { self.settings.unset(s) }
 
-    #[cfg_attr(feature = "lints", allow(block_in_if_condition_stmt))]
+    #[cfg_attr(feature = "lints", allow(clippy::block_in_if_condition_stmt))]
     pub fn verify_positionals(&self) -> bool {
         // Because you must wait until all arguments have been supplied, this is the first chance
         // to make assertions on positional argument indexes
@@ -778,7 +778,7 @@ where
     }
 
     // allow wrong self convention due to self.valid_neg_num = true and it's a private method
-    #[cfg_attr(feature = "lints", allow(wrong_self_convention))]
+    #[cfg_attr(feature = "lints", allow(clippy::wrong_self_convention))]
     fn is_new_arg(&mut self, arg_os: &OsStr, needs_val_of: ParseResult) -> bool {
         debugln!("Parser::is_new_arg:{:?}:{:?}", arg_os, needs_val_of);
         let app_wide_settings = if self.is_set(AS::AllowLeadingHyphen) {
@@ -839,7 +839,7 @@ where
     }
 
     // The actual parsing function
-    #[cfg_attr(feature = "lints", allow(while_let_on_iterator, collapsible_if))]
+    #[cfg_attr(feature = "lints", allow(clippy::while_let_on_iterator, clippy::collapsible_if))]
     pub fn get_matches_with<I, T>(
         &mut self,
         matcher: &mut ArgMatcher<'a>,
@@ -1635,7 +1635,7 @@ where
         ).map(|_| ParseResult::NotFound)
     }
 
-    #[cfg_attr(feature = "lints", allow(len_zero))]
+    #[cfg_attr(feature = "lints", allow(clippy::len_zero))]
     fn parse_short_arg(
         &mut self,
         matcher: &mut ArgMatcher<'a>,
@@ -2134,7 +2134,7 @@ where
     }
 
     // Only used for completion scripts due to bin_name messiness
-    #[cfg_attr(feature = "lints", allow(block_in_if_condition_stmt))]
+    #[cfg_attr(feature = "lints", allow(clippy::block_in_if_condition_stmt))]
     pub fn find_subcommand(&'b self, sc: &str) -> Option<&'b App<'a, 'b>> {
         debugln!("Parser::find_subcommand: sc={}", sc);
         debugln!(

--- a/src/app/usage.rs
+++ b/src/app/usage.rs
@@ -2,11 +2,11 @@
 use std::collections::{BTreeMap, VecDeque};
 
 // Internal
-use INTERNAL_ERROR_MSG;
-use args::{AnyArg, ArgMatcher, PosBuilder};
-use args::settings::ArgSettings;
-use app::settings::AppSettings as AS;
-use app::parser::Parser;
+use crate::INTERNAL_ERROR_MSG;
+use crate::args::{AnyArg, ArgMatcher, PosBuilder};
+use crate::args::settings::ArgSettings;
+use crate::app::settings::AppSettings as AS;
+use crate::app::parser::Parser;
 
 // Creates a usage string for display. This happens just after all arguments were parsed, but before
 // any subcommands have been parsed (so as to give subcommands their own usage recursively)

--- a/src/app/validator.rs
+++ b/src/app/validator.rs
@@ -4,16 +4,16 @@ use std::fmt::Display;
 use std::ascii::AsciiExt;
 
 // Internal
-use INTERNAL_ERROR_MSG;
-use INVALID_UTF8;
-use args::{AnyArg, ArgMatcher, MatchedArg};
-use args::settings::ArgSettings;
-use errors::{Error, ErrorKind};
-use errors::Result as ClapResult;
-use app::settings::AppSettings as AS;
-use app::parser::{ParseResult, Parser};
-use fmt::{Colorizer, ColorizerOption};
-use app::usage;
+use crate::INTERNAL_ERROR_MSG;
+use crate::INVALID_UTF8;
+use crate::args::{AnyArg, ArgMatcher, MatchedArg};
+use crate::args::settings::ArgSettings;
+use crate::errors::{Error, ErrorKind};
+use crate::errors::Result as ClapResult;
+use crate::app::settings::AppSettings as AS;
+use crate::app::parser::{ParseResult, Parser};
+use crate::fmt::{Colorizer, ColorizerOption};
+use crate::app::usage;
 
 pub struct Validator<'a, 'b, 'z>(&'z mut Parser<'a, 'b>)
 where
@@ -496,7 +496,7 @@ impl<'a, 'b, 'z> Validator<'a, 'b, 'z> {
         Ok(())
     }
 
-    fn validate_arg_conflicts(&self, a: &AnyArg, matcher: &ArgMatcher) -> Option<bool> {
+    fn validate_arg_conflicts(&self, a: &dyn AnyArg, matcher: &ArgMatcher) -> Option<bool> {
         debugln!("Validator::validate_arg_conflicts: a={:?};", a.name());
         a.blacklist().map(|bl| {
             bl.iter().any(|conf| {
@@ -510,7 +510,7 @@ impl<'a, 'b, 'z> Validator<'a, 'b, 'z> {
         })
     }
 
-    fn validate_required_unless(&self, a: &AnyArg, matcher: &ArgMatcher) -> Option<bool> {
+    fn validate_required_unless(&self, a: &dyn AnyArg, matcher: &ArgMatcher) -> Option<bool> {
         debugln!("Validator::validate_required_unless: a={:?};", a.name());
         macro_rules! check {
             ($how:ident, $_self:expr, $a:ident, $m:ident) => {{
@@ -565,7 +565,7 @@ impl<'a, 'b, 'z> Validator<'a, 'b, 'z> {
     }
 
     #[inline]
-    fn is_missing_required_ok(&self, a: &AnyArg, matcher: &ArgMatcher) -> bool {
+    fn is_missing_required_ok(&self, a: &dyn AnyArg, matcher: &ArgMatcher) -> bool {
         debugln!("Validator::is_missing_required_ok: a={}", a.name());
         self.validate_arg_conflicts(a, matcher).unwrap_or(false)
             || self.validate_required_unless(a, matcher).unwrap_or(false)

--- a/src/args/any_arg.rs
+++ b/src/args/any_arg.rs
@@ -4,9 +4,9 @@ use std::fmt as std_fmt;
 use std::ffi::{OsStr, OsString};
 
 // Internal
-use args::settings::ArgSettings;
-use map::{self, VecMap};
-use INTERNAL_ERROR_MSG;
+use crate::args::settings::ArgSettings;
+use crate::map::{self, VecMap};
+use crate::INTERNAL_ERROR_MSG;
 
 #[doc(hidden)]
 pub trait AnyArg<'n, 'e>: std_fmt::Display {
@@ -16,15 +16,15 @@ pub trait AnyArg<'n, 'e>: std_fmt::Display {
     fn requires(&self) -> Option<&[(Option<&'e str>, &'n str)]>;
     fn blacklist(&self) -> Option<&[&'e str]>;
     fn required_unless(&self) -> Option<&[&'e str]>;
-    fn is_set(&self, ArgSettings) -> bool;
-    fn set(&mut self, ArgSettings);
+    fn is_set(&self, _: ArgSettings) -> bool;
+    fn set(&mut self, _: ArgSettings);
     fn has_switch(&self) -> bool;
     fn max_vals(&self) -> Option<u64>;
     fn min_vals(&self) -> Option<u64>;
     fn num_vals(&self) -> Option<u64>;
     fn possible_vals(&self) -> Option<&[&'e str]>;
-    fn validator(&self) -> Option<&Rc<Fn(String) -> Result<(), String>>>;
-    fn validator_os(&self) -> Option<&Rc<Fn(&OsStr) -> Result<(), OsString>>>;
+    fn validator(&self) -> Option<&Rc<dyn Fn(String) -> Result<(), String>>>;
+    fn validator_os(&self) -> Option<&Rc<dyn Fn(&OsStr) -> Result<(), OsString>>>;
     fn short(&self) -> Option<char>;
     fn long(&self) -> Option<&'e str>;
     fn val_delim(&self) -> Option<char>;
@@ -57,8 +57,8 @@ impl<'n, 'e, 'z, T: ?Sized> AnyArg<'n, 'e> for &'z T where T: AnyArg<'n, 'e> + '
     fn min_vals(&self) -> Option<u64> { (*self).min_vals() }
     fn num_vals(&self) -> Option<u64> { (*self).num_vals() }
     fn possible_vals(&self) -> Option<&[&'e str]> { (*self).possible_vals() }
-    fn validator(&self) -> Option<&Rc<Fn(String) -> Result<(), String>>> { (*self).validator() }
-    fn validator_os(&self) -> Option<&Rc<Fn(&OsStr) -> Result<(), OsString>>> { (*self).validator_os() }
+    fn validator(&self) -> Option<&Rc<dyn Fn(String) -> Result<(), String>>> { (*self).validator() }
+    fn validator_os(&self) -> Option<&Rc<dyn Fn(&OsStr) -> Result<(), OsString>>> { (*self).validator_os() }
     fn short(&self) -> Option<char> { (*self).short() }
     fn long(&self) -> Option<&'e str> { (*self).long() }
     fn val_delim(&self) -> Option<char> { (*self).val_delim() }

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -3474,7 +3474,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// [`Arg::default_value_ifs`] only using [`OsStr`]s instead.
     /// [`Arg::default_value_ifs`]: ./struct.Arg.html#method.default_value_ifs
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    #[cfg_attr(feature = "lints", allow(explicit_counter_loop))]
+    #[cfg_attr(feature = "lints", allow(clippy::explicit_counter_loop))]
     pub fn default_value_ifs_os(mut self, ifs: &[(&'a str, Option<&'b OsStr>, &'b OsStr)]) -> Self {
         for &(arg, val, default) in ifs {
             self = self.default_value_if_os(arg, val, default);

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -3,18 +3,18 @@ use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::ffi::{OsStr, OsString};
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-use osstringext::OsStrExt3;
+use crate::osstringext::OsStrExt3;
 #[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 use std::os::unix::ffi::OsStrExt;
 use std::env;
 
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
-use map::VecMap;
+use crate::map::VecMap;
 
-use usage_parser::UsageParser;
-use args::settings::ArgSettings;
-use args::arg_builder::{Base, Switched, Valued};
+use crate::usage_parser::UsageParser;
+use crate::args::settings::ArgSettings;
+use crate::args::arg_builder::{Base, Switched, Valued};
 
 /// The abstract representation of a command line argument. Used to set all the options and
 /// relationships that define a valid argument for the program.
@@ -329,7 +329,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// ```
     /// [`short`]: ./struct.Arg.html#method.short
     pub fn short<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.s.short = s.as_ref().trim_left_matches(|c| c == '-').chars().nth(0);
+        self.s.short = s.as_ref().trim_start_matches(|c| c == '-').chars().nth(0);
         self
     }
 
@@ -369,7 +369,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// assert!(m.is_present("cfg"));
     /// ```
     pub fn long(mut self, l: &'b str) -> Self {
-        self.s.long = Some(l.trim_left_matches(|c| c == '-'));
+        self.s.long = Some(l.trim_start_matches(|c| c == '-'));
         self
     }
 

--- a/src/args/arg_builder/base.rs
+++ b/src/args/arg_builder/base.rs
@@ -1,4 +1,4 @@
-use args::{Arg, ArgFlags, ArgSettings};
+use crate::args::{Arg, ArgFlags, ArgSettings};
 
 #[derive(Debug, Clone, Default)]
 pub struct Base<'a, 'b>

--- a/src/args/arg_builder/flag.rs
+++ b/src/args/arg_builder/flag.rs
@@ -7,9 +7,9 @@ use std::ffi::{OsStr, OsString};
 use std::mem;
 
 // Internal
-use Arg;
-use args::{AnyArg, ArgSettings, Base, DispOrder, Switched};
-use map::{self, VecMap};
+use crate::Arg;
+use crate::args::{AnyArg, ArgSettings, Base, DispOrder, Switched};
+use crate::map::{self, VecMap};
 
 #[derive(Default, Clone, Debug)]
 #[doc(hidden)]
@@ -76,8 +76,8 @@ impl<'n, 'e> AnyArg<'n, 'e> for FlagBuilder<'n, 'e> {
     fn val_names(&self) -> Option<&VecMap<&'e str>> { None }
     fn num_vals(&self) -> Option<u64> { None }
     fn possible_vals(&self) -> Option<&[&'e str]> { None }
-    fn validator(&self) -> Option<&Rc<Fn(String) -> StdResult<(), String>>> { None }
-    fn validator_os(&self) -> Option<&Rc<Fn(&OsStr) -> StdResult<(), OsString>>> { None }
+    fn validator(&self) -> Option<&Rc<dyn Fn(String) -> StdResult<(), String>>> { None }
+    fn validator_os(&self) -> Option<&Rc<dyn Fn(&OsStr) -> StdResult<(), OsString>>> { None }
     fn min_vals(&self) -> Option<u64> { None }
     fn short(&self) -> Option<char> { self.s.short }
     fn long(&self) -> Option<&'e str> { self.s.long }
@@ -118,7 +118,7 @@ impl<'n, 'e> PartialEq for FlagBuilder<'n, 'e> {
 
 #[cfg(test)]
 mod test {
-    use args::settings::ArgSettings;
+    use crate::args::settings::ArgSettings;
     use super::FlagBuilder;
 
     #[test]

--- a/src/args/arg_builder/option.rs
+++ b/src/args/arg_builder/option.rs
@@ -6,9 +6,9 @@ use std::ffi::{OsStr, OsString};
 use std::mem;
 
 // Internal
-use args::{AnyArg, Arg, ArgSettings, Base, DispOrder, Switched, Valued};
-use map::{self, VecMap};
-use INTERNAL_ERROR_MSG;
+use crate::args::{AnyArg, Arg, ArgSettings, Base, DispOrder, Switched, Valued};
+use crate::map::{self, VecMap};
+use crate::INTERNAL_ERROR_MSG;
 
 #[allow(missing_debug_implementations)]
 #[doc(hidden)]
@@ -129,10 +129,10 @@ impl<'n, 'e> AnyArg<'n, 'e> for OptBuilder<'n, 'e> {
     fn val_terminator(&self) -> Option<&'e str> { self.v.terminator }
     fn num_vals(&self) -> Option<u64> { self.v.num_vals }
     fn possible_vals(&self) -> Option<&[&'e str]> { self.v.possible_vals.as_ref().map(|o| &o[..]) }
-    fn validator(&self) -> Option<&Rc<Fn(String) -> StdResult<(), String>>> {
+    fn validator(&self) -> Option<&Rc<dyn Fn(String) -> StdResult<(), String>>> {
         self.v.validator.as_ref()
     }
-    fn validator_os(&self) -> Option<&Rc<Fn(&OsStr) -> StdResult<(), OsString>>> {
+    fn validator_os(&self) -> Option<&Rc<dyn Fn(&OsStr) -> StdResult<(), OsString>>> {
         self.v.validator_os.as_ref()
     }
     fn min_vals(&self) -> Option<u64> { self.v.min_vals }
@@ -180,9 +180,9 @@ impl<'n, 'e> PartialEq for OptBuilder<'n, 'e> {
 
 #[cfg(test)]
 mod test {
-    use args::settings::ArgSettings;
+    use crate::args::settings::ArgSettings;
     use super::OptBuilder;
-    use map::VecMap;
+    use crate::map::VecMap;
 
     #[test]
     fn optbuilder_display1() {

--- a/src/args/arg_builder/positional.rs
+++ b/src/args/arg_builder/positional.rs
@@ -7,10 +7,10 @@ use std::ffi::{OsStr, OsString};
 use std::mem;
 
 // Internal
-use Arg;
-use args::{AnyArg, ArgSettings, Base, DispOrder, Valued};
-use INTERNAL_ERROR_MSG;
-use map::{self, VecMap};
+use crate::Arg;
+use crate::args::{AnyArg, ArgSettings, Base, DispOrder, Valued};
+use crate::INTERNAL_ERROR_MSG;
+use crate::map::{self, VecMap};
 
 #[allow(missing_debug_implementations)]
 #[doc(hidden)]
@@ -147,10 +147,10 @@ impl<'n, 'e> AnyArg<'n, 'e> for PosBuilder<'n, 'e> {
     fn val_terminator(&self) -> Option<&'e str> { self.v.terminator }
     fn num_vals(&self) -> Option<u64> { self.v.num_vals }
     fn possible_vals(&self) -> Option<&[&'e str]> { self.v.possible_vals.as_ref().map(|o| &o[..]) }
-    fn validator(&self) -> Option<&Rc<Fn(String) -> StdResult<(), String>>> {
+    fn validator(&self) -> Option<&Rc<dyn Fn(String) -> StdResult<(), String>>> {
         self.v.validator.as_ref()
     }
-    fn validator_os(&self) -> Option<&Rc<Fn(&OsStr) -> StdResult<(), OsString>>> {
+    fn validator_os(&self) -> Option<&Rc<dyn Fn(&OsStr) -> StdResult<(), OsString>>> {
         self.v.validator_os.as_ref()
     }
     fn min_vals(&self) -> Option<u64> { self.v.min_vals }
@@ -184,9 +184,9 @@ impl<'n, 'e> PartialEq for PosBuilder<'n, 'e> {
 
 #[cfg(test)]
 mod test {
-    use args::settings::ArgSettings;
+    use crate::args::settings::ArgSettings;
     use super::PosBuilder;
-    use map::VecMap;
+    use crate::map::VecMap;
 
     #[test]
     fn display_mult() {

--- a/src/args/arg_builder/switched.rs
+++ b/src/args/arg_builder/switched.rs
@@ -1,4 +1,4 @@
-use Arg;
+use crate::Arg;
 
 #[derive(Debug)]
 pub struct Switched<'b> {

--- a/src/args/arg_builder/valued.rs
+++ b/src/args/arg_builder/valued.rs
@@ -1,9 +1,9 @@
 use std::rc::Rc;
 use std::ffi::{OsStr, OsString};
 
-use map::VecMap;
+use crate::map::VecMap;
 
-use Arg;
+use crate::Arg;
 
 #[allow(missing_debug_implementations)]
 #[derive(Clone)]
@@ -16,8 +16,8 @@ where
     pub num_vals: Option<u64>,
     pub max_vals: Option<u64>,
     pub min_vals: Option<u64>,
-    pub validator: Option<Rc<Fn(String) -> Result<(), String>>>,
-    pub validator_os: Option<Rc<Fn(&OsStr) -> Result<(), OsString>>>,
+    pub validator: Option<Rc<dyn Fn(String) -> Result<(), String>>>,
+    pub validator_os: Option<Rc<dyn Fn(&OsStr) -> Result<(), OsString>>>,
     pub val_delim: Option<char>,
     pub default_val: Option<&'b OsStr>,
     pub default_vals_ifs: Option<VecMap<(&'a str, Option<&'b OsStr>, &'b OsStr)>>,

--- a/src/args/arg_matcher.rs
+++ b/src/args/arg_matcher.rs
@@ -6,9 +6,9 @@ use std::ops::Deref;
 use std::mem;
 
 // Internal
-use args::{ArgMatches, MatchedArg, SubCommand};
-use args::AnyArg;
-use args::settings::ArgSettings;
+use crate::args::{ArgMatches, MatchedArg, SubCommand};
+use crate::args::AnyArg;
+use crate::args::settings::ArgSettings;
 
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
@@ -21,7 +21,7 @@ impl<'a> Default for ArgMatcher<'a> {
 impl<'a> ArgMatcher<'a> {
     pub fn new() -> Self { ArgMatcher::default() }
 
-    pub fn process_arg_overrides<'b>(&mut self, a: Option<&AnyArg<'a, 'b>>, overrides: &mut Vec<(&'b str, &'a str)>, required: &mut Vec<&'a str>, check_all: bool) {
+    pub fn process_arg_overrides<'b>(&mut self, a: Option<&dyn AnyArg<'a, 'b>>, overrides: &mut Vec<(&'b str, &'a str)>, required: &mut Vec<&'a str>, check_all: bool) {
         debugln!("ArgMatcher::process_arg_overrides:{:?};", a.map_or(None, |a| Some(a.name())));
         if let Some(aa) = a {
             let mut self_done = false;
@@ -53,7 +53,7 @@ impl<'a> ArgMatcher<'a> {
         }
     }
 
-    pub fn handle_self_overrides<'b>(&mut self, a: Option<&AnyArg<'a, 'b>>) {
+    pub fn handle_self_overrides<'b>(&mut self, a: Option<&dyn AnyArg<'a, 'b>>) {
         debugln!("ArgMatcher::handle_self_overrides:{:?};", a.map_or(None, |a| Some(a.name())));
         if let Some(aa) = a {
             if !aa.has_switch() || aa.is_set(ArgSettings::Multiple) {

--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -6,9 +6,9 @@ use std::iter::Map;
 use std::slice::Iter;
 
 // Internal
-use INVALID_UTF8;
-use args::MatchedArg;
-use args::SubCommand;
+use crate::INVALID_UTF8;
+use crate::args::MatchedArg;
+use crate::args::SubCommand;
 
 /// Used to get information about the arguments that where supplied to the program at runtime by
 /// the user. New instances of this struct are obtained by using the [`App::get_matches`] family of

--- a/src/args/subcommand.rs
+++ b/src/args/subcommand.rs
@@ -3,8 +3,8 @@
 use yaml_rust::Yaml;
 
 // Internal
-use App;
-use ArgMatches;
+use crate::App;
+use crate::ArgMatches;
 
 /// The abstract representation of a command line subcommand.
 ///

--- a/src/completions/bash.rs
+++ b/src/completions/bash.rs
@@ -2,9 +2,9 @@
 use std::io::Write;
 
 // Internal
-use app::parser::Parser;
-use args::OptBuilder;
-use completions;
+use crate::app::parser::Parser;
+use crate::args::OptBuilder;
+use crate::completions;
 
 pub struct BashGen<'a, 'b>
 where
@@ -167,7 +167,7 @@ complete -F _{name} -o bashdefault -o default {name}
 
     fn vals_for(&self, o: &OptBuilder) -> String {
         debugln!("BashGen::vals_for: o={}", o.b.name);
-        use args::AnyArg;
+        use crate::args::AnyArg;
         if let Some(vals) = o.possible_vals() {
             format!(r#"$(compgen -W "{}" -- "${{cur}}")"#, vals.join(" "))
         } else {

--- a/src/completions/elvish.rs
+++ b/src/completions/elvish.rs
@@ -2,8 +2,8 @@
 use std::io::Write;
 
 // Internal
-use app::parser::Parser;
-use INTERNAL_ERROR_MSG;
+use crate::app::parser::Parser;
+use crate::INTERNAL_ERROR_MSG;
 
 pub struct ElvishGen<'a, 'b>
 where

--- a/src/completions/fish.rs
+++ b/src/completions/fish.rs
@@ -2,7 +2,7 @@
 use std::io::Write;
 
 // Internal
-use app::parser::Parser;
+use crate::app::parser::Parser;
 
 pub struct FishGen<'a, 'b>
 where

--- a/src/completions/mod.rs
+++ b/src/completions/mod.rs
@@ -11,7 +11,7 @@ mod shell;
 use std::io::Write;
 
 // Internal
-use app::parser::Parser;
+use crate::app::parser::Parser;
 use self::bash::BashGen;
 use self::fish::FishGen;
 use self::zsh::ZshGen;

--- a/src/completions/powershell.rs
+++ b/src/completions/powershell.rs
@@ -2,8 +2,8 @@
 use std::io::Write;
 
 // Internal
-use app::parser::Parser;
-use INTERNAL_ERROR_MSG;
+use crate::app::parser::Parser;
+use crate::INTERNAL_ERROR_MSG;
 
 pub struct PowerShellGen<'a, 'b>
 where

--- a/src/completions/shell.rs
+++ b/src/completions/shell.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::fmt;
 
 /// Describes which shell to produce a completions file for
-#[cfg_attr(feature = "lints", allow(enum_variant_names))]
+#[cfg_attr(feature = "lints", allow(clippy::enum_variant_names))]
 #[derive(Debug, Copy, Clone)]
 pub enum Shell {
     /// Generates a .bash completion file for the Bourne Again SHell (BASH)

--- a/src/completions/zsh.rs
+++ b/src/completions/zsh.rs
@@ -4,11 +4,11 @@ use std::io::Write;
 use std::ascii::AsciiExt;
 
 // Internal
-use app::App;
-use app::parser::Parser;
-use args::{AnyArg, ArgSettings};
-use completions;
-use INTERNAL_ERROR_MSG;
+use crate::app::App;
+use crate::app::parser::Parser;
+use crate::args::{AnyArg, ArgSettings};
+use crate::completions;
+use crate::INTERNAL_ERROR_MSG;
 
 pub struct ZshGen<'a, 'b>
 where

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,9 +8,9 @@ use std::process;
 use std::result::Result as StdResult;
 
 // Internal
-use args::AnyArg;
-use fmt::{ColorWhen, Colorizer, ColorizerOption};
-use suggestions;
+use crate::args::AnyArg;
+use crate::fmt::{ColorWhen, Colorizer, ColorizerOption};
+use crate::suggestions;
 
 /// Short hand for [`Result`] type
 ///
@@ -407,7 +407,7 @@ impl Error {
 
     #[doc(hidden)]
     pub fn argument_conflict<O, U>(
-        arg: &AnyArg,
+        arg: &dyn AnyArg,
         other: Option<O>,
         usage: U,
         color: ColorWhen,
@@ -445,7 +445,7 @@ impl Error {
     }
 
     #[doc(hidden)]
-    pub fn empty_value<U>(arg: &AnyArg, usage: U, color: ColorWhen) -> Self
+    pub fn empty_value<U>(arg: &dyn AnyArg, usage: U, color: ColorWhen) -> Self
     where
         U: Display,
     {
@@ -473,7 +473,7 @@ impl Error {
     pub fn invalid_value<B, G, U>(
         bad_val: B,
         good_vals: &[G],
-        arg: &AnyArg,
+        arg: &dyn AnyArg,
         usage: U,
         color: ColorWhen,
     ) -> Self
@@ -659,7 +659,7 @@ impl Error {
     }
 
     #[doc(hidden)]
-    pub fn too_many_values<V, U>(val: V, arg: &AnyArg, usage: U, color: ColorWhen) -> Self
+    pub fn too_many_values<V, U>(val: V, arg: &dyn AnyArg, usage: U, color: ColorWhen) -> Self
     where
         V: AsRef<str> + Display + ToOwned,
         U: Display,
@@ -688,7 +688,7 @@ impl Error {
 
     #[doc(hidden)]
     pub fn too_few_values<U>(
-        arg: &AnyArg,
+        arg: &dyn AnyArg,
         min_vals: u64,
         curr_vals: usize,
         usage: U,
@@ -721,7 +721,7 @@ impl Error {
     }
 
     #[doc(hidden)]
-    pub fn value_validation(arg: Option<&AnyArg>, err: String, color: ColorWhen) -> Self
+    pub fn value_validation(arg: Option<&dyn AnyArg>, err: String, color: ColorWhen) -> Self
     {
         let c = Colorizer::new(ColorizerOption {
             use_stderr: true,
@@ -745,13 +745,13 @@ impl Error {
 
     #[doc(hidden)]
     pub fn value_validation_auto(err: String) -> Self {
-        let n: Option<&AnyArg> = None;
+        let n: Option<&dyn AnyArg> = None;
         Error::value_validation(n, err, ColorWhen::Auto)
     }
 
     #[doc(hidden)]
     pub fn wrong_number_of_values<S, U>(
-        arg: &AnyArg,
+        arg: &dyn AnyArg,
         num_vals: u64,
         curr_vals: usize,
         suffix: S,
@@ -786,7 +786,7 @@ impl Error {
     }
 
     #[doc(hidden)]
-    pub fn unexpected_multiple_usage<U>(arg: &AnyArg, usage: U, color: ColorWhen) -> Self
+    pub fn unexpected_multiple_usage<U>(arg: &dyn AnyArg, usage: U, color: ColorWhen) -> Self
     where
         U: Display,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,11 +549,11 @@ extern crate yaml_rust;
 
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;
-pub use args::{Arg, ArgGroup, ArgMatches, ArgSettings, OsValues, SubCommand, Values};
-pub use app::{App, AppSettings};
-pub use fmt::Format;
-pub use errors::{Error, ErrorKind, Result};
-pub use completions::Shell;
+pub use crate::args::{Arg, ArgGroup, ArgMatches, ArgSettings, OsValues, SubCommand, Values};
+pub use crate::app::{App, AppSettings};
+pub use crate::fmt::Format;
+pub use crate::errors::{Error, ErrorKind, Result};
+pub use crate::completions::Shell;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,13 +524,11 @@
 //      unused_qualifications       (bitflags, clippy)
 //      trivial_numeric_casts       (bitflags)
 #![cfg_attr(not(any(feature = "lints", feature = "nightly")), forbid(unstable_features))]
-#![cfg_attr(feature = "lints", feature(plugin))]
-#![cfg_attr(feature = "lints", plugin(clippy))]
 // Need to disable deny(warnings) while deprecations are active
 // #![cfg_attr(feature = "lints", deny(warnings))]
-#![cfg_attr(feature = "lints", allow(cyclomatic_complexity))]
-#![cfg_attr(feature = "lints", allow(doc_markdown))]
-#![cfg_attr(feature = "lints", allow(explicit_iter_loop))]
+#![cfg_attr(feature = "lints", allow(clippy::cognitive_complexity))]
+#![cfg_attr(feature = "lints", allow(clippy::doc_markdown))]
+#![cfg_attr(feature = "lints", allow(clippy::explicit_iter_loop))]
 
 #[cfg(all(feature = "color", not(target_os = "windows")))]
 extern crate ansi_term;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -955,7 +955,7 @@ macro_rules! find_from {
 macro_rules! find_any_by_name {
     ($p:expr, $name:expr) => {
         {
-            fn as_trait_obj<'a, 'b, T: AnyArg<'a, 'b>>(x: &T) -> &AnyArg<'a, 'b> { x }
+            fn as_trait_obj<'a, 'b, T: AnyArg<'a, 'b>>(x: &T) -> &dyn AnyArg<'a, 'b> { x }
             find_by_name!($p, $name, flags, iter).map(as_trait_obj).or(
                 find_by_name!($p, $name, opts, iter).map(as_trait_obj).or(
                     find_by_name!($p, $name, positionals, values).map(as_trait_obj)

--- a/src/osstringext.rs
+++ b/src/osstringext.rs
@@ -1,5 +1,5 @@
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-use INVALID_UTF8;
+use crate::INVALID_UTF8;
 use std::ffi::OsStr;
 #[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 use std::os::unix::ffi::OsStrExt;

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -1,10 +1,10 @@
-use app::App;
+use crate::app::App;
 // Third Party
 #[cfg(feature = "suggestions")]
 use strsim;
 
 // Internal
-use fmt::Format;
+use crate::fmt::Format;
 
 /// Produces a string from a given list of possible values which is similar to
 /// the passed in value `v` with a certain confidence.

--- a/src/suggestions.rs
+++ b/src/suggestions.rs
@@ -11,7 +11,7 @@ use fmt::Format;
 /// Thus in a list of possible values like ["foo", "bar"], the value "fop" will yield
 /// `Some("foo")`, whereas "blark" would yield `None`.
 #[cfg(feature = "suggestions")]
-#[cfg_attr(feature = "lints", allow(needless_lifetimes))]
+#[cfg_attr(feature = "lints", allow(clippy::needless_lifetimes))]
 pub fn did_you_mean<'a, T: ?Sized, I>(v: &str, possible_values: I) -> Option<&'a str>
 where
     T: AsRef<str> + 'a,
@@ -41,7 +41,7 @@ where
 }
 
 /// Returns a suffix that can be empty, or is the standard 'did you mean' phrase
-#[cfg_attr(feature = "lints", allow(needless_lifetimes))]
+#[cfg_attr(feature = "lints", allow(clippy::needless_lifetimes))]
 pub fn did_you_mean_flag_suffix<'z, T, I>(
     arg: &str,
     args_rest: &'z [&str],

--- a/src/usage_parser.rs
+++ b/src/usage_parser.rs
@@ -1,8 +1,8 @@
 // Internal
-use INTERNAL_ERROR_MSG;
-use args::Arg;
-use args::settings::ArgSettings;
-use map::VecMap;
+use crate::INTERNAL_ERROR_MSG;
+use crate::args::Arg;
+use crate::args::settings::ArgSettings;
+use crate::map::VecMap;
 
 #[derive(PartialEq, Debug)]
 enum UsageToken {
@@ -221,8 +221,8 @@ fn help_start(b: u8) -> bool { b != b'\'' }
 
 #[cfg(test)]
 mod test {
-    use args::Arg;
-    use args::ArgSettings;
+    use crate::args::Arg;
+    use crate::args::ArgSettings;
 
     #[test]
     fn create_flag_usage() {


### PR DESCRIPTION
According to the readme, clap supports the last two versions of rust. This now is sufficient coverage to switch to using the 2018 edition.