### PR TITLE
Format with rustfmt 1.2.2-nightly (5274b49c 2019-04-24)

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1516,11 +1516,11 @@ impl<'b> App<'b> {
                         .args
                         .iter()
                         .filter(|a| a.is_set(ArgSettings::Global))
-                        {
-                            $sc.args.push(a.clone());
-                        }
+                    {
+                        $sc.args.push(a.clone());
+                    }
                 }
-            }}
+            }};
         }
 
         debugln!("App::_propagate:{}", self.name);
@@ -1532,14 +1532,18 @@ impl<'b> App<'b> {
                         sc._propagate(prop);
                     }
                 }
-            },
+            }
             Propagation::To(id) => {
-                let mut sc = self.subcommands.iter_mut().find(|sc| sc.id == id).expect(INTERNAL_ERROR_MSG);
+                let mut sc = self
+                    .subcommands
+                    .iter_mut()
+                    .find(|sc| sc.id == id)
+                    .expect(INTERNAL_ERROR_MSG);
                 propagate_subcmd!(self, sc);
-            },
+            }
             Propagation::None => {
                 return;
-            },
+            }
         }
     }
 

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -1116,10 +1116,7 @@ mod test {
             "validargfound".parse::<AppSettings>().unwrap(),
             AppSettings::ValidArgFound
         );
-        assert_eq!(
-            "built".parse::<AppSettings>().unwrap(),
-            AppSettings::Built
-        );
+        assert_eq!("built".parse::<AppSettings>().unwrap(), AppSettings::Built);
         assert_eq!(
             "trailingvalues".parse::<AppSettings>().unwrap(),
             AppSettings::TrailingValues


### PR DESCRIPTION
This reformats clap using the latest stable version of rustfmt.