### PR TITLE
Add hinting of arg value types for zsh/fish completion

### DIFF
--- a/clap_generate/examples/value_hints.rs
+++ b/clap_generate/examples/value_hints.rs
@@ -1,0 +1,114 @@
+//! Example to test arguments with different ValueHint values.
+//!
+//! Usage with zsh:
+//! ```sh
+//! cargo run --example value_hints -- --generate=zsh > /usr/local/share/zsh/site-functions/_value_hints
+//! compinit
+//! ./target/debug/examples/value_hints --<TAB>
+//! ```
+//! fish:
+//! ```sh
+//! cargo run --example value_hints -- --generate=fish > value_hints.fish
+//! . ./value_hints.fish
+//! ./target/debug/examples/value_hints --<TAB>
+//! ```
+use clap::{App, AppSettings, Arg, ValueHint};
+use clap_generate::generators::{Elvish, Fish, PowerShell, Zsh};
+use clap_generate::{generate, generators::Bash};
+use std::io;
+
+const APPNAME: &str = "value_hints";
+
+fn build_cli() -> App<'static> {
+    App::new(APPNAME)
+        .setting(AppSettings::DisableVersion)
+        .setting(AppSettings::TrailingVarArg)
+        .arg(Arg::new("generator").long("generate").possible_values(&[
+            "bash",
+            "elvish",
+            "fish",
+            "powershell",
+            "zsh",
+        ]))
+        .arg(
+            Arg::new("unknown")
+                .long("unknown")
+                .value_hint(ValueHint::Unknown),
+        )
+        .arg(Arg::new("other").long("other").value_hint(ValueHint::Other))
+        .arg(
+            Arg::new("path")
+                .long("path")
+                .short('p')
+                .value_hint(ValueHint::AnyPath),
+        )
+        .arg(
+            Arg::new("file")
+                .long("file")
+                .short('f')
+                .value_hint(ValueHint::FilePath),
+        )
+        .arg(
+            Arg::new("dir")
+                .long("dir")
+                .short('d')
+                .value_hint(ValueHint::DirPath),
+        )
+        .arg(
+            Arg::new("exe")
+                .long("exe")
+                .short('e')
+                .value_hint(ValueHint::ExecutablePath),
+        )
+        .arg(
+            Arg::new("cmd_name")
+                .long("cmd-name")
+                .value_hint(ValueHint::CommandName),
+        )
+        .arg(
+            Arg::new("cmd")
+                .long("cmd")
+                .short('c')
+                .value_hint(ValueHint::CommandString),
+        )
+        .arg(
+            Arg::new("command_with_args")
+                .multiple_values(true)
+                .value_hint(ValueHint::CommandWithArguments),
+        )
+        .arg(
+            Arg::new("user")
+                .short('u')
+                .long("user")
+                .value_hint(ValueHint::Username),
+        )
+        .arg(
+            Arg::new("host")
+                .short('h')
+                .long("host")
+                .value_hint(ValueHint::Hostname),
+        )
+        .arg(Arg::new("url").long("url").value_hint(ValueHint::Url))
+        .arg(
+            Arg::new("email")
+                .long("email")
+                .value_hint(ValueHint::EmailAddress),
+        )
+}
+
+fn main() {
+    let matches = build_cli().get_matches();
+
+    if let Some(generator) = matches.value_of("generator") {
+        let mut app = build_cli();
+        eprintln!("Generating completion file for {}...", generator);
+        match generator {
+            "bash" => generate::<Bash, _>(&mut app, APPNAME, &mut io::stdout()),
+            "elvish" => generate::<Elvish, _>(&mut app, APPNAME, &mut io::stdout()),
+            "fish" => generate::<Fish, _>(&mut app, APPNAME, &mut io::stdout()),
+            "powershell" => generate::<PowerShell, _>(&mut app, APPNAME, &mut io::stdout()),
+            "zsh" => generate::<Zsh, _>(&mut app, APPNAME, &mut io::stdout()),
+            _ => panic!("Unknown generator"),
+        }
+    }
+}

