### PR TITLE
Exclude clap_derive from coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
       before_script:
         - cargo install cargo-tarpaulin --git git://github.com/pksunkara/tarpaulin --branch develop
       script:
-        - cargo tarpaulin --workspace --features "yaml unstable" --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+        - cargo tarpaulin --workspace --features "yaml unstable" --ciserver travis-ci --coveralls $TRAVIS_JOB_ID --timeout 300
 script:
   - cargo test --features "yaml unstable"
 notifications:


### PR DESCRIPTION
They aren't working anyway and they're also ruining our CI