### PR TITLE
Allow replacing input on the fly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,6 +452,7 @@ pub use crate::derive::{Clap, FromArgMatches, IntoApp, Subcommand};
 pub use crate::output::fmt::Format;
 pub use crate::parse::errors::{Error, ErrorKind, Result};
 pub use crate::parse::{ArgMatches, OsValues, SubCommand, Values};
+
 #[cfg(feature = "yaml")]
 pub use yaml_rust::YamlLoader;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -934,13 +934,6 @@ macro_rules! flags {
     };
 }
 
-#[allow(unused_macros)]
-macro_rules! flags_mut {
-    ($app:expr) => {
-        $crate::flags!($app, iter_mut)
-    };
-}
-
 #[macro_export]
 #[doc(hidden)]
 macro_rules! opts {
@@ -956,46 +949,17 @@ macro_rules! opts {
     };
 }
 
-#[allow(unused_macros)]
-macro_rules! opts_mut {
-    ($app:expr) => {
-        opts!($app, iter_mut)
-    };
-}
-
 #[macro_export]
 #[doc(hidden)]
 macro_rules! positionals {
-    ($app:expr) => {
+    ($app:expr, $how:ident) => {{
         $app.args
             .args
-            .iter()
+            .$how()
             .filter(|a| !(a.short.is_some() || a.long.is_some()))
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! positionals_mut {
+    }};
     ($app:expr) => {
-        $app.args
-            .values_mut()
-            .filter(|a| !(a.short.is_some() || a.long.is_some()))
-    };
-}
-
-#[allow(unused_macros)]
-macro_rules! custom_headings_mut {
-    ($app:expr) => {
-        custom_headings!($app, values_mut)
-    };
-}
-
-macro_rules! subcommands_cloned {
-    ($app:expr, $how:ident) => {
-        $app.subcommands.$how().cloned()
-    };
-    ($app:expr) => {
-        subcommands_cloned!($app, iter)
+        positionals!($app, iter)
     };
 }
 
@@ -1010,12 +974,6 @@ macro_rules! subcommands {
     };
 }
 
-macro_rules! subcommands_mut {
-    ($app:expr) => {
-        subcommands!($app, iter_mut)
-    };
-}
-
 macro_rules! groups_for_arg {
     ($app:expr, $grp:expr) => {{
         debugln!("Parser::groups_for_arg: name={}", $grp);
@@ -1027,21 +985,26 @@ macro_rules! groups_for_arg {
 }
 
 macro_rules! find_subcmd_cloned {
-    ($_self:expr, $sc:expr) => {{
-        subcommands_cloned!($_self).find(|a| match_alias!(a, $sc, &*a.name))
+    ($app:expr, $sc:expr) => {{
+        subcommands!($app)
+            .cloned()
+            .find(|a| match_alias!(a, $sc, &*a.name))
     }};
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! find_subcmd {
-    ($app:expr, $sc:expr) => {{
-        subcommands!($app).find(|a| match_alias!(a, $sc, &*a.name))
+    ($app:expr, $sc:expr, $how:ident) => {{
+        subcommands!($app, $how).find(|a| match_alias!(a, $sc, &*a.name))
     }};
+    ($app:expr, $sc:expr) => {
+        find_subcmd!($app, $sc, iter)
+    };
 }
 
 macro_rules! longs {
-    ($app:expr) => {{
+    ($app:expr, $how:ident) => {{
         use crate::mkeymap::KeyType;
         $app.args.keys.iter().map(|x| &x.key).filter_map(|a| {
             if let KeyType::Long(v) = a {
@@ -1051,6 +1014,9 @@ macro_rules! longs {
             }
         })
     }};
+    ($app:expr) => {
+        longs!($app, iter)
+    };
 }
 
 #[macro_export]

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -9,5 +9,5 @@ mod validator;
 pub use self::arg_matcher::ArgMatcher;
 pub use self::matches::ArgMatches;
 pub use self::matches::{MatchedArg, OsValues, SubCommand, Values};
-pub use self::parser::{ParseResult, Parser};
+pub use self::parser::{Input, ParseResult, Parser};
 pub use self::validator::Validator;

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -32,7 +32,7 @@ impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
     pub fn validate(
         &mut self,
         needs_val_of: ParseResult,
-        subcmd_name: &Option<String>,
+        is_subcmd: bool,
         matcher: &mut ArgMatcher,
     ) -> ClapResult<()> {
         debugln!("Validator::validate;");
@@ -74,7 +74,7 @@ impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
             });
         }
         self.validate_conflicts(matcher)?;
-        if !(self.p.is_set(AS::SubcommandsNegateReqs) && subcmd_name.is_some() || reqs_validated) {
+        if !(self.p.is_set(AS::SubcommandsNegateReqs) && is_subcmd || reqs_validated) {
             self.validate_required(matcher)?;
             self.validate_required_unless(matcher)?;
         }

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -184,6 +184,20 @@ fn invisible_aliases_help_output() {
 }
 
 #[test]
+fn replace() {
+    let m = App::new("prog")
+        .subcommand(App::new("module").subcommand(App::new("install").about("Install module")))
+        .replace("install", &["module", "install"])
+        .get_matches_from(vec!["prog", "install"]);
+
+    assert_eq!(m.subcommand_name(), Some("module"));
+    assert_eq!(
+        m.subcommand_matches("module").unwrap().subcommand_name(),
+        Some("install")
+    );
+}
+
+#[test]
 fn issue_1031_args_with_same_name() {
     let res = App::new("prog")
         .arg(Arg::from("--ui-path=<PATH>"))


### PR DESCRIPTION
<!-- DO NOT DELETE THIS LINE! Internal hack, the shame is on you, bors! -->
<!--
If your PR closes some issues, please, put `Closes #XXXX`
lines to this comment (no quotes), where `XXXX` is the number
of the issue you want to fix. Each issue goes on it's own line.

YOUR COMMENT GOES BELOW
-->
Closes #1603 

I tried several different ways of implementing the above requested feature but failed because they always ended up trying to manipulate the input which is a no-go because it was a plain `Iterator`. And then the #1693 was filed, and reading it made me think that maybe we should allow input to be changed. So, I extracted it out and made it do the replacing.
