### PR TITLE
WIP: EXPERIMENT: Move from &'b str to Cow<'static, str>

### DIFF
--- a/clap_derive/src/derives/dummies.rs
+++ b/clap_derive/src/derives/dummies.rs
@@ -20,10 +20,10 @@ pub fn clap_enum(name: &Ident) {
 pub fn into_app(name: &Ident) {
     append_dummy(quote! {
         impl ::clap::IntoApp for #name {
-            fn into_app<'b>() -> ::clap::App<'b> {
+            fn into_app<'b>() -> ::clap::App {
                 unimplemented!()
             }
-            fn augment_clap<'b>(_app: ::clap::App<'b>) -> ::clap::App<'b> {
+            fn augment_clap<'b>(_app: ::clap::App) -> ::clap::App {
                 unimplemented!()
             }
         }
@@ -46,7 +46,7 @@ pub fn subcommand(name: &Ident) {
             fn from_subcommand(_name: &str, _matches: Option<&::clap::ArgMatches>) -> Option<Self> {
                 unimplemented!()
             }
-            fn augment_subcommands(_app: ::clap::App<'_>) -> ::clap::App<'_> {
+            fn augment_subcommands(_app: ::clap::App) -> ::clap::App {
                 unimplemented!()
             }
         }

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -48,13 +48,13 @@ pub fn gen_for_enum(name: &syn::Ident) -> TokenStream {
 
     quote! {
         impl ::clap::IntoApp for #name {
-            fn into_app<'b>() -> ::clap::App<'b> {
+            fn into_app<'b>() -> ::clap::App {
                 let app = ::clap::App::new(#app_name)
                     .setting(::clap::AppSettings::SubcommandRequiredElseHelp);
                 <#name as ::clap::IntoApp>::augment_clap(app)
             }
 
-            fn augment_clap<'b>(app: ::clap::App<'b>) -> ::clap::App<'b> {
+            fn augment_clap<'b>(app: ::clap::App) -> ::clap::App {
                 <#name as ::clap::Subcommand>::augment_subcommands(app)
             }
         }
@@ -74,7 +74,7 @@ fn gen_into_app_fn(attrs: &[syn::Attribute]) -> GenOutput {
     let name = attrs.cased_name();
 
     let tokens = quote! {
-        fn into_app<'b>() -> ::clap::App<'b> {
+        fn into_app<'b>() -> ::clap::App {
             Self::augment_clap(::clap::App::new(#name))
         }
     };
@@ -89,7 +89,7 @@ fn gen_augment_clap_fn(
     let app_var = syn::Ident::new("app", proc_macro2::Span::call_site());
     let augmentation = gen_app_augmentation(fields, &app_var, parent_attribute);
     quote! {
-        fn augment_clap<'b>(#app_var: ::clap::App<'b>) -> ::clap::App<'b> {
+        fn augment_clap<'b>(#app_var: ::clap::App) -> ::clap::App {
             #augmentation
         }
     }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -94,7 +94,7 @@ fn gen_augment_subcommands(
     let app_methods = parent_attribute.top_level_methods();
     let version = parent_attribute.version();
     quote! {
-        fn augment_subcommands<'b>(app: ::clap::App<'b>) -> ::clap::App<'b> {
+        fn augment_subcommands<'b>(app: ::clap::App) -> ::clap::App {
             let app = app #app_methods;
             #( #subcommands )*;
             app #version

--- a/clap_derive/tests/ui/non_existent_attr.stderr
+++ b/clap_derive/tests/ui/non_existent_attr.stderr
@@ -1,5 +1,5 @@
-error[E0599]: no method named `non_existing_attribute` found for type `clap::build::arg::Arg<'_>` in the current scope
+error[E0599]: no method named `non_existing_attribute` found for type `clap::build::arg::Arg` in the current scope
   --> $DIR/non_existent_attr.rs:14:19
    |
 14 |     #[clap(short, non_existing_attribute = 1)]
-   |                   ^^^^^^^^^^^^^^^^^^^^^^ method not found in `clap::build::arg::Arg<'_>`
+   |                   ^^^^^^^^^^^^^^^^^^^^^^ method not found in `clap::build::arg::Arg`

--- a/clap_generate/src/generators/mod.rs
+++ b/clap_generate/src/generators/mod.rs
@@ -73,7 +73,7 @@ pub trait Generator {
     /// **NOTE:** `path` should not contain the root `bin_name`.
     ///
     /// [clap]: ../clap/struct.App.html
-    fn find_subcommand_with_path<'b>(p: &'b App<'b>, path: Vec<&str>) -> &'b App<'b> {
+    fn find_subcommand_with_path<'b>(p: &'b App, path: Vec<&str>) -> &'b App {
         let mut app = p;
 
         for sc in path {
@@ -114,7 +114,7 @@ pub trait Generator {
 
     /// Gets all the short options and flags of a [`clap::App`](../clap/struct.App.html).
     /// Includes `h` and `V` depending on the [`clap::AppSettings`](../clap/enum.AppSettings.html).
-    fn shorts<'b>(p: &'b App<'b>) -> Vec<char> {
+    fn shorts<'b>(p: &'b App) -> Vec<char> {
         debugln!("shorts: name={}", p.name);
 
         let mut shorts: Vec<char> = p
@@ -143,7 +143,7 @@ pub trait Generator {
 
     /// Gets all the long options and flags of a [`clap::App`](../clap/struct.App.html).
     /// Includes `help` and `version` depending on the [`clap::AppSettings`](../clap/enum.AppSettings.html).
-    fn longs<'b>(p: &'b App<'b>) -> Vec<String> {
+    fn longs<'b>(p: &'b App) -> Vec<String> {
         debugln!("longs: name={}", p.name);
 
         let mut longs: Vec<String> = p
@@ -174,7 +174,7 @@ pub trait Generator {
 
     /// Gets all the flags of a [`clap::App`](../clap/struct.App.html).
     /// Includes `help` and `version` depending on the [`clap::AppSettings`](../clap/enum.AppSettings.html).
-    fn flags<'b>(p: &'b App<'b>) -> Vec<Arg> {
+    fn flags<'b>(p: &'b App) -> Vec<Arg> {
         debugln!("flags: name={}", p.name);
 
         let mut flags: Vec<_> = flags!(p).cloned().collect();
@@ -218,7 +218,7 @@ mod tests {
         }
     }
 
-    fn common() -> App<'static> {
+    fn common() -> App {
         let mut app = App::new("myapp")
             .subcommand(
                 App::new("test")

--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -61,11 +61,7 @@ fn get_tooltip<T: ToString>(help: Option<&str>, data: T) -> String {
     }
 }
 
-fn generate_inner<'b>(
-    p: &'b App<'b>,
-    previous_command_name: &str,
-    names: &mut Vec<&'b str>,
-) -> String {
+fn generate_inner<'b>(p: &'b App, previous_command_name: &str, names: &mut Vec<&'b str>) -> String {
     debugln!("Elvish::generate_inner;");
 
     let command_name = if previous_command_name.is_empty() {

--- a/clap_generate/src/generators/shells/powershell.rs
+++ b/clap_generate/src/generators/shells/powershell.rs
@@ -68,11 +68,7 @@ fn get_tooltip<T: ToString>(help: Option<&str>, data: T) -> String {
     }
 }
 
-fn generate_inner<'b>(
-    p: &'b App<'b>,
-    previous_command_name: &str,
-    names: &mut Vec<&'b str>,
-) -> String {
+fn generate_inner<'b>(p: &'b App, previous_command_name: &str, names: &mut Vec<&'b str>) -> String {
     debugln!("PowerShell::generate_inner;");
 
     let command_name = if previous_command_name.is_empty() {

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -255,7 +255,7 @@ esac",
     )
 }
 
-fn parser_of<'b>(p: &'b App<'b>, mut sc: &str) -> &'b App<'b> {
+fn parser_of<'b>(p: &'b App, mut sc: &str) -> &'b App {
     debugln!("Zsh::parser_of: sc={}", sc);
 
     if sc == p.get_bin_name().unwrap_or(&String::new()) {

--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -54,7 +54,7 @@ pub use generators::Generator;
 ///
 /// use clap::{App, Arg};
 ///
-/// pub fn build_cli() -> App<'static> {
+/// pub fn build_cli() -> App {
 ///     App::new("compl")
 ///         .about("Tests completions")
 ///         .arg(Arg::with_name("file")

--- a/clap_generate/tests/completions.rs
+++ b/clap_generate/tests/completions.rs
@@ -31,7 +31,7 @@ static BASH: &'static str = r#"_myapp() {
             myapp)
                 cmd="myapp"
                 ;;
-            
+
             help)
                 cmd+="__help"
                 ;;
@@ -51,7 +51,7 @@ static BASH: &'static str = r#"_myapp() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -59,7 +59,7 @@ static BASH: &'static str = r#"_myapp() {
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0
             ;;
-        
+
         myapp__help)
             opts=" -h -V  --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -67,7 +67,7 @@ static BASH: &'static str = r#"_myapp() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -82,7 +82,7 @@ static BASH: &'static str = r#"_myapp() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 --case)
                     COMPREPLY=($(compgen -f ${cur}))
                     return 0
@@ -164,14 +164,14 @@ _myapp_commands() {
 (( $+functions[_myapp__help_commands] )) ||
 _myapp__help_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'myapp help commands' commands "$@"
 }
 (( $+functions[_myapp__test_commands] )) ||
 _myapp__test_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'myapp test commands' commands "$@"
 }
@@ -492,28 +492,28 @@ _my_app_commands() {
 (( $+functions[_my_app__help_commands] )) ||
 _my_app__help_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'my_app help commands' commands "$@"
 }
 (( $+functions[_my_app__some-cmd-with-hypens_commands] )) ||
 _my_app__some-cmd-with-hypens_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'my_app some-cmd-with-hypens commands' commands "$@"
 }
 (( $+functions[_my_app__some_cmd_commands] )) ||
 _my_app__some_cmd_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'my_app some_cmd commands' commands "$@"
 }
 (( $+functions[_my_app__test_commands] )) ||
 _my_app__test_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'my_app test commands' commands "$@"
 }
@@ -552,7 +552,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
             my_app)
                 cmd="my_app"
                 ;;
-            
+
             help)
                 cmd+="__help"
                 ;;
