### PR TITLE
use std::sync::Once::new() rather than ONCE_INIT

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -459,7 +459,7 @@ macro_rules! crate_version {
 macro_rules! crate_authors {
     ($sep:expr) => {{
         use std::ops::Deref;
-        use std::sync::{Once, ONCE_INIT};
+        use std::sync::Once;
 
         #[allow(missing_copy_implementations)]
         #[allow(dead_code)]
@@ -472,7 +472,7 @@ macro_rules! crate_authors {
 
             #[allow(unsafe_code)]
             fn deref(&self) -> &'static str {
-                static ONCE: Once = ONCE_INIT;
+                static ONCE: Once = Once::new();
                 static mut VALUE: *const String = 0 as *const String;
 
                 unsafe {


### PR DESCRIPTION
ONCE_INIT is effectively an alias of Once::new(), but will be depriciated as of rust 1.38.0. 

Once::new() has been stable since 1.2.0, well before the current staetd release version in the README of 1.30.0.

This change silences the warnings in nightly builds when using crate_authors!().

Updated to v3-master per discussion on #1521