### PR TITLE
Use about() with help() and long_about() with long_help()

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -821,12 +821,13 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
         if let Some(author) = self.parser.app.author {
             write_thing!(author)
         }
-        if let Some(about) = self.parser.app.long_about {
+
+        if self.use_long && self.parser.app.long_about.is_some() {
             debugln!("Help::write_default_help: writing long about");
-            write_thing!(about)
-        } else if let Some(about) = self.parser.app.about {
+            write_thing!(self.parser.app.long_about.unwrap())
+        } else if self.parser.app.about.is_some() {
             debugln!("Help::write_default_help: writing about");
-            write_thing!(about)
+            write_thing!(self.parser.app.about.unwrap())
         }
 
         self.color(Format::Warning("\nUSAGE:"))?;

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1496,7 +1496,7 @@ fn show_long_about_issue_897() {
 }
 
 static ISSUE_897_SHORT: &str = "ctest-foo 0.1
-Long about foo
+About foo
 
 USAGE:
     ctest foo


### PR DESCRIPTION
I was going through the clap documentation and was under the impression that calling `help()` would call `about()` and `long_help()` would call `long_about()`, but I've actually discovered this not to be the case. Instead, the `long_about()` was always shown when it existed, rendering the output (in the about section) of programs called with `-h` and `--help` identical. Issue #1472 shows this and that is fixed here.

Note this doesn't remove the ability to use the same about in both cases: if `long_about()` is unset, then `about()` is used in both cases.

I've changed the implementation here to use `is_some()` and `unwrap()` as opposed to `if let` because it ultimately allows for less repetitive code. Ideally, I'd be able to pair `if let` with a secondary condition (namely `self.use_long`), but to my dismay, let-chains are not stabilized yet.

For a second opinion, here is the code a settled on:
```
if self.use_long && parser.meta.long_about.is_some() {
    debugln!("Help::write_default_help: writing long about");
    write_thing!(parser.meta.long_about.unwrap())
} else if parser.meta.about.is_some() {
    debugln!("Help::write_default_help: writing about");
    write_thing!(parser.meta.about.unwrap())
}
```
Here is the alternative:
```
if self.use_long {
    if let Some(about) = parser.meta.long_about {
        debugln!("Help::write_default_help: writing long about");
        write_thing!(about)
    } else if let Some(about) = parser.meta.about {
        debugln!("Help::write_default_help: writing about");
        write_thing!(about)
   }
} else {
    if let Some(about) = parser.meta.about {
        debugln!("Help::write_default_help: writing about");
        write_thing!(about)
    }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clap-rs/clap/1612)
<!-- Reviewable:end -->
