### PR TITLE
style: fix comma placement for valid values when using arg_enum

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -332,7 +332,7 @@ macro_rules! arg_enum {
                             $(stringify!($v),)+
                         ];
                         format!("valid values: {}",
-                            v.join(" ,"))
+                            v.join(", "))
                     }),
                 }
             }


### PR DESCRIPTION
When using `arg_enum`  and the user mistypes the parameter, the valid values are printed like this:

`valid values: A ,B ,C`

Note the position of the commas; this patch fixes their position to get placed right after the item:

`valid values: A, B, C`