### PR TITLE
Upgraded ansi_term dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ term_size = { version = "1.0.0-beta1", optional = true }
 clap_derive = { git = "https://github.com/clap-rs/clap_derive", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-ansi_term = { version = "0.11.0",  optional = true }
+ansi_term = { version = "0.12.1", optional = true }
 
 [dev-dependencies]
 regex = "1.0"


### PR DESCRIPTION
This is the same as #1531 but done against the master branch.