### PR TITLE
Supprt macro helper attributes in arg_enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ regex = "1"
 lazy_static = "1.3"
 version-sync = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [features]
 default     = ["suggestions", "color", "vec_map"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ ansi_term = { version = "0.11",  optional = true }
 regex = "1"
 lazy_static = "1.3"
 version-sync = "0.8"
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default     = ["suggestions", "color", "vec_map"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -345,63 +345,43 @@ macro_rules! arg_enum {
             }
         });
     };
-    ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+    // The following matches only when the last enum variant has no trailing comma
+    ($(#[$($m:meta),+])* pub enum $e:ident { $($(#[$($helper_m:meta),+])* $v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
-            ($(#[$($m),+])+
+            ($(#[$($m),+])*
             pub enum $e {
-                $($v$(=$val)*),+
+                $($(#[$($helper_m),+])*
+                $v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };
-    ($(#[$($m:meta),+])+ pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
+    // The following matches also when the last enum variant has a trailing comma
+    ($(#[$($m:meta),+])* pub enum $e:ident { $($(#[$($helper_m:meta),+])* $v:ident $(=$val:expr)*,)+ } ) => {
         arg_enum!(@impls
-            ($(#[$($m),+])+
+            ($(#[$($m),+])*
             pub enum $e {
-                $($v$(=$val)*),+
+                $($(#[$($helper_m),+])*
+                $v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };
-    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+    // The following matches only when the last enum variant has no trailing comma
+    ($(#[$($m:meta),+])* enum $e:ident { $($(#[$($helper_m:meta),+])* $v:ident $(=$val:expr)*),+ } ) => {
         arg_enum!(@impls
-            ($(#[$($m),+])+
-             enum $e {
-                 $($v$(=$val)*),+
-             }) -> ($e, $($v),+)
-        );
-    };
-    ($(#[$($m:meta),+])+ enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
-        arg_enum!(@impls
-            ($(#[$($m),+])+
-            enum $e {
-                $($v$(=$val)*),+
+            ($(#[$($m),+])*
+            pub enum $e {
+                $($(#[$($helper_m),+])*
+                $v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };
-    (pub enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
+    // The following matches also when the last enum variant has a trailing comma
+    ($(#[$($m:meta),+])* enum $e:ident { $($(#[$($helper_m:meta),+])* $v:ident $(=$val:expr)*,)+ } ) => {
         arg_enum!(@impls
-            (pub enum $e {
-                $($v$(=$val)*),+
-            }) -> ($e, $($v),+)
-        );
-    };
-    (pub enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
-        arg_enum!(@impls
-            (pub enum $e {
-                $($v$(=$val)*),+
-            }) -> ($e, $($v),+)
-        );
-    };
-    (enum $e:ident { $($v:ident $(=$val:expr)*,)+ } ) => {
-        arg_enum!(@impls
-            (enum $e {
-                $($v$(=$val)*),+
-            }) -> ($e, $($v),+)
-        );
-    };
-    (enum $e:ident { $($v:ident $(=$val:expr)*),+ } ) => {
-        arg_enum!(@impls
-            (enum $e {
-                $($v$(=$val)*),+
+            ($(#[$($m),+])*
+            pub enum $e {
+                $($(#[$($helper_m),+])*
+                $v$(=$val)*),+
             }) -> ($e, $($v),+)
         );
     };

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -388,4 +388,15 @@ fn arg_enum() {
             }
         }
     };
+    // meta YES, pub YES, trailing comma YES, multiple attributes
+    test_greek_meta! {
+        arg_enum!{
+            #[derive(Debug, PartialEq)]
+            #[derive(Copy, Clone)]
+            pub enum Greek {
+                Alpha,
+                Bravo,
+            }
+        }
+    };
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,10 @@
 #[macro_use]
 extern crate clap;
 extern crate regex;
+#[macro_use]
+extern crate serde;
 
+use serde::Serialize;
 use std::io::Write;
 use std::str;
 
@@ -218,6 +221,42 @@ arg_enum!{
         ValTwo
     }
 }
+// Test enums with derive macro helper attributes.
+// We use serde to test, as it is the most common dependency. We could also define our own test macro,
+// but we can't really use procedural macros from the same crate that define them, so we would have
+// to change the organization quite a bit.
+arg_enum!{
+    #[derive(Serialize)]
+    pub enum ValAttr1a {
+        #[serde(rename = "RenamedValOne")]
+        ValOne,
+        ValTwo
+    }
+}
+arg_enum!{
+    #[derive(Serialize)]
+    pub enum ValAttr1b {
+        ValOne,
+        #[serde(rename = "RenamedValTwo")]
+        ValTwo
+    }
+}
+arg_enum!{
+    #[derive(Serialize)]
+    enum ValAttr2a {
+        #[serde(rename = "RenamedValOne")]
+        ValOne,
+        ValTwo
+    }
+}
+arg_enum!{
+    #[derive(Serialize)]
+    enum ValAttr2b {
+        ValOne,
+        #[serde(rename = "RenamedValTwo")]
+        ValTwo
+    }
+}
 
 #[test]
 fn test_enums() {
@@ -264,26 +303,72 @@ fn test_enums() {
         Val4::ValOne => (),
         _ => panic!("Val1 didn't parse correctly"),
     }
+    // Helper attributes
+    let v1_lp = v1_lower.parse::<ValAttr1a>().unwrap();
+    let v1_cp = v1_camel.parse::<ValAttr1a>().unwrap();
+    match v1_lp {
+        ValAttr1a::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
+    match v1_cp {
+        ValAttr1a::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
+    let v1_lp = v1_lower.parse::<ValAttr1b>().unwrap();
+    let v1_cp = v1_camel.parse::<ValAttr1b>().unwrap();
+    match v1_lp {
+        ValAttr1b::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
+    match v1_cp {
+        ValAttr1b::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
+    let v1_lp = v1_lower.parse::<ValAttr2a>().unwrap();
+    let v1_cp = v1_camel.parse::<ValAttr2a>().unwrap();
+    match v1_lp {
+        ValAttr2a::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
+    match v1_cp {
+        ValAttr2a::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
+        let v1_lp = v1_lower.parse::<ValAttr2b>().unwrap();
+    let v1_cp = v1_camel.parse::<ValAttr2b>().unwrap();
+    match v1_lp {
+        ValAttr2b::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
+    match v1_cp {
+        ValAttr2b::ValOne => (),
+        _ => panic!("Val1 didn't parse correctly"),
+    }
 }
 
 #[test]
 fn create_app() {
-    let _ =
-        App::new("test").version("1.0").author("kevin").about("does awesome things").get_matches_from(vec![""]);
+    let _ = App::new("test")
+        .version("1.0")
+        .author("kevin")
+        .about("does awesome things")
+        .get_matches_from(vec![""]);
 }
 
 #[test]
 fn add_multiple_arg() {
     let _ = App::new("test")
-                .args(&[
-                    Arg::with_name("test").short("s"),
-                    Arg::with_name("test2").short("l")])
-                .get_matches_from(vec![""]);
+        .args(&[
+            Arg::with_name("test").short("s"),
+            Arg::with_name("test2").short("l"),
+        ])
+        .get_matches_from(vec![""]);
 }
 #[test]
 fn flag_x2_opt() {
-    check_complex_output("clap-test value -f -f -o some",
-"flag present 2 times
+    check_complex_output(
+        "clap-test value -f -f -o some",
+        "flag present 2 times
 option present 1 times with value: some
 An option: some
 positional present with value: value

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -225,32 +225,32 @@ arg_enum!{
 // We use serde to test, as it is the most common dependency. We could also define our own test macro,
 // but we can't really use procedural macros from the same crate that define them, so we would have
 // to change the organization quite a bit.
-arg_enum!{
-    #[derive(Serialize)]
+arg_enum! {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
     pub enum ValAttr1a {
         #[serde(rename = "RenamedValOne")]
         ValOne,
         ValTwo
     }
 }
-arg_enum!{
-    #[derive(Serialize)]
+arg_enum! {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
     pub enum ValAttr1b {
         ValOne,
         #[serde(rename = "RenamedValTwo")]
         ValTwo
     }
 }
-arg_enum!{
-    #[derive(Serialize)]
+arg_enum! {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
     enum ValAttr2a {
         #[serde(rename = "RenamedValOne")]
         ValOne,
         ValTwo
     }
 }
-arg_enum!{
-    #[derive(Serialize)]
+arg_enum! {
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
     enum ValAttr2b {
         ValOne,
         #[serde(rename = "RenamedValTwo")]
@@ -344,6 +344,31 @@ fn test_enums() {
         ValAttr2b::ValOne => (),
         _ => panic!("Val1 didn't parse correctly"),
     }
+}
+
+/// Tests that enums with derive macro helper attributes
+/// are parsed correctly.
+#[test]
+fn test_derive_macro_helper_attributes() {
+    let serialized = serde_json::to_string(&ValAttr1a::ValOne).unwrap();
+    assert_eq!("\"RenamedValOne\"", serialized);
+    let deserialized: ValAttr1a = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(ValAttr1a::ValOne, deserialized);
+
+    let serialized = serde_json::to_string(&ValAttr2a::ValOne).unwrap();
+    assert_eq!("\"RenamedValOne\"", serialized);
+    let deserialized: ValAttr2a = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(ValAttr2a::ValOne, deserialized);
+
+    let serialized = serde_json::to_string(&ValAttr1b::ValTwo).unwrap();
+    assert_eq!("\"RenamedValTwo\"", serialized);
+    let deserialized: ValAttr1b = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(ValAttr1b::ValTwo, deserialized);
+
+    let serialized = serde_json::to_string(&ValAttr2b::ValTwo).unwrap();
+    assert_eq!("\"RenamedValTwo\"", serialized);
+    let deserialized: ValAttr2b = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(ValAttr2b::ValTwo, deserialized);
 }
 
 #[test]


### PR DESCRIPTION
So that something like this is now possible:

```
arg_enum! {
    #[derive(Serialize, Deserialize, Debug, PartialEq)]
    enum ValAttr2b {
        ValOne,
        #[serde(rename = "RenamedValTwo")]
        ValTwo
    }
}
```
( Solves Issue #1451 )