### PR TITLE
Allow bench to fail in travis to reduce CI time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ branches:
 jobs:
   allow_failures:
     - rust: nightly
+    - name: Benchmarking
     - name: Coverage
   fast_finish: true
   include:


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
Closes #1699 

Benchmarking is now good.