### PR TITLE
Fix compiling on windows

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1918,11 +1918,6 @@ impl<'a> From<&'a Yaml> for App<'a> {
         yaml_str!(a, yaml, about);
         yaml_str!(a, yaml, before_help);
         yaml_str!(a, yaml, after_help);
-        yaml_str!(a, yaml, template);
-        yaml_str!(a, yaml, usage);
-        yaml_str!(a, yaml, help);
-        yaml_str!(a, yaml, help_message);
-        yaml_str!(a, yaml, version_message);
         yaml_str!(a, yaml, alias);
         yaml_str!(a, yaml, visible_alias);
 
@@ -2014,7 +2009,7 @@ impl<'a> From<&'a Yaml> for App<'a> {
         }
         if let Some(v) = yaml["subcommands"].as_vec() {
             for sc_yaml in v {
-                a = a.subcommand(::from_yaml(sc_yaml));
+                a = a.subcommand(App::from(sc_yaml));
             }
         }
         if let Some(v) = yaml["groups"].as_vec() {

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -2,8 +2,6 @@ mod settings;
 pub use self::settings::{ArgFlags, ArgSettings};
 
 // Std
-#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-use osstringext::OsStrExt3;
 use std::borrow::Cow;
 use std::cmp::{Ord, Ordering};
 use std::env;
@@ -22,6 +20,8 @@ use yaml_rust;
 // Internal
 use crate::build::UsageParser;
 use crate::util::Key;
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
+use crate::util::OsStrExt3;
 use crate::INTERNAL_ERROR_MSG;
 
 type Validator = Rc<Fn(String) -> Result<(), String>>;

--- a/src/parse/matches/subcommand.rs
+++ b/src/parse/matches/subcommand.rs
@@ -1,7 +1,3 @@
-// Third Party
-#[cfg(feature = "yaml")]
-use yaml_rust::Yaml;
-
 // Internal
 use crate::ArgMatches;
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1,6 +1,4 @@
 // Std
-#[cfg(all(feature = "debug", any(target_os = "windows", target_arch = "wasm32")))]
-use osstringext::OsStrExt3;
 use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
 use std::io::{self, BufWriter, Write};
@@ -26,6 +24,8 @@ use crate::parse::features::suggestions;
 use crate::parse::Validator;
 use crate::parse::{ArgMatcher, SubCommand};
 use crate::util::{self, ChildGraph, Key, OsStrExt2, EMPTY_HASH};
+#[cfg(all(feature = "debug", any(target_os = "windows", target_arch = "wasm32")))]
+use crate::util::OsStrExt3;
 use crate::INTERNAL_ERROR_MSG;
 use crate::INVALID_UTF8;
 
@@ -720,7 +720,7 @@ where
         debugln!("Parser::possible_subcommand: arg={:?}", arg_os);
         fn starts(h: &str, n: &OsStr) -> bool {
             #[cfg(target_os = "windows")]
-            use osstringext::OsStrExt3;
+            use crate::util::OsStrExt3;
             #[cfg(not(target_os = "windows"))]
             use std::os::unix::ffi::OsStrExt;
 

--- a/src/util/osstringext.rs
+++ b/src/util/osstringext.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 #[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-use INVALID_UTF8;
+use crate::INVALID_UTF8;
 
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 pub trait OsStrExt3 {


### PR DESCRIPTION
This fixes compilation errors when building clap targetting windows with:

```
% rustup run nightly cargo check --target x86_64-pc-windows-msvc
```