### PR TITLE
Convert clap to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "clap"
 version = "3.0.0-beta.1"
 authors = ["Kevin K. <kbknapp@gmail.com>"]
@@ -38,6 +37,7 @@ categories = ["command-line-interface"]
 description = """
 A simple to use, efficient, and full-featured Command Line Argument Parser
 """
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "clap-rs/clap" }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1918,11 +1918,6 @@ impl<'a> From<&'a Yaml> for App<'a> {
         yaml_str!(a, yaml, about);
         yaml_str!(a, yaml, before_help);
         yaml_str!(a, yaml, after_help);
-        yaml_str!(a, yaml, template);
-        yaml_str!(a, yaml, usage);
-        yaml_str!(a, yaml, help);
-        yaml_str!(a, yaml, help_message);
-        yaml_str!(a, yaml, version_message);
         yaml_str!(a, yaml, alias);
         yaml_str!(a, yaml, visible_alias);
 
@@ -2014,7 +2009,7 @@ impl<'a> From<&'a Yaml> for App<'a> {
         }
         if let Some(v) = yaml["subcommands"].as_vec() {
             for sc_yaml in v {
-                a = a.subcommand(::from_yaml(sc_yaml));
+                a = a.subcommand(App::from(sc_yaml));
             }
         }
         if let Some(v) = yaml["groups"].as_vec() {

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -24,8 +24,8 @@ use crate::build::UsageParser;
 use crate::util::Key;
 use crate::INTERNAL_ERROR_MSG;
 
-type Validator = Rc<Fn(String) -> Result<(), String>>;
-type ValidatorOs = Rc<Fn(&OsStr) -> Result<(), String>>;
+type Validator = Rc<dyn Fn(String) -> Result<(), String>>;
+type ValidatorOs = Rc<dyn Fn(&OsStr) -> Result<(), String>>;
 
 type Id = u64;
 
@@ -305,7 +305,7 @@ impl<'help> Arg<'help> {
     /// assert!(m.is_present("cfg"));
     /// ```
     pub fn long(mut self, l: &'help str) -> Self {
-        self.long = Some(l.trim_left_matches(|c| c == '-'));
+        self.long = Some(l.trim_start_matches(|c| c == '-'));
         self
     }
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -33,7 +33,7 @@ const TAB: &str = "    ";
 ///
 /// Wraps a writer stream providing different methods to generate help for `clap` objects.
 pub struct Help<'b, 'c, 'd, 'w> {
-    writer: &'w mut Write,
+    writer: &'w mut dyn Write,
     parser: &'d Parser<'b, 'c>,
     next_line_help: bool,
     hide_pv: bool,
@@ -48,7 +48,7 @@ pub struct Help<'b, 'c, 'd, 'w> {
 // Public Functions
 impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
     /// Create a new `Help` instance.
-    pub fn new(w: &'w mut Write, parser: &'d Parser<'b, 'c>, use_long: bool, stderr: bool) -> Self {
+    pub fn new(w: &'w mut dyn Write, parser: &'d Parser<'b, 'c>, use_long: bool, stderr: bool) -> Self {
         debugln!("Help::new;");
         let term_w = match parser.app.term_w {
             Some(0) => usize::MAX,

--- a/src/parse/features/suggestions.rs
+++ b/src/parse/features/suggestions.rs
@@ -3,7 +3,7 @@
 use strsim;
 
 // Internal
-use crate::build::{App, Propagation};
+use crate::build::App;
 use crate::output::fmt::Format;
 
 /// Produces a string from a given list of possible values which is similar to

--- a/src/parse/matches/subcommand.rs
+++ b/src/parse/matches/subcommand.rs
@@ -1,7 +1,3 @@
-// Third Party
-#[cfg(feature = "yaml")]
-use yaml_rust::Yaml;
-
 // Internal
 use crate::ArgMatches;
 


### PR DESCRIPTION
According to the README, clap supports the last 2 releases. This means
that clap can now switch over to the 2018 edition. This patch was auto
generated by running `cargo fix --edition`.