### PR TITLE
examples: Change flag arg to option arg

### DIFF
--- a/examples/04_using_matches.rs
+++ b/examples/04_using_matches.rs
@@ -30,7 +30,8 @@ fn main() {
             Arg::with_name("config")
                 .help("sets the config file to use")
                 .short('c')
-                .long("config"),
+                .long("config")
+		.takes_value(true),
         )
         .arg(
             Arg::with_name("input")


### PR DESCRIPTION
Comments in 04_using_matches.rs list the config arg
as an optional arg. However, -c --config is currently
a flag arg. This commit sets takes_value to true on
the config arg to make it an "option" argument.