### PR TITLE
Fix opts variable name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ fn main() {
 
     // You can handle information about subcommands by requesting their matches by name
     // (as below), requesting just the name used, or both at the same time
-    match matches.subcmd {
+    match opts.subcmd {
         SubCommand::Test @ t => {
             if t.debug {
                 println!("Printing debug info...");


### PR DESCRIPTION
Just a little thing I noticed, the example should now be correct.