--- a/clap_generate/tests/completions.rs
+++ b/clap_generate/tests/completions.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg};
+use clap::{App, Arg, ValueHint};
 use clap_generate::{generate, generators::*};
 use std::fmt;
 
@@ -182,7 +182,7 @@ static FISH: &str = r#"complete -c myapp -n "__fish_use_subcommand" -s h -l help
 complete -c myapp -n "__fish_use_subcommand" -s V -l version -d 'Prints version information'
 complete -c myapp -n "__fish_use_subcommand" -f -a "test" -d 'tests things'
 complete -c myapp -n "__fish_use_subcommand" -f -a "help" -d 'Prints this message or the help of the given subcommand(s)'
-complete -c myapp -n "__fish_seen_subcommand_from test" -l case -d 'the case to test'
+complete -c myapp -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
 complete -c myapp -n "__fish_seen_subcommand_from test" -s h -l help -d 'Prints help information'
 complete -c myapp -n "__fish_seen_subcommand_from test" -s V -l version -d 'Prints version information'
 complete -c myapp -n "__fish_seen_subcommand_from help" -s h -l help -d 'Prints help information'
@@ -526,10 +526,10 @@ complete -c my_app -n "__fish_use_subcommand" -f -a "test" -d 'tests things'
 complete -c my_app -n "__fish_use_subcommand" -f -a "some_cmd" -d 'tests other things'
 complete -c my_app -n "__fish_use_subcommand" -f -a "some-cmd-with-hypens"
 complete -c my_app -n "__fish_use_subcommand" -f -a "help" -d 'Prints this message or the help of the given subcommand(s)'
-complete -c my_app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test'
+complete -c my_app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
 complete -c my_app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Prints help information'
 complete -c my_app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Prints version information'
-complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -l config -d 'the other case to test'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -l config -d 'the other case to test' -r
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Prints help information'
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Prints version information'
 complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hypens" -s h -l help -d 'Prints help information'
