### PR TITLE
fix(README): fix compiler errors for first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ extern crate clap;
 struct Opts {
     /// Sets a custom config file. Could have been an Option<T> with no default too
     #[clap(short = "c", long = "config", default_value = "default.conf")]
-    file: String,
+    config: String,
     /// Some input. Because this isn't an Option<T> it's required to be used
     input: String,
     /// A level of verbosity, and can be used multiple times
@@ -190,7 +190,7 @@ enum SubCommand {
 /// A subcommand for controlling testing
 #[derive(Clap)]
 #[clap(name = "test", version = "1.3", author = "Someone Else")]
-Test {
+struct Test {
     /// Print debug info
     #[clap(short = "d")]
     debug: bool


### PR DESCRIPTION
The first example doesn't compile. The Test structure is missing a `struct` statement, and the `.config` field exists as `.file`. Looking at the flag fields, `config` seems like the expected field name.

Using 

```
[dependencies]
clap = { git = "https://github.com/clap-rs/clap", features = ["wrap_help"] }
```

Signed-Off-By: Matthew Fisher <matt.fisher@microsoft.com>