### PR TITLE
use std::sync::Once:new() rather than ONCE_INIT.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -456,7 +456,7 @@ macro_rules! crate_version {
 macro_rules! crate_authors {
     ($sep:expr) => {{
         use std::ops::Deref;
-        use std::sync::{ONCE_INIT, Once};
+        use std::sync::Once;
 
         #[allow(missing_copy_implementations)]
         #[allow(dead_code)]
@@ -467,7 +467,7 @@ macro_rules! crate_authors {
 
             #[allow(unsafe_code)]
             fn deref(&self) -> &'static str {
-                static ONCE: Once = ONCE_INIT;
+                static ONCE: Once = Once::new();
                 static mut VALUE: *const String = 0 as *const String;
 
                 unsafe {


### PR DESCRIPTION
ONCE_INIT is effectively an alias of Once::new(), but will be [depriciated as of rust 1.38.0](https://github.com/rust-lang/rust/blob/master/src/libstd/sync/once.rs#L118).

Once::new() has been [stable since 1.2.0](https://github.com/rust-lang/rust/blob/master/src/libstd/sync/once.rs#L152), well before the current stated release version in the README of 1.30.0.

This change will silence the warnings in nightly builds when using crate_authors!().