### PR TITLE
Make debug output show names of args along with hashes

### DIFF
--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -1,10 +1,9 @@
 // Std
+
 use std::fmt::{Debug, Formatter, Result};
 
 // Internal
-use crate::util::Key;
-
-type Id = u64;
+use crate::util::{Id, Key};
 
 /// `ArgGroup`s are a family of related [arguments] and way for you to express, "Any of these
 /// arguments". By placing arguments in a logical group, you can create easier requirement and
@@ -96,7 +95,7 @@ impl<'a> ArgGroup<'a> {
     }
     /// @TODO @p2 @docs @v3-beta1: Write Docs
     pub fn new<T: Key>(id: T) -> Self {
-        ArgGroup::_with_id(id.key())
+        ArgGroup::_with_id(id.into())
     }
     /// Creates a new instance of `ArgGroup` using a unique string name. The name will be used to
     /// get values from the group or refer to the group inside of conflict and requirement rules.
@@ -110,7 +109,7 @@ impl<'a> ArgGroup<'a> {
     /// ```
     pub fn with_name(n: &'a str) -> Self {
         ArgGroup {
-            id: n.key(),
+            id: n.into(),
             name: n,
             ..ArgGroup::default()
         }
@@ -152,7 +151,7 @@ impl<'a> ArgGroup<'a> {
     /// ```
     /// [argument]: ./struct.Arg.html
     pub fn arg<T: Key>(mut self, arg_id: T) -> Self {
-        self.args.push(arg_id.key());
+        self.args.push(arg_id.into());
         self
     }
 
@@ -298,7 +297,7 @@ impl<'a> ArgGroup<'a> {
     /// [required group]: ./struct.ArgGroup.html#method.required
     /// [argument requirement rules]: ./struct.Arg.html#method.requires
     pub fn requires<T: Key>(mut self, id: T) -> Self {
-        let arg_id = id.key();
+        let arg_id = id.into();
         if let Some(ref mut reqs) = self.requires {
             reqs.push(arg_id);
         } else {
@@ -374,7 +373,7 @@ impl<'a> ArgGroup<'a> {
     /// ```
     /// [argument exclusion rules]: ./struct.Arg.html#method.conflicts_with
     pub fn conflicts_with<T: Key>(mut self, id: T) -> Self {
-        let arg_id = id.key();
+        let arg_id = id.into();
         if let Some(ref mut confs) = self.conflicts {
             confs.push(arg_id);
         } else {
@@ -440,7 +439,7 @@ impl<'a> Debug for ArgGroup<'a> {
 impl<'a, 'z> From<&'z ArgGroup<'a>> for ArgGroup<'a> {
     fn from(g: &'z ArgGroup<'a>) -> Self {
         ArgGroup {
-            id: g.id,
+            id: g.id.clone(),
             name: g.name,
             required: g.required,
             args: g.args.clone(),
@@ -503,8 +502,7 @@ impl<'a> From<&'a yaml_rust::yaml::Hash> for ArgGroup<'a> {
 
 #[cfg(test)]
 mod test {
-    use super::ArgGroup;
-    use super::Key;
+    use super::{ArgGroup, Id};
     #[cfg(feature = "yaml")]
     use yaml_rust::YamlLoader;
 
@@ -522,9 +520,9 @@ mod test {
             .requires_all(&["r2", "r3"])
             .requires("r4");
 
-        let args = vec!["a1".key(), "a4".key(), "a2".key(), "a3".key()];
-        let reqs = vec!["r1".key(), "r2".key(), "r3".key(), "r4".key()];
-        let confs = vec!["c1".key(), "c2".key(), "c3".key(), "c4".key()];
+        let args = vec!["a1".into(), "a4".into(), "a2".into(), "a3".into()];
+        let reqs = vec!["r1".into(), "r2".into(), "r3".into(), "r4".into()];
+        let confs = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];
 
         assert_eq!(g.args, args);
         assert_eq!(g.requires, Some(reqs));
@@ -545,9 +543,24 @@ mod test {
             .requires_all(&["r2", "r3"])
             .requires("r4");
 
-        let args = vec!["a1".key(), "a4".key(), "a2".key(), "a3".key()];
-        let reqs = vec!["r1".key(), "r2".key(), "r3".key(), "r4".key()];
-        let confs = vec!["c1".key(), "c2".key(), "c3".key(), "c4".key()];
+        let args = vec![
+            Id::from("a1"),
+            Id::from("a4"),
+            Id::from("a2"),
+            Id::from("a3"),
+        ];
+        let reqs = vec![
+            Id::from("r1"),
+            Id::from("r2"),
+            Id::from("r3"),
+            Id::from("r4"),
+        ];
+        let confs = vec![
+            Id::from("c1"),
+            Id::from("c2"),
+            Id::from("c3"),
+            Id::from("c4"),
+        ];
 
         let debug_str = format!(
             "{{\n\
@@ -579,9 +592,9 @@ mod test {
             .requires_all(&["r2", "r3"])
             .requires("r4");
 
-        let args = vec!["a1".key(), "a4".key(), "a2".key(), "a3".key()];
-        let reqs = vec!["r1".key(), "r2".key(), "r3".key(), "r4".key()];
-        let confs = vec!["c1".key(), "c2".key(), "c3".key(), "c4".key()];
+        let args = vec!["a1".into(), "a4".into(), "a2".into(), "a3".into()];
+        let reqs = vec!["r1".into(), "r2".into(), "r3".into(), "r4".into()];
+        let confs = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];
 
         let g2 = ArgGroup::from(&g);
         assert_eq!(g2.args, args);
@@ -610,9 +623,9 @@ requires:
 - r4";
         let yml = &YamlLoader::load_from_str(g_yaml).expect("failed to load YAML file")[0];
         let g = ArgGroup::from_yaml(yml);
-        let args = vec!["a1".key(), "a4".key(), "a2".key(), "a3".key()];
-        let reqs = vec!["r1".key(), "r2".key(), "r3".key(), "r4".key()];
-        let confs = vec!["c1".key(), "c2".key(), "c3".key(), "c4".key()];
+        let args = vec!["a1".into(), "a4".into(), "a2".into(), "a3".into()];
+        let reqs = vec!["r1".into(), "r2".into(), "r3".into(), "r4".into()];
+        let confs = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];
         assert_eq!(g.args, args);
         assert_eq!(g.requires, Some(reqs));
         assert_eq!(g.conflicts, Some(confs));
@@ -622,7 +635,7 @@ requires:
 impl<'a> Clone for ArgGroup<'a> {
     fn clone(&self) -> Self {
         ArgGroup {
-            id: self.id,
+            id: self.id.clone(),
             name: self.name,
             required: self.required,
             args: self.args.clone(),

--- a/src/build/usage_parser.rs
+++ b/src/build/usage_parser.rs
@@ -1,6 +1,6 @@
 // Internal
 use crate::build::{Arg, ArgSettings};
-use crate::util::{Key, VecMap};
+use crate::util::VecMap;
 use crate::INTERNAL_ERROR_MSG;
 
 #[derive(PartialEq, Debug)]
@@ -90,7 +90,7 @@ impl<'a> UsageParser<'a> {
         let name = &self.usage[self.start..self.pos];
         if self.prev == UsageToken::Unknown {
             debugln!("UsageParser::name: setting name...{}", name);
-            arg.id = name.key();
+            arg.id = name.into();
             arg.name = name;
             if arg.long.is_none() && arg.short.is_none() {
                 debugln!("UsageParser::name: explicit name set...");
@@ -147,7 +147,7 @@ impl<'a> UsageParser<'a> {
         let name = &self.usage[self.start..self.pos];
         if !self.explicit_name_set {
             debugln!("UsageParser::long: setting name...{}", name);
-            arg.id = name.key();
+            arg.id = name.into();
             arg.name = name;
         }
         debugln!("UsageParser::long: setting long...{}", name);
@@ -165,7 +165,7 @@ impl<'a> UsageParser<'a> {
             // --long takes precedence but doesn't set self.explicit_name_set
             let name = &start[..short.len_utf8()];
             debugln!("UsageParser::short: setting name...{}", name);
-            arg.id = name.key();
+            arg.id = name.into();
             arg.name = name;
         }
         self.prev = UsageToken::Short;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -805,11 +805,11 @@ macro_rules! positionals {
 
 macro_rules! groups_for_arg {
     ($app:expr, $grp:expr) => {{
-        debugln!("Parser::groups_for_arg: name={}", $grp);
+        debugln!("Parser::groups_for_arg: name={:?}", $grp);
         $app.groups
             .iter()
-            .filter(|grp| grp.args.iter().any(|&a| a == $grp))
-            .map(|grp| grp.id)
+            .filter(|grp| grp.args.iter().any(|a| *a == $grp))
+            .map(|grp| grp.id.clone())
     }};
 }
 

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -1,7 +1,6 @@
 use crate::build::Arg;
+use crate::util::Id;
 use std::ffi::{OsStr, OsString};
-
-type Id = u64;
 
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) struct Key {
@@ -112,14 +111,14 @@ impl<'b> MKeyMap<'b> {
     //? probably shouldn't add a possibility for removal?
     //? or remove by replacement by some dummy object, so the order is preserved
 
-    pub(crate) fn remove_by_name(&mut self, _name: Id) -> Option<Arg<'b>> {
+    pub(crate) fn remove_by_name(&mut self, name: &Id) -> Option<Arg<'b>> {
         if self.built {
             panic!("Cannot remove args after being built");
         }
 
         self.args
             .iter()
-            .position(|arg| arg.id == _name)
+            .position(|arg| arg.id == *name)
             .map(|i| self.args.swap_remove(i))
     }
 }

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -7,8 +7,7 @@ use std::ops::Deref;
 // Internal
 use crate::build::{Arg, ArgSettings};
 use crate::parse::{ArgMatches, MatchedArg, SubCommand};
-
-type Id = u64;
+use crate::util::Id;
 
 #[derive(Debug)]
 pub(crate) struct ArgMatcher(pub(crate) ArgMatches);
@@ -45,7 +44,7 @@ impl ArgMatcher {
         global_arg_vec: &[Id],
         vals_map: &mut HashMap<Id, MatchedArg>,
     ) {
-        for &global_arg in global_arg_vec {
+        for global_arg in global_arg_vec {
             if let Some(ma) = self.get(global_arg) {
                 // We have to check if the parent's global arg wasn't used but still exists
                 // such as from a default value.
@@ -53,7 +52,7 @@ impl ArgMatcher {
                 // For example, `myprog subcommand --global-arg=value` where --global-arg defines
                 // a default value of `other` myprog would have an existing MatchedArg for
                 // --global-arg where the value is `other`, however the occurs will be 0.
-                let to_update = if let Some(parent_ma) = vals_map.get(&global_arg) {
+                let to_update = if let Some(parent_ma) = vals_map.get(global_arg) {
                     if parent_ma.occurs > 0 && ma.occurs == 0 {
                         parent_ma.clone()
                     } else {
@@ -62,7 +61,7 @@ impl ArgMatcher {
                 } else {
                     ma.clone()
                 };
-                vals_map.insert(global_arg, to_update);
+                vals_map.insert(global_arg.clone(), to_update);
             }
         }
         if let Some(ref mut sc) = self.0.subcommand {
@@ -71,21 +70,21 @@ impl ArgMatcher {
             mem::swap(&mut am.0, &mut sc.matches);
         }
 
-        for (&name, matched_arg) in vals_map.iter_mut() {
-            self.0.args.insert(name, matched_arg.clone());
+        for (name, matched_arg) in vals_map.iter_mut() {
+            self.0.args.insert(name.clone(), matched_arg.clone());
         }
     }
 
-    pub fn get_mut(&mut self, arg: Id) -> Option<&mut MatchedArg> {
-        self.0.args.get_mut(&arg)
+    pub fn get_mut(&mut self, arg: &Id) -> Option<&mut MatchedArg> {
+        self.0.args.get_mut(arg)
     }
 
-    pub fn get(&self, arg: Id) -> Option<&MatchedArg> {
-        self.0.args.get(&arg)
+    pub fn get(&self, arg: &Id) -> Option<&MatchedArg> {
+        self.0.args.get(arg)
     }
 
-    pub fn remove(&mut self, arg: Id) {
-        self.0.args.swap_remove(&arg);
+    pub fn remove(&mut self, arg: &Id) {
+        self.0.args.swap_remove(arg);
     }
 
     #[allow(dead_code)]
@@ -95,12 +94,12 @@ impl ArgMatcher {
         }
     }
 
-    pub fn insert(&mut self, name: Id) {
-        self.0.args.insert(name, MatchedArg::new());
+    pub fn insert(&mut self, name: &Id) {
+        self.0.args.insert(name.clone(), MatchedArg::new());
     }
 
-    pub fn contains(&self, arg: Id) -> bool {
-        self.0.args.contains_key(&arg)
+    pub fn contains(&self, arg: &Id) -> bool {
+        self.0.args.contains_key(arg)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -111,8 +110,8 @@ impl ArgMatcher {
         self.0.args.keys()
     }
 
-    pub fn entry(&mut self, arg: Id) -> indexmap::map::Entry<Id, MatchedArg> {
-        self.0.args.entry(arg)
+    pub fn entry(&mut self, arg: &Id) -> indexmap::map::Entry<Id, MatchedArg> {
+        self.0.args.entry(arg.clone())
     }
 
     pub fn subcommand(&mut self, sc: SubCommand) {
@@ -127,8 +126,8 @@ impl ArgMatcher {
         self.0.args.iter()
     }
 
-    pub fn inc_occurrence_of(&mut self, arg: Id) {
-        debugln!("ArgMatcher::inc_occurrence_of: arg={}", arg);
+    pub fn inc_occurrence_of(&mut self, arg: &Id) {
+        debugln!("ArgMatcher::inc_occurrence_of: arg={:?}", arg);
         if let Some(a) = self.get_mut(arg) {
             a.occurs += 1;
             return;
@@ -137,7 +136,7 @@ impl ArgMatcher {
         self.insert(arg);
     }
 
-    pub fn add_val_to(&mut self, arg: Id, val: &OsStr) {
+    pub fn add_val_to(&mut self, arg: &Id, val: &OsStr) {
         let ma = self.entry(arg).or_insert(MatchedArg {
             occurs: 0, // @TODO @question Shouldn't this be 1 if we're already adding a value to this arg?
             indices: Vec::with_capacity(1),
@@ -146,7 +145,7 @@ impl ArgMatcher {
         ma.vals.push(val.to_owned());
     }
 
-    pub fn add_index_to(&mut self, arg: Id, idx: usize) {
+    pub fn add_index_to(&mut self, arg: &Id, idx: usize) {
         let ma = self.entry(arg).or_insert(MatchedArg {
             occurs: 0,
             indices: Vec::with_capacity(1),
@@ -157,7 +156,7 @@ impl ArgMatcher {
 
     pub fn needs_more_vals(&self, o: &Arg) -> bool {
         debugln!("ArgMatcher::needs_more_vals: o={}", o.name);
-        if let Some(ma) = self.get(o.id) {
+        if let Some(ma) = self.get(&o.id) {
             if let Some(num) = o.num_vals {
                 debugln!("ArgMatcher::needs_more_vals: num_vals...{}", num);
                 return if o.is_set(ArgSettings::MultipleValues) {

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -11,10 +11,8 @@ use indexmap::IndexMap;
 
 // Internal
 use crate::parse::{MatchedArg, SubCommand};
-use crate::util::Key;
+use crate::util::{Id, Key};
 use crate::{Error, INVALID_UTF8};
-
-type Id = u64;
 
 /// Used to get information about the arguments that were supplied to the program at runtime by
 /// the user. New instances of this struct are obtained by using the [`App::get_matches`] family of
@@ -107,7 +105,7 @@ impl ArgMatches {
     /// [`ArgMatches::values_of`]: ./struct.ArgMatches.html#method.values_of
     /// [`panic!`]: https://doc.rust-lang.org/std/macro.panic!.html
     pub fn value_of<T: Key>(&self, id: T) -> Option<&str> {
-        if let Some(arg) = self.args.get(&id.key()) {
+        if let Some(arg) = self.args.get(&Id::from(id)) {
             if let Some(v) = arg.vals.get(0) {
                 return Some(v.to_str().expect(INVALID_UTF8));
             }
@@ -139,7 +137,7 @@ impl ArgMatches {
     /// ```
     /// [`Arg::values_of_lossy`]: ./struct.ArgMatches.html#method.values_of_lossy
     pub fn value_of_lossy<T: Key>(&self, id: T) -> Option<Cow<'_, str>> {
-        if let Some(arg) = self.args.get(&id.key()) {
+        if let Some(arg) = self.args.get(&Id::from(id)) {
             if let Some(v) = arg.vals.get(0) {
                 return Some(v.to_string_lossy());
             }
@@ -176,7 +174,7 @@ impl ArgMatches {
     /// [`ArgMatches::values_of_os`]: ./struct.ArgMatches.html#method.values_of_os
     pub fn value_of_os<T: Key>(&self, id: T) -> Option<&OsStr> {
         self.args
-            .get(&id.key())
+            .get(&Id::from(id))
             .and_then(|arg| arg.vals.get(0).map(OsString::as_os_str))
     }
 
@@ -206,7 +204,7 @@ impl ArgMatches {
     /// [`Values`]: ./struct.Values.html
     /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
     pub fn values_of<T: Key>(&self, id: T) -> Option<Values<'_>> {
-        self.args.get(&id.key()).map(|arg| {
+        self.args.get(&Id::from(id)).map(|arg| {
             fn to_str_slice(o: &OsString) -> &str {
                 o.to_str().expect(INVALID_UTF8)
             }
@@ -243,7 +241,7 @@ impl ArgMatches {
     /// assert_eq!(itr.next(), None);
     /// ```
     pub fn values_of_lossy<T: Key>(&self, id: T) -> Option<Vec<String>> {
-        self.args.get(&id.key()).map(|arg| {
+        self.args.get(&Id::from(id)).map(|arg| {
             arg.vals
                 .iter()
                 .map(|v| v.to_string_lossy().into_owned())
@@ -288,7 +286,7 @@ impl ArgMatches {
         }
         let to_str_slice: fn(&'a OsString) -> &'a OsStr = to_str_slice; // coerce to fn pointer
 
-        self.args.get(&id.key()).map(|arg| OsValues {
+        self.args.get(&Id::from(id)).map(|arg| OsValues {
             iter: arg.vals.iter().map(to_str_slice),
         })
     }
@@ -489,7 +487,7 @@ impl ArgMatches {
     /// assert!(m.is_present("debug"));
     /// ```
     pub fn is_present<T: Key>(&self, id: T) -> bool {
-        let id = id.key();
+        let id = Id::from(id);
 
         if let Some(ref sc) = self.subcommand {
             if sc.id == id {
@@ -539,7 +537,7 @@ impl ArgMatches {
     /// assert_eq!(m.occurrences_of("flag"), 1);
     /// ```
     pub fn occurrences_of<T: Key>(&self, id: T) -> u64 {
-        self.args.get(&id.key()).map_or(0, |a| a.occurs)
+        self.args.get(&Id::from(id)).map_or(0, |a| a.occurs)
     }
 
     /// Gets the starting index of the argument in respect to all other arguments. Indices are
@@ -673,7 +671,7 @@ impl ArgMatches {
     /// [`ArgMatches`]: ./struct.ArgMatches.html
     /// [delimiter]: ./struct.Arg.html#method.value_delimiter
     pub fn index_of<T: Key>(&self, name: T) -> Option<usize> {
-        if let Some(arg) = self.args.get(&name.key()) {
+        if let Some(arg) = self.args.get(&Id::from(name)) {
             if let Some(i) = arg.indices.get(0) {
                 return Some(*i);
             }
@@ -755,7 +753,7 @@ impl ArgMatches {
     /// [`ArgMatches::index_of`]: ./struct.ArgMatches.html#method.index_of
     /// [delimiter]: ./struct.Arg.html#method.value_delimiter
     pub fn indices_of<T: Key>(&self, id: T) -> Option<Indices<'_>> {
-        self.args.get(&id.key()).map(|arg| Indices {
+        self.args.get(&Id::from(id)).map(|arg| Indices {
             iter: arg.indices.iter().cloned(),
         })
     }
@@ -793,7 +791,7 @@ impl ArgMatches {
     /// [`ArgMatches`]: ./struct.ArgMatches.html
     pub fn subcommand_matches<T: Key>(&self, id: T) -> Option<&ArgMatches> {
         if let Some(ref s) = self.subcommand {
-            if s.id == id.key() {
+            if s.id == id.into() {
                 return Some(&s.matches);
             }
         }

--- a/src/parse/matches/subcommand.rs
+++ b/src/parse/matches/subcommand.rs
@@ -1,7 +1,6 @@
 // Internal
+use crate::util::Id;
 use crate::ArgMatches;
-
-type Id = u64;
 
 /// The abstract representation of a command line subcommand.
 ///

--- a/src/util/fnv.rs
+++ b/src/util/fnv.rs
@@ -1,3 +1,4 @@
+use std::fmt::Display;
 use std::hash::{Hash, Hasher};
 
 // precompute some common values
@@ -6,13 +7,13 @@ pub static VERSION_HASH: u64 = 0x30FF_0B7C_4D07_9478;
 pub static EMPTY_HASH: u64 = 0x1C9D_3ADB_639F_298E;
 const MAGIC_INIT: u64 = 0x811C_9DC5;
 
-pub trait Key: Hash {
+pub trait Key: Hash + Display {
     fn key(&self) -> u64;
 }
 
 impl<T> Key for T
 where
-    T: Hash,
+    T: Hash + Display,
 {
     fn key(&self) -> u64 {
         let mut hasher = FnvHasher::new();

--- a/src/util/graph.rs
+++ b/src/util/graph.rs
@@ -15,14 +15,14 @@ pub struct ChildGraph<T>(Vec<Child<T>>);
 
 impl<T> ChildGraph<T>
 where
-    T: Sized + PartialEq + Copy + Clone,
+    T: Sized + PartialEq + Clone,
 {
     pub fn with_capacity(s: usize) -> Self {
         ChildGraph(Vec::with_capacity(s))
     }
 
     pub fn insert(&mut self, req: T) -> usize {
-        if !self.contains(req) {
+        if !self.contains(&req) {
             let idx = self.0.len();
             self.0.push(Child::new(req));
             idx
@@ -55,7 +55,7 @@ where
         self.0.iter().map(|r| &r.id)
     }
 
-    pub fn contains(&self, req: T) -> bool {
-        self.0.iter().any(|r| r.id == req)
+    pub fn contains(&self, req: &T) -> bool {
+        self.0.iter().any(|r| r.id == *req)
     }
 }

--- a/src/util/id.rs
+++ b/src/util/id.rs
@@ -1,0 +1,85 @@
+use crate::util::fnv::{Key, EMPTY_HASH, HELP_HASH, VERSION_HASH};
+use std::fmt::{Debug, Formatter, Result};
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+
+#[derive(Clone, Eq, Default)]
+#[cfg_attr(not(debug_assertions), derive(Copy), repr(transparent))]
+pub(crate) struct Id {
+    #[cfg(debug_assertions)]
+    name: String,
+    id: u64,
+}
+
+macro_rules! precomputed_hashes {
+    ($($fn_name:ident, $const_name:ident, $name:expr;)*) => {
+        impl Id {
+            $(
+                pub(crate) fn $fn_name() -> Self {
+                    Id {
+                        #[cfg(debug_assertions)]
+                        name: $name.into(),
+                        id: $const_name,
+                    }
+                }
+            )*
+        }
+    };
+}
+
+precomputed_hashes! {
+    empty_hash, EMPTY_HASH, "";
+    help_hash, HELP_HASH, "help";
+    version_hash, VERSION_HASH, "version";
+}
+
+impl Id {
+    pub(crate) fn from_ref<T: Key>(val: T) -> Self {
+        Id {
+            #[cfg(debug_assertions)]
+            name: val.to_string(),
+            id: val.key(),
+        }
+    }
+}
+
+impl Debug for Id {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        #[cfg(debug_assertions)]
+        write!(f, "{:?} ", self.name)?;
+        write!(f, "[hash: {}]", self.id)
+    }
+}
+
+impl Deref for Id {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.id
+    }
+}
+
+impl<T: Key> From<T> for Id {
+    fn from(val: T) -> Self {
+        Id {
+            #[cfg(debug_assertions)]
+            name: val.to_string(),
+            id: val.key(),
+        }
+    }
+}
+
+impl Hash for Id {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.id.hash(state)
+    }
+}
+
+impl PartialEq for Id {
+    fn eq(&self, other: &Id) -> bool {
+        self.id == other.id
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,13 +1,13 @@
 mod fnv;
 mod graph;
+mod id;
 mod map;
 mod osstringext;
 mod strext;
 
-pub use self::fnv::{Key, EMPTY_HASH, HELP_HASH, VERSION_HASH};
-pub use self::graph::ChildGraph;
-pub use self::map::{Values, VecMap};
-pub(crate) use self::osstringext::OsStrExt2;
+pub use self::{fnv::Key, map::Values};
+
+pub(crate) use self::{graph::ChildGraph, id::Id, map::VecMap, osstringext::OsStrExt2};
+
 #[cfg(any(target_os = "windows", target_arch = "wasm32"))]
 pub(crate) use self::osstringext::OsStrExt3;
-pub use self::strext::_StrExt;


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
Talk is cheap, so let me cut to the chase:

Before;
```
DEBUG:clap:ArgMatcher::inc_occurrence_of: arg=10706354686124900129
DEBUG:clap:ArgMatcher::inc_occurrence_of: first instance
DEBUG:clap:Parser::groups_for_arg: name=10706354686124900129
DEBUG:clap:Parser::parse_opt: More arg vals required...
DEBUG:clap:Parser:get_matches_with: After parse_long_arg Opt(10706354686124900129)
DEBUG:clap:Parser::get_matches_with: Begin parsing '"foo"' ([102, 111, 111])
DEBUG:clap:Parser::is_new_arg:"foo":Opt(10706354686124900129)
DEBUG:clap:Parser::is_new_arg: arg_allows_tac=false
DEBUG:clap:Parser::is_new_arg: probably value
DEBUG:clap:Parser::is_new_arg: starts_new_arg=false
DEBUG:clap:Parser::add_val_to_arg; arg=output, val="foo"
DEBUG:clap:Parser::add_val_to_arg; trailing_vals=false, DontDelimTrailingVals=false
DEBUG:clap:Parser::add_single_val_to_arg;
DEBUG:clap:Parser::add_single_val_to_arg: adding val..."foo"
DEBUG:clap:Parser::groups_for_arg: name=10706354686124900129
DEBUG:clap:ArgMatcher::needs_more_vals: o=output
```

After:
```
DEBUG:clap:ArgMatcher::inc_occurrence_of: arg="output" [hash: 10706354686124900129]
DEBUG:clap:ArgMatcher::inc_occurrence_of: first instance
DEBUG:clap:Parser::groups_for_arg: name="output" [hash: 10706354686124900129]
DEBUG:clap:Parser::parse_opt: More arg vals required...
DEBUG:clap:Parser:get_matches_with: After parse_long_arg Opt("output" [hash: 10706354686124900129])
DEBUG:clap:Parser::get_matches_with: Begin parsing '"foo"' ([102, 111, 111])
DEBUG:clap:Parser::is_new_arg:"foo":Opt("output" [hash: 10706354686124900129])
DEBUG:clap:Parser::is_new_arg: arg_allows_tac=false
DEBUG:clap:Parser::is_new_arg: probably value
DEBUG:clap:Parser::is_new_arg: starts_new_arg=false
DEBUG:clap:Parser::add_val_to_arg; arg=output, val="foo"
DEBUG:clap:Parser::add_val_to_arg; trailing_vals=false, DontDelimTrailingVals=false
DEBUG:clap:Parser::add_single_val_to_arg;
DEBUG:clap:Parser::add_single_val_to_arg: adding val..."foo"
DEBUG:clap:Parser::groups_for_arg: name="output" [hash: 10706354686124900129]
DEBUG:clap:ArgMatcher::needs_more_vals: o=output
```

This is enabled only in debug, release doesn't suffer from the additional `String` cost.

Closes #1803 
