### PR TITLE
[WIP] Add Windows ANSI coloring

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,6 +16,7 @@ use std::rc::Rc;
 use std::result::Result as StdResult;
 
 // Third Party
+use ansi_term;
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
 
@@ -78,6 +79,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// # ;
     /// ```
     pub fn new<S: Into<String>>(n: S) -> Self {
+        ansi_term::enable_ansi_support();
         App {
             p: Parser::with_name(n.into()),
         }

--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -87,7 +87,7 @@ where
     }
 
     pub fn help_short(&mut self, s: &str) {
-        let c = s.trim_left_matches(|c| c == '-')
+        let c = s.trim_start_matches(|c| c == '-')
             .chars()
             .nth(0)
             .unwrap_or('h');
@@ -95,7 +95,7 @@ where
     }
 
     pub fn version_short(&mut self, s: &str) {
-        let c = s.trim_left_matches(|c| c == '-')
+        let c = s.trim_start_matches(|c| c == '-')
             .chars()
             .nth(0)
             .unwrap_or('V');

--- a/src/args/arg.rs
+++ b/src/args/arg.rs
@@ -329,7 +329,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// ```
     /// [`short`]: ./struct.Arg.html#method.short
     pub fn short<S: AsRef<str>>(mut self, s: S) -> Self {
-        self.s.short = s.as_ref().trim_left_matches(|c| c == '-').chars().nth(0);
+        self.s.short = s.as_ref().trim_start_matches(|c| c == '-').chars().nth(0);
         self
     }
 
@@ -369,7 +369,7 @@ impl<'a, 'b> Arg<'a, 'b> {
     /// assert!(m.is_present("cfg"));
     /// ```
     pub fn long(mut self, l: &'b str) -> Self {
-        self.s.long = Some(l.trim_left_matches(|c| c == '-'));
+        self.s.long = Some(l.trim_start_matches(|c| c == '-'));
         self
     }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,7 +1,7 @@
-#[cfg(all(feature = "color", not(target_os = "windows")))]
+#[cfg(feature = "color")]
 use ansi_term::ANSIString;
 
-#[cfg(all(feature = "color", not(target_os = "windows")))]
+#[cfg(feature = "color")]
 use ansi_term::Colour::{Green, Red, Yellow};
 
 #[cfg(feature = "color")]
@@ -127,7 +127,7 @@ pub enum Format<T> {
     None(T),
 }
 
-#[cfg(all(feature = "color", not(target_os = "windows")))]
+#[cfg(feature = "color")]
 impl<T: AsRef<str>> Format<T> {
     fn format(&self) -> ANSIString {
         match *self {
@@ -139,31 +139,31 @@ impl<T: AsRef<str>> Format<T> {
     }
 }
 
-#[cfg(any(not(feature = "color"), target_os = "windows"))]
-#[cfg_attr(feature = "lints", allow(match_same_arms))]
-impl<T: fmt::Display> Format<T> {
-    fn format(&self) -> &T {
-        match *self {
-            Format::Error(ref e) => e,
-            Format::Warning(ref e) => e,
-            Format::Good(ref e) => e,
-            Format::None(ref e) => e,
-        }
-    }
-}
+// #[cfg(any(not(feature = "color"), target_os = "windows"))]
+// #[cfg_attr(feature = "lints", allow(match_same_arms))]
+// impl<T: fmt::Display> Format<T> {
+//     fn format(&self) -> &T {
+//         match *self {
+//             Format::Error(ref e) => e,
+//             Format::Warning(ref e) => e,
+//             Format::Good(ref e) => e,
+//             Format::None(ref e) => e,
+//         }
+//     }
+// }
 
 
-#[cfg(all(feature = "color", not(target_os = "windows")))]
+#[cfg(feature = "color")]
 impl<T: AsRef<str>> fmt::Display for Format<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", &self.format()) }
 }
 
-#[cfg(any(not(feature = "color"), target_os = "windows"))]
-impl<T: fmt::Display> fmt::Display for Format<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", &self.format()) }
-}
+// #[cfg(any(not(feature = "color"), target_os = "windows"))]
+// impl<T: fmt::Display> fmt::Display for Format<T> {
+//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", &self.format()) }
+// }
 
-#[cfg(all(test, feature = "color", not(target_os = "windows")))]
+#[cfg(all(test, feature = "color"))]
 mod test {
     use ansi_term::ANSIString;
     use ansi_term::Colour::{Green, Red, Yellow};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@
 #![cfg_attr(feature = "lints", allow(doc_markdown))]
 #![cfg_attr(feature = "lints", allow(explicit_iter_loop))]
 
-#[cfg(all(feature = "color", not(target_os = "windows")))]
+#[cfg(feature = "color")]
 extern crate ansi_term;
 #[cfg(feature = "color")]
 extern crate atty;


### PR DESCRIPTION
This PR adds support for Windows ANSI to `clap`. This is done by calling `enable_ansi_support()` during the creation of an `App` instance.

The PR is blocked by ogham/rust-ansi-term#55, as I had to add a no-op function for other platforms beside Windows to the crate. Additionally, ogham/rust-ansi-term#55 fixes the Windows compilation problem that occured some time ago.

After the merge landed on ogham/rust-ansi-term#55, I'll clean up the rest of the code (removing the commented out parts), squash my commits and push to upstream again.

Closes #836. This needs more elaboration as I do not know to what extend you guys want to refactor the coloring code. Is this PR enough? If not, I would love to get more details and implement the feature :smile: