### PR TITLE
Rename assert_cli to assert_cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ covering this specific target.
 There are several excellent crates which can be used with `clap`, I recommend checking them all out! If you've got a crate that would be a good fit to be used with `clap` open an issue and let me know, I'd love to add it!
 
 * [`structopt`](https://github.com/TeXitoi/structopt) - This crate allows you to define a struct, and build a CLI from it! No more "stringly typed" and it uses `clap` behind the scenes! (*Note*: There is work underway to pull this crate into mainline `clap`).
-* [`assert_cli`](https://github.com/assert-rs/assert_cli) - This crate allows you test your CLIs in a very intuitive and functional way!
+* [`assert_cmd`](https://github.com/assert-rs/assert_cmd) - This crate allows you test your CLIs in a very intuitive and functional way!
 
 ## Recent Breaking Changes
 


### PR DESCRIPTION
`assert_cli` [is deprecated](https://github.com/assert-rs/assert_cli). This PR adds a link to `assert_cmd`, which is it's successor.