### PR TITLE
Merge pull request #1637 from danielthegray/use-USAGE-error-exit-code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ maintenance = {status = "actively-developed"}
 
 [dependencies]
 bitflags              = "1.2"
+exitcode              = "1.1.2"
 unicode-width         = "0.1.4"
 textwrap              = "0.11"
 indexmap              = "1.0.1"

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1193,7 +1193,7 @@ impl<'b> App<'b> {
                         i.lock().read_line(&mut s).unwrap();
                     }
                     drop(e);
-                    process::exit(1);
+                    process::exit(exitcode::USAGE);
                 }
 
                 e.exit()
@@ -1268,7 +1268,7 @@ impl<'b> App<'b> {
                 }
                 drop(self);
                 drop(e);
-                process::exit(1);
+                process::exit(exitcode::USAGE);
             }
 
             drop(self);


### PR DESCRIPTION
The reason to do this is described well in issue #1327.
It is also a recommendation of the Rust book itself:
https://rust-cli.github.io/book/in-depth/exit-code.html

I have run the tests with no failures:
```
$ cargo test --no-default-features
...
test result: ok. 286 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out
$ cargo test --features "yaml unstable"
...
test result: ok. 286 passed; 0 failed; 14 ignored; 0 measured; 0 filtered out
```