@@ -578,7 +578,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -586,7 +586,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
             COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
             return 0
             ;;
-        
+
         my_app__help)
             opts=" -h -V  --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
@@ -594,7 +594,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -609,7 +609,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 *)
                     COMPREPLY=()
                     ;;
@@ -624,7 +624,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 --config)
                     COMPREPLY=($(compgen -f ${cur}))
                     return 0
@@ -643,7 +643,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
                 return 0
             fi
             case "${prev}" in
-                
+
                 --case)
                     COMPREPLY=($(compgen -f ${cur}))
                     return 0
@@ -699,24 +699,24 @@ _my_app() {
 '-V[Prints version information]' \
 '--version[Prints version information]' \
 && ret=0
-    
+
 }
 
 (( $+functions[_my_app_commands] )) ||
 _my_app_commands() {
     local commands; commands=(
-        
+
     )
     _describe -t commands 'my_app commands' commands "$@"
 }
 
 _my_app "$@""#;
 
-fn build_app() -> App<'static> {
+fn build_app() -> App {
     build_app_with_name("myapp")
 }
 
-fn build_app_with_name(s: &'static str) -> App<'static> {
+fn build_app_with_name(s: &'static str) -> App {
     App::new(s)
         .about("Tests completions")
         .arg(Arg::with_name("file").help("some input file"))
@@ -730,7 +730,7 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
         )
 }
 
-fn build_app_special_commands() -> App<'static> {
+fn build_app_special_commands() -> App {
     build_app_with_name("my_app")
         .subcommand(
             App::new("some_cmd").about("tests other things").arg(
@@ -743,7 +743,7 @@ fn build_app_special_commands() -> App<'static> {
         .subcommand(App::new("some-cmd-with-hypens").alias("hyphen"))
 }
 
-fn build_app_special_help() -> App<'static> {
+fn build_app_special_help() -> App {
     App::new("my_app")
         .arg(
             Arg::with_name("single-quotes")

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1,5 +1,6 @@
 mod settings;
 pub use self::settings::{AppFlags, AppSettings};
+use std::borrow::Cow;
 
 // Std
 use std::collections::HashMap;
@@ -64,7 +65,7 @@ pub enum Propagation {
 /// ```
 /// [`App::get_matches`]: ./struct.App.html#method.get_matches
 #[derive(Default, Debug, Clone)]
-pub struct App<'b> {
+pub struct App {
     #[doc(hidden)]
     pub id: Id,
     #[doc(hidden)]
@@ -72,27 +73,27 @@ pub struct App<'b> {
     #[doc(hidden)]
     pub bin_name: Option<String>,
     #[doc(hidden)]
-    pub author: Option<&'b str>,
+    pub author: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub version: Option<&'b str>,
+    pub version: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub long_version: Option<&'b str>,
+    pub long_version: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub about: Option<&'b str>,
+    pub about: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub long_about: Option<&'b str>,
+    pub long_about: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub more_help: Option<&'b str>,
+    pub more_help: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub pre_help: Option<&'b str>,
+    pub pre_help: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub aliases: Option<Vec<(&'b str, bool)>>, // (name, visible)
+    pub aliases: Option<Vec<(Cow<'static, str>, bool)>>, // (name, visible)
     #[doc(hidden)]
-    pub usage_str: Option<&'b str>,
+    pub usage_str: Option<Cow<'static, str>>,
     #[doc(hidden)]
     pub usage: Option<String>,
     #[doc(hidden)]
-    pub help_str: Option<&'b str>,
+    pub help_str: Option<Cow<'static, str>>,
     #[doc(hidden)]
     pub disp_ord: usize,
     #[doc(hidden)]
@@ -100,24 +101,24 @@ pub struct App<'b> {
     #[doc(hidden)]
     pub max_w: Option<usize>,
     #[doc(hidden)]
-    pub template: Option<&'b str>,
+    pub template: Option<Cow<'static, str>>,
     #[doc(hidden)]
     pub settings: AppFlags,
     #[doc(hidden)]
     pub g_settings: AppFlags,
     #[doc(hidden)]
-    pub args: MKeyMap<'b>,
+    pub args: MKeyMap,
     #[doc(hidden)]
-    pub subcommands: Vec<App<'b>>,
+    pub subcommands: Vec<App>,
     #[doc(hidden)]
-    pub replacers: HashMap<&'b str, &'b [&'b str]>,
+    pub replacers: HashMap<Cow<'static, str>, &'static [Cow<'static, str>]>,
     #[doc(hidden)]
-    pub groups: Vec<ArgGroup<'b>>,
+    pub groups: Vec<ArgGroup>,
     #[doc(hidden)]
-    pub help_headings: Vec<Option<&'b str>>,
+    pub help_headings: Vec<Option<Cow<'static, str>>>,
 }
 
-impl<'b> App<'b> {
+impl App {
     /// Creates a new instance of an application requiring a name. The name may be, but doesn't
     /// have to be, same as the binary. The name will be displayed to the user when they request to
     /// print version or help and usage information.
@@ -168,7 +169,7 @@ impl<'b> App<'b> {
     /// ```
     /// [`crate_authors!`]: ./macro.crate_authors!.html
     /// [`examples/`]: https://github.com/kbknapp/clap-rs/tree/master/examples
-    pub fn author<S: Into<&'b str>>(mut self, author: S) -> Self {
+    pub fn author<S: Into<Cow<'static, str>>>(mut self, author: S) -> Self {
         self.author = Some(author.into());
         self
     }
@@ -214,7 +215,7 @@ impl<'b> App<'b> {
     /// # ;
     /// ```
     /// [`App::long_about`]: ./struct.App.html#method.long_about
-    pub fn about<S: Into<&'b str>>(mut self, about: S) -> Self {
+    pub fn about<S: Into<Cow<'static, str>>>(mut self, about: S) -> Self {
         self.about = Some(about.into());
         self
     }
@@ -240,7 +241,7 @@ impl<'b> App<'b> {
     /// # ;
     /// ```
     /// [`App::about`]: ./struct.App.html#method.about
-    pub fn long_about<S: Into<&'b str>>(mut self, about: S) -> Self {
+    pub fn long_about<S: Into<Cow<'static, str>>>(mut self, about: S) -> Self {
         self.long_about = Some(about.into());
         self
     }
@@ -280,7 +281,7 @@ impl<'b> App<'b> {
     ///     .after_help("Does really amazing things to great people...but be careful with -R")
     /// # ;
     /// ```
-    pub fn after_help<S: Into<&'b str>>(mut self, help: S) -> Self {
+    pub fn after_help<S: Into<Cow<'static, str>>>(mut self, help: S) -> Self {
         self.more_help = Some(help.into());
         self
     }
@@ -297,7 +298,7 @@ impl<'b> App<'b> {
     ///     .before_help("Some info I'd like to appear before the help info")
     /// # ;
     /// ```
-    pub fn before_help<S: Into<&'b str>>(mut self, help: S) -> Self {
+    pub fn before_help<S: Into<Cow<'static, str>>>(mut self, help: S) -> Self {
         self.pre_help = Some(help.into());
         self
     }
@@ -323,7 +324,7 @@ impl<'b> App<'b> {
     /// [`crate_version!`]: ./macro.crate_version!.html
     /// [`examples/`]: https://github.com/kbknapp/clap-rs/tree/master/examples
     /// [`App::long_version`]: ./struct.App.html#method.long_version
-    pub fn version<S: Into<&'b str>>(mut self, ver: S) -> Self {
+    pub fn version<S: Into<Cow<'static, str>>>(mut self, ver: S) -> Self {
         self.version = Some(ver.into());
         self
     }
@@ -354,7 +355,7 @@ impl<'b> App<'b> {
     /// [`crate_version!`]: ./macro.crate_version!.html
     /// [`examples/`]: https://github.com/kbknapp/clap-rs/tree/master/examples
     /// [`App::version`]: ./struct.App.html#method.version
-    pub fn long_version<S: Into<&'b str>>(mut self, ver: S) -> Self {
+    pub fn long_version<S: Into<Cow<'static, str>>>(mut self, ver: S) -> Self {
         self.long_version = Some(ver.into());
         self
     }
@@ -378,7 +379,7 @@ impl<'b> App<'b> {
     /// # ;
     /// ```
     /// [`ArgMatches::usage`]: ./struct.ArgMatches.html#method.usage
-    pub fn override_usage<S: Into<&'b str>>(mut self, usage: S) -> Self {
+    pub fn override_usage<S: Into<Cow<'static, str>>>(mut self, usage: S) -> Self {
         self.usage_str = Some(usage.into());
         self
     }
@@ -417,7 +418,7 @@ impl<'b> App<'b> {
     /// # ;
     /// ```
     /// [`Arg::override_help`]: ./struct.Arg.html#method.override_help
-    pub fn override_help<S: Into<&'b str>>(mut self, help: S) -> Self {
+    pub fn override_help<S: Into<Cow<'static, str>>>(mut self, help: S) -> Self {
         self.help_str = Some(help.into());
         self
     }
@@ -460,7 +461,7 @@ impl<'b> App<'b> {
     /// [`App::after_help`]: ./struct.App.html#method.after_help
     /// [`App::before_help`]: ./struct.App.html#method.before_help
     /// [`AppSettings::UnifiedHelpMessage`]: ./enum.AppSettings.html#variant.UnifiedHelpMessage
-    pub fn help_template<S: Into<&'b str>>(mut self, s: S) -> Self {
+    pub fn help_template<S: Into<Cow<'static, str>>>(mut self, s: S) -> Self {
         self.template = Some(s.into());
         self
     }
@@ -628,12 +629,13 @@ impl<'b> App<'b> {
     /// # ;
     /// ```
     /// [argument]: ./struct.Arg.html
-    pub fn arg<A: Into<Arg<'b>>>(mut self, a: A) -> Self {
-        let help_heading: Option<&'b str> = if let Some(option_str) = self.help_headings.last() {
-            *option_str
-        } else {
-            None
-        };
+    pub fn arg<A: Into<Arg>>(mut self, a: A) -> Self {
+        let help_heading: Option<Cow<'static, str>> =
+            if let Some(option_str) = self.help_headings.last() {
+                *option_str
+            } else {
+                None
+            };
         let arg = a.into().help_heading(help_heading);
         self.args.push(arg);
         self
@@ -642,7 +644,7 @@ impl<'b> App<'b> {
     /// Set a custom section heading for future args. Every call to arg will
     /// have this header (instead of its default header) until a subsequent
     /// call to help_heading
-    pub fn help_heading(mut self, heading: &'b str) -> Self {
+    pub fn help_heading(mut self, heading: Cow<'static, str>) -> Self {
         self.help_headings.push(Some(heading));
         self
     }
@@ -670,7 +672,7 @@ impl<'b> App<'b> {
     pub fn args<I, T>(mut self, args: I) -> Self
     where
         I: IntoIterator<Item = T>,
-        T: Into<Arg<'b>>,
+        T: Into<Arg>,
     {
         // @TODO @perf @p4 @v3-beta: maybe extend_from_slice would be possible and perform better?
         // But that may also not let us do `&["-a 'some'", "-b 'other']` because of not Into<Arg>
@@ -696,7 +698,7 @@ impl<'b> App<'b> {
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
     /// [``]: ./struct..html
-    pub fn alias<S: Into<&'b str>>(mut self, name: S) -> Self {
+    pub fn alias<S: Into<Cow<'static, str>>>(mut self, name: S) -> Self {
         if let Some(ref mut als) = self.aliases {
             als.push((name.into(), false));
         } else {
@@ -725,7 +727,7 @@ impl<'b> App<'b> {
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
     /// [``]: ./struct..html
-    pub fn aliases(mut self, names: &[&'b str]) -> Self {
+    pub fn aliases(mut self, names: &[Cow<'static, str>]) -> Self {
         if let Some(ref mut als) = self.aliases {
             for n in names {
                 als.push((n, false));
@@ -751,7 +753,7 @@ impl<'b> App<'b> {
     /// ```
     /// [``]: ./struct..html
     /// [`App::alias`]: ./struct.App.html#method.alias
-    pub fn visible_alias<S: Into<&'b str>>(mut self, name: S) -> Self {
+    pub fn visible_alias<S: Into<Cow<'static, str>>>(mut self, name: S) -> Self {
         if let Some(ref mut als) = self.aliases {
             als.push((name.into(), true));
         } else {
@@ -775,7 +777,7 @@ impl<'b> App<'b> {
     /// ```
     /// [``]: ./struct..html
     /// [`App::aliases`]: ./struct.App.html#method.aliases
-    pub fn visible_aliases(mut self, names: &[&'b str]) -> Self {
+    pub fn visible_aliases(mut self, names: &[Cow<'static, str>]) -> Self {
         if let Some(ref mut als) = self.aliases {
             for n in names {
                 als.push((n, true));
@@ -803,7 +805,11 @@ impl<'b> App<'b> {
     /// assert!(m.subcommand_matches("module").is_some());
     /// assert!(m.subcommand_matches("module").unwrap().subcommand_matches("install").is_some());
     /// ```
-    pub fn replace(mut self, name: &'b str, target: &'b [&'b str]) -> Self {
+    pub fn replace(
+        mut self,
+        name: Cow<'static, str>,
+        target: &'static [Cow<'static, str>],
+    ) -> Self {
         self.replacers.insert(name, target);
         self
     }
@@ -841,7 +847,7 @@ impl<'b> App<'b> {
     /// # ;
     /// ```
     /// [`ArgGroup`]: ./struct.ArgGroup.html
-    pub fn group(mut self, group: ArgGroup<'b>) -> Self {
+    pub fn group(mut self, group: ArgGroup) -> Self {
         self.groups.push(group);
         self
     }
@@ -870,7 +876,7 @@ impl<'b> App<'b> {
     /// ```
     /// [`ArgGroup`]: ./struct.ArgGroup.html
     /// [`App`]: ./struct.App.html
-    pub fn groups(mut self, groups: &[ArgGroup<'b>]) -> Self {
+    pub fn groups(mut self, groups: &[ArgGroup]) -> Self {
         for g in groups {
             self = self.group(g.into());
         }
@@ -894,7 +900,7 @@ impl<'b> App<'b> {
     /// ```
     /// [``]: ./struct..html
     /// [`App`]: ./struct.App.html
-    pub fn subcommand(mut self, subcmd: App<'b>) -> Self {
+    pub fn subcommand(mut self, subcmd: App) -> Self {
         self.subcommands.push(subcmd);
         self
     }
@@ -917,7 +923,7 @@ impl<'b> App<'b> {
     /// [`IntoIterator`]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html
     pub fn subcommands<I>(mut self, subcmds: I) -> Self
     where
-        I: IntoIterator<Item = App<'b>>,
+        I: IntoIterator<Item = App>,
     {
         for subcmd in subcmds {
             self.subcommands.push(subcmd);
@@ -1002,8 +1008,8 @@ impl<'b> App<'b> {
     /// [`Arg`]: ./struct.Arg.html
     pub fn mut_arg<T, F>(mut self, arg_id: T, f: F) -> Self
     where
-        F: FnOnce(Arg<'b>) -> Arg<'b>,
-        T: Key + Into<&'b str>,
+        F: FnOnce(Arg) -> Arg,
+        T: Key + Into<Cow<'static, str>>,
     {
         let id = arg_id.key();
         let a = self.args.remove_by_name(id).unwrap_or_else(|| Arg {
@@ -1396,7 +1402,7 @@ impl<'b> App<'b> {
 
 // Internally used only
 #[doc(hidden)]
-impl<'b> App<'b> {
+impl<'b> App {
     #[doc(hidden)]
     fn _do_parse(&mut self, it: &mut Input) -> ClapResult<ArgMatches> {
         debugln!("App::_do_parse;");
@@ -1791,8 +1797,8 @@ impl<'b> App<'b> {
 
 // Internal Query Methods
 #[doc(hidden)]
-impl<'b> App<'b> {
-    pub(crate) fn find(&self, arg_id: Id) -> Option<&Arg<'b>> {
+impl App {
+    pub(crate) fn find(&self, arg_id: Id) -> Option<&Arg> {
         self.args.args.iter().find(|a| a.id == arg_id)
     }
 
@@ -1952,7 +1958,7 @@ impl<'b> App<'b> {
 }
 
 #[cfg(feature = "yaml")]
-impl<'a> From<&'a Yaml> for App<'a> {
+impl From<&'static Yaml> for App {
     #[allow(clippy::cognitive_complexity)]
     fn from(mut yaml: &'a Yaml) -> Self {
         // We WANT this to panic on error...so expect() is good.
@@ -2090,7 +2096,7 @@ impl<'a> From<&'a Yaml> for App<'a> {
     }
 }
 
-impl<'e> fmt::Display for App<'e> {
+impl<'e> fmt::Display for App {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.name)
     }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -53,15 +53,15 @@ type Id = u64;
 /// [`Arg`]: ./struct.Arg.html
 #[allow(missing_debug_implementations)]
 #[derive(Default, Clone)]
-pub struct Arg<'help> {
+pub struct Arg {
     #[doc(hidden)]
     pub id: Id,
     #[doc(hidden)]
-    pub name: &'help str,
+    pub name: Cow<'static, str>,
     #[doc(hidden)]
-    pub help: Option<&'help str>,
+    pub help: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub long_help: Option<&'help str>,
+    pub long_help: Option<Cow<'static, str>>,
     #[doc(hidden)]
     pub blacklist: Option<Vec<Id>>,
     #[doc(hidden)]
@@ -73,21 +73,21 @@ pub struct Arg<'help> {
     #[doc(hidden)]
     pub groups: Option<Vec<Id>>,
     #[doc(hidden)]
-    pub requires: Option<Vec<(Option<&'help str>, Id)>>,
+    pub requires: Option<Vec<(Option<Cow<'static, str>>, Id)>>,
     #[doc(hidden)]
     pub short: Option<char>,
     #[doc(hidden)]
-    pub long: Option<&'help str>,
+    pub long: Option<Cow<'static, str>>,
     #[doc(hidden)]
-    pub aliases: Option<Vec<(&'help str, bool)>>, // (name, visible)
+    pub aliases: Option<Vec<(Cow<'static, str>, bool)>>, // (name, visible)
     #[doc(hidden)]
     pub disp_ord: usize,
     #[doc(hidden)]
     pub unified_ord: usize,
     #[doc(hidden)]
-    pub possible_vals: Option<Vec<&'help str>>,
+    pub possible_vals: Option<Vec<Cow<'static, str>>>,
     #[doc(hidden)]
-    pub val_names: Option<VecMap<&'help str>>,
+    pub val_names: Option<VecMap<Cow<'static, str>>>,
     #[doc(hidden)]
     pub num_vals: Option<u64>,
     #[doc(hidden)]
@@ -101,26 +101,26 @@ pub struct Arg<'help> {
     #[doc(hidden)]
     pub val_delim: Option<char>,
     #[doc(hidden)]
-    pub default_vals: Option<Vec<&'help OsStr>>,
+    pub default_vals: Option<Vec<Cow<'static, OsStr>>>,
     #[doc(hidden)]
-    pub default_vals_ifs: Option<VecMap<(Id, Option<&'help OsStr>, &'help OsStr)>>,
+    pub default_vals_ifs: Option<VecMap<(Id, Option<Cow<'static, OsStr>>, Cow<'static, OsStr>)>>,
     #[doc(hidden)]
-    pub env: Option<(&'help OsStr, Option<OsString>)>,
+    pub env: Option<(Cow<'static, OsStr>, Option<OsString>)>,
     #[doc(hidden)]
-    pub terminator: Option<&'help str>,
+    pub terminator: Option<Cow<'static, str>>,
     #[doc(hidden)]
     pub index: Option<u64>,
     #[doc(hidden)]
-    pub r_ifs: Option<Vec<(Id, &'help str)>>,
+    pub r_ifs: Option<Vec<(Id, Cow<'static, str>)>>,
     #[doc(hidden)]
-    pub help_heading: Option<&'help str>,
+    pub help_heading: Option<Cow<'static, str>>,
     #[doc(hidden)]
     pub global: bool,
     #[doc(hidden)]
     pub exclusive: bool,
 }
 
-impl<'help> Arg<'help> {
+impl Arg {
     /// @TODO @p2 @docs @v3-beta1: Write Docs
     pub fn new<T: Key>(t: T) -> Self {
         Arg {
@@ -147,7 +147,7 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
     /// [`Arg`]: ./struct.Arg.html
-    pub fn with_name(n: &'help str) -> Self {
+    pub fn with_name<T: Into<Cow<'static, str>>>(n: T) -> Self {
         Arg {
             id: n.key(),
             name: n,
@@ -310,7 +310,7 @@ impl<'help> Arg<'help> {
     ///
     /// assert!(m.is_present("cfg"));
     /// ```
-    pub fn long(mut self, l: &'help str) -> Self {
+    pub fn long<T: Into<Cow<'static, str>>>(mut self, l: T) -> Self {
         self.long = Some(l.trim_start_matches(|c| c == '-'));
         self
     }
@@ -336,7 +336,7 @@ impl<'help> Arg<'help> {
     /// assert_eq!(m.value_of("test"), Some("cool"));
     /// ```
     /// [`Arg`]: ./struct.Arg.html
-    pub fn alias<S: Into<&'help str>>(mut self, name: S) -> Self {
+    pub fn alias<S: Into<Cow<'static, str>>>(mut self, name: S) -> Self {
         if let Some(ref mut als) = self.aliases {
             als.push((name.into(), false));
         } else {
@@ -366,7 +366,7 @@ impl<'help> Arg<'help> {
     /// assert!(m.is_present("test"));
     /// ```
     /// [`Arg`]: ./struct.Arg.html
-    pub fn aliases(mut self, names: &[&'help str]) -> Self {
+    pub fn aliases<T: Into<Cow<'static, str>>>(mut self, names: &[T]) -> Self {
         if let Some(ref mut als) = self.aliases {
             for n in names {
                 als.push((n, false));
@@ -397,7 +397,7 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg`]: ./struct.Arg.html
     /// [`App::alias`]: ./struct.Arg.html#method.alias
-    pub fn visible_alias<S: Into<&'help str>>(mut self, name: S) -> Self {
+    pub fn visible_alias<S: Into<Cow<'static, str>>>(mut self, name: S) -> Self {
         if let Some(ref mut als) = self.aliases {
             als.push((name.into(), true));
         } else {
@@ -424,7 +424,7 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg`]: ./struct.Arg.html
     /// [`App::aliases`]: ./struct.Arg.html#method.aliases
-    pub fn visible_aliases(mut self, names: &[&'help str]) -> Self {
+    pub fn visible_aliases<T: Into<Cow<'static, OsStr>>>(mut self, names: &[T]) -> Self {
         if let Some(ref mut als) = self.aliases {
             for n in names {
                 als.push((n, true));
@@ -485,7 +485,7 @@ impl<'help> Arg<'help> {
     /// -V, --version    Prints version information
     /// ```
     /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
-    pub fn help(mut self, h: &'help str) -> Self {
+    pub fn help<T: Into<Cow<'static, str>>>(mut self, h: T) -> Self {
         self.help = Some(h);
         self
     }
@@ -556,7 +556,7 @@ impl<'help> Arg<'help> {
     ///         Prints version information
     /// ```
     /// [`Arg::help`]: ./struct.Arg.html#method.help
-    pub fn long_help(mut self, h: &'help str) -> Self {
+    pub fn long_help<T: Into<Cow<'static, str>>>(mut self, h: T) -> Self {
         self.long_help = Some(h);
         self
     }
@@ -817,7 +817,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
     /// ```
-    ///     
+    ///
     /// [`Arg::conflicts_with_all(names)`]: ./struct.Arg.html#method.conflicts_with_all
     /// [`Arg::exclusive(true)`]: ./struct.Arg.html#method.exclusive
 
@@ -1206,7 +1206,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::requires(name)`]: ./struct.Arg.html#method.requires
     /// [Conflicting]: ./struct.Arg.html#method.conflicts_with
     /// [override]: ./struct.Arg.html#method.overrides_with
-    pub fn requires_if<T: Key>(mut self, val: &'help str, arg_id: T) -> Self {
+    pub fn requires_if<T: Key, V: Into<Cow<'static, str>>>(mut self, val: V, arg_id: T) -> Self {
         let arg = arg_id.key();
         if let Some(ref mut vec) = self.requires {
             vec.push((Some(val), arg));
@@ -1267,7 +1267,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::requires(name)`]: ./struct.Arg.html#method.requires
     /// [Conflicting]: ./struct.Arg.html#method.conflicts_with
     /// [override]: ./struct.Arg.html#method.overrides_with
-    pub fn requires_ifs<T: Key>(mut self, ifs: &[(&'help str, T)]) -> Self {
+    pub fn requires_ifs<T: Key, V: Into<Cow<'static, str>>>(mut self, ifs: &[(V, T)]) -> Self {
         if let Some(ref mut vec) = self.requires {
             for (val, arg) in ifs {
                 vec.push((Some(val), arg.key()));
@@ -1345,7 +1345,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::requires(name)`]: ./struct.Arg.html#method.requires
     /// [Conflicting]: ./struct.Arg.html#method.conflicts_with
     /// [required]: ./struct.Arg.html#method.required
-    pub fn required_if<T: Key>(mut self, arg_id: T, val: &'help str) -> Self {
+    pub fn required_if<T: Key, V: Into<Cow<'static, str>>>(mut self, arg_id: T, val: V) -> Self {
         let arg = arg_id.key();
         if let Some(ref mut vec) = self.r_ifs {
             vec.push((arg, val));
@@ -1435,7 +1435,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::requires(name)`]: ./struct.Arg.html#method.requires
     /// [Conflicting]: ./struct.Arg.html#method.conflicts_with
     /// [required]: ./struct.Arg.html#method.required
-    pub fn required_ifs<T: Key>(mut self, ifs: &[(T, &'help str)]) -> Self {
+    pub fn required_ifs<T: Key, V: Into<Cow<'static, str>>>(mut self, ifs: &[(T, V)]) -> Self {
         if let Some(ref mut vec) = self.r_ifs {
             for r_if in ifs {
                 vec.push((r_if.0.key(), r_if.1));
@@ -1624,7 +1624,7 @@ impl<'help> Arg<'help> {
     /// [`min_values`]: ./struct.Arg.html#method.min_values
     /// [`number_of_values`]: ./struct.Arg.html#method.number_of_values
     /// [`max_values`]: ./struct.Arg.html#method.max_values
-    pub fn value_terminator(mut self, term: &'help str) -> Self {
+    pub fn value_terminator<T: Into<Cow<'static, str>>>(mut self, term: T) -> Self {
         self.setb(ArgSettings::TakesValue);
         self.terminator = Some(term);
         self
@@ -1677,7 +1677,7 @@ impl<'help> Arg<'help> {
     /// ```
     /// [options]: ./struct.Arg.html#method.takes_value
     /// [positional arguments]: ./struct.Arg.html#method.index
-    pub fn possible_values(mut self, names: &[&'help str]) -> Self {
+    pub fn possible_values<T: Into<Cow<'static, str>>>(mut self, names: &[T]) -> Self {
         self.setb(ArgSettings::TakesValue);
         if let Some(ref mut vec) = self.possible_vals {
             for s in names {
@@ -1742,7 +1742,7 @@ impl<'help> Arg<'help> {
     /// ```
     /// [options]: ./struct.Arg.html#method.takes_value
     /// [positional arguments]: ./struct.Arg.html#method.index
-    pub fn possible_value(mut self, name: &'help str) -> Self {
+    pub fn possible_value<T: Into<Cow<'static, str>>>(mut self, name: T) -> Self {
         self.setb(ArgSettings::TakesValue);
         if let Some(ref mut vec) = self.possible_vals {
             vec.push(name);
@@ -2109,15 +2109,11 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::use_delimiter(true)`]: ./struct.Arg.html#method.use_delimiter
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
-    pub fn value_delimiter(mut self, d: &str) -> Self {
+    pub fn value_delimiter(mut self, d: char) -> Self {
         self.unsetb(ArgSettings::ValueDelimiterNotSet);
         self.setb(ArgSettings::TakesValue);
         self.setb(ArgSettings::UseValueDelimiter);
-        self.val_delim = Some(
-            d.chars()
-                .nth(0)
-                .expect("Failed to get value_delimiter from arg"),
-        );
+        self.val_delim = Some(d);
         self
     }
 
@@ -2180,7 +2176,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::number_of_values`]: ./struct.Arg.html#method.number_of_values
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
     /// [`Arg::multiple(true)`]: ./struct.Arg.html#method.multiple
-    pub fn value_names(mut self, names: &[&'help str]) -> Self {
+    pub fn value_names<T: Into<Cow<'static, str>>>(mut self, names: &[T]) -> Self {
         self.setb(ArgSettings::TakesValue);
         if self.is_set(ArgSettings::ValueDelimiterNotSet) {
             self.unsetb(ArgSettings::ValueDelimiterNotSet);
@@ -2248,7 +2244,7 @@ impl<'help> Arg<'help> {
     /// [option]: ./struct.Arg.html#method.takes_value
     /// [positional]: ./struct.Arg.html#method.index
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
-    pub fn value_name(mut self, name: &'help str) -> Self {
+    pub fn value_name<T: Into<Cow<'static, str>>>(mut self, name: T) -> Self {
         self.setb(ArgSettings::TakesValue);
         if let Some(ref mut vals) = self.val_names {
             let l = vals.len();
@@ -2324,7 +2320,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
     /// [`ArgMatches::is_present`]: ./struct.ArgMatches.html#method.is_present
     /// [`Arg::default_value_if`]: ./struct.Arg.html#method.default_value_if
-    pub fn default_value(self, val: &'help str) -> Self {
+    pub fn default_value<T: Into<Cow<'static, str>>>(self, val: T) -> Self {
         self.default_values_os(&[OsStr::from_bytes(val.as_bytes())])
     }
 
@@ -2332,13 +2328,13 @@ impl<'help> Arg<'help> {
     /// only using [`OsStr`]s instead.
     /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    pub fn default_value_os(self, val: &'help OsStr) -> Self {
+    pub fn default_value_os<T: Into<Cow<'static, OsStr>>>(self, val: T) -> Self {
         self.default_values_os(&[val])
     }
 
     /// Like [`Arg::default_value'] but for args taking multiple values
     /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value
-    pub fn default_values(self, vals: &[&'help str]) -> Self {
+    pub fn default_values<T: Into<Cow<'static, str>>>(self, vals: &[T]) -> Self {
         let vals_vec: Vec<_> = vals
             .iter()
             .map(|val| OsStr::from_bytes(val.as_bytes()))
@@ -2350,7 +2346,7 @@ impl<'help> Arg<'help> {
     /// only using [`OsStr`]s instead.
     /// [`Arg::default_values`]: ./struct.Arg.html#method.default_values
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    pub fn default_values_os(mut self, vals: &[&'help OsStr]) -> Self {
+    pub fn default_values_os<T: Into<Cow<'static, OsStr>>>(mut self, vals: &[T]) -> Self {
         self.setb(ArgSettings::TakesValue);
         self.default_vals = Some(vals.to_vec());
         self
@@ -2452,11 +2448,11 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
     /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value
-    pub fn default_value_if<T: Key>(
+    pub fn default_value_if<T: Key, V: Into<Cow<'static, str>>>(
         self,
         arg_id: T,
-        val: Option<&'help str>,
-        default: &'help str,
+        val: V,
+        default: V,
     ) -> Self {
         self.default_value_if_os(
             arg_id,
@@ -2469,11 +2465,11 @@ impl<'help> Arg<'help> {
     /// only using [`OsStr`]s instead.
     /// [`Arg::default_value_if`]: ./struct.Arg.html#method.default_value_if
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    pub fn default_value_if_os<T: Key>(
+    pub fn default_value_if_os<T: Key, V: Into<Cow<'static, OsStr>>>(
         mut self,
         arg_id: T,
-        val: Option<&'help OsStr>,
-        default: &'help OsStr,
+        val: V,
+        default: V,
     ) -> Self {
         let arg = arg_id.key();
         self.setb(ArgSettings::TakesValue);
@@ -2572,9 +2568,9 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
     /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value
-    pub fn default_value_ifs<T: Key>(
+    pub fn default_value_ifs<T: Key, V: Into<Cow<'static, str>>>(
         mut self,
-        ifs: &[(T, Option<&'help str>, &'help str)],
+        ifs: &[(T, Option<V>, V)],
     ) -> Self {
         for (arg, val, default) in ifs {
             self = self.default_value_if_os(
@@ -2590,9 +2586,9 @@ impl<'help> Arg<'help> {
     /// [`Arg::default_value_ifs`] only using [`OsStr`]s instead.
     /// [`Arg::default_value_ifs`]: ./struct.Arg.html#method.default_value_ifs
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    pub fn default_value_ifs_os<T: Key>(
+    pub fn default_value_ifs_os<T: Key, V: Into<Cow<'static, OsStr>>>(
         mut self,
-        ifs: &[(T, Option<&'help OsStr>, &'help OsStr)],
+        ifs: &[(T, Option<V>, V)],
     ) -> Self {
         for (arg, val, default) in ifs {
             self = self.default_value_if_os(arg.key(), *val, default);
@@ -2699,14 +2695,14 @@ impl<'help> Arg<'help> {
     ///
     /// assert_eq!(m.values_of("flag").unwrap().collect::<Vec<_>>(), vec!["env1", "env2"]);
     /// ```
-    pub fn env(self, name: &'help str) -> Self {
+    pub fn env<T: Into<Cow<'static, str>>>(self, name: T) -> Self {
         self.env_os(OsStr::new(name))
     }
 
     /// Specifies that if the value is not passed in as an argument, that it should be retrieved
     /// from the environment if available in the exact same manner as [`Arg::env`] only using
     /// [`OsStr`]s instead.
-    pub fn env_os(mut self, name: &'help OsStr) -> Self {
+    pub fn env_os<T: Into<Cow<'static, OsStr>>>(mut self, name: T) -> Self {
         if !self.is_set(ArgSettings::MultipleOccurrences) {
             self.setb(ArgSettings::TakesValue);
         }
@@ -4061,7 +4057,7 @@ impl<'help> Arg<'help> {
     }
 
     /// Set a custom heading for this arg to be printed under
-    pub fn help_heading(mut self, s: Option<&'help str>) -> Self {
+    pub fn help_heading<T: Into<Cow<'static, str>>>(mut self, s: T) -> Self {
         self.help_heading = s;
         self
     }
@@ -4160,25 +4156,26 @@ impl<'help> Arg<'help> {
     }
 }
 
-impl<'help, 'z> From<&'z Arg<'help>> for Arg<'help> {
-    fn from(a: &'z Arg<'help>) -> Self {
+impl From<&'_ Arg> for Arg {
+    fn from(a: &'_ Arg) -> Self {
         a.clone()
     }
 }
 
-impl<'help> From<&'help str> for Arg<'help> {
-    fn from(s: &'help str) -> Self {
+impl<T: Into<Cow<'static, str>>> From<T> for Arg {
+    fn from(s: T) -> Self {
         UsageParser::from_usage(s).parse()
     }
 }
 
-impl<'help> PartialEq for Arg<'help> {
-    fn eq(&self, other: &Arg<'help>) -> bool {
+// FIXME (@CreepySkeleton): Looks like a footgun
+impl PartialEq for Arg {
+    fn eq(&self, other: &Arg) -> bool {
         self.name == other.name
     }
 }
 
-impl<'help> Display for Arg<'help> {
+impl Display for Arg {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         if self.index.is_some() || (self.long.is_none() && self.short.is_none()) {
             // Positional
@@ -4276,22 +4273,23 @@ impl<'help> Display for Arg<'help> {
     }
 }
 
-impl<'help> PartialOrd for Arg<'help> {
+impl PartialOrd for Arg {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'help> Ord for Arg<'help> {
+impl Ord for Arg {
     fn cmp(&self, other: &Arg) -> Ordering {
         self.name.cmp(&other.name)
     }
 }
 
-impl<'help> Eq for Arg<'help> {}
+impl Eq for Arg {}
 
-impl<'help> fmt::Debug for Arg<'help> {
+impl fmt::Debug for Arg {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        // FIXME (@CreepySkeleton): Rewrite using `fmt::Formatter::debug_struct`
         write!(
             f,
             "Arg {{ id: {:X?}, name: {:?}, help: {:?}, long_help: {:?}, conflicts_with: {:?}, \

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -1,4 +1,5 @@
 // Std
+use std::borrow::Cow;
 use std::fmt::{Debug, Formatter, Result};
 
 // Third Party
@@ -81,11 +82,11 @@ type Id = u64;
 /// [conflict]: ./struct.Arg.html#method.conflicts_with
 /// [requirement]: ./struct.Arg.html#method.requires
 #[derive(Default)]
-pub struct ArgGroup<'a> {
+pub struct ArgGroup {
     #[doc(hidden)]
     pub id: Id,
     #[doc(hidden)]
-    pub name: &'a str,
+    pub name: Cow<'static, str>,
     #[doc(hidden)]
     pub args: Vec<Id>,
     #[doc(hidden)]
@@ -98,7 +99,7 @@ pub struct ArgGroup<'a> {
     pub multiple: bool,
 }
 
-impl<'a> ArgGroup<'a> {
+impl<'a> ArgGroup {
     #[doc(hidden)]
     pub fn _with_id(id: Id) -> Self {
         ArgGroup {
@@ -138,7 +139,7 @@ impl<'a> ArgGroup<'a> {
     /// let ag = ArgGroup::from_yaml(yml);
     /// ```
     #[cfg(feature = "yaml")]
-    pub fn from_yaml(y: &'a yaml_rust::Yaml) -> ArgGroup<'a> {
+    pub fn from_yaml(y: &'a yaml_rust::Yaml) -> ArgGroup {
         ArgGroup::from(y.as_hash().unwrap())
     }
 
@@ -433,7 +434,7 @@ impl<'a> ArgGroup<'a> {
     }
 }
 
-impl<'a> Debug for ArgGroup<'a> {
+impl<'a> Debug for ArgGroup {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(
             f,
@@ -449,8 +450,8 @@ impl<'a> Debug for ArgGroup<'a> {
     }
 }
 
-impl<'a, 'z> From<&'z ArgGroup<'a>> for ArgGroup<'a> {
-    fn from(g: &'z ArgGroup<'a>) -> Self {
+impl<'a, 'z> From<&'z ArgGroup> for ArgGroup {
+    fn from(g: &'z ArgGroup) -> Self {
         ArgGroup {
             id: g.id,
             name: g.name,
@@ -464,7 +465,7 @@ impl<'a, 'z> From<&'z ArgGroup<'a>> for ArgGroup<'a> {
 }
 
 #[cfg(feature = "yaml")]
-impl<'a> From<&'a yaml_rust::yaml::Hash> for ArgGroup<'a> {
+impl<'a> From<&'a yaml_rust::yaml::Hash> for ArgGroup {
     fn from(b: &'a yaml_rust::yaml::Hash) -> Self {
         // We WANT this to panic on error...so expect() is good.
         let mut a = ArgGroup::default();
@@ -631,7 +632,7 @@ requires:
     }
 }
 
-impl<'a> Clone for ArgGroup<'a> {
+impl<'a> Clone for ArgGroup {
     fn clone(&self) -> Self {
         ArgGroup {
             id: self.id,

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -121,10 +121,11 @@ impl<'a> ArgGroup {
     /// ArgGroup::with_name("config")
     /// # ;
     /// ```
-    pub fn with_name(n: &'a str) -> Self {
+    pub fn with_name<T: Into<Cow<'static, str>>>(n: T) -> Self {
+        let name = n.into();
         ArgGroup {
-            id: n.key(),
-            name: n,
+            id: name.key(),
+            name,
             ..ArgGroup::default()
         }
     }

--- a/src/build/usage_parser.rs
+++ b/src/build/usage_parser.rs
@@ -42,7 +42,7 @@ impl<'a> UsageParser<'a> {
         UsageParser::new(usage)
     }
 
-    pub fn parse(mut self) -> Arg<'a> {
+    pub fn parse(mut self) -> Arg {
         debugln!("UsageParser::parse;");
         let mut arg = Arg::default();
         arg.disp_ord = 999;
@@ -74,7 +74,7 @@ impl<'a> UsageParser<'a> {
         arg
     }
 
-    fn name(&mut self, arg: &mut Arg<'a>) {
+    fn name(&mut self, arg: &mut Arg) {
         debugln!("UsageParser::name;");
         if *self
             .usage
@@ -125,7 +125,7 @@ impl<'a> UsageParser<'a> {
             .count();
     }
 
-    fn short_or_long(&mut self, arg: &mut Arg<'a>) {
+    fn short_or_long(&mut self, arg: &mut Arg) {
         debugln!("UsageParser::short_or_long;");
         self.pos += 1;
         if *self
@@ -142,7 +142,7 @@ impl<'a> UsageParser<'a> {
         self.short(arg)
     }
 
-    fn long(&mut self, arg: &mut Arg<'a>) {
+    fn long(&mut self, arg: &mut Arg) {
         debugln!("UsageParser::long;");
         self.stop_at(long_end);
         let name = &self.usage[self.start..self.pos];
@@ -156,7 +156,7 @@ impl<'a> UsageParser<'a> {
         self.prev = UsageToken::Long;
     }
 
-    fn short(&mut self, arg: &mut Arg<'a>) {
+    fn short(&mut self, arg: &mut Arg) {
         debugln!("UsageParser::short;");
         let start = &self.usage[self.pos..];
         let short = start.chars().next().expect(INTERNAL_ERROR_MSG);
@@ -194,7 +194,7 @@ impl<'a> UsageParser<'a> {
         }
     }
 
-    fn help(&mut self, arg: &mut Arg<'a>) {
+    fn help(&mut self, arg: &mut Arg) {
         debugln!("UsageParser::help;");
         self.stop_at(help_start);
         self.start = self.pos + 1;
@@ -208,7 +208,7 @@ impl<'a> UsageParser<'a> {
         self.prev = UsageToken::Help;
     }
 
-    fn default(&mut self, arg: &mut Arg<'a>) {
+    fn default(&mut self, arg: &mut Arg) {
         debugln!(
             "UsageParser::default; from: \"{}\"",
             &self.usage[self.pos..self.usage.len()]

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -45,9 +45,9 @@ pub trait Clap: FromArgMatches + IntoApp + Sized {
 /// Also serves for flattening
 pub trait IntoApp: Sized {
     /// @TODO @release @docs
-    fn into_app<'b>() -> App<'b>;
+    fn into_app() -> App;
     /// @TODO @release @docs
-    fn augment_clap(app: App<'_>) -> App<'_>;
+    fn augment_clap(app: App) -> App;
 }
 
 /// Extract values from ArgMatches into the struct.
@@ -61,7 +61,7 @@ pub trait Subcommand: Sized {
     /// @TODO @release @docs
     fn from_subcommand(name: &str, matches: Option<&ArgMatches>) -> Option<Self>;
     /// @TODO @release @docs
-    fn augment_subcommands(app: App<'_>) -> App<'_>;
+    fn augment_subcommands(app: App) -> App;
 }
 
 /// @TODO @release @docs
@@ -96,10 +96,10 @@ impl<T: Clap> Clap for Box<T> {
 }
 
 impl<T: IntoApp> IntoApp for Box<T> {
-    fn into_app<'b>() -> App<'b> {
+    fn into_app<'b>() -> App {
         <T as IntoApp>::into_app()
     }
-    fn augment_clap(app: App<'_>) -> App<'_> {
+    fn augment_clap(app: App) -> App {
         <T as IntoApp>::augment_clap(app)
     }
 }
@@ -114,7 +114,7 @@ impl<T: Subcommand> Subcommand for Box<T> {
     fn from_subcommand(name: &str, matches: Option<&ArgMatches>) -> Option<Self> {
         <T as Subcommand>::from_subcommand(name, matches).map(Box::new)
     }
-    fn augment_subcommands(app: App<'_>) -> App<'_> {
+    fn augment_subcommands(app: App) -> App {
         <T as Subcommand>::augment_subcommands(app)
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1027,12 +1027,15 @@ macro_rules! names {
         $app.args.args.iter().map(|a| &*a.name)
     }};
     (@sc $app:expr) => {{
-        $app.subcommands.iter().map(|s| &*s.name).chain(
-            $app.subcommands
-                .iter()
-                .filter(|s| s.aliases.is_some())
-                .flat_map(|s| s.aliases.as_ref().unwrap().iter().map(|&(n, _)| n)),
-        )
+        $app.subcommands
+            .iter()
+            .map(|s| Cow::Borrowed(s.name.as_str()))
+            .chain(
+                $app.subcommands
+                    .iter()
+                    .filter(|s| s.aliases.is_some())
+                    .flat_map(|s| s.aliases.as_ref().unwrap().iter().map(|&(n, _)| n)),
+            )
     }};
 }
 
@@ -1055,6 +1058,6 @@ macro_rules! match_alias {
                     .as_ref()
                     .unwrap()
                     .iter()
-                    .any(|alias| alias.0 == $to))
+                    .any(|alias| *alias.0 == *$to))
     }};
 }

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -10,9 +10,9 @@ pub struct Key {
 }
 
 #[derive(Default, PartialEq, Debug, Clone)]
-pub struct MKeyMap<'b> {
+pub struct MKeyMap {
     pub keys: Vec<Key>,
-    pub args: Vec<Arg<'b>>,
+    pub args: Vec<Arg>,
     built: bool, // mutation isn't possible after being built
 }
 
@@ -51,7 +51,7 @@ impl PartialEq<char> for KeyType {
     }
 }
 
-impl<'b> MKeyMap<'b> {
+impl<'b> MKeyMap {
     pub fn new() -> Self {
         MKeyMap::default()
     }
@@ -75,13 +75,13 @@ impl<'b> MKeyMap<'b> {
         self.keys.iter().any(|x| x.key == key)
     }
 
-    pub fn insert(&mut self, key: KeyType, value: Arg<'b>) -> usize {
+    pub fn insert(&mut self, key: KeyType, value: Arg) -> usize {
         let index = self.push(value);
         self.keys.push(Key { key, index });
         index
     }
 
-    pub fn push(&mut self, value: Arg<'b>) -> usize {
+    pub fn push(&mut self, value: Arg) -> usize {
         if self.built {
             panic!("Cannot add Args to the map after the map is built");
         }
@@ -104,7 +104,7 @@ impl<'b> MKeyMap<'b> {
 
     // ! Arg mutation functionality
 
-    pub fn get(&self, key: &KeyType) -> Option<&Arg<'b>> {
+    pub fn get(&self, key: &KeyType) -> Option<&Arg> {
         self.keys
             .iter()
             .find(|k| k.key == *key)
@@ -112,7 +112,7 @@ impl<'b> MKeyMap<'b> {
     }
     //TODO ::get_first([KeyA, KeyB])
 
-    pub fn get_mut(&mut self, key: &KeyType) -> Option<&mut Arg<'b>> {
+    pub fn get_mut(&mut self, key: &KeyType) -> Option<&mut Arg> {
         let key = self.keys.iter().find(|k| k.key == *key);
 
         match key {
@@ -185,7 +185,7 @@ impl<'b> MKeyMap<'b> {
             .expect("No such name found")
     }
 
-    pub fn remove(&mut self, key: &KeyType) -> Option<Arg<'b>> {
+    pub fn remove(&mut self, key: &KeyType) -> Option<Arg> {
         if self.built {
             panic!("Cannot remove args after being built");
         }
@@ -206,7 +206,7 @@ impl<'b> MKeyMap<'b> {
     //? probably shouldn't add a possibility for removal?
     //? or remove by replacement by some dummy object, so the order is preserved
 
-    pub fn remove_by_name(&mut self, _name: Id) -> Option<Arg<'b>> {
+    pub fn remove_by_name(&mut self, _name: Id) -> Option<Arg> {
         if self.built {
             panic!("Cannot remove args after being built");
         }

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -9,16 +9,15 @@ use crate::INTERNAL_ERROR_MSG;
 
 type Id = u64;
 
-pub struct Usage<'b, 'c, 'z>
+pub struct Usage<'c, 'z>
 where
-    'b: 'c,
     'c: 'z,
 {
-    p: &'z Parser<'b, 'c>,
+    p: &'z Parser<'c>,
 }
 
-impl<'b, 'c, 'z> Usage<'b, 'c, 'z> {
-    pub fn new(p: &'z Parser<'b, 'c>) -> Self {
+impl<'c, 'z> Usage<'c, 'z> {
+    pub fn new(p: &'z Parser<'c>) -> Self {
         Usage { p }
     }
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -61,7 +61,7 @@ where
 }
 
 impl Input {
-    pub fn next(&mut self, new: Option<&[&str]>) -> Option<(&OsStr, Option<&OsStr>)> {
+    pub fn next(&mut self, new: Option<&[Cow<'static, str>]>) -> Option<(&OsStr, Option<&OsStr>)> {
         if new.is_some() {
             let mut new_items: Vec<OsString> = new
                 .expect(INTERNAL_ERROR_MSG)
@@ -424,7 +424,7 @@ where
         let mut subcmd_name: Option<String> = None;
         let mut needs_val_of: ParseResult = ParseResult::NotFound;
         let mut pos_counter = 1;
-        let mut replace: Option<&[&Cow<'static, str>]> = None;
+        let mut replace: Option<&[Cow<'static, str>]> = None;
 
         while let Some((arg_os, next_arg)) = it.next(replace) {
             replace = None;
@@ -811,11 +811,11 @@ where
                 .collect::<Vec<_>>();
 
             if v.len() == 1 {
-                return Some(v[0]);
+                return Some(&*v[0]);
             }
 
             for sc in &v {
-                if OsStr::new(sc) == arg_os {
+                if **sc == *arg_os {
                     return Some(sc);
                 }
             }
@@ -1344,7 +1344,7 @@ where
 
         // @TODO @docs @p4 docs should probably note that terminator doesn't get an index
         if let Some(t) = arg.terminator {
-            if t == v {
+            if *t == *v {
                 return Ok(ParseResult::ValuesDone);
             }
         }

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -12,17 +12,16 @@ use crate::INVALID_UTF8;
 
 type Id = u64;
 
-pub struct Validator<'b, 'c, 'z>
+pub struct Validator<'c, 'z>
 where
-    'b: 'c,
     'c: 'z,
 {
-    p: &'z mut Parser<'b, 'c>,
+    p: &'z mut Parser<'c>,
     c: ChildGraph<Id>,
 }
 
-impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
-    pub fn new(p: &'z mut Parser<'b, 'c>) -> Self {
+impl<'c, 'z> Validator<'c, 'z> {
+    pub fn new(p: &'z mut Parser<'c>) -> Self {
         Validator {
             p,
             c: ChildGraph::with_capacity(5),
@@ -483,7 +482,7 @@ impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
 
     fn validate_arg_requires(
         &self,
-        a: &Arg<'b>,
+        a: &Arg,
         ma: &MatchedArg,
         matcher: &ArgMatcher,
     ) -> ClapResult<()> {
@@ -552,12 +551,12 @@ impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
         Ok(())
     }
 
-    fn is_missing_required_ok(&self, a: &Arg<'b>, matcher: &ArgMatcher) -> bool {
+    fn is_missing_required_ok(&self, a: &Arg, matcher: &ArgMatcher) -> bool {
         debugln!("Validator::is_missing_required_ok: {}", a.name);
         self.validate_arg_conflicts(a, matcher) || self.p.overriden.contains(&a.id)
     }
 
-    fn validate_arg_conflicts(&self, a: &Arg<'b>, matcher: &ArgMatcher) -> bool {
+    fn validate_arg_conflicts(&self, a: &Arg, matcher: &ArgMatcher) -> bool {
         debugln!("Validator::validate_arg_conflicts: a={:?};", a.name);
         a.blacklist
             .as_ref()
@@ -597,7 +596,7 @@ impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
     }
 
     // Failing a required unless means, the arg's "unless" wasn't present, and neither were they
-    fn fails_arg_required_unless(&self, a: &Arg<'b>, matcher: &ArgMatcher) -> bool {
+    fn fails_arg_required_unless(&self, a: &Arg, matcher: &ArgMatcher) -> bool {
         debugln!("Validator::fails_arg_required_unless: a={:?};", a.name);
         macro_rules! check {
             ($how:ident, $_self:expr, $a:ident, $m:ident) => {{

--- a/src/util/cow.rs
+++ b/src/util/cow.rs
@@ -1,0 +1,22 @@
+// REVIEW_NEEDED
+
+use std::{
+    borrow::Cow,
+    ffi::{OsStr, OsString},
+};
+
+use super::OsStrExt3;
+
+pub(crate) trait _CowStrExt {
+    fn into_os_str(self) -> Cow<'static, OsStr>;
+}
+
+impl _CowStrExt for Cow<'static, str> {
+    fn into_os_str(self) -> Cow<'static, OsStr> {
+        match self {
+            Cow::Borrowed(s) => Cow::Borrowed(OsStr::from_bytes(s.as_bytes())),
+            // TODO: this always copies the data, while it shouldn't
+            Cow::Owned(s) => Cow::Owned(OsString::from(s)),
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+mod cow;
 mod fnv;
 mod graph;
 mod map;
@@ -11,3 +12,4 @@ pub use self::osstringext::OsStrExt2;
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 pub use self::osstringext::OsStrExt3;
 pub use self::strext::_StrExt;
+pub(crate) use cow::_CowStrExt;

--- a/tests/global_args.rs
+++ b/tests/global_args.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use clap::{App, Arg};
 
-fn get_app() -> App<'static> {
+fn get_app() -> App {
     App::new("myprog")
         .arg(
             Arg::with_name("GLOBAL_ARG")

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -475,14 +475,14 @@ USAGE:
     myapp [arg1]
 
 ARGS:
-    <arg1>    
+    <arg1>
             some option
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information";
 
 static HIDE_ENV_VALS: &str = "ctest 0.1
@@ -528,20 +528,20 @@ OPTIONS:
 NETWORKING:
     -n, --no-proxy    Do not use system proxy settings";
 
-static ISSUE_1487: &str = "test 
+static ISSUE_1487: &str = "test
 
 USAGE:
     ctest <arg1|arg2>
 
 ARGS:
-    <arg1>    
-    <arg2>    
+    <arg1>
+    <arg2>
 
 FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
-fn setup() -> App<'static> {
+fn setup() -> App {
     App::new("test")
         .author("Kevin K.")
         .about("tests stuff")
@@ -1273,7 +1273,7 @@ fn hidden_default_val() {
     ));
 }
 
-fn issue_1112_setup() -> App<'static> {
+fn issue_1112_setup() -> App {
     App::new("test")
         .author("Kevin K.")
         .about("tests stuff")
@@ -1507,10 +1507,10 @@ USAGE:
     ctest foo
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information";
 
 #[test]

--- a/tests/propagate_globals.rs
+++ b/tests/propagate_globals.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use clap::{App, Arg, ArgMatches, ArgSettings};
 
-fn get_app() -> App<'static> {
+fn get_app() -> App {
     App::new("myprog")
         .arg(
             Arg::with_name("GLOBAL_ARG")
@@ -22,7 +22,7 @@ fn get_app() -> App<'static> {
         .subcommand(App::new("outer").subcommand(App::new("inner")))
 }
 
-fn get_matches(app: App<'static>, argv: &'static str) -> ArgMatches {
+fn get_matches(app: App, argv: &'static str) -> ArgMatches {
     app.get_matches_from(argv.split(' ').collect::<Vec<_>>())
 }
 

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -672,7 +672,7 @@ USAGE:
 
 For more information try --help";
 
-fn issue_1158_app() -> App<'static> {
+fn issue_1158_app() -> App {
     App::new("example")
         .arg(
             Arg::from("-c, --config [FILE] 'Custom config file.'")

--- a/tests/template_help.rs
+++ b/tests/template_help.rs
@@ -147,7 +147,7 @@ fn template_author_version() {
 
 // ----------
 
-fn get_app() -> App<'static> {
+fn get_app() -> App {
     App::new("MyApp")
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -60,7 +60,7 @@ pub fn compare_output2(l: App, args: &str, right1: &str, right2: &str, stderr: b
 
 // Legacy tests from the pyhton script days
 
-pub fn complex_app() -> App<'static> {
+pub fn complex_app() -> App {
     let opt3_vals = ["fast", "slow"];
     let pos3_vals = ["vi", "emacs"];
 


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
OK, this is the very early stage of the ambitious "get rid of lifetimes" plan. 

As @pksunkara and I have discussed, it should be possible to remove lifetimes entirely by making use of `Cow<'static, str/OsStr>` instead of plain references. This would be very useful for those who generate their data at runtime, as described in #1041.

The plan is simple: turn `fn method(self, data: &'b str)` interface into `fn method<T: Into<Cow<'static, str>>>(self, data: T)`. Since all of `&str`, `&OsStr`, `String`, `OsString` implement `Into<Cow>`, the transition should be more or less painless for our users.

There are three ways people could possibly build `clap::App`:
* Use statically borrowed data (`&'static str`), explicitly written as `app.help("some string")`. Those would be turned into `Cow::Borrowed`, involving no clones.
* Use dynamically owned data (`String`), the data **is not** needed anywhere else. Those would be turned into `Cow::Owned(s)` by moving the string into the app, no cloning would be involved either.
* Use dynamically owned data (`String`), the data **is** needed somewhere else. The "out of luck" case, users would need to explicitly clone the data. For what it's worth, I've never seen such a usage in the wild.

Well, let's make it build and see the benches.

Closes #1041 

___
List of significant changes I've made:
* Turn slice-based API (`&[&str]`) into iterator based
___

List of TODOs:
- [ ] Sanitize `std::borrow::Cow`