### PR TITLE
Drop unnecessary `unsafe`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -470,19 +470,16 @@ macro_rules! crate_authors {
         impl Deref for CargoAuthors {
             type Target = str;
 
-            #[allow(unsafe_code)]
             fn deref(&self) -> &'static str {
                 static ONCE: Once = Once::new();
                 static mut VALUE: *const String = 0 as *const String;
 
-                unsafe {
-                    ONCE.call_once(|| {
-                        let s = env!("CARGO_PKG_AUTHORS").replace(':', $sep);
-                        VALUE = Box::into_raw(Box::new(s));
-                    });
+                ONCE.call_once(|| {
+                    let s = env!("CARGO_PKG_AUTHORS").replace(':', $sep);
+                    VALUE = Box::leak(s);
+                });
 
-                    &(*VALUE)[..]
-                }
+                &(*VALUE)[..]
             }
         }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -479,6 +479,9 @@ macro_rules! crate_authors {
                     self.authors.replace(Some(unwrapped_authors));
                     unwrapped_authors
                 } else {
+                    // This caches the result for subsequent invocations of the same instance of the macro
+                    // to avoid performing one memory allocation per call.
+                    // If performance ever becomes a problem for this code, it should be moved to build.rs
                     let s: Box<String> = Box::new(env!("CARGO_PKG_AUTHORS").replace(':', $sep));
                     let static_string = Box::leak(s);
                     self.authors.replace(Some(&*static_string));

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -459,7 +459,7 @@ macro_rules! crate_version {
 macro_rules! crate_authors {
     ($sep:expr) => {{
         use std::ops::Deref;
-        use std::sync::Once;
+        use std::boxed::Box;
 
         #[allow(missing_copy_implementations)]
         #[allow(dead_code)]
@@ -471,15 +471,9 @@ macro_rules! crate_authors {
             type Target = str;
 
             fn deref(&self) -> &'static str {
-                static ONCE: Once = Once::new();
-                static mut VALUE: *const String = 0 as *const String;
-
-                ONCE.call_once(|| {
-                    let s = env!("CARGO_PKG_AUTHORS").replace(':', $sep);
-                    VALUE = Box::leak(s);
-                });
-
-                &(*VALUE)[..]
+                let s: Box<String> = Box::new(env!("CARGO_PKG_AUTHORS").replace(':', $sep));
+                let s2 = Box::leak(s);
+                &*s2 // weird but compiler-suggested way to turn a String into &str
             }
         }
 


### PR DESCRIPTION
This bit of bespoke unsafe code can be replaced with a standard library function, [`Box::leak()`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak). It's been available since Rust 1.26 so there is no MSRV concern.

Thanks to TyPR124 and Lokathor for pointing this out.