### PR TITLE
Don't export App and Arg fields

### DIFF
--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -50,7 +50,7 @@ bitflags! {
 
 #[doc(hidden)]
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct AppFlags(Flags);
+pub(crate) struct AppFlags(Flags);
 
 impl BitOr for AppFlags {
     type Output = Self;
@@ -62,9 +62,6 @@ impl Default for AppFlags {
 }
 
 impl AppFlags {
-    pub fn new() -> Self { AppFlags::default() }
-    pub fn zeroed() -> Self { AppFlags(Flags::empty()) }
-
     impl_settings! { AppSettings,
         ArgRequiredElseHelp => Flags::A_REQUIRED_ELSE_HELP,
         ArgsNegateSubcommands => Flags::ARGS_NEGATE_SCS,

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -54,68 +54,37 @@ type Id = u64;
 #[allow(missing_debug_implementations)]
 #[derive(Default, Clone)]
 pub struct Arg<'help> {
-    #[doc(hidden)]
-    pub id: Id,
-    #[doc(hidden)]
-    pub name: &'help str,
-    #[doc(hidden)]
-    pub help: Option<&'help str>,
-    #[doc(hidden)]
-    pub long_help: Option<&'help str>,
-    #[doc(hidden)]
-    pub blacklist: Option<Vec<Id>>,
-    #[doc(hidden)]
-    pub settings: ArgFlags,
-    #[doc(hidden)]
-    pub r_unless: Option<Vec<Id>>,
-    #[doc(hidden)]
-    pub overrides: Option<Vec<Id>>,
-    #[doc(hidden)]
-    pub groups: Option<Vec<Id>>,
-    #[doc(hidden)]
-    pub requires: Option<Vec<(Option<&'help str>, Id)>>,
-    #[doc(hidden)]
-    pub short: Option<char>,
-    #[doc(hidden)]
-    pub long: Option<&'help str>,
-    #[doc(hidden)]
-    pub aliases: Option<Vec<(&'help str, bool)>>, // (name, visible)
-    #[doc(hidden)]
-    pub disp_ord: usize,
-    #[doc(hidden)]
-    pub unified_ord: usize,
-    #[doc(hidden)]
-    pub possible_vals: Option<Vec<&'help str>>,
-    #[doc(hidden)]
-    pub val_names: Option<VecMap<&'help str>>,
-    #[doc(hidden)]
-    pub num_vals: Option<u64>,
-    #[doc(hidden)]
-    pub max_vals: Option<u64>,
-    #[doc(hidden)]
-    pub min_vals: Option<u64>,
-    #[doc(hidden)]
-    pub validator: Option<Validator>,
-    #[doc(hidden)]
-    pub validator_os: Option<ValidatorOs>,
-    #[doc(hidden)]
-    pub val_delim: Option<char>,
-    #[doc(hidden)]
-    pub default_val: Option<&'help OsStr>,
-    #[doc(hidden)]
-    pub default_vals_ifs: Option<VecMap<(Id, Option<&'help OsStr>, &'help OsStr)>>,
-    #[doc(hidden)]
-    pub env: Option<(&'help OsStr, Option<OsString>)>,
-    #[doc(hidden)]
-    pub terminator: Option<&'help str>,
-    #[doc(hidden)]
-    pub index: Option<u64>,
-    #[doc(hidden)]
-    pub r_ifs: Option<Vec<(Id, &'help str)>>,
-    #[doc(hidden)]
-    pub help_heading: Option<&'help str>,
-    #[doc(hidden)]
-    pub global: bool,
+    pub(crate) id: Id,
+    pub(crate) name: &'help str,
+    pub(crate) help: Option<&'help str>,
+    pub(crate) long_help: Option<&'help str>,
+    pub(crate) blacklist: Option<Vec<Id>>,
+    pub(crate) settings: ArgFlags,
+    pub(crate) r_unless: Option<Vec<Id>>,
+    pub(crate) overrides: Option<Vec<Id>>,
+    pub(crate) groups: Option<Vec<Id>>,
+    pub(crate) requires: Option<Vec<(Option<&'help str>, Id)>>,
+    pub(crate) short: Option<char>,
+    pub(crate) long: Option<&'help str>,
+    pub(crate) aliases: Option<Vec<(&'help str, bool)>>, // (name, visible)
+    pub(crate) disp_ord: usize,
+    pub(crate) unified_ord: usize,
+    pub(crate) possible_vals: Option<Vec<&'help str>>,
+    pub(crate) val_names: Option<VecMap<&'help str>>,
+    pub(crate) num_vals: Option<u64>,
+    pub(crate) max_vals: Option<u64>,
+    pub(crate) min_vals: Option<u64>,
+    pub(crate) validator: Option<Validator>,
+    pub(crate) validator_os: Option<ValidatorOs>,
+    pub(crate) val_delim: Option<char>,
+    pub(crate) default_val: Option<&'help OsStr>,
+    pub(crate) default_vals_ifs: Option<VecMap<(Id, Option<&'help OsStr>, &'help OsStr)>>,
+    pub(crate) env: Option<(&'help OsStr, Option<OsString>)>,
+    pub(crate) terminator: Option<&'help str>,
+    pub(crate) index: Option<u64>,
+    pub(crate) r_ifs: Option<Vec<(Id, &'help str)>>,
+    pub(crate) help_heading: Option<&'help str>,
+    pub(crate) global: bool,
 }
 
 impl<'help> Arg<'help> {
@@ -4367,5 +4336,29 @@ mod test {
         p2.val_names = Some(vm);
 
         assert_eq!(&*format!("{}", p2), "<file1> <file2>");
+    }
+
+    #[test]
+    fn short_flag_misspel() {
+        let a = Arg::from("-f1, --flag 'some flag'");
+        assert_eq!(a.name, "flag");
+        assert_eq!(a.short.unwrap(), 'f');
+        assert_eq!(a.long.unwrap(), "flag");
+        assert_eq!(a.help.unwrap(), "some flag");
+        assert!(!a.is_set(ArgSettings::MultipleOccurrences));
+        assert!(a.val_names.is_none());
+        assert!(a.num_vals.is_none());
+    }
+
+    #[test]
+    fn short_flag_name_missing() {
+        let a = Arg::from("-f 'some flag'");
+        assert_eq!(a.name, "f");
+        assert_eq!(a.short.unwrap(), 'f');
+        assert!(a.long.is_none());
+        assert_eq!(a.help.unwrap(), "some flag");
+        assert!(!a.is_set(ArgSettings::MultipleOccurrences));
+        assert!(a.val_names.is_none());
+        assert!(a.num_vals.is_none());
     }
 }

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -32,8 +32,6 @@ bitflags! {
 pub struct ArgFlags(Flags);
 
 impl ArgFlags {
-    pub fn new() -> Self { ArgFlags::default() }
-
     // @TODO @p6 @internal: Reorder alphabetically
     impl_settings! {ArgSettings,
         Required => Flags::REQUIRED,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,13 +1,13 @@
 #[macro_use]
 mod macros;
 
-pub mod app;
-pub mod arg;
+pub(crate) mod app;
+pub(crate) mod arg;
 
 mod arg_group;
 mod usage_parser;
 
-pub use self::app::{App, AppFlags, AppSettings, Propagation};
+pub use self::app::{App, AppSettings, Propagation};
 pub use self::arg::{Arg, ArgFlags, ArgSettings};
 pub use self::arg_group::ArgGroup;
 pub use self::usage_parser::UsageParser;

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -4,20 +4,20 @@ use std::ffi::{OsStr, OsString};
 type Id = u64;
 
 #[derive(PartialEq, Debug, Clone)]
-pub struct Key {
-    pub key: KeyType,
-    pub index: usize,
+pub(crate) struct Key {
+    pub(crate) key: KeyType,
+    pub(crate) index: usize,
 }
 
 #[derive(Default, PartialEq, Debug, Clone)]
-pub struct MKeyMap<'b> {
-    pub keys: Vec<Key>,
-    pub args: Vec<Arg<'b>>,
+pub(crate) struct MKeyMap<'b> {
+    pub(crate) keys: Vec<Key>,
+    pub(crate) args: Vec<Arg<'b>>,
     built: bool, // mutation isn't possible after being built
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub enum KeyType {
+pub(crate) enum KeyType {
     Short(char),
     Long(OsString),
     Position(u64),
@@ -51,21 +51,9 @@ impl PartialEq<char> for KeyType {
 }
 
 impl<'b> MKeyMap<'b> {
-    pub fn new() -> Self { MKeyMap::default() }
-    //TODO ::from(x), ::with_capacity(n) etc
-    //? set theory ops?
+    pub(crate) fn contains_short(&self, c: char) -> bool { self.keys.iter().any(|x| x.key == c) }
 
-    pub fn contains_long(&self, l: &str) -> bool { self.keys.iter().any(|x| x.key == l) }
-
-    pub fn contains_short(&self, c: char) -> bool { self.keys.iter().any(|x| x.key == c) }
-
-    pub fn insert(&mut self, key: KeyType, value: Arg<'b>) -> usize {
-        let index = self.push(value);
-        self.keys.push(Key { key, index });
-        index
-    }
-
-    pub fn push(&mut self, value: Arg<'b>) -> usize {
+    pub(crate) fn push(&mut self, value: Arg<'b>) -> usize {
         if self.built {
             panic!("Cannot add Args to the map after the map is built");
         }
@@ -77,7 +65,7 @@ impl<'b> MKeyMap<'b> {
     }
     //TODO ::push_many([x, y])
 
-    pub fn insert_key(&mut self, key: KeyType, index: usize) {
+    pub(crate) fn insert_key(&mut self, key: KeyType, index: usize) {
         if index >= self.args.len() {
             panic!("Index out of bounds");
         }
@@ -88,7 +76,7 @@ impl<'b> MKeyMap<'b> {
 
     // ! Arg mutation functionality
 
-    pub fn get(&self, key: &KeyType) -> Option<&Arg<'b>> {
+    pub(crate) fn get(&self, key: &KeyType) -> Option<&Arg<'b>> {
         for k in &self.keys {
             if &k.key == key {
                 return Some(&self.args[k.index]);
@@ -98,38 +86,9 @@ impl<'b> MKeyMap<'b> {
     }
     //TODO ::get_first([KeyA, KeyB])
 
-    pub fn get_mut(&mut self, key: &KeyType) -> Option<&mut Arg<'b>> {
-        for k in &self.keys {
-            if &k.key == key {
-                return self.args.get_mut(k.index);
-            }
-        }
-        None
-    }
+    pub(crate) fn is_empty(&self) -> bool { self.keys.is_empty() && self.args.is_empty() }
 
-    pub fn is_empty(&self) -> bool { self.keys.is_empty() && self.args.is_empty() }
-
-    pub fn remove_key(&mut self, key: &KeyType) {
-        let mut idx = None;
-        for (i, k) in self.keys.iter().enumerate() {
-            if &k.key == key {
-                idx = Some(i);
-                break;
-            }
-        }
-        if let Some(idx) = idx {
-            self.keys.swap_remove(idx);
-        }
-    }
-    //TODO ::remove_keys([KeyA, KeyB])
-
-    pub fn insert_key_by_name(&mut self, key: KeyType, name: &str) {
-        let index = self.find_by_name(name);
-
-        self.keys.push(Key { key, index });
-    }
-
-    pub fn _build(&mut self) {
+    pub(crate) fn _build(&mut self) {
         self.built = true;
 
         for (i, arg) in self.args.iter_mut().enumerate() {
@@ -139,69 +98,12 @@ impl<'b> MKeyMap<'b> {
         }
     }
 
-    pub fn make_entries_by_index(&mut self, index: usize) {
-        let short;
-        let positional;
-        let mut longs: Vec<_>;
-
-        {
-            let arg = &self.args[index];
-            short = arg.short.map(KeyType::Short);
-            positional = arg.index.map(KeyType::Position);
-
-            longs = arg
-                .aliases
-                .clone()
-                .map(|v| {
-                    v.iter()
-                        .map(|(n, _)| KeyType::Long(OsString::from(n)))
-                        .collect()
-                })
-                .unwrap_or_default();
-            longs.extend(arg.long.map(|l| KeyType::Long(OsString::from(l))));
-        }
-
-        if let Some(s) = short {
-            self.insert_key(s, index)
-        }
-        if let Some(p) = positional {
-            self.insert_key(p, index)
-        }
-    }
-
-    pub fn find_by_name(&mut self, name: &str) -> usize {
-        self.args
-            .iter()
-            .position(|x| x.name == name)
-            .expect("No such name found")
-    }
-
-    pub fn remove(&mut self, key: &KeyType) -> Option<Arg<'b>> {
-        if self.built {
-            panic!("Cannot remove args after being built");
-        }
-        let mut idx = None;
-        for k in self.keys.iter() {
-            if &k.key == key {
-                idx = Some(k.index);
-                break;
-            }
-        }
-        if let Some(idx) = idx {
-            let arg = self.args.swap_remove(idx);
-            for key in _get_keys(&arg) {
-                self.remove_key(&key);
-            }
-            return Some(arg);
-        }
-        None
-    }
 
     //TODO ::remove_many([KeyA, KeyB])
     //? probably shouldn't add a possibility for removal?
     //? or remove by replacement by some dummy object, so the order is preserved
 
-    pub fn remove_by_name(&mut self, _name: Id) -> Option<Arg<'b>> {
+    pub(crate) fn remove_by_name(&mut self, _name: Id) -> Option<Arg<'b>> {
         if self.built {
             panic!("Cannot remove args after being built");
         }
@@ -249,9 +151,17 @@ mod tests {
     use self::KeyType::*;
     use super::*;
 
+    impl<'b> MKeyMap<'b> {
+        fn insert(&mut self, key: KeyType, value: Arg<'b>) -> usize {
+            let index = self.push(value);
+            self.insert_key(key, index);
+            index
+        }
+    }
+
     #[test]
     fn get_some_value() {
-        let mut map: MKeyMap = MKeyMap::new();
+        let mut map: MKeyMap = MKeyMap::default();
 
         map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
 
@@ -263,7 +173,7 @@ mod tests {
 
     #[test]
     fn get_none_value() {
-        let mut map: MKeyMap = MKeyMap::new();
+        let mut map: MKeyMap = MKeyMap::default();
 
         map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
         map.get(&Long(OsString::from("Two")));
@@ -273,7 +183,7 @@ mod tests {
 
     //    #[test]
     //    fn insert_delete_value() {
-    //        let mut map = MKeyMap::new();
+    //        let mut map = MKeyMap::default();
     //        map.insert("One", clap::Arg::with_name("Value1"));
     //        assert_eq!(map.remove("One"), Some(clap::Arg::with_name("Value1")));
     //        assert!(map.is_empty());
@@ -281,7 +191,7 @@ mod tests {
 
     #[test]
     fn insert_duplicate_key() {
-        let mut map: MKeyMap = MKeyMap::new();
+        let mut map: MKeyMap = MKeyMap::default();
 
         map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
 
@@ -294,7 +204,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn insert_duplicate_value() {
-        let mut map: MKeyMap = MKeyMap::new();
+        let mut map: MKeyMap = MKeyMap::default();
 
         map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
 
@@ -311,7 +221,7 @@ mod tests {
 
     //    #[test]
     //    fn insert_delete_none() {
-    //        let mut map = MKeyMap::new();
+    //        let mut map = MKeyMap::default();
     //        map.insert("One", clap::Arg::with_name("Value1"));
     //        assert_eq!(map.remove("Two"), None);
     //        assert!(!map.is_empty());
@@ -320,7 +230,7 @@ mod tests {
 
     #[test]
     fn insert_multiple_keys() {
-        let mut map: MKeyMap = MKeyMap::new();
+        let mut map: MKeyMap = MKeyMap::default();
         let index = map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
 
         map.insert_key(Long(OsString::from("Two")), index);
@@ -334,7 +244,7 @@ mod tests {
 
     // #[test]
     // fn insert_by_name() {
-    //     let mut map: MKeyMap<Arg> = MKeyMap::new();
+    //     let mut map: MKeyMap<Arg> = MKeyMap::default();
     //     let index = map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
 
     //     map.insert_key_by_name(Long(OsString::from("Two")), "Value1");
@@ -346,9 +256,10 @@ mod tests {
     //     assert_eq!(map.values.len(), 1);
     // }
 
+    /*
     #[test]
     fn get_mutable() {
-        let mut map: MKeyMap = MKeyMap::new();
+        let mut map: MKeyMap = MKeyMap::default();
 
         map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
 
@@ -357,10 +268,12 @@ mod tests {
             Some(&mut Arg::with_name("Value1"))
         );
     }
+    */
 
+    /*
     #[test]
     fn remove_key() {
-        let mut map: MKeyMap = MKeyMap::new();
+        let mut map: MKeyMap = MKeyMap::default();
         let index = map.insert(Long(OsString::from("One")), Arg::with_name("Value1"));
 
         map.insert_key(Long(OsString::from("Two")), index);
@@ -369,4 +282,5 @@ mod tests {
         assert_eq!(map.keys.len(), 1);
         assert_eq!(map.args.len(), 1);
     }
+    */
 }

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -736,8 +736,8 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
         let mut ord_m = VecMap::new();
         for sc in subcommands!(app).filter(|s| !s.is_set(AppSettings::Hidden)) {
             let btm = ord_m.entry(sc.disp_ord).or_insert(BTreeMap::new());
-            self.longest = cmp::max(self.longest, str_width(sc.name.as_str()));
-            btm.insert(sc.name.clone(), sc.clone());
+            self.longest = cmp::max(self.longest, str_width(&sc.name));
+            btm.insert(&sc.name, sc);
         }
 
         let mut first = true;

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -1,7 +1,7 @@
 extern crate clap;
 extern crate regex;
 
-use clap::{App, AppSettings, Arg, ErrorKind, Propagation};
+use clap::{App, AppSettings, Arg, ErrorKind};
 
 include!("../clap-test.rs");
 
@@ -80,16 +80,6 @@ fn sub_command_negate_required() {
         .arg(Arg::with_name("test").required(true).index(1))
         .subcommand(App::new("sub1"))
         .get_matches_from(vec!["myprog", "sub1"]);
-}
-
-#[test]
-fn global_version() {
-    let mut app = App::new("global_version")
-        .setting(AppSettings::GlobalVersion)
-        .version("1.1")
-        .subcommand(App::new("sub1"));
-    app._propagate(Propagation::NextLevel);
-    assert_eq!(app.subcommands[0].version, Some("1.1"));
 }
 
 #[test]
@@ -280,44 +270,6 @@ fn skip_possible_values() {
 }
 
 #[test]
-fn global_setting() {
-    let mut app = App::new("test")
-        .global_setting(AppSettings::ColoredHelp)
-        .subcommand(App::new("subcmd"));
-    app._propagate(Propagation::NextLevel);
-    assert!(app
-        .subcommands
-        .iter()
-        .filter(|s| s.name == "subcmd")
-        .next()
-        .unwrap()
-        .is_set(AppSettings::ColoredHelp));
-}
-
-#[test]
-fn global_settings() {
-    let mut app = App::new("test")
-        .global_setting(AppSettings::ColoredHelp)
-        .global_setting(AppSettings::TrailingVarArg)
-        .subcommand(App::new("subcmd"));
-    app._propagate(Propagation::NextLevel);
-    assert!(app
-        .subcommands
-        .iter()
-        .filter(|s| s.name == "subcmd")
-        .next()
-        .unwrap()
-        .is_set(AppSettings::ColoredHelp));
-    assert!(app
-        .subcommands
-        .iter()
-        .filter(|s| s.name == "subcmd")
-        .next()
-        .unwrap()
-        .is_set(AppSettings::TrailingVarArg));
-}
-
-#[test]
 fn stop_delim_values_only_pos_follows() {
     let r = App::new("onlypos")
         .setting(AppSettings::DontDelimitTrailingValues)
@@ -499,24 +451,6 @@ fn unset_setting() {
 
     let m = m.unset_setting(AppSettings::AllArgsOverrideSelf);
     assert!(!m.is_set(AppSettings::AllArgsOverrideSelf));
-}
-
-#[test]
-fn unset_settings() {
-    let m = App::new("unset_settings");
-    assert!(&m.is_set(AppSettings::AllowInvalidUtf8));
-    assert!(&m.is_set(AppSettings::ColorAuto));
-
-    let m = m
-        .unset_setting(AppSettings::AllowInvalidUtf8)
-        .unset_setting(AppSettings::ColorAuto);
-    assert!(
-        !m.is_set(AppSettings::AllowInvalidUtf8),
-        "l: {:?}\ng:{:?}",
-        m.settings,
-        m.g_settings
-    );
-    assert!(!m.is_set(AppSettings::ColorAuto));
 }
 
 #[test]

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -1,6 +1,6 @@
 extern crate clap;
 
-use clap::{App, Arg, ArgSettings};
+use clap::{App, Arg};
 
 #[test]
 fn flag_using_short() {
@@ -111,28 +111,4 @@ fn multiple_flags_in_single() {
     assert!(m.is_present("flag"));
     assert!(m.is_present("color"));
     assert!(m.is_present("debug"));
-}
-
-#[test]
-fn short_flag_misspel() {
-    let a = Arg::from("-f1, --flag 'some flag'");
-    assert_eq!(a.name, "flag");
-    assert_eq!(a.short.unwrap(), 'f');
-    assert_eq!(a.long.unwrap(), "flag");
-    assert_eq!(a.help.unwrap(), "some flag");
-    assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-    assert!(a.val_names.is_none());
-    assert!(a.num_vals.is_none());
-}
-
-#[test]
-fn short_flag_name_missing() {
-    let a = Arg::from("-f 'some flag'");
-    assert_eq!(a.name, "f");
-    assert_eq!(a.short.unwrap(), 'f');
-    assert!(a.long.is_none());
-    assert_eq!(a.help.unwrap(), "some flag");
-    assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-    assert!(a.val_names.is_none());
-    assert!(a.num_vals.is_none());
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -68,7 +68,7 @@ fn quoted_app_name() {
             (@arg scpositional: index(1) "tests positionals"))
     );
 
-    assert_eq!(app.name, "app name with spaces-and-hyphens");
+    assert_eq!(app.get_name(), "app name with spaces-and-hyphens");
 
     let mut help_text = vec![];
     app.write_help(&mut help_text)


### PR DESCRIPTION
The `App` and `Arg` fields were public (but #[doc(hidden)]) in order
to support tests that access those fields. This patch makes those fields
private, and moves the tests into those files so they can still access
those fields.

This resulted in a number of methods not being accessible anymore in
MKeyMap, so they were removed.

In addition, this removes some unnecessary clones in output::help.