### PR TITLE
Remove almost all #[doc(hidden)]

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -169,6 +169,16 @@ impl<'b> App<'b> {
             vec![]
         }
     }
+
+    /// Check if the setting was set either with [`App::setting`] or [`App::global_setting`]
+    pub fn is_set(&self, s: AppSettings) -> bool {
+        self.settings.is_set(s) || self.g_settings.is_set(s)
+    }
+
+    /// Check whether this app has subcommands
+    pub fn has_subcommands(&self) -> bool {
+        !self.subcommands.is_empty()
+    }
 }
 
 impl<'b> App<'b> {
@@ -1440,9 +1450,7 @@ impl<'b> App<'b> {
 }
 
 // Internally used only
-#[doc(hidden)]
 impl<'b> App<'b> {
-    #[doc(hidden)]
     fn _do_parse(&mut self, it: &mut Input) -> ClapResult<ArgMatches> {
         debugln!("App::_do_parse;");
         let mut matcher = ArgMatcher::default();
@@ -1470,7 +1478,6 @@ impl<'b> App<'b> {
         Ok(matcher.into_inner())
     }
 
-    #[allow(clippy::debug_assert_with_mut_call)]
     // used in clap_generate (https://github.com/clap-rs/clap_generate)
     #[doc(hidden)]
     pub fn _build(&mut self) {
@@ -1886,7 +1893,6 @@ impl<'b> App<'b> {
 }
 
 // Internal Query Methods
-#[doc(hidden)]
 impl<'b> App<'b> {
     pub(crate) fn find(&self, arg_id: Id) -> Option<&Arg<'b>> {
         self.args.args.iter().find(|a| a.id == arg_id)
@@ -1914,14 +1920,6 @@ impl<'b> App<'b> {
         }
 
         self.args.contains(s)
-    }
-
-    pub fn is_set(&self, s: AppSettings) -> bool {
-        self.settings.is_set(s) || self.g_settings.is_set(s)
-    }
-
-    pub fn has_subcommands(&self) -> bool {
-        !self.subcommands.is_empty()
     }
 
     pub(crate) fn set(&mut self, s: AppSettings) {

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -50,7 +50,6 @@ bitflags! {
     }
 }
 
-#[doc(hidden)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub(crate) struct AppFlags(Flags);
 

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -29,7 +29,6 @@ bitflags! {
     }
 }
 
-#[doc(hidden)]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ArgFlags(Flags);
 

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -8,8 +8,7 @@ use std::env;
 use std::fmt;
 
 #[derive(Debug, Copy, Clone, PartialEq)]
-#[doc(hidden)]
-pub enum ColorWhen {
+pub(crate) enum ColorWhen {
     Auto,
     Always,
     Never,

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -10,9 +10,8 @@ use crate::parse::{ArgMatches, MatchedArg, SubCommand};
 
 type Id = u64;
 
-#[doc(hidden)]
 #[derive(Debug)]
-pub struct ArgMatcher(pub ArgMatches);
+pub(crate) struct ArgMatcher(pub(crate) ArgMatches);
 
 impl Default for ArgMatcher {
     fn default() -> Self {
@@ -30,11 +29,6 @@ impl Deref for ArgMatcher {
 impl ArgMatcher {
     pub fn into_inner(self) -> ArgMatches {
         self.0
-    }
-
-    #[allow(dead_code)]
-    pub fn is_present(&self, name: Id) -> bool {
-        self.0._id_is_present(name)
     }
 
     pub fn propagate_globals(&mut self, global_arg_vec: &[Id]) {
@@ -72,7 +66,7 @@ impl ArgMatcher {
             }
         }
         if let Some(ref mut sc) = self.0.subcommand {
-            let mut am = ArgMatcher(mem::replace(&mut sc.matches, ArgMatches::new()));
+            let mut am = ArgMatcher(mem::take(&mut sc.matches));
             am.fill_in_global_values(global_arg_vec, vals_map);
             mem::swap(&mut am.0, &mut sc.matches);
         }

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -411,13 +411,13 @@ impl Error {
         process::exit(0);
     }
 
-    #[doc(hidden)]
+    /// Render and write the error into `w`.
     pub fn write_to<W: Write>(&self, w: &mut W) -> io::Result<()> {
         write!(w, "{}", self.message)
     }
 
-    #[doc(hidden)]
-    pub fn group_conflict<O, U>(
+    #[allow(unused)] // requested by @pksunkara
+    pub(crate) fn group_conflict<O, U>(
         group: &ArgGroup,
         other: Option<O>,
         usage: U,
@@ -471,8 +471,12 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn argument_conflict<O, U>(arg: &Arg, other: Option<O>, usage: U, color: ColorWhen) -> Self
+    pub(crate) fn argument_conflict<O, U>(
+        arg: &Arg,
+        other: Option<O>,
+        usage: U,
+        color: ColorWhen,
+    ) -> Self
     where
         O: Into<String>,
         U: Display,
@@ -521,8 +525,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn empty_value<U>(arg: &Arg, usage: U, color: ColorWhen) -> Self
+    pub(crate) fn empty_value<U>(arg: &Arg, usage: U, color: ColorWhen) -> Self
     where
         U: Display,
     {
@@ -550,8 +553,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn invalid_value<B, G, U>(
+    pub(crate) fn invalid_value<B, G, U>(
         bad_val: B,
         good_vals: &[G],
         arg: &Arg,
@@ -603,8 +605,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn invalid_subcommand<S, D, N, U>(
+    pub(crate) fn invalid_subcommand<S, D, N, U>(
         subcmd: S,
         did_you_mean: D,
         name: N,
@@ -645,8 +646,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn unrecognized_subcommand<S, N>(subcmd: S, name: N, color: ColorWhen) -> Self
+    pub(crate) fn unrecognized_subcommand<S, N>(subcmd: S, name: N, color: ColorWhen) -> Self
     where
         S: Into<String>,
         N: Display,
@@ -674,8 +674,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn missing_required_argument<R, U>(required: R, usage: U, color: ColorWhen) -> Self
+    pub(crate) fn missing_required_argument<R, U>(required: R, usage: U, color: ColorWhen) -> Self
     where
         R: Display,
         U: Display,
@@ -703,8 +702,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn missing_subcommand<N, U>(name: N, usage: U, color: ColorWhen) -> Self
+    pub(crate) fn missing_subcommand<N, U>(name: N, usage: U, color: ColorWhen) -> Self
     where
         N: AsRef<str> + Display,
         U: Display,
@@ -729,8 +727,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn invalid_utf8<U>(usage: U, color: ColorWhen) -> Self
+    pub(crate) fn invalid_utf8<U>(usage: U, color: ColorWhen) -> Self
     where
         U: Display,
     {
@@ -753,8 +750,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn too_many_values<V, U>(val: V, arg: &Arg, usage: U, color: ColorWhen) -> Self
+    pub(crate) fn too_many_values<V, U>(val: V, arg: &Arg, usage: U, color: ColorWhen) -> Self
     where
         V: AsRef<str> + Display + ToOwned,
         U: Display,
@@ -785,8 +781,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn too_few_values<U>(
+    pub(crate) fn too_few_values<U>(
         arg: &Arg,
         min_vals: u64,
         curr_vals: usize,
@@ -824,8 +819,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn value_validation(arg: Option<&Arg>, err: &str, color: ColorWhen) -> Self {
+    pub(crate) fn value_validation(arg: Option<&Arg>, err: &str, color: ColorWhen) -> Self {
         let c = Colorizer::new(&ColorizerOption {
             use_stderr: true,
             when: color,
@@ -855,14 +849,12 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn value_validation_auto(err: &str) -> Self {
+    pub(crate) fn value_validation_auto(err: &str) -> Self {
         let n: Option<&Arg> = None;
         Error::value_validation(n, err, ColorWhen::Auto)
     }
 
-    #[doc(hidden)]
-    pub fn wrong_number_of_values<U>(
+    pub(crate) fn wrong_number_of_values<U>(
         arg: &Arg,
         num_vals: u64,
         curr_vals: usize,
@@ -900,8 +892,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn unexpected_multiple_usage<U>(arg: &Arg, usage: U, color: ColorWhen) -> Self
+    pub(crate) fn unexpected_multiple_usage<U>(arg: &Arg, usage: U, color: ColorWhen) -> Self
     where
         U: Display,
     {
@@ -929,8 +920,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn unknown_argument<A, U>(
+    pub(crate) fn unknown_argument<A, U>(
         arg: A,
         did_you_mean: Option<String>,
         usage: U,
@@ -976,22 +966,7 @@ impl Error {
         }
     }
 
-    #[doc(hidden)]
-    pub fn io_error(e: &Error, color: ColorWhen) -> Self {
-        let c = Colorizer::new(&ColorizerOption {
-            use_stderr: true,
-            when: color,
-        });
-        Error {
-            cause: e.to_string(),
-            message: format!("{} {}", c.error("error:"), e),
-            kind: ErrorKind::Io,
-            info: None,
-        }
-    }
-
-    #[doc(hidden)]
-    pub fn argument_not_found_auto<A>(arg: A) -> Self
+    pub(crate) fn argument_not_found_auto<A>(arg: A) -> Self
     where
         A: Into<String>,
     {

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -65,10 +65,8 @@ type Id = u64;
 /// [`App::get_matches`]: ./struct.App.html#method.get_matches
 #[derive(Debug, Clone)]
 pub struct ArgMatches {
-    #[doc(hidden)]
-    pub args: IndexMap<Id, MatchedArg>,
-    #[doc(hidden)]
-    pub subcommand: Option<Box<SubCommand>>,
+    pub(crate) args: IndexMap<Id, MatchedArg>,
+    pub(crate) subcommand: Option<Box<SubCommand>>,
 }
 
 impl<'a> Default for ArgMatches {
@@ -81,13 +79,6 @@ impl<'a> Default for ArgMatches {
 }
 
 impl ArgMatches {
-    #[doc(hidden)]
-    pub fn new() -> Self {
-        ArgMatches {
-            ..Default::default()
-        }
-    }
-
     /// Gets the value of a specific [option] or [positional] argument (i.e. an argument that takes
     /// an additional value at runtime). If the option wasn't present at runtime
     /// it returns `None`.
@@ -498,17 +489,14 @@ impl ArgMatches {
     /// assert!(m.is_present("debug"));
     /// ```
     pub fn is_present<T: Key>(&self, id: T) -> bool {
-        self._id_is_present(id.key())
-    }
+        let id = id.key();
 
-    #[doc(hidden)]
-    pub fn _id_is_present(&self, arg_id: Id) -> bool {
         if let Some(ref sc) = self.subcommand {
-            if sc.id == arg_id {
+            if sc.id == id {
                 return true;
             }
         }
-        self.args.contains_key(&arg_id)
+        self.args.contains_key(&id)
     }
 
     /// Returns the number of times an argument was used at runtime. If an argument isn't present
@@ -1123,7 +1111,7 @@ mod tests {
 
     #[test]
     fn test_default_values_with_shorter_lifetime() {
-        let matches = ArgMatches::new();
+        let matches = ArgMatches::default();
         let mut values = matches.values_of("").unwrap_or_default();
         assert_eq!(values.next(), None);
     }
@@ -1136,7 +1124,7 @@ mod tests {
 
     #[test]
     fn test_default_osvalues_with_shorter_lifetime() {
-        let matches = ArgMatches::new();
+        let matches = ArgMatches::default();
         let mut values = matches.values_of_os("").unwrap_or_default();
         assert_eq!(values.next(), None);
     }
@@ -1149,7 +1137,7 @@ mod tests {
 
     #[test]
     fn test_default_indices_with_shorter_lifetime() {
-        let matches = ArgMatches::new();
+        let matches = ArgMatches::default();
         let mut indices = matches.indices_of("").unwrap_or_default();
         assert_eq!(indices.next(), None);
     }

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -1,15 +1,11 @@
 // Std
 use std::ffi::{OsStr, OsString};
 
-#[doc(hidden)]
 #[derive(Debug, Clone)]
 pub struct MatchedArg {
-    #[doc(hidden)]
-    pub occurs: u64,
-    #[doc(hidden)]
-    pub indices: Vec<usize>,
-    #[doc(hidden)]
-    pub vals: Vec<OsString>,
+    pub(crate) occurs: u64,
+    pub(crate) indices: Vec<usize>,
+    pub(crate) vals: Vec<OsString>,
 }
 
 impl Default for MatchedArg {

--- a/src/parse/matches/subcommand.rs
+++ b/src/parse/matches/subcommand.rs
@@ -26,10 +26,7 @@ type Id = u64;
 /// [arguments]: ./struct.Arg.html
 #[derive(Debug, Clone)]
 pub struct SubCommand {
-    #[doc(hidden)]
-    pub id: Id,
-    #[doc(hidden)]
-    pub name: String,
-    #[doc(hidden)]
-    pub matches: ArgMatches,
+    pub(crate) id: Id,
+    pub(crate) name: String,
+    pub(crate) matches: ArgMatches,
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -6,8 +6,8 @@ pub mod matches;
 mod parser;
 mod validator;
 
-pub use self::arg_matcher::ArgMatcher;
+pub(crate) use self::arg_matcher::ArgMatcher;
 pub use self::matches::ArgMatches;
 pub use self::matches::{MatchedArg, OsValues, SubCommand, Values};
-pub use self::parser::{Input, ParseResult, Parser};
+pub(crate) use self::parser::{Input, ParseResult, Parser};
 pub use self::validator::Validator;

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -27,8 +27,7 @@ use crate::INVALID_UTF8;
 type Id = u64;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-#[doc(hidden)]
-pub enum ParseResult {
+pub(crate) enum ParseResult {
     Flag,
     Opt(Id),
     Pos(Id),
@@ -39,8 +38,7 @@ pub enum ParseResult {
 }
 
 #[derive(Debug)]
-#[doc(hidden)]
-pub struct Input {
+pub(crate) struct Input {
     items: Vec<OsString>,
     cursor: usize,
 }
@@ -59,7 +57,7 @@ where
 }
 
 impl Input {
-    pub fn next(&mut self, new: Option<&[&str]>) -> Option<(&OsStr, Option<&OsStr>)> {
+    pub(crate) fn next(&mut self, new: Option<&[&str]>) -> Option<(&OsStr, Option<&OsStr>)> {
         if new.is_some() {
             let mut new_items: Vec<OsString> = new
                 .expect(INTERNAL_ERROR_MSG)
@@ -93,16 +91,15 @@ impl Input {
     }
 }
 
-#[doc(hidden)]
-pub struct Parser<'b, 'c>
+pub(crate) struct Parser<'b, 'c>
 where
     'b: 'c,
 {
-    pub app: &'c mut App<'b>,
-    pub required: ChildGraph<Id>,
-    pub overriden: Vec<Id>,
-    seen: Vec<Id>,
-    cur_idx: Cell<usize>,
+    pub(crate) app: &'c mut App<'b>,
+    pub(crate) required: ChildGraph<Id>,
+    pub(crate) overriden: Vec<Id>,
+    pub(crate) seen: Vec<Id>,
+    pub(crate) cur_idx: Cell<usize>,
 }
 
 // Initializing Methods
@@ -416,7 +413,11 @@ where
 {
     // The actual parsing function
     #[allow(clippy::cognitive_complexity)]
-    pub fn get_matches_with(&mut self, matcher: &mut ArgMatcher, it: &mut Input) -> ClapResult<()> {
+    pub(crate) fn get_matches_with(
+        &mut self,
+        matcher: &mut ArgMatcher,
+        it: &mut Input,
+    ) -> ClapResult<()> {
         debugln!("Parser::get_matches_with;");
         // Verify all positional assertions pass
         self._build();

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -22,14 +22,14 @@ where
 }
 
 impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
-    pub fn new(p: &'z mut Parser<'b, 'c>) -> Self {
+    pub(crate) fn new(p: &'z mut Parser<'b, 'c>) -> Self {
         Validator {
             p,
             c: ChildGraph::with_capacity(5),
         }
     }
 
-    pub fn validate(
+    pub(crate) fn validate(
         &mut self,
         needs_val_of: ParseResult,
         is_subcmd: bool,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,7 +7,7 @@ mod strext;
 pub use self::fnv::{Key, EMPTY_HASH, HELP_HASH, VERSION_HASH};
 pub use self::graph::ChildGraph;
 pub use self::map::{Values, VecMap};
-pub use self::osstringext::OsStrExt2;
+pub(crate) use self::osstringext::OsStrExt2;
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-pub use self::osstringext::OsStrExt3;
+pub(crate) use self::osstringext::OsStrExt3;
 pub use self::strext::_StrExt;

--- a/src/util/osstringext.rs
+++ b/src/util/osstringext.rs
@@ -5,13 +5,12 @@ use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
 
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
-pub trait OsStrExt3 {
+pub(crate) trait OsStrExt3 {
     fn from_bytes(b: &[u8]) -> &Self;
     fn as_bytes(&self) -> &[u8];
 }
 
-#[doc(hidden)]
-pub trait OsStrExt2 {
+pub(crate) trait OsStrExt2 {
     fn starts_with(&self, s: &[u8]) -> bool;
     fn split_at_byte(&self, b: u8) -> (&OsStr, &OsStr);
     fn split_at(&self, i: usize) -> (&OsStr, &OsStr);
@@ -92,9 +91,8 @@ impl OsStrExt2 for OsStr {
     }
 }
 
-#[doc(hidden)]
 #[derive(Clone, Debug)]
-pub struct OsSplit<'a> {
+pub(crate) struct OsSplit<'a> {
     sep: u8,
     val: &'a [u8],
     pos: usize,


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->

The infestation has been contained, majority of the patients has been cured, and those who weren't fail into one of these groups:

* Hidden `AppSettings` variants that are not exposed to user but used by clap itself. I'd prefer extracting them into separate enum, but this is not priority right now.
* Macros. I guess this explains it. Maybe I'll see into converting them into functions, but it's not an immediate concern.
* Such methods as `App::_build` and friends. The basically exist because clap has no distinction between "builder" and "built app" at type system level. I'll be looking into it too.