### PR TITLE
Add env_set

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -1909,6 +1909,9 @@ where
 
         matcher.add_val_to(arg.name(), v);
         matcher.add_index_to(arg.name(), self.cur_idx.get());
+        if let Some((_, Some(_))) = arg.env() {
+            matcher.set_env_set(arg.name());
+        }
 
         // Increment or create the group "args"
         if let Some(grps) = self.groups_for_arg(arg.name()) {

--- a/src/args/arg_matcher.rs
+++ b/src/args/arg_matcher.rs
@@ -218,8 +218,14 @@ impl<'a> ArgMatcher<'a> {
         }
     }
 
+    pub fn set_env_set(&mut self, arg: &'a str) {
+        let ma = self.entry(arg).or_insert(MatchedArg::new());
+        ma.env_set = true;
+    }
+
     pub fn add_val_to(&mut self, arg: &'a str, val: &OsStr) {
         let ma = self.entry(arg).or_insert(MatchedArg {
+            env_set: false,
             occurs: 0,
             indices: Vec::with_capacity(1),
             vals: Vec::with_capacity(1),
@@ -229,6 +235,7 @@ impl<'a> ArgMatcher<'a> {
 
     pub fn add_index_to(&mut self, arg: &'a str, idx: usize) {
         let ma = self.entry(arg).or_insert(MatchedArg {
+            env_set: false,
             occurs: 0,
             indices: Vec::with_capacity(1),
             vals: Vec::new(),

--- a/src/args/arg_matches.rs
+++ b/src/args/arg_matches.rs
@@ -596,6 +596,45 @@ impl<'a> ArgMatches<'a> {
         None
     }
 
+    /// Returns true if this arguments environment variable was set.
+    /// 
+    /// This is useful for determining if the argument's value came from the default value or the
+    /// environment variable.
+    /// 
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// # use std::env;
+    /// let app = App::new("myapp")
+    ///     .arg(Arg::with_name("arg")
+    ///         .long("arg")
+    ///         .takes_value(true)
+    ///         .env("ENV_ARG"));
+    /// let m = app.clone().get_matches_from(vec!["myapp"]);
+    /// assert!(!m.env_set("arg"));
+    /// ```
+    /// 
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// # use std::env;
+    /// env::set_var("ENV_ARG", "from_env");
+    /// let app = App::new("myapp")
+    ///     .arg(Arg::with_name("arg")
+    ///         .long("arg")
+    ///         .takes_value(true)
+    ///         .env("ENV_ARG"));
+    /// let m = app.clone().get_matches_from(vec!["myapp"]);
+    /// assert!(m.env_set("arg"));
+    /// ```
+    pub fn env_set<S: AsRef<str>>(&self, name: S) -> bool {
+        if let Some(arg) = self.args.get(name.as_ref()) {
+            arg.env_set
+        } else {
+            false
+        }
+    }
+
     /// Because [`Subcommand`]s are essentially "sub-[`App`]s" they have their own [`ArgMatches`]
     /// as well. This method returns the [`ArgMatches`] for a particular subcommand or `None` if
     /// the subcommand wasn't present at runtime.

--- a/src/args/matched_arg.rs
+++ b/src/args/matched_arg.rs
@@ -5,6 +5,8 @@ use std::ffi::OsString;
 #[derive(Debug, Clone)]
 pub struct MatchedArg {
     #[doc(hidden)]
+    pub env_set: bool,
+    #[doc(hidden)]
     pub occurs: u64,
     #[doc(hidden)]
     pub indices: Vec<usize>,
@@ -15,6 +17,7 @@ pub struct MatchedArg {
 impl Default for MatchedArg {
     fn default() -> Self {
         MatchedArg {
+            env_set: false,
             occurs: 1,
             indices: Vec::new(),
             vals: Vec::new(),


### PR DESCRIPTION
This PR adds the `env_set` method to `ArgMatches`. Previously, there was no way to determine if an argument's environment variable was set. This could have a variety of uses, but specifically, it was added to allow determining if an argument's value came from its default value or an environment variable.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>