### PR TITLE
[RFC/WIP] fix missing optional values (v3-compatible version; feature?)

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -105,6 +105,8 @@ pub struct Arg<'help> {
     #[doc(hidden)]
     pub default_vals_ifs: Option<VecMap<(Id, Option<&'help OsStr>, &'help OsStr)>>,
     #[doc(hidden)]
+    pub default_missing_value: Option<&'help OsStr>,
+    #[doc(hidden)]
     pub env: Option<(&'help OsStr, Option<OsString>)>,
     #[doc(hidden)]
     pub terminator: Option<&'help str>,
@@ -207,6 +209,7 @@ impl<'help> Arg<'help> {
                 "default_value" => yaml_to_str!(a, v, default_value),
                 "default_value_if" => yaml_tuple3!(a, v, default_value_if),
                 "default_value_ifs" => yaml_tuple3!(a, v, default_value_if),
+                "default_missing_value" => yaml_to_str!(a, v, default_missing_value),
                 "env" => yaml_to_str!(a, v, env),
                 "value_names" => yaml_vec_or_str!(v, a, value_name),
                 "groups" => yaml_vec_or_str!(v, a, group),
@@ -2267,6 +2270,16 @@ impl<'help> Arg<'help> {
         self.default_value_os(OsStr::from_bytes(val.as_bytes()))
     }
 
+    /// ... docs ...
+    pub fn default_missing_value(self, val: &'help str) -> Self {
+        self.default_missing_value_os(OsStr::from_bytes(val.as_bytes()))
+    }
+    /// ... docs ...
+    pub fn default_missing_value_os(mut self, val: &'help OsStr) -> Self {
+        self.default_missing_value = Some(val);
+        self
+    }
+
     /// Provides a default value in the exact same manner as [`Arg::default_value`]
     /// only using [`OsStr`]s instead.
     /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value
@@ -4199,6 +4212,7 @@ impl<'help> fmt::Debug for Arg<'help> {
              max_values: {:?}, min_values: {:?}, value_delimiter: {:?}, default_value_ifs: {:?}, \
              value_terminator: {:?}, display_order: {:?}, env: {:?}, unified_ord: {:?}, \
              default_value: {:?}, validator: {}, validator_os: {} \
+             default_missing_value: {:?}, \
              }}",
             self.id,
             self.name,
@@ -4228,7 +4242,8 @@ impl<'help> fmt::Debug for Arg<'help> {
             self.unified_ord,
             self.default_val,
             self.validator.as_ref().map_or("None", |_| "Some(Fn)"),
-            self.validator_os.as_ref().map_or("None", |_| "Some(Fn)")
+            self.validator_os.as_ref().map_or("None", |_| "Some(Fn)"),
+            self.default_missing_value
         )
     }
 }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1181,6 +1181,15 @@ where
             ));
         } else {
             sdebugln!("None");
+            if needs_eq && min_vals_zero {
+                // OPTION with missing optional value?
+                let default_missing_value = opt.default_missing_value;
+                debugln!("default_missing_value = {:?}", default_missing_value);
+                if let Some(ref value) = default_missing_value {
+                    debugln!("setting value from default_missing_value = {:?}", value);
+                    self.add_val_to_arg(opt, value, matcher)?;
+                };
+            }
         }
 
         matcher.inc_occurrence_of(opt.id);


### PR DESCRIPTION
v3-compatible version of #1468.

> RFC/WIP ~ this PR is a quick proof-of-concept, inviting commentary before being updated and fleshed out (documentation, tests, etc).
>
> For an OPTION taking optional values (ie, .min_values(0).require_equals(true)), currently any time that option is encountered multiple times, occurs is incremented, but no entry is made into the indices and vals arrays for options with no/missing value. "None" would seem like a good entry but the vals array contains just that, values, not Options, so that would break compatibility without any great upside. However, adding a default for missing values can be done without breaking anything else...
>
> This PR adds support to supply a value for the "None"/missing-value case (eg, for "--OPTION") via a default_missing_value() method. Notably, the supplied value to default_missing_value() may differ from the OPTION's default_value().

`clap` (v3) compiles and tests without error after this patch, but there is no specific testing of the feature as of yet (WIP).

I'm happy to put some more effort towards this (adding tests, documentation, etc) if it is a desired feature addition.