### PR TITLE
Fix building v3-master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_script:
 script:
   - |
     travis-cargo test -- --verbose --no-default-features &&
-    travis-cargo --skip nightly test -- --verbose --features "unstable" &&
-    travis-cargo --only nightly test -- --verbose --features "unstable nightly" &&
+    travis-cargo --skip nightly test -- --verbose --features "yaml unstable" &&
+    travis-cargo --only nightly test -- --verbose --features "yaml unstable nightly" &&
     travis-cargo --only nightly bench
 addons:
   apt:
@@ -50,7 +50,7 @@ after_success:
     cd ../.. &&
     rm -rf kcov-master &&
     cargo clean &&
-    cargo test --no-run --features "unstable" &&
+    cargo test --no-run --features "yaml unstable" &&
     for file in target/debug/*-*; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo --verify "target/cov/$(basename $file)" "$file"; done &&
     kcov --coveralls-id=$TRAVIS_JOB_ID --merge target/cov target/cov/* &&
     echo "Uploaded code coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_script:
 script:
   - |
     travis-cargo test -- --verbose --no-default-features &&
-    travis-cargo --skip nightly test -- --verbose --features "yaml unstable" &&
-    travis-cargo --only nightly test -- --verbose --features "yaml unstable nightly" &&
+    travis-cargo --skip nightly test -- --verbose --features "unstable" &&
+    travis-cargo --only nightly test -- --verbose --features "unstable nightly" &&
     travis-cargo --only nightly bench
 addons:
   apt:
@@ -50,7 +50,7 @@ after_success:
     cd ../.. &&
     rm -rf kcov-master &&
     cargo clean &&
-    cargo test --no-run --features "yaml unstable" &&
+    cargo test --no-run --features "unstable" &&
     for file in target/debug/*-*; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo --verify "target/cov/$(basename $file)" "$file"; done &&
     kcov --coveralls-id=$TRAVIS_JOB_ID --merge target/cov target/cov/* &&
     echo "Uploaded code coverage"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: rust
 cache: cargo
 rust:
   - nightly
-  - nightly-2019-03-23
+  - nightly-2019-06-18
   - beta
   - stable
-  - 1.30.0
+  - 1.33.0
 matrix:
     allow_failures:
         - rust: nightly
-    nightly-2019-03-23:
+    nightly-2019-06-18:
         - script: cargo clippy
 before_script:
   - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+#### Minimum Required Rust
+
+* As of this release, `clap` requires `rustc 1.33.0` or greater.
+
 <a name="v2.29.2"></a>
 ### v2.29.2 (2018-01-16)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "clap"
 version = "3.0.0-beta.1"
 authors = ["Kevin K. <kbknapp@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -537,9 +537,9 @@ This is inherently an unresolvable crate graph in Cargo right now. Cargo require
 
 #### Minimum Version of Rust
 
-`clap` will officially support current stable Rust, minus two releases, but may work with prior releases as well. For example, current stable Rust at the time of this writing is 1.21.0, meaning `clap` is guaranteed to compile with 1.19.0 and beyond.
+`clap` will officially support current stable Rust, minus two releases, but may work with prior releases as well. For example, current stable Rust at the time of this writing is 1.35.0, meaning `clap` is guaranteed to compile with 1.33.0 and beyond.
 
-At the 1.22.0 stable release, `clap` will be guaranteed to compile with 1.20.0 and beyond, etc.
+At the 1.36.0 stable release, `clap` will be guaranteed to compile with 1.34.0 and beyond, etc.
 
 Upon bumping the minimum version of Rust (assuming it's within the stable-2 range), it *must* be clearly annotated in the `CHANGELOG.md`
 

--- a/benches/03_complex.rs
+++ b/benches/03_complex.rs
@@ -19,7 +19,7 @@ macro_rules! create_app {
             .author("Kevin K. <kbknapp@gmail.com>")
             .arg("-o --option=[opt]... 'tests options'")
             .arg("[positional] 'tests positionals'")
-            .arg(Arg::from("-f --flag... 'tests flags'").setting(ArgSettings::Global))
+            .arg(Arg::from("-f --flag... 'tests flags'").global(true))
             .args(&[
                 Arg::from("[flag2] -F 'tests flags with exclusions'")
                     .conflicts_with("flag")
@@ -76,7 +76,8 @@ fn create_app_builder(b: &mut Bencher) {
                     .short('f')
                     .help("tests flags")
                     .long("flag")
-                    .settings(&[ArgSettings::MultipleOccurrences, ArgSettings::Global]),
+                    .global(true)
+                    .settings(&[ArgSettings::MultipleOccurrences]),
             )
             .arg(
                 Arg::with_name("flag2")

--- a/examples/17_yaml.rs
+++ b/examples/17_yaml.rs
@@ -32,7 +32,7 @@ fn main() {
     // Finally we call get_matches() to start the parsing process. We use the matches just as we
     // normally would
     let yml = load_yaml!("17_yaml.yml");
-    let m = App::from_yaml(yml).get_matches();
+    let m = App::from(yml).get_matches();
 
     // Because the example 17_yaml.yml is rather large we'll just look a single arg so you can
     // see that it works...

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1398,7 +1398,7 @@ impl<'b> App<'b> {
             .args
             .args
             .iter()
-            .filter(|a| a.is_set(ArgSettings::Global))
+            .filter(|a| a.global)
             .map(|ga| ga.id)
             .collect();
 
@@ -1515,7 +1515,7 @@ impl<'b> App<'b> {
                         .args
                         .args
                         .iter()
-                        .filter(|a| a.is_set(ArgSettings::Global))
+                        .filter(|a| a.global)
                         {
                             $sc.args.push(a.clone());
                         }
@@ -1666,7 +1666,7 @@ impl<'b> App<'b> {
             );
         }
         assert!(
-            !(a.is_set(ArgSettings::Required) && a.is_set(ArgSettings::Global)),
+            !(a.is_set(ArgSettings::Required) && a.global),
             "Global arguments cannot be required.\n\n\t'{}' is marked as \
              global and required",
             a.name

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1911,11 +1911,6 @@ impl<'a> From<&'a Yaml> for App<'a> {
         yaml_str!(a, yaml, about);
         yaml_str!(a, yaml, before_help);
         yaml_str!(a, yaml, after_help);
-        yaml_str!(a, yaml, template);
-        yaml_str!(a, yaml, usage);
-        yaml_str!(a, yaml, help);
-        yaml_str!(a, yaml, help_message);
-        yaml_str!(a, yaml, version_message);
         yaml_str!(a, yaml, alias);
         yaml_str!(a, yaml, visible_alias);
 
@@ -2007,7 +2002,7 @@ impl<'a> From<&'a Yaml> for App<'a> {
         }
         if let Some(v) = yaml["subcommands"].as_vec() {
             for sc_yaml in v {
-                a = a.subcommand(::from_yaml(sc_yaml));
+                a = a.subcommand(App::from(sc_yaml));
             }
         }
         if let Some(v) = yaml["groups"].as_vec() {

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1769,13 +1769,6 @@ impl<'b> App<'b> {
         }
     }
 
-    pub(crate) fn contains_long(&self, l: &str) -> bool {
-        if !self.is_set(AppSettings::Built) {
-            panic!("If App::_build hasn't been called, manually search through Arg longs");
-        }
-        self.args.contains_long(l)
-    }
-
     pub(crate) fn contains_short(&self, s: char) -> bool {
         if !self.is_set(AppSettings::Built) {
             panic!("If App::_build hasn't been called, manually search through Arg shorts");

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -1,6 +1,5 @@
 // Std
 #[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::ops::BitOr;
 use std::str::FromStr;
 

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -61,7 +61,6 @@ impl Default for AppFlags {
     fn default() -> Self { AppFlags(Flags::UTF8_NONE | Flags::COLOR_AUTO) }
 }
 
-#[allow(deprecated)]
 impl AppFlags {
     pub fn new() -> Self { AppFlags::default() }
     pub fn zeroed() -> Self { AppFlags(Flags::empty()) }
@@ -90,7 +89,6 @@ impl AppFlags {
         NoAutoHelp => Flags::NO_AUTO_HELP,
         NoAutoVersion => Flags::NO_AUTO_VERSION,
         NoBinaryName => Flags::NO_BIN_NAME,
-        PropagateGlobalValuesDown=> Flags::PROPAGATE_VALS_DOWN,
         StrictUtf8 => Flags::UTF8_STRICT,
         SubcommandsNegateReqs => Flags::SC_NEGATE_REQS,
         SubcommandRequired => Flags::SC_REQUIRED,
@@ -668,45 +666,6 @@ pub enum AppSettings {
     ///     .get_matches();
     /// ```
     NextLineHelp,
-
-    /// **DEPRECATED**: This setting is no longer required in order to propagate values up or down
-    ///
-    /// Specifies that the parser should propagate global arg's values down or up through any *used*
-    /// child subcommands. Meaning, if a subcommand wasn't used, the values won't be propagated to
-    /// said subcommand.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, AppSettings, };
-    /// let m = App::new("myprog")
-    ///     .arg(Arg::from("[cmd] 'command to run'")
-    ///         .global(true))
-    ///     .subcommand(App::new("foo"))
-    ///     .get_matches_from(vec!["myprog", "set", "foo"]);
-    ///
-    /// assert_eq!(m.value_of("cmd"), Some("set"));
-    ///
-    /// let sub_m = m.subcommand_matches("foo").unwrap();
-    /// assert_eq!(sub_m.value_of("cmd"), Some("set"));
-    /// ```
-    /// Now doing the same thing, but *not* using any subcommands will result in the value not being
-    /// propagated down.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, AppSettings, };
-    /// let m = App::new("myprog")
-    ///     .arg(Arg::from("[cmd] 'command to run'")
-    ///         .global(true))
-    ///     .subcommand(App::new("foo"))
-    ///     .get_matches_from(vec!["myprog", "set"]);
-    ///
-    /// assert_eq!(m.value_of("cmd"), Some("set"));
-    ///
-    /// assert!(m.subcommand_matches("foo").is_none());
-    /// ```
-    #[deprecated(since = "2.27.0", note = "No longer required to propagate values")]
-    PropagateGlobalValuesDown,
 
     /// Allows [``]s to override all requirements of the parent command.
     /// For example if you had a subcommand or top level application with a required argument

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -2,8 +2,6 @@ mod settings;
 pub use self::settings::{ArgFlags, ArgSettings};
 
 // Std
-#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-use osstringext::OsStrExt3;
 use std::borrow::Cow;
 use std::cmp::{Ord, Ordering};
 use std::env;
@@ -22,6 +20,8 @@ use yaml_rust;
 // Internal
 use crate::build::UsageParser;
 use crate::util::Key;
+#[cfg(any(target_os = "windows", target_arch = "wasm32"))]
+use crate::util::OsStrExt3;
 use crate::INTERNAL_ERROR_MSG;
 
 type Validator = Rc<Fn(String) -> Result<(), String>>;

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -24,8 +24,8 @@ use crate::util::Key;
 use crate::util::OsStrExt3;
 use crate::INTERNAL_ERROR_MSG;
 
-type Validator = Rc<Fn(String) -> Result<(), String>>;
-type ValidatorOs = Rc<Fn(&OsStr) -> Result<(), String>>;
+type Validator = Rc<dyn Fn(String) -> Result<(), String>>;
+type ValidatorOs = Rc<dyn Fn(&OsStr) -> Result<(), String>>;
 
 type Id = u64;
 
@@ -305,7 +305,7 @@ impl<'help> Arg<'help> {
     /// assert!(m.is_present("cfg"));
     /// ```
     pub fn long(mut self, l: &'help str) -> Self {
-        self.long = Some(l.trim_left_matches(|c| c == '-'));
+        self.long = Some(l.trim_start_matches(|c| c == '-'));
         self
     }
 
@@ -3281,7 +3281,6 @@ impl<'help> Arg<'help> {
     ///
     /// ```rust
     /// # use clap::{App, Arg, ArgSettings};
-    /// # use std::ascii::AsciiExt;
     /// let m = App::new("pv")
     ///     .arg(Arg::with_name("option")
     ///         .long("--option")

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -114,6 +114,8 @@ pub struct Arg<'help> {
     pub r_ifs: Option<Vec<(Id, &'help str)>>,
     #[doc(hidden)]
     pub help_heading: Option<&'help str>,
+    #[doc(hidden)]
+    pub global: bool,
 }
 
 impl<'help> Arg<'help> {
@@ -191,7 +193,6 @@ impl<'help> Arg<'help> {
                 "multiple" => yaml_to_bool!(a, v, multiple),
                 "hidden" => yaml_to_bool!(a, v, hidden),
                 "next_line_help" => yaml_to_bool!(a, v, next_line_help),
-                "empty_values" => yaml_to_bool!(a, v, empty_values),
                 "group" => yaml_to_str!(a, v, group),
                 "number_of_values" => yaml_to_u64!(a, v, number_of_values),
                 "max_values" => yaml_to_u64!(a, v, max_values),
@@ -3020,7 +3021,7 @@ impl<'help> Arg<'help> {
     /// # use clap::{App, Arg, ArgSettings};
     /// Arg::with_name("debug")
     ///     .short('d')
-    ///     .setting(ArgSettings::Global)
+    ///     .global(true)
     /// # ;
     /// ```
     ///
@@ -3034,7 +3035,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::with_name("verb")
     ///         .long("verbose")
     ///         .short('v')
-    ///         .setting(ArgSettings::Global))
+    ///         .global(true))
     ///     .subcommand(App::new("test"))
     ///     .subcommand(App::new("do-stuff"))
     ///     .get_matches_from(vec![
@@ -3050,12 +3051,9 @@ impl<'help> Arg<'help> {
     /// [`ArgMatches`]: ./struct.ArgMatches.html
     /// [`ArgMatches::is_present("flag")`]: ./struct.ArgMatches.html#method.is_present
     /// [`Arg`]: ./struct.Arg.html
-    pub fn global(self, g: bool) -> Self {
-        if g {
-            self.setting(ArgSettings::Global)
-        } else {
-            self.unset_setting(ArgSettings::Global)
-        }
+    pub fn global(mut self, g: bool) -> Self {
+        self.global = g;
+        self
     }
 
     /// Specifies that *multiple values* may only be set using the delimiter. This means if an
@@ -3207,20 +3205,6 @@ impl<'help> Arg<'help> {
             self.setting(ArgSettings::HideDefaultValue)
         } else {
             self.unset_setting(ArgSettings::HideDefaultValue)
-        }
-    }
-
-    /// **Deprecated**
-    #[deprecated(
-        since = "2.30.0",
-        note = "Use `Arg::setting(ArgSettings::AllowEmptyValues)` instead. Will be removed in v3.0-beta"
-    )]
-    pub fn empty_values(mut self, ev: bool) -> Self {
-        if ev {
-            self.setting(ArgSettings::AllowEmptyValues)
-        } else {
-            self = self.setting(ArgSettings::TakesValue);
-            self.unset_setting(ArgSettings::AllowEmptyValues)
         }
     }
 

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -1,6 +1,4 @@
 // Std
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::str::FromStr;
 
 bitflags! {

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -40,7 +40,6 @@ impl ArgFlags {
         MultipleOccurrences => Flags::MULTIPLE_OCC,
         MultipleValues => Flags::MULTIPLE_VALS,
         AllowEmptyValues => Flags::EMPTY_VALS,
-        Global => Flags::GLOBAL,
         Hidden => Flags::HIDDEN,
         TakesValue => Flags::TAKES_VAL,
         UseValueDelimiter => Flags::USE_DELIM,
@@ -82,10 +81,6 @@ pub enum ArgSettings {
     MultipleOccurrences,
     /// Allows an arg accept empty values such as `""`
     AllowEmptyValues,
-    /// Sets an arg to be global (i.e. exist in all subcommands)
-    /// **DEPRECATED**
-    #[deprecated(since = "2.32.0", note = "Use `App::global_arg` instead")]
-    Global,
     /// Hides an arg from the help message
     Hidden,
     /// Allows an argument to take a value (such as `--option value`)
@@ -128,7 +123,6 @@ impl FromStr for ArgSettings {
     fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
         match &*s.to_ascii_lowercase() {
             "required" => Ok(ArgSettings::Required),
-            "global" => Ok(ArgSettings::Global),
             "allowemptyvalues" => Ok(ArgSettings::AllowEmptyValues),
             "hidden" => Ok(ArgSettings::Hidden),
             "takesvalue" => Ok(ArgSettings::TakesValue),
@@ -164,10 +158,6 @@ mod test {
         assert_eq!(
             "allowemptyvalues".parse::<ArgSettings>().unwrap(),
             ArgSettings::AllowEmptyValues
-        );
-        assert_eq!(
-            "global".parse::<ArgSettings>().unwrap(),
-            ArgSettings::Global
         );
         assert_eq!(
             "hidepossiblevalues".parse::<ArgSettings>().unwrap(),

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -625,9 +625,9 @@ requires:
 - r4";
         let yml = &YamlLoader::load_from_str(g_yaml).expect("failed to load YAML file")[0];
         let g = ArgGroup::from_yaml(yml);
-        let args = vec!["a1", "a4", "a2", "a3"];
-        let reqs = vec!["r1", "r2", "r3", "r4"];
-        let confs = vec!["c1", "c2", "c3", "c4"];
+        let args = vec!["a1".key(), "a4".key(), "a2".key(), "a3".key()];
+        let reqs = vec!["r1".key(), "r2".key(), "r3".key(), "r4".key()];
+        let confs = vec!["c1".key(), "c2".key(), "c3".key(), "c4".key()];
         assert_eq!(g.args, args);
         assert_eq!(g.requires, Some(reqs));
         assert_eq!(g.conflicts, Some(confs));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -324,8 +324,6 @@ macro_rules! arg_enum {
             type Err = String;
 
             fn from_str(s: &str) -> ::std::result::Result<Self,Self::Err> {
-                #[allow(unused_imports)]
-                use ::std::ascii::AsciiExt;
                 match s {
                     $(stringify!($v) |
                     _ if s.eq_ignore_ascii_case(stringify!($v)) => Ok($e::$v)),+,

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -30,18 +30,6 @@ impl KeyType {
             _ => false,
         }
     }
-    pub(crate) fn is_short(&self) -> bool {
-        match *self {
-            KeyType::Short(_) => true,
-            _ => false,
-        }
-    }
-    pub(crate) fn is_long(&self) -> bool {
-        match *self {
-            KeyType::Long(_) => true,
-            _ => false,
-        }
-    }
 }
 
 impl PartialEq<&str> for KeyType {

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -33,7 +33,7 @@ const TAB: &str = "    ";
 ///
 /// Wraps a writer stream providing different methods to generate help for `clap` objects.
 pub struct Help<'b, 'c, 'd, 'w> {
-    writer: &'w mut Write,
+    writer: &'w mut dyn Write,
     parser: &'d Parser<'b, 'c>,
     next_line_help: bool,
     hide_pv: bool,
@@ -48,7 +48,7 @@ pub struct Help<'b, 'c, 'd, 'w> {
 // Public Functions
 impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
     /// Create a new `Help` instance.
-    pub fn new(w: &'w mut Write, parser: &'d Parser<'b, 'c>, use_long: bool, stderr: bool) -> Self {
+    pub fn new(w: &'w mut dyn Write, parser: &'d Parser<'b, 'c>, use_long: bool, stderr: bool) -> Self {
         debugln!("Help::new;");
         let term_w = match parser.app.term_w {
             Some(0) => usize::MAX,

--- a/src/parse/features/suggestions.rs
+++ b/src/parse/features/suggestions.rs
@@ -3,7 +3,7 @@
 use strsim;
 
 // Internal
-use crate::build::{App, Propagation};
+use crate::build::App;
 use crate::output::fmt::Format;
 
 /// Produces a string from a given list of possible values which is similar to

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -744,14 +744,6 @@ impl ArgMatches {
             .as_ref()
             .map_or(("", None), |sc| (&sc.name[..], Some(&sc.matches)))
     }
-
-    // @TODO @v3-beta: remove
-    /// **Deprecated**
-    #[deprecated(
-        since = "2.32.0",
-        note = "Use App::usage instead. Will be removed in v3-beta"
-    )]
-    pub fn usage(&self) -> &str { panic!("Use App::usage instead. Will be removed in v3-beta") }
 }
 
 // The following were taken and adapated from vec_map source

--- a/src/parse/matches/subcommand.rs
+++ b/src/parse/matches/subcommand.rs
@@ -1,7 +1,3 @@
-// Third Party
-#[cfg(feature = "yaml")]
-use yaml_rust::Yaml;
-
 // Internal
 use crate::ArgMatches;
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1,6 +1,4 @@
 // Std
-#[cfg(all(feature = "debug", any(target_os = "windows", target_arch = "wasm32")))]
-use osstringext::OsStrExt3;
 use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
 use std::io::{self, BufWriter, Write};
@@ -26,6 +24,8 @@ use crate::parse::features::suggestions;
 use crate::parse::Validator;
 use crate::parse::{ArgMatcher, SubCommand};
 use crate::util::{self, ChildGraph, Key, OsStrExt2, EMPTY_HASH};
+#[cfg(all(feature = "debug", any(target_os = "windows", target_arch = "wasm32")))]
+use crate::util::OsStrExt3;
 use crate::INTERNAL_ERROR_MSG;
 use crate::INVALID_UTF8;
 
@@ -720,7 +720,7 @@ where
         debugln!("Parser::possible_subcommand: arg={:?}", arg_os);
         fn starts(h: &str, n: &OsStr) -> bool {
             #[cfg(target_os = "windows")]
-            use osstringext::OsStrExt3;
+            use crate::util::OsStrExt3;
             #[cfg(not(target_os = "windows"))]
             use std::os::unix::ffi::OsStrExt;
 

--- a/src/util/osstringext.rs
+++ b/src/util/osstringext.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 #[cfg(not(any(target_os = "windows", target_arch = "wasm32")))]
 use std::os::unix::ffi::OsStrExt;
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-use INVALID_UTF8;
+use crate::INVALID_UTF8;
 
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 pub trait OsStrExt3 {

--- a/tests/app.yml
+++ b/tests/app.yml
@@ -4,8 +4,11 @@ about: tests clap library
 author: Kevin K. <kbknapp@gmail.com>
 settings:
     - ArgRequiredElseHelp
-help_message: prints help with a nonstandard description
 args:
+    - help:
+        short: h
+        long: help
+        help: prints help with a nonstandard description
     - opt:
         short: o
         long: option

--- a/tests/app_2space.yml
+++ b/tests/app_2space.yml
@@ -4,8 +4,11 @@ about: tests clap library
 author: Kevin K. <kbknapp@gmail.com>
 settings:
   - ArgRequiredElseHelp
-help_message: prints help with a nonstandard description
 args:
+  - help:
+    short: h
+    long: help
+    help: prints help with a nonstandard description
   - opt:
     short: o
     long: option

--- a/tests/possible_values.rs
+++ b/tests/possible_values.rs
@@ -3,9 +3,6 @@ extern crate regex;
 
 include!("../clap-test.rs");
 
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
-
 use clap::{App, Arg, ErrorKind};
 
 #[cfg(feature = "suggestions")]

--- a/tests/propagate_globals.rs
+++ b/tests/propagate_globals.rs
@@ -12,7 +12,7 @@ mod tests {
                 Arg::with_name("GLOBAL_ARG")
                     .long("global-arg")
                     .help("Specifies something needed by the subcommands")
-                    .setting(ArgSettings::Global)
+                    .global(true)
                     .setting(ArgSettings::TakesValue)
                     .default_value("default_value"),
             )
@@ -20,8 +20,8 @@ mod tests {
                 Arg::with_name("GLOBAL_FLAG")
                     .long("global-flag")
                     .help("Specifies something needed by the subcommands")
-                    .setting(ArgSettings::MultipleOccurrences)
-                    .setting(ArgSettings::Global),
+                    .global(true)
+                    .setting(ArgSettings::MultipleOccurrences),
             )
             .subcommand(App::new("outer").subcommand(App::new("inner")))
     }

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -8,7 +8,7 @@ use clap::App;
 #[test]
 fn create_app_from_yaml() {
     let yml = load_yaml!("app.yml");
-    App::from_yaml(yml);
+    App::from(yml);
 }
 
 // TODO: Uncomment to test yaml with 2 spaces https://github.com/chyh1990/yaml-rust/issues/101
@@ -21,7 +21,7 @@ fn create_app_from_yaml() {
 #[test]
 fn help_message() {
     let yml = load_yaml!("app.yml");
-    let mut app = App::from_yaml(yml);
+    let mut app = App::from(yml);
     // Generate the full help message!
     let _ = app.try_get_matches_from_mut(Vec::<String>::new());
 
@@ -36,7 +36,7 @@ fn help_message() {
 #[test]
 fn author() {
     let yml = load_yaml!("app.yml");
-    let mut app = App::from_yaml(yml);
+    let mut app = App::from(yml);
     // Generate the full help message!
     let _ = app.try_get_matches_from_mut(Vec::<String>::new());
 


### PR DESCRIPTION
This fixes v3-master to pass travis and appveyor tests. To do that, it:

* bumps the minimum version to rust 1.33.0
* fixes compiling on windows.
* Removes unused `App::contains_long`
* Removes `std::ascii::AsciiExt` (deprecated in 1.26)
* Replaces `trim_left_matches` with `trim_start_matches` (added in 1.30)
* Adds `dyn` (added in 1.27)
* Removes unused `mkeymap::KeyType::{is_short,is_long}`
* Cleans up unused imports
* Fixes `--features yaml`
* Removes deprecated features (and eliminates the last of the warnings).