### PR TITLE
adds Arg::default_values

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -454,16 +454,23 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
             spec_vals.push(env_info);
         }
         if !a.is_set(ArgSettings::HideDefaultValue) {
-            if let Some(pv) = a.default_val {
+            if let Some(ref pv) = a.default_vals {
                 debugln!("Help::spec_vals: Found default value...[{:?}]", pv);
-                spec_vals.push(format!(
-                    " [default: {}]",
-                    if self.color {
-                        self.cizer.good(pv.to_string_lossy())
-                    } else {
-                        Format::None(pv.to_string_lossy())
-                    }
-                ));
+
+                let pvs = if self.color {
+                    pv
+                        .iter()
+                        .map(|&pvs| format!("{}", self.cizer.good(pvs.to_string_lossy())))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                } else {
+                    pv
+                        .iter()
+                        .map(|&pvs| format!("{}", Format::None(pvs.to_string_lossy())))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                };
+                spec_vals.push(format!(" [default: {}]", pvs));
             }
         }
         if let Some(ref aliases) = a.aliases {

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1365,7 +1365,7 @@ where
         debugln!("Parser::add_defaults;");
         macro_rules! add_val {
             (@default $_self:ident, $a:ident, $m:ident) => {
-                if let Some(ref val) = $a.default_val {
+                if let Some(ref vals) = $a.default_vals {
                     debugln!("Parser::add_defaults:iter:{}: has default vals", $a.name);
                     if $m
                         .get($a.id)
@@ -1377,7 +1377,9 @@ where
                             "Parser::add_defaults:iter:{}: has no user defined vals",
                             $a.name
                         );
-                        $_self.add_val_to_arg($a, OsStr::new(val), $m)?;
+                        for val in vals {
+                            $_self.add_val_to_arg($a, val, $m)?;
+                        }
                     } else if $m.get($a.id).is_some() {
                         debugln!(
                             "Parser::add_defaults:iter:{}: has user defined vals",
@@ -1386,7 +1388,9 @@ where
                     } else {
                         debugln!("Parser::add_defaults:iter:{}: wasn't used", $a.name);
 
-                        $_self.add_val_to_arg($a, OsStr::new(val), $m)?;
+                        for val in vals {
+                            $_self.add_val_to_arg($a, val, $m)?;
+                        }
                     }
                 } else {
                     debugln!(

--- a/tests/default_vals.rs
+++ b/tests/default_vals.rs
@@ -448,6 +448,38 @@ fn conditional_reqs_pass() {
 }
 
 #[test]
+fn multiple_defaults() {
+    let r = App::new("diff")
+        .arg(
+            Arg::with_name("files")
+                .long("files")
+                .number_of_values(2)
+                .default_values(&["old", "new"]),
+        )
+        .try_get_matches_from(vec![""]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(m.is_present("files"));
+    assert_eq!(m.values_of_lossy("files").unwrap(), vec!["old", "new"]);
+}
+
+#[test]
+fn multiple_defaults_override() {
+    let r = App::new("diff")
+        .arg(
+            Arg::with_name("files")
+                .long("files")
+                .number_of_values(2)
+                .default_values(&["old", "new"]),
+        )
+        .try_get_matches_from(vec!["", "--files", "other", "mine"]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(m.is_present("files"));
+    assert_eq!(m.values_of_lossy("files").unwrap(), vec!["other", "mine"]);
+}
+
+#[test]
 fn issue_1050_num_vals_and_defaults() {
     let res = App::new("hello")
         .arg(


### PR DESCRIPTION
This will (someday) fix #1002 

I'm taking baby steps here. I have started by adding a `default_vals` field to `Arg`

Next steps:

- [x] Read and actually use the default values (remember to include a test)
- [x] Provide `default_values_os`
- [x] Special-case all `default_value` functions and remove `Arg::default_val` (singular)
