### PR TITLE
add App::help_subcommand_about() (close #1512)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -510,6 +510,26 @@ impl<'a, 'b> App<'a, 'b> {
         self
     }
 
+    /// Sets the about text for the auto-generated `help` subcommand.
+    ///
+    /// By default `clap` sets this to `"Prints this message or the help of the given subcommand(s)"`, but if you're using a
+    /// different convention for your help messages and would prefer a different phrasing you can
+    /// override it.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .about_subcommand_help("Print this message or the help of the given subcommand(s)") // Perhaps you want imperative help messages
+    ///
+    /// # ;
+    /// ```
+    pub fn about_subcommand_help<S: Into<&'a str>>(mut self, s: S) -> Self {
+        self.p.about_subcommand_help = Some(s.into());
+        self
+    }
+
     /// Sets the help text for the auto-generated `version` argument.
     ///
     /// By default `clap` sets this to `"Prints version information"`, but if you're using a
@@ -1677,6 +1697,7 @@ impl<'a> From<&'a Yaml> for App<'a, 'a> {
         yaml_str!(a, yaml, help_short);
         yaml_str!(a, yaml, version_short);
         yaml_str!(a, yaml, help_message);
+        yaml_str!(a, yaml, about_subcommand_help);
         yaml_str!(a, yaml, version_message);
         yaml_str!(a, yaml, alias);
         yaml_str!(a, yaml, visible_alias);

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -70,6 +70,7 @@ where
     cache: Option<&'a str>,
     pub help_message: Option<&'a str>,
     pub version_message: Option<&'a str>,
+    pub about_subcommand_help: Option<&'a str>,
     cur_idx: Cell<usize>,
 }
 
@@ -1464,7 +1465,7 @@ where
             debugln!("Parser::create_help_and_version: Building help");
             self.subcommands.push(
                 App::new("help")
-                    .about("Prints this message or the help of the given subcommand(s)"),
+                    .about(self.about_subcommand_help.unwrap_or("Prints this message or the help of the given subcommand(s)")),
             );
         }
     }

--- a/tests/app.yml
+++ b/tests/app.yml
@@ -5,6 +5,7 @@ author: Kevin K. <kbknapp@gmail.com>
 settings:
     - ArgRequiredElseHelp
 help_message: prints help with a nonstandard description
+about_subcommand_help: prints this help or help for sucommand(s) with a nonstandard description
 args:
     - opt:
         short: o

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -346,11 +346,15 @@ Nobody <odysseus@example.com>
 You can customize the version and help text
 
 USAGE:
-    customize
+    customize [SUBCOMMAND]
 
 FLAGS:
     -H, --help       Print help information
-    -v, --version    Print version information";
+    -v, --version    Print version information
+
+SUBCOMMANDS:
+    help      Print this message or the help of the given subcommand(s)
+    subcmd    tests subcommands";
 
 static LAST_ARG: &'static str = "last 0.1
 
@@ -980,8 +984,10 @@ fn customize_version_and_help() {
         .about("You can customize the version and help text")
         .help_short("H")
         .help_message("Print help information")
+        .about_subcommand_help("Print this message or the help of the given subcommand(s)")
         .version_short("v")
-        .version_message("Print version information");
+        .version_message("Print version information")
+        .subcommand(SubCommand::with_name("subcmd").about("tests subcommands"));
     assert!(test::compare_output(app, "customize --help", CUSTOM_VERSION_AND_HELP, false));
 }
 

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -26,6 +26,20 @@ fn help_message() {
 }
 
 #[test]
+fn about_subcommand_help() {
+    let yml = load_yaml!("app.yml");
+    let mut app = App::from_yaml(yml);
+    // Generate the full help message!
+    let _ = app.get_matches_from_safe_borrow(Vec::<String>::new());
+
+    let mut help_buffer = Vec::new();
+    app.write_help(&mut help_buffer).unwrap();
+    let help_string = String::from_utf8(help_buffer).unwrap();
+    assert!(help_string.contains("SUBCOMMANDS:
+    help      prints this help or help for sucommand(s) with a nonstandard description"));
+}
+
+#[test]
 fn author() {
     let yml = load_yaml!("app.yml");
     let mut app = App::from_yaml(yml);


### PR DESCRIPTION
I chose to name this method `help_subcommand_about()`, but I'm open to suggestions of better names.