### PR TITLE
Allow missing docs on arg_enum

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -346,6 +346,7 @@ macro_rules! arg_enum {
         }
         impl $e {
             #[allow(dead_code)]
+            #[allow(missing_docs)]
             pub fn variants() -> [&'static str; $crate::_clap_count_exprs!($(stringify!($v)),+)] {
                 [
                     $(stringify!($v),)+


### PR DESCRIPTION
<!-- DO NOT DELETE THIS LINE! Internal hack, the shame is on you, bors! -->
<!--
If your PR closes some issues, please, put `Closes #XXXX`
lines to this comment (no quotes), where `XXXX` is the number
of the issue you want to fix. Each issue goes on it's own line.

YOUR COMMENT GOES BELOW
-->

I'm using `deny(missing_docs)` on my whole crate but I get warnings of `arg_enum` because it adds the function `variants()` which has no doc. This will fix the warning.