### PR TITLE
required_unless for ArgGroup

### DIFF
--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -83,6 +83,7 @@ pub struct ArgGroup<'a> {
     pub(crate) args: Vec<Id>,
     pub(crate) required: bool,
     pub(crate) requires: Option<Vec<Id>>,
+    pub(crate) r_unless: Option<Vec<Id>>,
     pub(crate) conflicts: Option<Vec<Id>>,
     pub(crate) multiple: bool,
 }
@@ -346,6 +347,17 @@ impl<'a> ArgGroup<'a> {
         self
     }
 
+    /// TODO
+    pub fn required_unless<T: Key>(mut self, arg_id: T) -> Self {
+        let name = arg_id.key();
+        if let Some(ref mut vec) = self.r_unless {
+            vec.push(name);
+        } else {
+            self.r_unless = Some(vec![name]);
+        }
+        self
+    }
+
     /// Sets the exclusion rules of this group. Exclusion (aka conflict) rules function just like
     /// [argument exclusion rules], you can name other arguments or groups that must *not* be
     /// present when one of the arguments from this group are used.
@@ -445,6 +457,7 @@ impl<'a, 'z> From<&'z ArgGroup<'a>> for ArgGroup<'a> {
             required: g.required,
             args: g.args.clone(),
             requires: g.requires.clone(),
+            r_unless: g.r_unless.clone(),
             conflicts: g.conflicts.clone(),
             multiple: g.multiple,
         }
@@ -627,6 +640,7 @@ impl<'a> Clone for ArgGroup<'a> {
             required: self.required,
             args: self.args.clone(),
             requires: self.requires.clone(),
+            r_unless: self.r_unless.clone(),
             conflicts: self.conflicts.clone(),
             multiple: self.multiple,
         }

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -244,6 +244,79 @@ fn required_unless_err() {
     assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
 }
 
+#[test]
+fn required_unless_arg_group() {
+    let res = App::new("prog")
+        .arg(
+            Arg::with_name("input-file")
+                .long("input-file")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("input-url")
+                .long("input-url")
+                .takes_value(true),
+        )
+        .arg(Arg::with_name("no-input").long("no-input"))
+        .group(
+            ArgGroup::with_name("inputs")
+                .args(&["input-file", "input-url"])
+                .required_unless("no-input"),
+        )
+        .try_get_matches_from(vec!["prog", "--no-input"]);
+
+    assert!(res.is_ok());
+}
+
+#[test]
+fn required_unless_arg_group_2() {
+    let res = App::new("prog")
+        .arg(
+            Arg::with_name("input-file")
+                .long("input-file")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("input-url")
+                .long("input-url")
+                .takes_value(true),
+        )
+        .arg(Arg::with_name("no-input").long("no-input"))
+        .group(
+            ArgGroup::with_name("inputs")
+                .args(&["input-file", "input-url"])
+                .required_unless("no-input"),
+        )
+        .try_get_matches_from(vec!["prog", "--input-file", "info.txt"]);
+
+    assert!(res.is_ok());
+}
+
+#[test]
+fn required_unless_arg_group_err() {
+    let res = App::new("prog")
+        .arg(
+            Arg::with_name("input-file")
+                .long("input-file")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("input-url")
+                .long("input-url")
+                .takes_value(true),
+        )
+        .arg(Arg::with_name("no-input").long("no-input"))
+        .group(
+            ArgGroup::with_name("inputs")
+                .args(&["input-file", "input-url"])
+                .required_unless("no-input"),
+        )
+        .try_get_matches_from(vec!["prog"]);
+
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+}
+
 // REQUIRED_UNLESS_ALL
 
 #[test]


### PR DESCRIPTION
Closes #1801

Initial attempt at solving the issue above. I'm new to Rust so would love any feedback you have to offer.

I've noticed something that doesn't seem ideal about my approach: the implementation of the `required_*` functions will be the same for both `ArgGroup` and `Arg`. This could be solved with a macro that implements those functions, but I'm not sure if that is overkill. What are your thoughts on this?