@@ -719,7 +719,11 @@ fn build_app() -> App<'static> {
 fn build_app_with_name(s: &'static str) -> App<'static> {
     App::new(s)
         .about("Tests completions")
-        .arg(Arg::new("file").about("some input file"))
+        .arg(
+            Arg::new("file")
+                .value_hint(ValueHint::FilePath)
+                .about("some input file"),
+        )
         .subcommand(
             App::new("test").about("tests things").arg(
                 Arg::new("case")
@@ -773,7 +777,7 @@ fn build_app_special_help() -> App<'static> {
         )
 }
 
-fn common<G: Generator>(app: &mut App, name: &str, fixture: &str) {
+pub fn common<G: Generator>(app: &mut App, name: &str, fixture: &str) {
     let mut buf = vec![];
     generate::<G, _>(app, name, &mut buf);
     let string = String::from_utf8(buf).unwrap();

--- a/clap_generate/tests/value_hints.rs
+++ b/clap_generate/tests/value_hints.rs
@@ -1,0 +1,161 @@
+use clap::{App, AppSettings, Arg, ValueHint};
+use clap_generate::generators::*;
+use completions::common;
+
+mod completions;
+
+pub fn build_app_with_value_hints() -> App<'static> {
+    App::new("my_app")
+        .setting(AppSettings::DisableVersion)
+        .setting(AppSettings::TrailingVarArg)
+        .arg(
+            Arg::new("choice")
+                .long("choice")
+                .possible_values(&["bash", "fish", "zsh"]),
+        )
+        .arg(
+            Arg::new("unknown")
+                .long("unknown")
+                .value_hint(ValueHint::Unknown),
+        )
+        .arg(Arg::new("other").long("other").value_hint(ValueHint::Other))
+        .arg(
+            Arg::new("path")
+                .long("path")
+                .short('p')
+                .value_hint(ValueHint::AnyPath),
+        )
+        .arg(
+            Arg::new("file")
+                .long("file")
+                .short('f')
+                .value_hint(ValueHint::FilePath),
+        )
+        .arg(
+            Arg::new("dir")
+                .long("dir")
+                .short('d')
+                .value_hint(ValueHint::DirPath),
+        )
+        .arg(
+            Arg::new("exe")
+                .long("exe")
+                .short('e')
+                .value_hint(ValueHint::ExecutablePath),
+        )
+        .arg(
+            Arg::new("cmd_name")
+                .long("cmd-name")
+                .value_hint(ValueHint::CommandName),
+        )
+        .arg(
+            Arg::new("cmd")
+                .long("cmd")
+                .short('c')
+                .value_hint(ValueHint::CommandString),
+        )
+        .arg(
+            Arg::new("command_with_args")
+                .multiple_values(true)
+                .value_hint(ValueHint::CommandWithArguments),
+        )
+        .arg(
+            Arg::new("user")
+                .short('u')
+                .long("user")
+                .value_hint(ValueHint::Username),
+        )
+        .arg(
+            Arg::new("host")
+                .short('h')
+                .long("host")
+                .value_hint(ValueHint::Hostname),
+        )
+        .arg(Arg::new("url").long("url").value_hint(ValueHint::Url))
+        .arg(
+            Arg::new("email")
+                .long("email")
+                .value_hint(ValueHint::EmailAddress),
+        )
+}
+
+static ZSH_VALUE_HINTS: &str = r#"#compdef my_app
+
+autoload -U is-at-least
+
+_my_app() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" \
+'--choice=[]: :(bash fish zsh)' \
+'--unknown=[]' \
+'--other=[]: :( )' \
+'-p+[]: :_files' \
+'--path=[]: :_files' \
+'-f+[]: :_files' \
+'--file=[]: :_files' \
+'-d+[]: :_files -/' \
+'--dir=[]: :_files -/' \
+'-e+[]: :_absolute_command_paths' \
+'--exe=[]: :_absolute_command_paths' \
+'--cmd-name=[]: :_command_names -e' \
+'-c+[]: :_cmdstring' \
+'--cmd=[]: :_cmdstring' \
+'-u+[]: :_users' \
+'--user=[]: :_users' \
+'-h+[]: :_hosts' \
+'--host=[]: :_hosts' \
+'--url=[]: :_urls' \
+'--email=[]: :_email_addresses' \
+'--help[Prints help information]' \
+'*::command_with_args:_cmdambivalent' \
+&& ret=0
+    
+}
+
+(( $+functions[_my_app_commands] )) ||
+_my_app_commands() {
+    local commands; commands=(
+        
+    )
+    _describe -t commands 'my_app commands' commands "$@"
+}
+
+_my_app "$@""#;
+
+static FISH_VALUE_HINTS: &str = r#"complete -c my_app -n "__fish_use_subcommand" -l choice -r -f -a "bash fish zsh"
+complete -c my_app -n "__fish_use_subcommand" -l unknown -r
+complete -c my_app -n "__fish_use_subcommand" -l other -r -f
+complete -c my_app -n "__fish_use_subcommand" -s p -l path -r -F
+complete -c my_app -n "__fish_use_subcommand" -s f -l file -r -F
+complete -c my_app -n "__fish_use_subcommand" -s d -l dir -r -f -a "(__fish_complete_directories)"
+complete -c my_app -n "__fish_use_subcommand" -s e -l exe -r -F
+complete -c my_app -n "__fish_use_subcommand" -l cmd-name -r -f -a "(__fish_complete_command)"
+complete -c my_app -n "__fish_use_subcommand" -s c -l cmd -r -f -a "(__fish_complete_command)"
+complete -c my_app -n "__fish_use_subcommand" -s u -l user -r -f -a "(__fish_complete_users)"
+complete -c my_app -n "__fish_use_subcommand" -s h -l host -r -f -a "(__fish_print_hostnames)"
+complete -c my_app -n "__fish_use_subcommand" -l url -r -f
+complete -c my_app -n "__fish_use_subcommand" -l email -r -f
+complete -c my_app -n "__fish_use_subcommand" -l help -d 'Prints help information'
+"#;
+
+#[test]
+fn zsh_with_value_hints() {
+    let mut app = build_app_with_value_hints();
+    common::<Zsh>(&mut app, "my_app", ZSH_VALUE_HINTS);
+}
+
+#[test]
+fn fish_with_value_hints() {
+    let mut app = build_app_with_value_hints();
+    common::<Fish>(&mut app, "my_app", FISH_VALUE_HINTS);
+}

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     output::{fmt::Colorizer, Help, HelpWriter, Usage},
     parse::{ArgMatcher, ArgMatches, Input, Parser},
     util::{safe_exit, termcolor::ColorChoice, ArgStr, Id, Key},
-    Result as ClapResult, INTERNAL_ERROR_MSG,
+    Result as ClapResult, ValueHint, INTERNAL_ERROR_MSG,
 };
 
 // FIXME (@CreepySkeleton): some of these variants are never constructed
@@ -2249,6 +2249,20 @@ impl<'help> App<'help> {
                 "Argument '{}' has both `validator` and `validator_os` set which is not allowed",
                 arg.name
             );
+
+            if arg.value_hint == ValueHint::CommandWithArguments {
+                assert!(
+                    arg.short.is_none() && arg.long.is_none(),
+                    "Argument '{}' has hint CommandWithArguments and must be positional.",
+                    arg.name
+                );
+
+                assert!(
+                    self.is_set(AppSettings::TrailingVarArg),
+                    "Positional argument '{}' has hint CommandWithArguments, so App must have TrailingVarArg set.",
+                    arg.name
+                );
+            }
         }
 
         for group in &self.groups {

--- a/src/build/arg/value_hint.rs
+++ b/src/build/arg/value_hint.rs
@@ -1,0 +1,92 @@
+use std::str::FromStr;
+
+/// Provides hints about argument types for shell command completion.
+///
+/// See the `clap_generate` crate for completion script generation.
+///
+/// Overview of which hints are supported by which shell:
+///
+/// | Hint                   | zsh | fish[^1]|
+/// | ---------------------- | --- | ------- |
+/// | `AnyPath`              | Yes | Yes     |
+/// | `FilePath`             | Yes | Yes     |
+/// | `DirPath`              | Yes | Yes     |
+/// | `ExecutablePath`       | Yes | Partial |
+/// | `CommandName`          | Yes | Yes     |
+/// | `CommandString`        | Yes | Partial |
+/// | `CommandWithArguments` | Yes |         |
+/// | `Username`             | Yes | Yes     |
+/// | `Hostname`             | Yes | Yes     |
+/// | `Url`                  | Yes |         |
+/// | `EmailAddress`         | Yes |         |
+///
+/// [^1]: fish completions currently only support named arguments (e.g. -o or --opt), not
+///       positional arguments.
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum ValueHint {
+    /// Default value if hint is not specified. Follows shell default behavior, which is usually
+    /// auto-completing filenames.
+    Unknown,
+    /// None of the hints below apply. Disables shell completion for this argument.
+    Other,
+    /// Any existing path.
+    AnyPath,
+    /// Path to a file.
+    FilePath,
+    /// Path to a directory.
+    DirPath,
+    /// Path to an executable file.
+    ExecutablePath,
+    /// Name of a command, without arguments. May be relative to PATH, or full path to executable.
+    CommandName,
+    /// A single string containing a command and its arguments.
+    CommandString,
+    /// Capture the remaining arguments as a command name and arguments for that command. This is
+    /// common when writing shell wrappers that execute anther command, for example `sudo` or `env`.
+    ///
+    /// This hint is special, the argument must be a positional argument and have
+    /// [`.multiple(true)`] and App must use [`AppSettings::TrailingVarArg`]. The result is that the
+    /// command line `my_app ls -la /` will be parsed as `["ls", "-la", "/"]` and clap won't try to
+    /// parse the `-la` argument itself.
+    ///
+    /// [`.multiple(true)`]: ./struct.Arg.html#method.multiple
+    /// [`AppSettings::TrailingVarArg`]: ./enum.AppSettings.html#variant.TrailingVarArg
+    CommandWithArguments,
+    /// Name of a local operating system user.
+    Username,
+    /// Host name of a computer.
+    /// Shells usually parse `/etc/hosts` and `.ssh/known_hosts` to complete hostnames.
+    Hostname,
+    /// Complete web address.
+    Url,
+    /// Email address.
+    EmailAddress,
+}
+
+impl Default for ValueHint {
+    fn default() -> Self {
+        ValueHint::Unknown
+    }
+}
+
+impl FromStr for ValueHint {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+        Ok(match &*s.to_ascii_lowercase() {
+            "unknown" => ValueHint::Unknown,
+            "other" => ValueHint::Other,
+            "anypath" => ValueHint::AnyPath,
+            "filepath" => ValueHint::FilePath,
+            "dirpath" => ValueHint::DirPath,
+            "executablepath" => ValueHint::ExecutablePath,
+            "commandname" => ValueHint::CommandName,
+            "commandstring" => ValueHint::CommandString,
+            "commandwitharguments" => ValueHint::CommandWithArguments,
+            "username" => ValueHint::Username,
+            "hostname" => ValueHint::Hostname,
+            "url" => ValueHint::Url,
+            "emailaddress" => ValueHint::EmailAddress,
+            _ => return Err(format!("unknown ValueHint: `{}`", s)),
+        })
+    }
+}

