### PR TITLE
fix: Don't print 'OPTIONS' when all options are hidden for short help

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -633,7 +633,9 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
                 acc
             }
         }) > 0;
-        let opts = self.parser.has_opts();
+        let opts = opts!(self.parser.app)
+            .filter(|arg| should_show_arg(self.use_long, arg))
+            .collect::<Vec<_>>();
         let subcmds = self.parser.has_visible_subcommands();
 
         let custom_headings = self.parser.app.args.args.iter().fold(0, |acc, arg| {
@@ -654,7 +656,7 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
 
         let unified_help = self.parser.is_set(AppSettings::UnifiedHelpMessage);
 
-        if unified_help && (flags || opts) {
+        if unified_help && (flags || !opts.is_empty()) {
             let opts_flags = self
                 .parser
                 .app
@@ -679,12 +681,12 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
                 self.write_args(&*flags_v)?;
                 first = false;
             }
-            if opts {
+            if !opts.is_empty() {
                 if !first {
                     self.none("\n\n")?;
                 }
                 self.warning("OPTIONS:\n")?;
-                self.write_args(&*opts!(self.parser.app).collect::<Vec<_>>())?;
+                self.write_args(&opts)?;
                 first = false;
             }
             if custom_headings {

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -551,6 +551,19 @@ FLAGS:
     -h, --help       Prints help information
     -V, --version    Prints version information";
 
+static ISSUE_1364: &str = "demo 
+
+USAGE:
+    demo [FLAGS] [OPTIONS] [FILES]...
+
+ARGS:
+    <FILES>...    
+
+FLAGS:
+    -f               
+    -h, --help       Prints help information
+    -V, --version    Prints version information";
+
 fn setup() -> App<'static> {
     App::new("test")
         .author("Kevin K.")
@@ -1585,6 +1598,21 @@ fn show_short_about_issue_897() {
         ISSUE_897_SHORT,
         false
     ));
+}
+
+#[test]
+fn issue_1364_no_short_options() {
+    let app = App::new("demo")
+        .arg(Arg::with_name("foo").short('f'))
+        .arg(
+            Arg::with_name("baz")
+                .short('z')
+                .value_name("BAZ")
+                .hidden_short_help(true),
+        )
+        .arg(Arg::with_name("files").value_name("FILES").multiple(true));
+
+    assert!(utils::compare_output(app, "demo -h", ISSUE_1364, false));
 }
 
 #[rustfmt::skip]


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
Don't print the 'OPTIONS' section of the short help message when all option-taking arguments are set with `.hidden_short_help(true)`.

Closes #1364