### PR TITLE
Include version message in `VersionDisplayed` kinds of `Error`s

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1548,12 +1548,11 @@ where
 
     fn _version(&self, use_long: bool) -> Error {
         debugln!("Parser::_version: ");
-        let out = io::stdout();
-        let mut buf_w = BufWriter::new(out.lock());
-        match self.print_version(&mut buf_w, use_long) {
+        let mut buf = vec![];
+        match self.print_version(&mut buf, use_long) {
             Err(e) => e,
             _ => Error {
-                message: String::new(),
+                message: String::from_utf8(buf).unwrap_or_default(),
                 kind: ErrorKind::VersionDisplayed,
                 info: None,
             },


### PR DESCRIPTION
Not sure if v2.x.x PRs are still being accepted. Please close if that's not the case.

This PR adds the version message to the `VersionDisplay` error that is produced. The same way that the help message is added to the `HelpDisplayed` error.