--- a/src/build/macros.rs
+++ b/src/build/macros.rs
@@ -118,6 +118,17 @@ macro_rules! yaml_str {
 }
 
 #[cfg(feature = "yaml")]
+macro_rules! yaml_str_parse {
+    ($a:ident, $v:ident, $c:ident) => {{
+        $a.$c($v
+            .as_str()
+            .unwrap_or_else(|| panic!("failed to convert YAML {:?} value to a string", $v))
+            .parse()
+            .unwrap_or_else(|err| panic!("{}", err)))
+    }};
+}
+
+#[cfg(feature = "yaml")]
 macro_rules! yaml_to_char {
     ($a:ident, $v:ident, $c:ident) => {{
         $a.$c(yaml_char!($v))

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -9,6 +9,6 @@ mod usage_parser;
 
 pub use self::{
     app::{App, AppSettings},
-    arg::{Arg, ArgSettings},
+    arg::{Arg, ArgSettings, ValueHint},
     arg_group::ArgGroup,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 compile_error!("`std` feature is currently required to build `clap`");
 
 pub use crate::{
-    build::{App, AppSettings, Arg, ArgGroup, ArgSettings},
+    build::{App, AppSettings, Arg, ArgGroup, ArgSettings, ValueHint},
     derive::{ArgEnum, Clap, FromArgMatches, IntoApp, Subcommand},
     parse::errors::{Error, ErrorKind, Result},
     parse::{ArgMatches, Indices, OsValues, Values},

--- a/tests/fixtures/app.yaml
+++ b/tests/fixtures/app.yaml
@@ -112,6 +112,10 @@ args:
         help: Test case_insensitive
         possible_values: [test123, test321]
         case_insensitive: true
+    - value_hint:
+        long: value-hint
+        help: Test value_hint
+        value_hint: FilePath
 
 arg_groups:
     - test:

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "yaml")]
 
-use clap::{load_yaml, App};
+use clap::{load_yaml, App, ValueHint};
 
 #[test]
 fn create_app_from_yaml() {
@@ -40,4 +40,17 @@ fn author() {
     app.write_help(&mut help_buffer).unwrap();
     let help_string = String::from_utf8(help_buffer).unwrap();
     assert!(help_string.contains("Kevin K. <kbknapp@gmail.com>"));
+}
+
+// ValueHint must be parsed correctly from Yaml
+#[test]
+fn value_hint() {
+    let yml = load_yaml!("fixtures/app.yaml");
+    let app = App::from(yml);
+
+    let arg = app
+        .get_arguments()
+        .find(|a| a.get_name() == "value_hint")
+        .unwrap();
+    assert_eq!(arg.get_value_hint(), ValueHint::FilePath);
 }


### PR DESCRIPTION
Adds new method/attribute `Arg::value_hint`, taking a `ValueHint` enum
as argument. The hint can denote accepted values, for example: paths,
usernames, hostnames, commands, etc.

This initial implementation supports hints for the zsh and fish
completion generators, support for other shells can be added later.