### PR TITLE
Make bash completion more flexible

### DIFF
--- a/src/completions/bash.rs
+++ b/src/completions/bash.rs
@@ -33,8 +33,8 @@ impl<'a, 'b> BashGen<'a, 'b> {
     for i in ${{COMP_WORDS[@]}}
     do
         case "${{i}}" in
-            {name})
-                cmd="{name}"
+            "${{1}}")
+                cmd="${{1}}"
                 ;;
             {subcmds}
             *)
@@ -43,7 +43,7 @@ impl<'a, 'b> BashGen<'a, 'b> {
     done
 
     case "${{cmd}}" in
-        {name})
+        "${{1}}")
             opts="{name_opts}"
             if [[ ${{cur}} == -* || ${{COMP_CWORD}} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${{opts}}" -- "${{cur}}") )

--- a/tests/completions.rs
+++ b/tests/completions.rs
@@ -15,8 +15,8 @@ static BASH: &'static str = r#"_myapp() {
     for i in ${COMP_WORDS[@]}
     do
         case "${i}" in
-            myapp)
-                cmd="myapp"
+            "${1}")
+                cmd="${1}"
                 ;;
             
             help)
@@ -31,7 +31,7 @@ static BASH: &'static str = r#"_myapp() {
     done
 
     case "${cmd}" in
-        myapp)
+        "${1}")
             opts=" -h -V  --help --version  <file>  test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -536,8 +536,8 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
     for i in ${COMP_WORDS[@]}
     do
         case "${i}" in
-            my_app)
-                cmd="my_app"
+            "${1}")
+                cmd="${1}"
                 ;;
             
             help)
@@ -558,7 +558,7 @@ static BASH_SPECIAL_CMDS: &'static str = r#"_my_app() {
     done
 
     case "${cmd}" in
-        my_app)
+        "${1}")
             opts=" -h -V  --help --version  <file>  test some_cmd some-cmd-with-hypens help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )


### PR DESCRIPTION
The bash completion, as it is generated by clap, is specific to the
command it is created for. E.g., that is, if it was created for 'myapp'
it can only ever be used for completion on the 'myapp' command. This
constraint is rooted in said command (being provided at build time)
being embedded in the generated code. While it is sensible to enable
completion for the supplied command by default, there should be a way to
make it apply to other commands as well (think, bash aliases, for
example).
Completions for other tools such as git support this out of the box via
an indirection: by providing a function that registers the completion
and that accepts the command to register it for.
With this change we enable this use case for the clap generated bash
completion as well. Instead of hard coding the command name we expect,
we rely on the first argument provided by the complete built-in, which
evaluates to exactly this command (see bash(1); ctrl-f '-F function').
The completion for myapp as it occurs when sourcing the completion
script is unaffected.
With this change, a completion generated for 'myapp' can now be
repurposed to work with a hypothetical alias 'app' as follows:
  > complete -F _myapp -o bashdefault -o default app

Fixes #1764

----

I am not familar with `clap_generate` and I need the fix on `v2`, hence, pull request for `v2-master`. Change can be crossported to `master` if desired.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
