### PR TITLE
chore: fix cache issue on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: true
 language: rust
-cache: cargo
+cache:
+  directories:
+    - $HOME/.cargo
+    - $HOME/.rustup
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
 rust:
   - nightly
   - nightly-2019-06-18


### PR DESCRIPTION
Some Travis builds are errored because of caches. `cache: cargo` can be the big cache size so I attempt to reduce it.