### PR TITLE
set the default disp_ord of App to 999. 

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -120,6 +120,7 @@ impl<'b> App<'b> {
         App {
             id,
             name,
+            disp_ord: 999,
             ..Default::default()
         }
     }

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -28,7 +28,6 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     test    Some help";
 
-
 static SUBCMD_ALPHA_ORDER: &str = "test 1
 
 USAGE:
@@ -155,12 +154,14 @@ fn subcommand_multiple() {
 
 #[test]
 fn subcommand_display_order() {
-    let app_subcmd_alpha_order = App::new("test")
-        .version("1")
-        .subcommands(vec![
-            App::new("b1").about("blah b1").arg(Arg::with_name("test").short('t')),
-            App::new("a1").about("blah a1").arg(Arg::with_name("roster").short('r')),
-        ]);
+    let app_subcmd_alpha_order = App::new("test").version("1").subcommands(vec![
+        App::new("b1")
+            .about("blah b1")
+            .arg(Arg::with_name("test").short('t')),
+        App::new("a1")
+            .about("blah a1")
+            .arg(Arg::with_name("roster").short('r')),
+    ]);
 
     assert!(utils::compare_output(
         app_subcmd_alpha_order,
@@ -173,8 +174,12 @@ fn subcommand_display_order() {
         .version("1")
         .setting(clap::AppSettings::DeriveDisplayOrder)
         .subcommands(vec![
-            App::new("b1").about("blah b1").arg(Arg::with_name("test").short('t')),
-            App::new("a1").about("blah a1").arg(Arg::with_name("roster").short('r')),
+            App::new("b1")
+                .about("blah b1")
+                .arg(Arg::with_name("test").short('t')),
+            App::new("a1")
+                .about("blah a1")
+                .arg(Arg::with_name("roster").short('r')),
         ]);
 
     assert!(utils::compare_output(
@@ -184,7 +189,6 @@ fn subcommand_display_order() {
         false,
     ));
 }
-
 
 #[test]
 fn single_alias() {

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -28,6 +28,35 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     test    Some help";
 
+
+static SUBCMD_ALPHA_ORDER: &str = "test 1
+
+USAGE:
+    test [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    a1      blah a1
+    b1      blah b1
+    help    Prints this message or the help of the given subcommand(s)";
+
+static SUBCMD_DECL_ORDER: &str = "test 1
+
+USAGE:
+    test [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    b1      blah b1
+    a1      blah a1
+    help    Prints this message or the help of the given subcommand(s)";
+
 #[cfg(feature = "suggestions")]
 static DYM_SUBCMD: &str = "error: The subcommand 'subcm' wasn't recognized
 	Did you mean 'subcmd'?
@@ -123,6 +152,39 @@ fn subcommand_multiple() {
     assert!(sub_m.is_present("test"));
     assert_eq!(sub_m.value_of("test").unwrap(), "testing");
 }
+
+#[test]
+fn subcommand_display_order() {
+    let app_subcmd_alpha_order = App::new("test")
+        .version("1")
+        .subcommands(vec![
+            App::new("b1").about("blah b1").arg(Arg::with_name("test").short('t')),
+            App::new("a1").about("blah a1").arg(Arg::with_name("roster").short('r')),
+        ]);
+
+    assert!(utils::compare_output(
+        app_subcmd_alpha_order,
+        "test --help",
+        SUBCMD_ALPHA_ORDER,
+        false,
+    ));
+
+    let app_subcmd_decl_order = App::new("test")
+        .version("1")
+        .setting(clap::AppSettings::DeriveDisplayOrder)
+        .subcommands(vec![
+            App::new("b1").about("blah b1").arg(Arg::with_name("test").short('t')),
+            App::new("a1").about("blah a1").arg(Arg::with_name("roster").short('r')),
+        ]);
+
+    assert!(utils::compare_output(
+        app_subcmd_decl_order,
+        "test --help",
+        SUBCMD_DECL_ORDER,
+        false,
+    ));
+}
+
 
 #[test]
 fn single_alias() {


### PR DESCRIPTION
Required for display_order and DeriveDisplay to work properly for subcommands. This fix lets you change the subcommand order correctly.

 Add a unit test that checks that DeriveDisplay works correctly.