### PR TITLE
Update the documentation regarding which features are enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,9 +461,9 @@ Then run `cargo build` or `cargo update && cargo build` for your project.
 #### Features enabled by default
 
 * **derive**: Enables the custom derive (i.e. `#[derive(Clap)]`). Without this you must use one of the other methods of creating a `clap` CLI listed above
-* **"suggestions"**: Turns on the `Did you mean '--myoption'?` feature for when users make typos. (builds dependency `strsim`)
-* **"color"**: Turns on colored error messages. This feature only works on non-Windows OSs. (builds dependency `ansi-term`)
-* **"vec_map"**: Use [`VecMap`](https://crates.io/crates/vec_map) internally instead of a [`BTreeMap`](https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html). This feature provides a _slight_ performance improvement. (builds dependency `vec_map`)
+* **suggestions**: Turns on the `Did you mean '--myoption'?` feature for when users make typos. (builds dependency `strsim`)
+* **color**: Turns on colored error messages. This feature only works on non-Windows OSs. (builds dependency `ansi-term`)
+* **vec_map**: Use [`VecMap`](https://crates.io/crates/vec_map) internally instead of a [`BTreeMap`](https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html). This feature provides a _slight_ performance improvement. (builds dependency `vec_map`)
 
 To disable these, add this to your `Cargo.toml`:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,11 +317,10 @@
 //!
 //! #### Features enabled by default
 //!
+//! * `derive`: Enables the custom derive (i.e. `#[derive(Clap)]`). Without this you must use one of the other methods of creating a `clap` CLI listed above
 //! * `suggestions`: Turns on the `Did you mean '--myoption'?` feature for when users make typos. (builds dependency `strsim`)
-//! * `color`: Turns on colored error messages. This feature only works on non-Windows OSs. (builds dependency `ansi-term` and `atty`)
-//! * `wrap_help`: Wraps the help at the actual terminal width when
-//!  available, instead of 120 chracters. (builds dependency `textwrap`
-//! with feature `term_size`)
+//! * `color`: Turns on colored error messages. This feature only works on non-Windows OSs. (builds dependency `ansi-term`)
+//! * `vec_map`: Use [`VecMap`](https://crates.io/crates/vec_map) internally instead of a [`BTreeMap`](https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html). This feature provides a _slight_ performance improvement. (builds dependency `vec_map`)
 //!
 //! To disable these, add this to your `Cargo.toml`:
 //!
@@ -346,6 +345,7 @@
 //!
 //! * **"yaml"**: Enables building CLIs from YAML documents. (builds dependency `yaml-rust`)
 //! * **"unstable"**: Enables unstable `clap` features that may change from release to release
+//! * **"wrap_help"**: Turns on the help text wrapping feature, based on the terminal size. (builds dependency `term-size`)
 //!
 //! ### Dependencies Tree
 //!


### PR DESCRIPTION
Update the documentation regarding which features are enabled by default. I also made the formatting in `README.md` more consistent, and made the documentation in `src/lib.rs` match what is written in `README.md`.

Keeping these two files in sync appears to be error prone. I suggest using something like [Tagref](https://github.com/stepchowfun/tagref) to have these files point to each other so contributors are reminded to update both together. (This PR does not set that up, however.)

@CreepySkeleton @Dylan-DPC

Closes #1430