### PR TITLE
Don't run actions on some events

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,9 +1,9 @@
 name: Linux
 on:
   push:
-    branches: [master, staging, trying]
+    branches: [staging, trying]
   pull_request:
-    branches: [master, staging, trying]
+    branches: [master]
     types: [opened, reopened, synchronize]
 jobs:
   test-release:


### PR DESCRIPTION
push(master) is not run because they would be run on staging anyway.

pull_request(staging, trying) are not run because pull requests shouldn't be made to them

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
