### PR TITLE
Clarify documentation usage as help text for subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ struct Opts {
 
 #[derive(Clap)]
 enum SubCommand {
+    /// A help message for the Test subcommand
     Test(Test),
 }
 

--- a/README.md
+++ b/README.md
@@ -185,12 +185,12 @@ struct Opts {
 #[derive(Clap)]
 enum SubCommand {
     /// A help message for the Test subcommand
+    #[clap(name = "test", version = "1.3", author = "Someone Else")]
     Test(Test),
 }
 
 /// A subcommand for controlling testing
 #[derive(Clap)]
-#[clap(name = "test", version = "1.3", author = "Someone Else")]
 struct Test {
     /// Print debug info
     #[clap(short = "d")]


### PR DESCRIPTION
As outlined in https://github.com/clap-rs/clap/issues/1619 I did not understand why the `SUBCOMMANDS` section of `help` would not print a String `/// A subcommand for controlling testing` for the `Test` subcommand.

This PR updates the README to hopefully make this clearer.

The only change is adding a doc line:
```rust
#[derive(Clap)]
enum SubCommand {
    /// A help message for the Test subcommand
    Test(Test),
}
```