### PR TITLE
Change arg from char to String literal

### DIFF
--- a/examples/05_flag_args.rs
+++ b/examples/05_flag_args.rs
@@ -16,7 +16,7 @@ fn main() {
         .arg(
             Arg::with_name("awesome")
                 .help("turns up the awesome") // Displayed when showing help info
-                .short('a') // Trigger this arg with "-a"
+                .short("a") // Trigger this arg with "-a"
                 .long("awesome") // Trigger this arg with "--awesome"
                 .multiple(true) // This flag should allow multiple
                 // occurrences such as "-aaa" or "-a -a"


### PR DESCRIPTION
In example "05_flag_args", the use of a [char literal flag short name](https://github.com/clap-rs/clap/blob/master/examples/05_flag_args.rs#L19) causes a compiler error:  `the trait `std::convert::AsRef<str>` is not implemented for 'char'`
Char literal changed to String literal instead.
