### PR TITLE
Deprecate Arg::help in favour of Arg::about [WIP]

### DIFF
--- a/benches/03_complex.rs
+++ b/benches/03_complex.rs
@@ -54,7 +54,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                 .author("Kevin K. <kbknapp@gmail.com>")
                 .arg(
                     Arg::with_name("opt")
-                        .help("tests options")
+                        .about("tests options")
                         .short('o')
                         .long("option")
                         .setting(ArgSettings::MultipleValues)
@@ -62,13 +62,13 @@ pub fn build_from_builder(c: &mut Criterion) {
                 )
                 .arg(
                     Arg::with_name("positional")
-                        .help("tests positionals")
+                        .about("tests positionals")
                         .index(1),
                 )
                 .arg(
                     Arg::with_name("flag")
                         .short('f')
-                        .help("tests flags")
+                        .about("tests flags")
                         .long("flag")
                         .global(true)
                         .settings(&[ArgSettings::MultipleOccurrences]),
@@ -76,13 +76,13 @@ pub fn build_from_builder(c: &mut Criterion) {
                 .arg(
                     Arg::with_name("flag2")
                         .short('F')
-                        .help("tests flags with exclusions")
+                        .about("tests flags with exclusions")
                         .conflicts_with("flag")
                         .requires("option2"),
                 )
                 .arg(
                     Arg::with_name("option2")
-                        .help("tests long options with exclusions")
+                        .about("tests long options with exclusions")
                         .conflicts_with("option")
                         .requires("positional2")
                         .setting(ArgSettings::TakesValue)
@@ -91,28 +91,28 @@ pub fn build_from_builder(c: &mut Criterion) {
                 .arg(
                     Arg::with_name("positional2")
                         .index(3)
-                        .help("tests positionals with exclusions"),
+                        .about("tests positionals with exclusions"),
                 )
                 .arg(
                     Arg::with_name("option3")
                         .short('O')
                         .long("Option")
                         .setting(ArgSettings::TakesValue)
-                        .help("tests options with specific value sets")
+                        .about("tests options with specific value sets")
                         .possible_values(&OPT3_VALS),
                 )
                 .arg(
                     Arg::with_name("positional3")
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .help("tests positionals with specific values")
+                        .about("tests positionals with specific values")
                         .index(4)
                         .possible_values(&POS3_VALS),
                 )
                 .arg(
                     Arg::with_name("multvals")
                         .long("multvals")
-                        .help("Tests mutliple values, not mult occs")
+                        .about("Tests mutliple values, not mult occs")
                         .value_names(&["one", "two"]),
                 )
                 .arg(
@@ -120,7 +120,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .long("multvalsmo")
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .help("Tests mutliple values, not mult occs")
+                        .about("Tests mutliple values, not mult occs")
                         .value_names(&["one", "two"]),
                 )
                 .arg(
@@ -128,7 +128,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .long("minvals2")
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .help("Tests 2 min vals")
+                        .about("Tests 2 min vals")
                         .min_values(2),
                 )
                 .arg(
@@ -136,7 +136,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .long("maxvals3")
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .help("Tests 3 max vals")
+                        .about("Tests 3 max vals")
                         .max_values(3),
                 )
                 .subcommand(
@@ -150,12 +150,12 @@ pub fn build_from_builder(c: &mut Criterion) {
                                 .long("option")
                                 .setting(ArgSettings::MultipleValues)
                                 .setting(ArgSettings::MultipleOccurrences)
-                                .help("tests options"),
+                                .about("tests options"),
                         )
                         .arg(
                             Arg::with_name("scpositional")
                                 .index(1)
-                                .help("tests positionals"),
+                                .about("tests positionals"),
                         ),
                 )
         })

--- a/benches/04_new_help.rs
+++ b/benches/04_new_help.rs
@@ -36,17 +36,17 @@ fn app_example3<'c>() -> App<'c> {
     App::new("MyApp")
         .arg(
             Arg::with_name("debug")
-                .help("turn on debugging information")
+                .about("turn on debugging information")
                 .short('d'),
         )
         .args(&[
             Arg::with_name("config")
-                .help("sets the config file to use")
+                .about("sets the config file to use")
                 .setting(ArgSettings::TakesValue)
                 .short('c')
                 .long("config"),
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .index(1)
                 .setting(ArgSettings::Required),
         ])
@@ -62,19 +62,19 @@ fn app_example4<'c>() -> App<'c> {
         .author("Kevin K. <kbknapp@gmail.com>")
         .arg(
             Arg::with_name("debug")
-                .help("turn on debugging information")
+                .about("turn on debugging information")
                 .short('d')
                 .long("debug"),
         )
         .arg(
             Arg::with_name("config")
-                .help("sets the config file to use")
+                .about("sets the config file to use")
                 .short('c')
                 .long("config"),
         )
         .arg(
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .index(1)
                 .setting(ArgSettings::Required),
         )
@@ -83,7 +83,7 @@ fn app_example4<'c>() -> App<'c> {
 fn app_example5<'c>() -> App<'c> {
     App::new("MyApp").arg(
         Arg::with_name("awesome")
-            .help("turns up the awesome")
+            .about("turns up the awesome")
             .short('a')
             .long("awesome")
             .setting(ArgSettings::MultipleOccurrences)
@@ -96,7 +96,7 @@ fn app_example6<'c>() -> App<'c> {
     App::new("MyApp")
         .arg(
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .index(1)
                 .requires("config")
                 .conflicts_with("output")
@@ -104,7 +104,7 @@ fn app_example6<'c>() -> App<'c> {
         )
         .arg(
             Arg::with_name("config")
-                .help("the config file to use")
+                .about("the config file to use")
                 .index(2),
         )
 }
@@ -115,7 +115,7 @@ fn app_example7<'c>() -> App<'c> {
         .arg(Arg::with_name("output"))
         .arg(
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .settings(&[
                     ArgSettings::MultipleValues,
                     ArgSettings::MultipleOccurrences,
@@ -134,7 +134,7 @@ fn app_example8<'c>() -> App<'c> {
         .arg(Arg::with_name("output"))
         .arg(
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .settings(&[
                     ArgSettings::MultipleValues,
                     ArgSettings::MultipleOccurrences,
@@ -150,7 +150,7 @@ fn app_example8<'c>() -> App<'c> {
 fn app_example10<'c>() -> App<'c> {
     App::new("myapp").about("does awesome things").arg(
         Arg::with_name("CONFIG")
-            .help("The config file to use (default is \"config.json\")")
+            .about("The config file to use (default is \"config.json\")")
             .short('c')
             .setting(ArgSettings::TakesValue),
     )

--- a/benches/05_ripgrep.rs
+++ b/benches/05_ripgrep.rs
@@ -298,7 +298,7 @@ fn app<F>(_next_line_help: bool, doc: F) -> App<'static>
 where
     F: Fn(&'static str) -> &'static str,
 {
-    let arg = |name| Arg::with_name(name).help(doc(name));
+    let arg = |name| Arg::with_name(name).about(doc(name));
     let flag = |name| arg(name).long(name);
 
     App::new("ripgrep")

--- a/benches/06_rustup.rs
+++ b/benches/06_rustup.rs
@@ -31,7 +31,7 @@ fn build_cli() -> App<'static> {
         // .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
             Arg::with_name("verbose")
-                .help("Enable verbose output")
+                .about("Enable verbose output")
                 .short('v')
                 .long("verbose"),
         )
@@ -54,7 +54,7 @@ fn build_cli() -> App<'static> {
                 .arg(Arg::with_name("toolchain").setting(ArgSettings::Required))
                 .arg(
                     Arg::with_name("no-self-update")
-                        .help("Don't perform self update when running the `rustup` command")
+                        .about("Don't perform self update when running the `rustup` command")
                         .long("no-self-update")
                         .setting(ArgSettings::Hidden),
                 ),
@@ -227,12 +227,12 @@ fn build_cli() -> App<'static> {
                             Arg::with_name("path")
                                 .long("path")
                                 .setting(ArgSettings::TakesValue)
-                                .help("Path to the directory"),
+                                .about("Path to the directory"),
                         )
                         .arg(
                             Arg::with_name("nonexistent")
                                 .long("nonexistent")
-                                .help("Remove override toolchain for all nonexistent directories"),
+                                .about("Remove override toolchain for all nonexistent directories"),
                         ),
                 )
                 .subcommand(
@@ -252,7 +252,7 @@ fn build_cli() -> App<'static> {
                         .arg(
                             Arg::with_name("nonexistent")
                                 .long("nonexistent")
-                                .help("Remove override toolchain for all nonexistent directories"),
+                                .about("Remove override toolchain for all nonexistent directories"),
                         ),
                 ),
         )
@@ -280,12 +280,12 @@ fn build_cli() -> App<'static> {
                 .arg(
                     Arg::with_name("book")
                         .long("book")
-                        .help("The Rust Programming Language book"),
+                        .about("The Rust Programming Language book"),
                 )
                 .arg(
                     Arg::with_name("std")
                         .long("std")
-                        .help("Standard library API documentation"),
+                        .about("Standard library API documentation"),
                 )
                 .group(ArgGroup::with_name("page").args(&["book", "std"])),
         )

--- a/clap_derive/examples/doc_comments.rs
+++ b/clap_derive/examples/doc_comments.rs
@@ -37,7 +37,7 @@ struct Opt {
     #[clap(
         short,
         long,
-        long_help = r"This is a raw string.
+        long_about = r"This is a raw string.
 
 It can be used to pass well formatted content (e.g. lists or source
 code) in the description:

--- a/clap_derive/src/derives/attrs.rs
+++ b/clap_derive/src/derives/attrs.rs
@@ -660,9 +660,10 @@ impl Attrs {
 
     pub fn has_doc_methods(&self) -> bool {
         !self.doc_comment.is_empty()
-            || self.methods.iter().any(|m| {
-                m.name == "about" || m.name == "long_about"
-            })
+            || self
+                .methods
+                .iter()
+                .any(|m| m.name == "about" || m.name == "long_about")
     }
 }
 

--- a/clap_derive/src/derives/attrs.rs
+++ b/clap_derive/src/derives/attrs.rs
@@ -95,7 +95,6 @@ pub struct Attrs {
     methods: Vec<Method>,
     parser: Sp<Parser>,
     author: Option<Method>,
-    about: Option<Method>,
     version: Option<Method>,
     verbatim_doc_comment: Option<Ident>,
     is_enum: bool,
@@ -257,7 +256,6 @@ impl Attrs {
             doc_comment: vec![],
             methods: vec![],
             parser: Parser::default_spanned(default_span),
-            about: None,
             author: None,
             version: None,
             verbatim_doc_comment: None,
@@ -342,7 +340,10 @@ impl Attrs {
                 }
 
                 About(ident, about) => {
-                    self.about = Method::from_lit_or_env(ident, about, "CARGO_PKG_DESCRIPTION");
+                    let method = Method::from_lit_or_env(ident, about, "CARGO_PKG_DESCRIPTION");
+                    if let Some(m) = method {
+                        self.methods.push(m);
+                    }
                 }
 
                 Author(ident, author) => {
@@ -583,11 +584,10 @@ impl Attrs {
     /// generate methods from attributes on top of struct or enum
     pub fn top_level_methods(&self) -> TokenStream {
         let author = &self.author;
-        let about = &self.about;
         let methods = &self.methods;
         let doc_comment = &self.doc_comment;
 
-        quote!( #(#doc_comment)* #author #about #(#methods)*  )
+        quote!( #(#doc_comment)* #author #(#methods)*)
     }
 
     /// generate methods on top of a field

--- a/clap_derive/src/derives/attrs.rs
+++ b/clap_derive/src/derives/attrs.rs
@@ -439,7 +439,7 @@ impl Attrs {
             env_casing,
         );
         res.push_attrs(&field.attrs);
-        res.push_doc_comment(&field.attrs, "help");
+        res.push_doc_comment(&field.attrs, "about");
 
         match &*res.kind {
             Kind::Flatten => {
@@ -655,16 +655,13 @@ impl Attrs {
     pub fn has_explicit_methods(&self) -> bool {
         self.methods
             .iter()
-            .any(|m| m.name != "help" && m.name != "long_help")
+            .any(|m| m.name != "about" && m.name != "long_about")
     }
 
     pub fn has_doc_methods(&self) -> bool {
         !self.doc_comment.is_empty()
             || self.methods.iter().any(|m| {
-                m.name == "help"
-                    || m.name == "long_help"
-                    || m.name == "about"
-                    || m.name == "long_about"
+                m.name == "about" || m.name == "long_about"
             })
     }
 }

--- a/clap_derive/tests/doc-comments-help.rs
+++ b/clap_derive/tests/doc-comments-help.rs
@@ -40,7 +40,7 @@ fn help_is_better_than_comments() {
     #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
         /// Fooify a bar
-        #[clap(short, long, help = "DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES")]
+        #[clap(short, long, about = "DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES")]
         foo: bool,
     }
 
@@ -107,7 +107,7 @@ fn top_long_doc_comment_both_help_long_help() {
         ///
         /// Or something else
         Foo {
-            #[clap(help = "foo")]
+            #[clap(about = "foo")]
             bars: Vec<String>,
         },
     }

--- a/clap_derive/tests/skip.rs
+++ b/clap_derive/tests/skip.rs
@@ -96,10 +96,10 @@ fn skip_enum() {
 fn skip_help_doc_comments() {
     #[derive(Clap, Debug, PartialEq)]
     pub struct Opt {
-        #[clap(skip, help = "internal_stuff")]
+        #[clap(skip, about = "internal_stuff")]
         a: u32,
 
-        #[clap(skip, long_help = "internal_stuff\ndo not touch")]
+        #[clap(skip, long_about = "internal_stuff\ndo not touch")]
         b: u32,
 
         /// Not meant to be used by clap.

--- a/clap_generate/src/generators/mod.rs
+++ b/clap_generate/src/generators/mod.rs
@@ -186,7 +186,7 @@ pub trait Generator {
                 Arg::with_name("help")
                     .short('h')
                     .long("help")
-                    .help("Prints help information"),
+                    .about("Prints help information"),
             );
         }
 
@@ -197,7 +197,7 @@ pub trait Generator {
                 Arg::with_name("version")
                     .short('V')
                     .long("version")
-                    .help("Prints version information"),
+                    .about("Prints version information"),
             );
         }
 

--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -79,14 +79,14 @@ fn generate_inner<'b>(
 
     for option in opts!(p) {
         if let Some(data) = option.get_short() {
-            let tooltip = get_tooltip(option.get_help(), data);
+            let tooltip = get_tooltip(option.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(format!("-{} '{}'", data, tooltip).as_str());
         }
 
         if let Some(data) = option.get_long() {
-            let tooltip = get_tooltip(option.get_help(), data);
+            let tooltip = get_tooltip(option.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
@@ -95,14 +95,14 @@ fn generate_inner<'b>(
 
     for flag in Elvish::flags(p) {
         if let Some(data) = flag.get_short() {
-            let tooltip = get_tooltip(flag.get_help(), data);
+            let tooltip = get_tooltip(flag.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(format!("-{} '{}'", data, tooltip).as_str());
         }
 
         if let Some(data) = flag.get_long() {
-            let tooltip = get_tooltip(flag.get_help(), data);
+            let tooltip = get_tooltip(flag.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(format!("--{} '{}'", data, tooltip).as_str());

--- a/clap_generate/src/generators/shells/fish.rs
+++ b/clap_generate/src/generators/shells/fish.rs
@@ -65,7 +65,7 @@ fn gen_fish_inner(root_command: &str, app: &App, buffer: &mut String) {
             template.push_str(format!(" -l {}", data).as_str());
         }
 
-        if let Some(data) = option.get_help() {
+        if let Some(data) = option.get_about() {
             template.push_str(format!(" -d '{}'", escape_string(data)).as_str());
         }
 
@@ -88,7 +88,7 @@ fn gen_fish_inner(root_command: &str, app: &App, buffer: &mut String) {
             template.push_str(format!(" -l {}", data).as_str());
         }
 
-        if let Some(data) = flag.get_help() {
+        if let Some(data) = flag.get_about() {
             template.push_str(format!(" -d '{}'", escape_string(data)).as_str());
         }
 

--- a/clap_generate/src/generators/shells/powershell.rs
+++ b/clap_generate/src/generators/shells/powershell.rs
@@ -86,7 +86,7 @@ fn generate_inner<'b>(
 
     for option in opts!(p) {
         if let Some(data) = option.get_short() {
-            let tooltip = get_tooltip(option.get_help(), data);
+            let tooltip = get_tooltip(option.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(
@@ -99,7 +99,7 @@ fn generate_inner<'b>(
         }
 
         if let Some(data) = option.get_long() {
-            let tooltip = get_tooltip(option.get_help(), data);
+            let tooltip = get_tooltip(option.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(
@@ -114,7 +114,7 @@ fn generate_inner<'b>(
 
     for flag in PowerShell::flags(p) {
         if let Some(data) = flag.get_short() {
-            let tooltip = get_tooltip(flag.get_help(), data);
+            let tooltip = get_tooltip(flag.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(
@@ -127,7 +127,7 @@ fn generate_inner<'b>(
         }
 
         if let Some(data) = flag.get_long() {
-            let tooltip = get_tooltip(flag.get_help(), data);
+            let tooltip = get_tooltip(flag.get_about(), data);
 
             completions.push_str(&preamble);
             completions.push_str(

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -357,7 +357,7 @@ fn write_opts_of(p: &App) -> String {
     for o in opts!(p) {
         debug!("write_opts_of:iter: o={}", o.get_name());
 
-        let help = o.get_help().map_or(String::new(), escape_help);
+        let help = o.get_about().map_or(String::new(), escape_help);
         let conflicts = arg_conflicts(p, o);
 
         // @TODO @soundness should probably be either multiple occurrences or multiple values and
@@ -444,7 +444,7 @@ fn write_flags_of(p: &App) -> String {
     for f in Zsh::flags(p) {
         debug!("write_flags_of:iter: f={}", f.get_name());
 
-        let help = f.get_help().map_or(String::new(), escape_help);
+        let help = f.get_about().map_or(String::new(), escape_help);
         let conflicts = arg_conflicts(p, &f);
 
         let multiple = if f.is_set(ArgSettings::MultipleOccurrences) {
@@ -504,7 +504,7 @@ fn write_positionals_of(p: &App) -> String {
             optional = optional,
             name = arg.get_name(),
             help = arg
-                .get_help()
+                .get_about()
                 .map_or("".to_owned(), |v| " -- ".to_owned() + v)
                 .replace("[", "\\[")
                 .replace("]", "\\]")

--- a/clap_generate/tests/completions.rs
+++ b/clap_generate/tests/completions.rs
@@ -719,13 +719,13 @@ fn build_app() -> App<'static> {
 fn build_app_with_name(s: &'static str) -> App<'static> {
     App::new(s)
         .about("Tests completions")
-        .arg(Arg::with_name("file").help("some input file"))
+        .arg(Arg::with_name("file").about("some input file"))
         .subcommand(
             App::new("test").about("tests things").arg(
                 Arg::with_name("case")
                     .long("case")
                     .takes_value(true)
-                    .help("the case to test"),
+                    .about("the case to test"),
             ),
         )
 }
@@ -737,7 +737,7 @@ fn build_app_special_commands() -> App<'static> {
                 Arg::with_name("config")
                     .long("--config")
                     .takes_value(true)
-                    .help("the other case to test"),
+                    .about("the other case to test"),
             ),
         )
         .subcommand(App::new("some-cmd-with-hypens").alias("hyphen"))
@@ -748,32 +748,32 @@ fn build_app_special_help() -> App<'static> {
         .arg(
             Arg::with_name("single-quotes")
                 .long("single-quotes")
-                .help("Can be 'always', 'auto', or 'never'"),
+                .about("Can be 'always', 'auto', or 'never'"),
         )
         .arg(
             Arg::with_name("double-quotes")
                 .long("double-quotes")
-                .help("Can be \"always\", \"auto\", or \"never\""),
+                .about("Can be \"always\", \"auto\", or \"never\""),
         )
         .arg(
             Arg::with_name("backticks")
                 .long("backticks")
-                .help("For more information see `echo test`"),
+                .about("For more information see `echo test`"),
         )
         .arg(
             Arg::with_name("backslash")
                 .long("backslash")
-                .help("Avoid '\\n'"),
+                .about("Avoid '\\n'"),
         )
         .arg(
             Arg::with_name("brackets")
                 .long("brackets")
-                .help("List packages [filter]"),
+                .about("List packages [filter]"),
         )
         .arg(
             Arg::with_name("expansions")
                 .long("expansions")
-                .help("Execute the shell command with $SHELL"),
+                .about("Execute the shell command with $SHELL"),
         )
 }
 

--- a/examples/01b_quick_example.rs
+++ b/examples/01b_quick_example.rs
@@ -40,24 +40,24 @@ fn main() {
                 .short('c')
                 .long("config")
                 .value_name("FILE")
-                .help("Sets a custom config file")
+                .about("Sets a custom config file")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("output")
-                .help("Sets an optional output file")
+                .about("Sets an optional output file")
                 .index(1),
         )
         .arg(
             Arg::with_name("debug")
                 .short('d')
                 .multiple(true)
-                .help("Turn debugging information on"),
+                .about("Turn debugging information on"),
         )
         .subcommand(
             App::new("test")
                 .about("does testing things")
-                .arg(Arg::with_name("list").short('l').help("lists test values")),
+                .arg(Arg::with_name("list").short('l').about("lists test values")),
         )
         .get_matches();
 

--- a/examples/03_args.rs
+++ b/examples/03_args.rs
@@ -28,19 +28,19 @@ fn main() {
         // A simple "Flag" argument example (i.e. "-d") using the builder pattern
         .arg(
             Arg::with_name("debug")
-                .help("turn on debugging information")
+                .about("turn on debugging information")
                 .short('d'),
         )
         // Two arguments, one "Option" argument (i.e. one that takes a value) such
         // as "-c some", and one positional argument (i.e. "myapp some_file")
         .args(&[
             Arg::with_name("config")
-                .help("sets the config file to use")
+                .about("sets the config file to use")
                 .takes_value(true)
                 .short('c')
                 .long("config"),
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .index(1)
                 .required(true),
         ])

--- a/examples/04_using_matches.rs
+++ b/examples/04_using_matches.rs
@@ -20,20 +20,20 @@ fn main() {
         .author("Kevin K. <kbknapp@gmail.com>")
         .arg(
             Arg::with_name("debug")
-                .help("turn on debugging information")
+                .about("turn on debugging information")
                 .short('d')
                 .long("debug"),
         )
         .arg(
             Arg::with_name("config")
-                .help("sets the config file to use")
+                .about("sets the config file to use")
                 .short('c')
                 .long("config")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .index(1)
                 .required(true),
         )

--- a/examples/05_flag_args.rs
+++ b/examples/05_flag_args.rs
@@ -15,7 +15,7 @@ fn main() {
         // you want for your individual case.
         .arg(
             Arg::with_name("awesome")
-                .help("turns up the awesome") // Displayed when showing help info
+                .about("turns up the awesome") // Displayed when showing help info
                 .short('a') // Trigger this arg with "-a"
                 .long("awesome") // Trigger this arg with "--awesome"
                 .multiple(true) // This flag should allow multiple

--- a/examples/06_positional_args.rs
+++ b/examples/06_positional_args.rs
@@ -13,7 +13,7 @@ fn main() {
         // ones that apply to your individual case.
         .arg(
             Arg::with_name("input")
-                .help("the input file to use") // Displayed when showing help info
+                .about("the input file to use") // Displayed when showing help info
                 .index(1) // Set the order in which the user must
                 // specify this argument (Starts at 1)
                 .requires("config") // Says, "If the user uses "input", they MUST
@@ -30,7 +30,7 @@ fn main() {
         )
         .arg(
             Arg::with_name("config")
-                .help("the config file to use")
+                .about("the config file to use")
                 .index(2),
         ) // Note, we do not need to specify required(true)
         // if we don't want to, because "input" already

--- a/examples/07_option_args.rs
+++ b/examples/07_option_args.rs
@@ -15,7 +15,7 @@ fn main() {
         // to your particular case.
         .arg(
             Arg::with_name("input")
-                .help("the input file to use") // Displayed when showing help info
+                .about("the input file to use") // Displayed when showing help info
                 .takes_value(true) // MUST be set to true in order to be an "option" argument
                 .short('i') // This argument is triggered with "-i"
                 .long("input") // This argument is triggered with "--input"

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -28,7 +28,7 @@ fn main() {
                 .author("Kevin K.") // And authors
                 .arg(
                     Arg::with_name("input") // And their own arguments
-                        .help("the file to add")
+                        .about("the file to add")
                         .index(1)
                         .required(true),
                 ),

--- a/examples/10_default_values.rs
+++ b/examples/10_default_values.rs
@@ -11,7 +11,7 @@ fn main() {
         .about("does awesome things")
         .arg(
             Arg::with_name("INPUT")
-                .help("The input file to use") // Note, we don't need to specify
+                .about("The input file to use") // Note, we don't need to specify
                 // anything like, "Defaults to..."
                 // because clap will automatically
                 // generate that for us, and place
@@ -24,7 +24,7 @@ fn main() {
             Arg::with_name("CONFIG")
                 // Note that we have to manaully include some verbage to the user
                 // telling them what the default will be.
-                .help("The config file to use (default is \"config.json\")")
+                .about("The config file to use (default is \"config.json\")")
                 .short('c')
                 .takes_value(true),
         )

--- a/examples/11_only_specific_values.rs
+++ b/examples/11_only_specific_values.rs
@@ -14,7 +14,7 @@ fn main() {
         .about("does awesome things")
         .arg(
             Arg::with_name("MODE")
-                .help("What mode to run the program in")
+                .about("What mode to run the program in")
                 .index(1)
                 .possible_values(&["fast", "slow"])
                 .required(true),

--- a/examples/15_custom_validator.rs
+++ b/examples/15_custom_validator.rs
@@ -9,7 +9,7 @@ fn main() {
         // Application logic goes here...
         .arg(
             Arg::with_name("input")
-                .help("the input file to use")
+                .about("the input file to use")
                 .index(1)
                 .required(true)
                 // You can pass in a closure, or a function

--- a/examples/20_subcommands.rs
+++ b/examples/20_subcommands.rs
@@ -49,7 +49,7 @@ fn main() {
         .subcommand(
             App::new("clone").about("clones repos").arg(
                 Arg::with_name("repo")
-                    .help("The repo to clone")
+                    .about("The repo to clone")
                     .required(true),
             ),
         )
@@ -64,7 +64,7 @@ fn main() {
                         .arg(
                             Arg::with_name("repo")
                                 .required(true)
-                                .help("The remote repo to push things to"),
+                                .about("The remote repo to push things to"),
                         ),
                 )
                 .subcommand(App::new("local").about("pushes local things")),
@@ -78,7 +78,7 @@ fn main() {
                 .arg(
                     Arg::with_name("stuff")
                         .long("stuff")
-                        .help("Stuff to add")
+                        .about("Stuff to add")
                         .takes_value(true)
                         .multiple(true),
                 ),

--- a/examples/21_aliases.rs
+++ b/examples/21_aliases.rs
@@ -10,7 +10,7 @@ fn main() {
                 .author("Kevin K.")
                 .arg(
                     Arg::with_name("input")
-                        .help("the file to add")
+                        .about("the file to add")
                         .index(1)
                         .required(true),
                 ),

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1562,7 +1562,7 @@ impl<'b> App<'b> {
                 .args
                 .args
                 .iter()
-                .filter(|arg| arg.about.is_none() && arg.long_help.is_none())
+                .filter(|arg| arg.about.is_none() && arg.long_about.is_none())
                 .map(|arg| String::from(arg.name))
                 .collect();
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1562,7 +1562,7 @@ impl<'b> App<'b> {
                 .args
                 .args
                 .iter()
-                .filter(|arg| arg.help.is_none() && arg.long_help.is_none())
+                .filter(|arg| arg.about.is_none() && arg.long_help.is_none())
                 .map(|arg| String::from(arg.name))
                 .collect();
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1804,7 +1804,7 @@ impl<'b> App<'b> {
             debug!("App::_create_help_and_version: Building --help");
             let mut help = Arg::with_name("help")
                 .long("help")
-                .help("Prints help information");
+                .about("Prints help information");
             if !self.args.args.iter().any(|x| x.short == Some('h')) {
                 help = help.short('h');
             }
@@ -1821,7 +1821,7 @@ impl<'b> App<'b> {
             debug!("App::_create_help_and_version: Building --version");
             let mut version = Arg::with_name("version")
                 .long("version")
-                .help("Prints version information");
+                .about("Prints version information");
             if !self.args.args.iter().any(|x| x.short == Some('V')) {
                 version = version.short('V');
             }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -41,7 +41,7 @@ type ValidatorOs = Rc<dyn Fn(&OsStr) -> Result<(), String>>;
 ///       .long("config")
 ///       .takes_value(true)
 ///       .value_name("FILE")
-///       .help("Provides a config file to myprog");
+///       .about("Provides a config file to myprog");
 /// // Using a usage string (setting a similar argument to the one above)
 /// let input = Arg::from("-i, --input=[FILE] 'Provides an input file to the program'");
 /// ```
@@ -52,7 +52,7 @@ pub struct Arg<'help> {
     pub(crate) id: Id,
     pub(crate) name: &'help str,
     pub(crate) about: Option<&'help str>,
-    pub(crate) long_help: Option<&'help str>,
+    pub(crate) long_about: Option<&'help str>,
     pub(crate) blacklist: Option<Vec<Id>>,
     pub(crate) settings: ArgFlags,
     pub(crate) overrides: Option<Vec<Id>>,
@@ -496,13 +496,87 @@ impl<'help> Arg<'help> {
     /// -h, --help       Prints help information
     /// -V, --version    Prints version information
     /// ```
-    /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
+    /// [`Arg::help`]: ./struct.Arg.html#method.help
     #[deprecated(
         since = "3.0.0",
         note = "Please use `about` method instead"
     )]
     pub fn help(self, h: &'help str) -> Self {
         self.about(h)
+    }
+
+    /// Sets the long help text of the argument that will be displayed to the user when they print
+    /// the help information with `--help`. Typically this a more detailed (multi-line) message
+    /// that describes the arg.
+    ///
+    /// **NOTE:** If only `long_help` is provided, and not [`Arg::help`] but the user requests `-h`
+    /// clap will still display the contents of `long_help` appropriately
+    ///
+    /// **NOTE:** Only [`Arg::help`] is used in completion script generation in order to be concise
+    ///
+    /// # Examples
+    ///
+    /// Any valid UTF-8 is allowed in the help text. The one exception is when one wishes to
+    /// include a newline in the help text and have the following text be properly aligned with all
+    /// the other help text.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::with_name("config")
+    ///     .long_help(
+    /// "The config file used by the myprog must be in JSON format
+    /// with only valid keys and may not contain other nonsense
+    /// that cannot be read by this program. Obviously I'm going on
+    /// and on, so I'll stop now.")
+    /// # ;
+    /// ```
+    ///
+    /// Setting `help` displays a short message to the side of the argument when the user passes
+    /// `-h` or `--help` (by default).
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::with_name("cfg")
+    ///         .long("config")
+    ///         .long_help(
+    /// "The config file used by the myprog must be in JSON format
+    /// with only valid keys and may not contain other nonsense
+    /// that cannot be read by this program. Obviously I'm going on
+    /// and on, so I'll stop now."))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays
+    ///
+    /// ```notrust
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [FLAGS]
+    ///
+    /// FLAGS:
+    ///    --config
+    ///         The config file used by the myprog must be in JSON format
+    ///         with only valid keys and may not contain other nonsense
+    ///         that cannot be read by this program. Obviously I'm going on
+    ///         and on, so I'll stop now.
+    ///
+    /// -h, --help
+    ///         Prints help information
+    ///
+    /// -V, --version
+    ///         Prints version information
+    /// ```
+    /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
+    #[deprecated(
+        since = "3.0.0",
+        note = "Please use `long_about` method instead"
+    )]
+    pub fn long_help(self, h: &'help str) -> Self {
+        self.long_about(h)
     }
 
     /// Sets the short help text of the argument that will be displayed to the user when they print
@@ -554,7 +628,7 @@ impl<'help> Arg<'help> {
     /// -h, --help       Prints help information
     /// -V, --version    Prints version information
     /// ```
-    /// [`Arg::long_about`]: ./struct.Arg.html#method.long_about
+    /// [`Arg::about`]: ./struct.Arg.html#method.about
     pub fn about(mut self, h: &'help str) -> Self {
         self.about = Some(h);
         self
@@ -578,7 +652,7 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::{App, Arg};
     /// Arg::with_name("config")
-    ///     .long_help(
+    ///     .long_about(
     /// "The config file used by the myprog must be in JSON format
     /// with only valid keys and may not contain other nonsense
     /// that cannot be read by this program. Obviously I'm going on
@@ -594,7 +668,7 @@ impl<'help> Arg<'help> {
     /// let m = App::new("prog")
     ///     .arg(Arg::with_name("cfg")
     ///         .long("config")
-    ///         .long_help(
+    ///         .long_about(
     /// "The config file used by the myprog must be in JSON format
     /// with only valid keys and may not contain other nonsense
     /// that cannot be read by this program. Obviously I'm going on
@@ -624,11 +698,10 @@ impl<'help> Arg<'help> {
     ///
     /// -V, --version
     ///         Prints version information
-    /// ```
-    /// [`Arg::help`]: ./struct.Arg.html#method.help
-    #[inline]
-    pub fn long_help(mut self, h: &'help str) -> Self {
-        self.long_help = Some(h);
+    ///
+    /// [`Arg::long_about`]: ./struct.Arg.html#method.long_about
+    pub fn long_about(mut self, h: &'help str) -> Self {
+        self.long_about = Some(h);
         self
     }
 
@@ -4410,7 +4483,7 @@ impl<'help> fmt::Debug for Arg<'help> {
             self.id,
             self.name,
             self.about,
-            self.long_help,
+            self.long_about,
             self.blacklist,
             self.settings,
             self.r_unless,

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -498,10 +498,7 @@ impl<'help> Arg<'help> {
     /// -V, --version    Prints version information
     /// ```
     /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
-    #[deprecated(
-        since = "3.0.0",
-        note = "Please use `about` method instead"
-    )]
+    #[deprecated(since = "3.0.0", note = "Please use `about` method instead")]
     #[inline]
     pub fn help(self, h: &'help str) -> Self {
         self.about(h)
@@ -573,10 +570,7 @@ impl<'help> Arg<'help> {
     ///         Prints version information
     /// ```
     /// [`Arg::help`]: ./struct.Arg.html#method.help
-    #[deprecated(
-        since = "3.0.0",
-        note = "Please use `long_about` method instead"
-    )]
+    #[deprecated(since = "3.0.0", note = "Please use `long_about` method instead")]
     #[inline]
     pub fn long_help(self, h: &'help str) -> Self {
         self.long_about(h)

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -51,11 +51,6 @@ type ValidatorOs = Rc<dyn Fn(&OsStr) -> Result<(), String>>;
 pub struct Arg<'help> {
     pub(crate) id: Id,
     pub(crate) name: &'help str,
-    #[deprecated(
-        since = "3.0.0",
-        note = "Please use `about` field instead"
-    )]
-    pub(crate) help: Option<&'help str>,
     pub(crate) about: Option<&'help str>,
     pub(crate) long_help: Option<&'help str>,
     pub(crate) blacklist: Option<Vec<Id>>,
@@ -94,15 +89,6 @@ impl<'help> Arg<'help> {
     #[inline]
     pub fn get_name(&self) -> &str {
         &self.name
-    }
-
-    /// Get the help specified for this argument, if any
-    #[deprecated(
-        since = "3.0.0",
-        note = "Please use `get_about` method instead"
-    )]
-    pub fn get_help(&self) -> Option<&str> {
-        self.about
     }
 
     /// Get the help specified for this argument, if any
@@ -511,8 +497,65 @@ impl<'help> Arg<'help> {
     /// -V, --version    Prints version information
     /// ```
     /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
-    #[inline]
-    pub fn help(mut self, h: &'help str) -> Self {
+    #[deprecated(
+        since = "3.0.0",
+        note = "Please use `about` method instead"
+    )]
+    pub fn help(self, h: &'help str) -> Self {
+        self.about(h)
+    }
+
+    /// Sets the short help text of the argument that will be displayed to the user when they print
+    /// the help information with `-h`. Typically, this is a short (one line) description of the
+    /// arg.
+    ///
+    /// **NOTE:** If only `Arg::about` is provided, and not [`Arg::long_about`] but the user requests
+    /// `--help` clap will still display the contents of `help` appropriately
+    ///
+    /// **NOTE:** Only `Arg::about` is used in completion script generation in order to be concise
+    ///
+    /// # Examples
+    ///
+    /// Any valid UTF-8 is allowed in the help text. The one exception is when one wishes to
+    /// include a newline in the help text and have the following text be properly aligned with all
+    /// the other help text.
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// Arg::with_name("config")
+    ///     .about("The config file used by the myprog")
+    /// # ;
+    /// ```
+    ///
+    /// Setting `about` displays a short message to the side of the argument when the user passes
+    /// `-h` or `--help` (by default).
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    /// let m = App::new("prog")
+    ///     .arg(Arg::with_name("cfg")
+    ///         .long("config")
+    ///         .about("Some help text describing the --config arg"))
+    ///     .get_matches_from(vec![
+    ///         "prog", "--help"
+    ///     ]);
+    /// ```
+    ///
+    /// The above example displays
+    ///
+    /// ```notrust
+    /// helptest
+    ///
+    /// USAGE:
+    ///    helptest [FLAGS]
+    ///
+    /// FLAGS:
+    ///     --config     Some help text describing the --config arg
+    /// -h, --help       Prints help information
+    /// -V, --version    Prints version information
+    /// ```
+    /// [`Arg::long_about`]: ./struct.Arg.html#method.long_about
+    pub fn about(mut self, h: &'help str) -> Self {
         self.about = Some(h);
         self
     }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -632,6 +632,7 @@ impl<'help> Arg<'help> {
     /// -V, --version    Prints version information
     /// ```
     /// [`Arg::long_about`]: ./struct.Arg.html#method.long_about
+    #[inline]
     pub fn about(mut self, h: &'help str) -> Self {
         self.about = Some(h);
         self
@@ -703,6 +704,7 @@ impl<'help> Arg<'help> {
     ///         Prints version information
     ///
     /// [`Arg::about`]: ./struct.Arg.html#method.about
+    #[inline]
     pub fn long_about(mut self, h: &'help str) -> Self {
         self.long_about = Some(h);
         self

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -51,7 +51,12 @@ type ValidatorOs = Rc<dyn Fn(&OsStr) -> Result<(), String>>;
 pub struct Arg<'help> {
     pub(crate) id: Id,
     pub(crate) name: &'help str,
+    #[deprecated(
+        since = "3.0.0",
+        note = "Please use `about` field instead"
+    )]
     pub(crate) help: Option<&'help str>,
+    pub(crate) about: Option<&'help str>,
     pub(crate) long_help: Option<&'help str>,
     pub(crate) blacklist: Option<Vec<Id>>,
     pub(crate) settings: ArgFlags,
@@ -92,9 +97,17 @@ impl<'help> Arg<'help> {
     }
 
     /// Get the help specified for this argument, if any
-    #[inline]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Please use `get_about` method instead"
+    )]
     pub fn get_help(&self) -> Option<&str> {
-        self.help
+        self.about
+    }
+
+    /// Get the help specified for this argument, if any
+    pub fn get_about(&self) -> Option<&str> {
+        self.about
     }
 
     /// Get the help heading specified for this argument, if any
@@ -500,7 +513,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
     #[inline]
     pub fn help(mut self, h: &'help str) -> Self {
-        self.help = Some(h);
+        self.about = Some(h);
         self
     }
 
@@ -4353,7 +4366,7 @@ impl<'help> fmt::Debug for Arg<'help> {
              }}",
             self.id,
             self.name,
-            self.help,
+            self.about,
             self.long_help,
             self.blacklist,
             self.settings,

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -92,6 +92,7 @@ impl<'help> Arg<'help> {
     }
 
     /// Get the help specified for this argument, if any
+    #[inline]
     pub fn get_about(&self) -> Option<&str> {
         self.about
     }
@@ -190,8 +191,8 @@ impl<'help> Arg<'help> {
                 "short" => yaml_to_char!(a, v, short),
                 "long" => yaml_to_str!(a, v, long),
                 "aliases" => yaml_vec_or_str!(v, a, alias),
-                "help" => yaml_to_str!(a, v, help),
-                "long_help" => yaml_to_str!(a, v, long_help),
+                "about" => yaml_to_str!(a, v, about),
+                "long_about" => yaml_to_str!(a, v, long_about),
                 "required" => yaml_to_bool!(a, v, required),
                 "required_if" => yaml_tuple2!(a, v, required_if),
                 "required_ifs" => yaml_tuple2!(a, v, required_if),
@@ -496,11 +497,12 @@ impl<'help> Arg<'help> {
     /// -h, --help       Prints help information
     /// -V, --version    Prints version information
     /// ```
-    /// [`Arg::help`]: ./struct.Arg.html#method.help
+    /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
     #[deprecated(
         since = "3.0.0",
         note = "Please use `about` method instead"
     )]
+    #[inline]
     pub fn help(self, h: &'help str) -> Self {
         self.about(h)
     }
@@ -570,11 +572,12 @@ impl<'help> Arg<'help> {
     /// -V, --version
     ///         Prints version information
     /// ```
-    /// [`Arg::long_help`]: ./struct.Arg.html#method.long_help
+    /// [`Arg::help`]: ./struct.Arg.html#method.help
     #[deprecated(
         since = "3.0.0",
         note = "Please use `long_about` method instead"
     )]
+    #[inline]
     pub fn long_help(self, h: &'help str) -> Self {
         self.long_about(h)
     }
@@ -628,7 +631,7 @@ impl<'help> Arg<'help> {
     /// -h, --help       Prints help information
     /// -V, --version    Prints version information
     /// ```
-    /// [`Arg::about`]: ./struct.Arg.html#method.about
+    /// [`Arg::long_about`]: ./struct.Arg.html#method.long_about
     pub fn about(mut self, h: &'help str) -> Self {
         self.about = Some(h);
         self
@@ -638,10 +641,10 @@ impl<'help> Arg<'help> {
     /// the help information with `--help`. Typically this a more detailed (multi-line) message
     /// that describes the arg.
     ///
-    /// **NOTE:** If only `long_help` is provided, and not [`Arg::help`] but the user requests `-h`
-    /// clap will still display the contents of `long_help` appropriately
+    /// **NOTE:** If only `long_about` is provided, and not [`Arg::about`] but the user requests `-h`
+    /// clap will still display the contents of `long_about` appropriately
     ///
-    /// **NOTE:** Only [`Arg::help`] is used in completion script generation in order to be concise
+    /// **NOTE:** Only [`Arg::about`] is used in completion script generation in order to be concise
     ///
     /// # Examples
     ///
@@ -699,7 +702,7 @@ impl<'help> Arg<'help> {
     /// -V, --version
     ///         Prints version information
     ///
-    /// [`Arg::long_about`]: ./struct.Arg.html#method.long_about
+    /// [`Arg::about`]: ./struct.Arg.html#method.about
     pub fn long_about(mut self, h: &'help str) -> Self {
         self.long_about = Some(h);
         self

--- a/src/build/arg/tests.rs
+++ b/src/build/arg/tests.rs
@@ -6,7 +6,7 @@ fn short_flag_misspel() {
     assert_eq!(a.name, "flag");
     assert_eq!(a.short.unwrap(), 'f');
     assert_eq!(a.long.unwrap(), "flag");
-    assert_eq!(a.help.unwrap(), "some flag");
+    assert_eq!(a.about.unwrap(), "some flag");
     assert!(!a.is_set(ArgSettings::MultipleOccurrences));
     assert!(a.val_names.is_none());
     assert!(a.num_vals.is_none());
@@ -18,7 +18,7 @@ fn short_flag_name_missing() {
     assert_eq!(a.name, "f");
     assert_eq!(a.short.unwrap(), 'f');
     assert!(a.long.is_none());
-    assert_eq!(a.help.unwrap(), "some flag");
+    assert_eq!(a.about.unwrap(), "some flag");
     assert!(!a.is_set(ArgSettings::MultipleOccurrences));
     assert!(a.val_names.is_none());
     assert!(a.num_vals.is_none());

--- a/src/build/usage_parser.rs
+++ b/src/build/usage_parser.rs
@@ -202,7 +202,7 @@ impl<'a> UsageParser<'a> {
             "UsageParser::help: setting help...{}",
             &self.usage[self.start..self.pos]
         );
-        arg.help = Some(&self.usage[self.start..self.pos]);
+        arg.about = Some(&self.usage[self.start..self.pos]);
         self.pos += 1; // Move to next byte to keep from thinking ending ' is a start
         self.prev = UsageToken::Help;
     }
@@ -262,7 +262,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -271,7 +271,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -280,7 +280,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -289,7 +289,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.short.unwrap(), 'f');
         assert_eq!(a.long.unwrap(), "flag");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -298,7 +298,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -307,7 +307,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert_eq!(a.short.unwrap(), 'f');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -316,7 +316,7 @@ mod test {
         assert_eq!(a.name, "flag");
         assert_eq!(a.long.unwrap(), "flag");
         assert_eq!(a.short.unwrap(), 'f');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -351,7 +351,7 @@ mod test {
         assert_eq!(a.name, "f");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.val_names.is_none());
         assert!(a.num_vals.is_none());
@@ -377,7 +377,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -392,7 +392,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -407,7 +407,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -422,7 +422,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -437,7 +437,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -452,7 +452,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
@@ -466,7 +466,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -481,7 +481,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -496,7 +496,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
@@ -510,7 +510,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert_eq!(a.short.unwrap(), 'o');
         assert!(a.long.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -525,7 +525,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -540,7 +540,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -558,7 +558,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -573,7 +573,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -591,7 +591,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -606,7 +606,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
@@ -620,7 +620,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -638,7 +638,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
@@ -653,7 +653,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
@@ -667,7 +667,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -686,7 +686,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -702,7 +702,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -721,7 +721,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -737,7 +737,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -756,7 +756,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -772,7 +772,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
@@ -786,7 +786,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -805,7 +805,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -821,7 +821,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
@@ -835,7 +835,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert!(a.short.is_none());
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -854,7 +854,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -873,7 +873,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -892,7 +892,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -908,7 +908,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -927,7 +927,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
@@ -944,7 +944,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -963,7 +963,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
@@ -977,7 +977,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -996,7 +996,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1015,7 +1015,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1034,7 +1034,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1050,7 +1050,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1069,7 +1069,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
@@ -1086,7 +1086,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1105,7 +1105,7 @@ mod test {
         assert_eq!(a.name, "option");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
@@ -1119,7 +1119,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert_eq!(a.long.unwrap(), "opt");
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1138,7 +1138,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert!(a.long.is_none());
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1157,7 +1157,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert!(a.long.is_none());
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1176,7 +1176,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1195,7 +1195,7 @@ mod test {
         assert_eq!(a.name, "myopt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1214,7 +1214,7 @@ mod test {
         assert_eq!(a.name, "opt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1227,7 +1227,7 @@ mod test {
     fn create_positional_usage() {
         let a = Arg::from("[pos] 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1240,7 +1240,7 @@ mod test {
     fn create_positional_usage0() {
         let a = Arg::from("<pos> 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1253,7 +1253,7 @@ mod test {
     fn pos_mult_help() {
         let a = Arg::from("[pos]... 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1266,7 +1266,7 @@ mod test {
     fn pos_help_lit_single_quote() {
         let a = Arg::from("[pos]... 'some help\' info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help' info");
+        assert_eq!(a.about.unwrap(), "some help' info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1279,7 +1279,7 @@ mod test {
     fn pos_help_double_lit_single_quote() {
         let a = Arg::from("[pos]... 'some \'help\' info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some 'help' info");
+        assert_eq!(a.about.unwrap(), "some 'help' info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1295,7 +1295,7 @@ mod test {
              info'",
         );
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help\ninfo");
+        assert_eq!(a.about.unwrap(), "some help\ninfo");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1311,7 +1311,7 @@ mod test {
              info'",
         );
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help' stuff\ninfo");
+        assert_eq!(a.about.unwrap(), "some help' stuff\ninfo");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1324,7 +1324,7 @@ mod test {
     fn pos_req_mult_help() {
         let a = Arg::from("<pos>... 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1361,7 +1361,7 @@ mod test {
     fn pos_req_mult_def_help() {
         let a = Arg::from("<pos>... @a 'some help info'");
         assert_eq!(a.name, "pos");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
@@ -1377,7 +1377,7 @@ mod test {
         assert_eq!(a.name, "o");
         assert!(a.long.is_none());
         assert_eq!(a.short.unwrap(), 'o');
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1397,7 +1397,7 @@ mod test {
         assert_eq!(a.name, "myopt");
         assert!(a.short.is_none());
         assert_eq!(a.long.unwrap(), "opt");
-        assert_eq!(a.help.unwrap(), "some help info");
+        assert_eq!(a.about.unwrap(), "some help info");
         assert!(
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
@@ -1415,21 +1415,21 @@ mod test {
     fn nonascii() {
         let a = Arg::from("<ASCII> 'üñíčöĐ€'");
         assert_eq!(a.name, "ASCII");
-        assert_eq!(a.help, Some("üñíčöĐ€"));
+        assert_eq!(a.about, Some("üñíčöĐ€"));
         let a = Arg::from("<üñíčöĐ€> 'ASCII'");
         assert_eq!(a.name, "üñíčöĐ€");
-        assert_eq!(a.help, Some("ASCII"));
+        assert_eq!(a.about, Some("ASCII"));
         let a = Arg::from("<üñíčöĐ€> 'üñíčöĐ€'");
         assert_eq!(a.name, "üñíčöĐ€");
-        assert_eq!(a.help, Some("üñíčöĐ€"));
+        assert_eq!(a.about, Some("üñíčöĐ€"));
         let a = Arg::from("-ø 'ø'");
         assert_eq!(a.name, "ø");
         assert_eq!(a.short, Some('ø'));
-        assert_eq!(a.help, Some("ø"));
+        assert_eq!(a.about, Some("ø"));
         let a = Arg::from("--üñíčöĐ€ 'Nōṫ ASCII'");
         assert_eq!(a.name, "üñíčöĐ€");
         assert_eq!(a.long, Some("üñíčöĐ€"));
-        assert_eq!(a.help, Some("Nōṫ ASCII"));
+        assert_eq!(a.about, Some("Nōṫ ASCII"));
         let a = Arg::from("[ñämê] --ôpt=[üñíčöĐ€] 'hælp'");
         assert_eq!(a.name, "ñämê");
         assert_eq!(a.long, Some("ôpt"));
@@ -1437,6 +1437,6 @@ mod test {
             a.val_names.unwrap().values().collect::<Vec<_>>(),
             [&"üñíčöĐ€"]
         );
-        assert_eq!(a.help, Some("hælp"));
+        assert_eq!(a.about, Some("hælp"));
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -486,7 +486,7 @@ macro_rules! clap_app {
     };
     (@as_expr $expr:expr) => { $expr };
     // Help
-    (@arg ($arg:expr) $modes:tt $desc:tt) => { $arg.help(clap_app!{ @as_expr $desc }) };
+    (@arg ($arg:expr) $modes:tt $desc:tt) => { $arg.about(clap_app!{ @as_expr $desc }) };
     // Handle functions that need to be called multiple times for each argument
     (@arg ($arg:expr) $modes:tt $ident:ident[$($target:literal)*] $($tail:tt)*) => {
         $crate::clap_app!{ @arg ($arg $( .$ident(stringify!($target).trim_matches('"')) )*) $modes $($tail)* }

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -399,9 +399,9 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
     fn help(&mut self, arg: &Arg<'c>, spec_vals: &str, prevent_nlh: bool) -> io::Result<()> {
         debug!("Help::help");
         let h = if self.use_long {
-            arg.long_help.unwrap_or_else(|| arg.about.unwrap_or(""))
+            arg.long_about.unwrap_or_else(|| arg.about.unwrap_or(""))
         } else {
-            arg.about.unwrap_or_else(|| arg.long_help.unwrap_or(""))
+            arg.about.unwrap_or_else(|| arg.long_about.unwrap_or(""))
         };
         let mut help = String::from(h) + spec_vals;
         let nlh = self.next_line_help || arg.is_set(ArgSettings::NextLineHelp) || self.use_long;

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -312,7 +312,7 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
         }
 
         let spec_vals = self.spec_vals(arg);
-        let h = arg.help.unwrap_or("");
+        let h = arg.about.unwrap_or("");
         let h_w = str_width(h) + str_width(&*spec_vals);
         let nlh = self.next_line_help || arg.is_set(ArgSettings::NextLineHelp);
         let taken = self.longest + 12;
@@ -399,9 +399,9 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
     fn help(&mut self, arg: &Arg<'c>, spec_vals: &str, prevent_nlh: bool) -> io::Result<()> {
         debug!("Help::help");
         let h = if self.use_long {
-            arg.long_help.unwrap_or_else(|| arg.help.unwrap_or(""))
+            arg.long_help.unwrap_or_else(|| arg.about.unwrap_or(""))
         } else {
-            arg.help.unwrap_or_else(|| arg.long_help.unwrap_or(""))
+            arg.about.unwrap_or_else(|| arg.long_help.unwrap_or(""))
         };
         let mut help = String::from(h) + spec_vals;
         let nlh = self.next_line_help || arg.is_set(ArgSettings::NextLineHelp) || self.use_long;

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -893,7 +893,7 @@ where
             let mut pb = Arg::with_name("subcommand")
                 .index(1)
                 .setting(ArgSettings::MultipleValues)
-                .help("The subcommand whose help message to display");
+                .about("The subcommand whose help message to display");
 
             pb._build();
             //parser.positionals.insert(1, pb.name);

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1089,7 +1089,7 @@ where
         // specified by the user is sent through. If HiddenShortHelp is not included,
         // then items specified with hidden_short_help will also be hidden.
         let should_long = |v: &Arg| {
-            v.long_help.is_some()
+            v.long_about.is_some()
                 || v.is_set(ArgSettings::HiddenLongHelp)
                 || v.is_set(ArgSettings::HiddenShortHelp)
         };

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -491,9 +491,9 @@ fn dont_collapse_args() {
         .version("v1.4.8")
         .setting(AppSettings::DontCollapseArgsInUsage)
         .args(&[
-            Arg::with_name("arg1").help("some"),
-            Arg::with_name("arg2").help("some"),
-            Arg::with_name("arg3").help("some"),
+            Arg::with_name("arg1").about("some"),
+            Arg::with_name("arg2").about("some"),
+            Arg::with_name("arg3").about("some"),
         ]);
     assert!(utils::compare_output(
         app,
@@ -512,7 +512,7 @@ fn require_eq() {
             .required(true)
             .require_equals(true)
             .value_name("FILE")
-            .help("some"),
+            .about("some"),
     );
     assert!(utils::compare_output(
         app,

--- a/tests/arg_aliases.rs
+++ b/tests/arg_aliases.rs
@@ -37,7 +37,7 @@ fn single_alias_of_option() {
             Arg::with_name("alias")
                 .long("alias")
                 .takes_value(true)
-                .help("single alias")
+                .about("single alias")
                 .alias("new-opt"),
         )
         .try_get_matches_from(vec!["", "--new-opt", "cool"]);
@@ -53,7 +53,7 @@ fn multiple_aliases_of_option() {
         Arg::with_name("aliases")
             .long("aliases")
             .takes_value(true)
-            .help("multiple aliases")
+            .about("multiple aliases")
             .aliases(&["alias1", "alias2", "alias3"]),
     );
     let long = a
@@ -142,7 +142,7 @@ fn alias_on_a_subcommand_option() {
                     .long("test")
                     .takes_value(true)
                     .alias("opt")
-                    .help("testing testing"),
+                    .about("testing testing"),
             ),
         )
         .arg(

--- a/tests/borrowed.rs
+++ b/tests/borrowed.rs
@@ -5,11 +5,11 @@ fn borrowed_args() {
     let arg = Arg::with_name("some")
         .short('s')
         .long("some")
-        .help("other help");
+        .about("other help");
     let arg2 = Arg::with_name("some2")
         .short('S')
         .long("some-thing")
-        .help("other help");
+        .about("other help");
     let result = App::new("sub_command_negate")
         .arg(Arg::with_name("test").index(1))
         .arg(&arg)

--- a/tests/derive_order.rs
+++ b/tests/derive_order.rs
@@ -117,16 +117,16 @@ OPTIONS:
 #[test]
 fn no_derive_order() {
     let app = App::new("test").version("1.2").args(&[
-        Arg::with_name("flag_b").long("flag_b").help("first flag"),
+        Arg::with_name("flag_b").long("flag_b").about("first flag"),
         Arg::with_name("option_b")
             .long("option_b")
             .takes_value(true)
-            .help("first option"),
-        Arg::with_name("flag_a").long("flag_a").help("second flag"),
+            .about("first option"),
+        Arg::with_name("flag_a").long("flag_a").about("second flag"),
         Arg::with_name("option_a")
             .long("option_a")
             .takes_value(true)
-            .help("second option"),
+            .about("second option"),
     ]);
 
     assert!(utils::compare_output(
@@ -143,16 +143,16 @@ fn derive_order() {
         .setting(AppSettings::DeriveDisplayOrder)
         .version("1.2")
         .args(&[
-            Arg::with_name("flag_b").long("flag_b").help("first flag"),
+            Arg::with_name("flag_b").long("flag_b").about("first flag"),
             Arg::with_name("option_b")
                 .long("option_b")
                 .takes_value(true)
-                .help("first option"),
-            Arg::with_name("flag_a").long("flag_a").help("second flag"),
+                .about("first option"),
+            Arg::with_name("flag_a").long("flag_a").about("second flag"),
             Arg::with_name("option_a")
                 .long("option_a")
                 .takes_value(true)
-                .help("second option"),
+                .about("second option"),
         ]);
 
     assert!(utils::compare_output(
@@ -169,16 +169,16 @@ fn unified_help() {
         .setting(AppSettings::UnifiedHelpMessage)
         .version("1.2")
         .args(&[
-            Arg::with_name("flag_b").long("flag_b").help("first flag"),
+            Arg::with_name("flag_b").long("flag_b").about("first flag"),
             Arg::with_name("option_b")
                 .long("option_b")
                 .takes_value(true)
-                .help("first option"),
-            Arg::with_name("flag_a").long("flag_a").help("second flag"),
+                .about("first option"),
+            Arg::with_name("flag_a").long("flag_a").about("second flag"),
             Arg::with_name("option_a")
                 .long("option_a")
                 .takes_value(true)
-                .help("second option"),
+                .about("second option"),
         ]);
 
     assert!(utils::compare_output(
@@ -196,16 +196,16 @@ fn unified_help_and_derive_order() {
         .setting(AppSettings::UnifiedHelpMessage)
         .version("1.2")
         .args(&[
-            Arg::with_name("flag_b").long("flag_b").help("first flag"),
+            Arg::with_name("flag_b").long("flag_b").about("first flag"),
             Arg::with_name("option_b")
                 .long("option_b")
                 .takes_value(true)
-                .help("first option"),
-            Arg::with_name("flag_a").long("flag_a").help("second flag"),
+                .about("first option"),
+            Arg::with_name("flag_a").long("flag_a").about("second flag"),
             Arg::with_name("option_a")
                 .long("option_a")
                 .takes_value(true)
-                .help("second option"),
+                .about("second option"),
         ]);
 
     assert!(utils::compare_output(
@@ -223,16 +223,16 @@ fn derive_order_subcommand_propagate() {
         .version("1.2")
         .subcommand(
             App::new("sub").version("1.2").args(&[
-                Arg::with_name("flag_b").long("flag_b").help("first flag"),
+                Arg::with_name("flag_b").long("flag_b").about("first flag"),
                 Arg::with_name("option_b")
                     .long("option_b")
                     .takes_value(true)
-                    .help("first option"),
-                Arg::with_name("flag_a").long("flag_a").help("second flag"),
+                    .about("first option"),
+                Arg::with_name("flag_a").long("flag_a").about("second flag"),
                 Arg::with_name("option_a")
                     .long("option_a")
                     .takes_value(true)
-                    .help("second option"),
+                    .about("second option"),
             ]),
         );
 
@@ -250,16 +250,16 @@ fn unified_help_subcommand_propagate() {
         .global_setting(AppSettings::UnifiedHelpMessage)
         .subcommand(
             App::new("sub").version("1.2").args(&[
-                Arg::with_name("flag_b").long("flag_b").help("first flag"),
+                Arg::with_name("flag_b").long("flag_b").about("first flag"),
                 Arg::with_name("option_b")
                     .long("option_b")
                     .takes_value(true)
-                    .help("first option"),
-                Arg::with_name("flag_a").long("flag_a").help("second flag"),
+                    .about("first option"),
+                Arg::with_name("flag_a").long("flag_a").about("second flag"),
                 Arg::with_name("option_a")
                     .long("option_a")
                     .takes_value(true)
-                    .help("second option"),
+                    .about("second option"),
             ]),
         );
 
@@ -278,16 +278,16 @@ fn unified_help_and_derive_order_subcommand_propagate() {
         .global_setting(AppSettings::UnifiedHelpMessage)
         .subcommand(
             App::new("sub").version("1.2").args(&[
-                Arg::with_name("flag_b").long("flag_b").help("first flag"),
+                Arg::with_name("flag_b").long("flag_b").about("first flag"),
                 Arg::with_name("option_b")
                     .long("option_b")
                     .takes_value(true)
-                    .help("first option"),
-                Arg::with_name("flag_a").long("flag_a").help("second flag"),
+                    .about("first option"),
+                Arg::with_name("flag_a").long("flag_a").about("second flag"),
                 Arg::with_name("option_a")
                     .long("option_a")
                     .takes_value(true)
-                    .help("second option"),
+                    .about("second option"),
             ]),
         );
 
@@ -306,19 +306,19 @@ fn unified_help_and_derive_order_subcommand_propagate_with_explicit_display_orde
         .global_setting(AppSettings::UnifiedHelpMessage)
         .subcommand(
             App::new("sub").version("1.2").args(&[
-                Arg::with_name("flag_b").long("flag_b").help("first flag"),
+                Arg::with_name("flag_b").long("flag_b").about("first flag"),
                 Arg::with_name("option_b")
                     .long("option_b")
                     .takes_value(true)
-                    .help("first option"),
+                    .about("first option"),
                 Arg::with_name("flag_a")
                     .long("flag_a")
-                    .help("second flag")
+                    .about("second flag")
                     .display_order(0),
                 Arg::with_name("option_a")
                     .long("option_a")
                     .takes_value(true)
-                    .help("second option"),
+                    .about("second option"),
             ]),
         );
 

--- a/tests/fixtures/app.yml
+++ b/tests/fixtures/app.yml
@@ -8,17 +8,17 @@ args:
     - help:
         short: h
         long: help
-        help: prints help with a nonstandard description
+        about: prints help with a nonstandard description
     - option:
         short: o
         long: option
         multiple: true
-        help: tests options
+        about: tests options
     - positional:
-        help: tests positionals
+        about: tests positionals
         index: 1
     - positional2:
-        help: tests positionals with exclusions
+        about: tests positionals with exclusions
         index: 2
         default_value_if:
             - [flag, Null, some]
@@ -27,18 +27,18 @@ args:
         short: f
         long: flag
         multiple: true
-        help: tests flags
+        about: tests flags
         global: true
     - flag2:
         short: F
-        help: tests flags with exclusions
+        about: tests flags with exclusions
         conflicts_with:
             - flag
         requires:
             - option2
     - option2:
         long: long-option-2
-        help: tests long options with exclusions
+        about: tests long options with exclusions
         conflicts_with:
             - option
         requires:
@@ -46,7 +46,7 @@ args:
     - option3:
         short: O
         long: Option
-        help: tests options with specific value sets
+        about: tests options with specific value sets
         takes_value: true
         possible_values:
             - fast
@@ -55,47 +55,47 @@ args:
             - [fast, flag]
     - positional3:
         index: 3
-        help: tests positionals with specific values
+        about: tests positionals with specific values
         possible_values: [ vi, emacs ]
     - multvals:
         long: multvals
-        help: Tests mutliple values, not mult occs
+        about: Tests mutliple values, not mult occs
         value_names:
             - one
             - two
     - multvalsmo:
         long: multvalsmo
         multiple: true
-        help: Tests mutliple values, not mult occs
+        about: Tests mutliple values, not mult occs
         value_names: [one, two]
     - multvalsdelim:
         long: multvalsdelim
-        help: Tests mutliple values with required delimiter
+        about: Tests mutliple values with required delimiter
         multiple: true
         require_delimiter: true
     - singlealias:
         long: singlealias
-        help: Tests single alias
+        about: Tests single alias
         aliases: [alias]
         required_if:
             - [multvalsmo, two]
     - multaliases:
         long: multaliases
-        help: Tests mutliple aliases
+        about: Tests mutliple aliases
         aliases: [als1, als2, als3]
     - minvals2:
         long: minvals2
         multiple: true
-        help: Tests 2 min vals
+        about: Tests 2 min vals
         min_values: 2
     - maxvals3:
         long: maxvals3
         multiple: true
-        help: Tests 3 max vals
+        about: Tests 3 max vals
         max_values: 3
     - exclusive:
         long: exclusive
-        help: Tests 3 exclusive
+        about: Tests 3 exclusive
         exclusive: true
     
     
@@ -118,8 +118,8 @@ subcommands:
                 short: o
                 long: option
                 multiple: true
-                help: tests options
+                about: tests options
                 takes_value: true
             - scpositional:
-                help: tests positionals
+                about: tests positionals
                 index: 1

--- a/tests/fixtures/app_2space.yml
+++ b/tests/fixtures/app_2space.yml
@@ -8,9 +8,9 @@ args:
   - help:
     short: h
     long: help
-    help: prints help with a nonstandard description
+    about: prints help with a nonstandard description
   - opt:
     short: o
     long: option
     multiple: true
-    help: tests options
+    about: tests options

--- a/tests/global_args.rs
+++ b/tests/global_args.rs
@@ -7,7 +7,7 @@ fn get_app() -> App<'static> {
         .arg(
             Arg::with_name("GLOBAL_ARG")
                 .long("global-arg")
-                .help("Specifies something needed by the subcommands")
+                .about("Specifies something needed by the subcommands")
                 .global(true)
                 .takes_value(true)
                 .default_value("default_value"),
@@ -15,7 +15,7 @@ fn get_app() -> App<'static> {
         .arg(
             Arg::with_name("GLOBAL_FLAG")
                 .long("global-flag")
-                .help("Specifies something needed by the subcommands")
+                .about("Specifies something needed by the subcommands")
                 .multiple(true)
                 .global(true),
         )

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -631,33 +631,33 @@ fn args_with_last_usage() {
         .setting(AppSettings::TrailingVarArg)
         .arg(
             Arg::with_name("verbose")
-                .help("Prints out more stuff.")
+                .about("Prints out more stuff.")
                 .short('v')
                 .long("verbose")
                 .setting(ArgSettings::MultipleOccurrences),
         )
         .arg(
             Arg::with_name("timeout")
-                .help("Timeout in seconds.")
+                .about("Timeout in seconds.")
                 .short('t')
                 .long("timeout")
                 .value_name("SECONDS"),
         )
         .arg(
             Arg::with_name("frequency")
-                .help("The sampling frequency.")
+                .about("The sampling frequency.")
                 .short('f')
                 .long("frequency")
                 .value_name("HERTZ"),
         )
         .arg(
             Arg::with_name("binary path")
-                .help("The path of the binary to be profiled. for a binary.")
+                .about("The path of the binary to be profiled. for a binary.")
                 .value_name("BINFILE"),
         )
         .arg(
             Arg::with_name("pass through args")
-                .help("Any arguments you wish to pass to the being profiled.")
+                .about("Any arguments you wish to pass to the being profiled.")
                 .settings(&[
                     ArgSettings::MultipleValues,
                     ArgSettings::MultipleOccurrences,
@@ -784,7 +784,7 @@ fn issue_626_unicode_cutoff() {
             .short('c')
             .long("cafe")
             .value_name("FILE")
-            .help(
+            .about(
                 "A coffeehouse, coffee shop, or café is an establishment \
                  which primarily serves hot coffee, related coffee beverages \
                  (e.g., café latte, cappuccino, espresso), tea, and other hot \
@@ -812,7 +812,7 @@ fn hide_possible_vals() {
                 .long("pos")
                 .value_name("VAL")
                 .possible_values(&["fast", "slow"])
-                .help("Some vals")
+                .about("Some vals")
                 .takes_value(true),
         )
         .arg(
@@ -822,7 +822,7 @@ fn hide_possible_vals() {
                 .value_name("FILE")
                 .hide_possible_values(true)
                 .possible_values(&["fast", "slow"])
-                .help("A coffeehouse, coffee shop, or café.")
+                .about("A coffeehouse, coffee shop, or café.")
                 .takes_value(true),
         );
     assert!(utils::compare_output(
@@ -842,7 +842,7 @@ fn issue_626_panic() {
            .short('c')
            .long("cafe")
            .value_name("FILE")
-           .help("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
+           .about("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
            d'Afrique et d'Asie, dans des plantations qui sont cultivées pour les marchés d'exportation. \
            Le café est souvent une contribution majeure aux exportations des régions productrices.")
            .takes_value(true));
@@ -864,7 +864,7 @@ fn issue_626_variable_panic() {
                .short('c')
                .long("cafe")
                .value_name("FILE")
-               .help("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
+               .about("La culture du café est très développée dans de nombreux pays à climat chaud d'Amérique, \
                d'Afrique et d'Asie, dans des plantations qui sont cultivées pour les marchés d'exportation. \
                Le café est souvent une contribution majeure aux exportations des régions productrices.")
                .takes_value(true))
@@ -888,7 +888,7 @@ fn wrapping_newline_chars() {
     let app = App::new("ctest")
         .version("0.1")
         .set_term_width(60)
-        .arg(Arg::with_name("mode").help(
+        .arg(Arg::with_name("mode").about(
             "x, max, maximum   20 characters, contains symbols.\n\
              l, long           Copy-friendly, 14 characters, contains symbols.\n\
              m, med, medium    Copy-friendly, 8 characters, contains symbols.\n",
@@ -906,7 +906,7 @@ fn old_newline_chars() {
     let app = App::new("ctest").version("0.1").arg(
         Arg::with_name("mode")
             .short('m')
-            .help("Some help with some wrapping\n(Defaults to something)"),
+            .about("Some help with some wrapping\n(Defaults to something)"),
     );
     assert!(utils::compare_output(
         app,
@@ -925,7 +925,7 @@ fn issue_688_hidden_pos_vals() {
 			.set_term_width(120)
 			.setting(AppSettings::HidePossibleValuesInHelp)
 			.arg(Arg::with_name("filter")
-				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
+				.about("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
                 images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
 				.long("filter")
 				.possible_values(&filter_values)
@@ -941,7 +941,7 @@ fn issue_688_hidden_pos_vals() {
             .version("0.1")
 			.set_term_width(120)
 			.arg(Arg::with_name("filter")
-				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
+				.about("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
                 images. The default is Linear (Bilinear).")
 				.long("filter")
 				.possible_values(&filter_values)
@@ -957,7 +957,7 @@ fn issue_688_hidden_pos_vals() {
             .version("0.1")
 			.set_term_width(120)
 			.arg(Arg::with_name("filter")
-				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
+				.about("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
                 images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
 				.long("filter")
 				.takes_value(true));
@@ -975,25 +975,25 @@ fn issue_702_multiple_values() {
         .version("1.0")
         .author("foo")
         .about("bar")
-        .arg(Arg::with_name("arg1").help("some option"))
-        .arg(Arg::with_name("arg2").multiple(true).help("some option"))
+        .arg(Arg::with_name("arg1").about("some option"))
+        .arg(Arg::with_name("arg2").multiple(true).about("some option"))
         .arg(
             Arg::with_name("some")
-                .help("some option")
+                .about("some option")
                 .short('s')
                 .long("some")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("other")
-                .help("some other option")
+                .about("some other option")
                 .short('o')
                 .long("other")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("label")
-                .help("a label")
+                .about("a label")
                 .short('l')
                 .long("label")
                 .multiple(true)
@@ -1011,7 +1011,7 @@ fn long_about() {
         .long_about(
             "something really really long, with\nmultiple lines of text\nthat should be displayed",
         )
-        .arg(Arg::with_name("arg1").help("some option"));
+        .arg(Arg::with_name("arg1").about("some option"));
     assert!(utils::compare_output(
         app,
         "myapp --help",
@@ -1026,7 +1026,7 @@ fn issue_760() {
         .version("0.1")
         .arg(
             Arg::with_name("option")
-                .help("tests options")
+                .about("tests options")
                 .short('o')
                 .long("option")
                 .takes_value(true)
@@ -1035,7 +1035,7 @@ fn issue_760() {
         )
         .arg(
             Arg::with_name("opt")
-                .help("tests options")
+                .about("tests options")
                 .short('O')
                 .long("opt")
                 .takes_value(true),
@@ -1095,7 +1095,7 @@ fn sc_negates_reqs() {
         .version("1.0")
         .setting(AppSettings::SubcommandsNegateReqs)
         .arg("-o, --opt <FILE> 'tests options'")
-        .arg(Arg::with_name("PATH").help("help"))
+        .arg(Arg::with_name("PATH").about("help"))
         .subcommand(App::new("test"));
     assert!(utils::compare_output(
         app,
@@ -1127,7 +1127,7 @@ fn args_negate_sc() {
         .setting(AppSettings::ArgsNegateSubcommands)
         .arg("-f, --flag 'testing flags'")
         .arg("-o, --opt [FILE] 'tests options'")
-        .arg(Arg::with_name("PATH").help("help"))
+        .arg(Arg::with_name("PATH").about("help"))
         .subcommand(App::new("test"));
     assert!(utils::compare_output(
         app,
@@ -1143,7 +1143,7 @@ fn issue_1046_hidden_scs() {
         .version("1.0")
         .arg("-f, --flag 'testing flags'")
         .arg("-o, --opt [FILE] 'tests options'")
-        .arg(Arg::with_name("PATH").help("some"))
+        .arg(Arg::with_name("PATH").about("some"))
         .subcommand(App::new("test").setting(AppSettings::Hidden));
     assert!(utils::compare_output(
         app,
@@ -1170,12 +1170,12 @@ fn customize_version_and_help() {
         .author("Nobody <odysseus@example.com>")
         .about("You can customize the version and help text")
         .mut_arg("help", |h| {
-            h.short('H').long("help").help("Print help information")
+            h.short('H').long("help").about("Print help information")
         })
         .mut_arg("version", |v| {
             v.short('v')
                 .long("version")
-                .help("Print version information")
+                .about("Print version information")
         });
     assert!(utils::compare_output(
         app,
@@ -1211,13 +1211,13 @@ fn arg_short_conflict_with_help_mut_arg() {
 fn last_arg_mult_usage() {
     let app = App::new("last")
         .version("0.1")
-        .arg(Arg::with_name("TARGET").required(true).help("some"))
-        .arg(Arg::with_name("CORPUS").help("some"))
+        .arg(Arg::with_name("TARGET").required(true).about("some"))
+        .arg(Arg::with_name("CORPUS").about("some"))
         .arg(
             Arg::with_name("ARGS")
                 .multiple(true)
                 .last(true)
-                .help("some"),
+                .about("some"),
         );
     assert!(utils::compare_output(app, "last --help", LAST_ARG, false));
 }
@@ -1226,14 +1226,14 @@ fn last_arg_mult_usage() {
 fn last_arg_mult_usage_req() {
     let app = App::new("last")
         .version("0.1")
-        .arg(Arg::with_name("TARGET").required(true).help("some"))
-        .arg(Arg::with_name("CORPUS").help("some"))
+        .arg(Arg::with_name("TARGET").required(true).about("some"))
+        .arg(Arg::with_name("CORPUS").about("some"))
         .arg(
             Arg::with_name("ARGS")
                 .multiple(true)
                 .last(true)
                 .required(true)
-                .help("some"),
+                .about("some"),
         );
     assert!(utils::compare_output(
         app,
@@ -1248,14 +1248,14 @@ fn last_arg_mult_usage_req_with_sc() {
     let app = App::new("last")
         .version("0.1")
         .setting(AppSettings::SubcommandsNegateReqs)
-        .arg(Arg::with_name("TARGET").required(true).help("some"))
-        .arg(Arg::with_name("CORPUS").help("some"))
+        .arg(Arg::with_name("TARGET").required(true).about("some"))
+        .arg(Arg::with_name("CORPUS").about("some"))
         .arg(
             Arg::with_name("ARGS")
                 .multiple(true)
                 .last(true)
                 .required(true)
-                .help("some"),
+                .about("some"),
         )
         .subcommand(App::new("test").about("some"));
     assert!(utils::compare_output(
@@ -1271,13 +1271,13 @@ fn last_arg_mult_usage_with_sc() {
     let app = App::new("last")
         .version("0.1")
         .setting(AppSettings::ArgsNegateSubcommands)
-        .arg(Arg::with_name("TARGET").required(true).help("some"))
-        .arg(Arg::with_name("CORPUS").help("some"))
+        .arg(Arg::with_name("TARGET").required(true).about("some"))
+        .arg(Arg::with_name("CORPUS").about("some"))
         .arg(
             Arg::with_name("ARGS")
                 .multiple(true)
                 .last(true)
-                .help("some"),
+                .about("some"),
         )
         .subcommand(App::new("test").about("some"));
     assert!(utils::compare_output(
@@ -1292,7 +1292,7 @@ fn last_arg_mult_usage_with_sc() {
 fn hidden_default_val() {
     let app1 = App::new("default").version("0.1").set_term_width(120).arg(
         Arg::with_name("argument")
-            .help("Pass an argument to the program. [default: default-argument]")
+            .about("Pass an argument to the program. [default: default-argument]")
             .long("arg")
             .default_value("default-argument")
             .hide_default_value(true),
@@ -1306,7 +1306,7 @@ fn hidden_default_val() {
 
     let app2 = App::new("default").version("0.1").set_term_width(120).arg(
         Arg::with_name("argument")
-            .help("Pass an argument to the program.")
+            .about("Pass an argument to the program.")
             .long("arg")
             .default_value("default-argument"),
     );
@@ -1401,7 +1401,7 @@ fn hide_env_vals() {
                 .long("pos")
                 .value_name("VAL")
                 .possible_values(&["fast", "slow"])
-                .help("Some vals")
+                .about("Some vals")
                 .takes_value(true),
         )
         .arg(
@@ -1411,7 +1411,7 @@ fn hide_env_vals() {
                 .value_name("FILE")
                 .hide_env_values(true)
                 .env("ENVVAR")
-                .help("A coffeehouse, coffee shop, or café.")
+                .about("A coffeehouse, coffee shop, or café.")
                 .takes_value(true),
         );
     assert!(utils::compare_output(
@@ -1435,7 +1435,7 @@ fn show_env_vals() {
                 .long("pos")
                 .value_name("VAL")
                 .possible_values(&["fast", "slow"])
-                .help("Some vals")
+                .about("Some vals")
                 .takes_value(true),
         )
         .arg(
@@ -1445,7 +1445,7 @@ fn show_env_vals() {
                 .value_name("FILE")
                 .hide_possible_values(true)
                 .env("ENVVAR")
-                .help("A coffeehouse, coffee shop, or café.")
+                .about("A coffeehouse, coffee shop, or café.")
                 .takes_value(true),
         );
     assert!(utils::compare_output(
@@ -1472,7 +1472,7 @@ fn custom_headers_headers() {
             Arg::with_name("no-proxy")
                 .short('n')
                 .long("no-proxy")
-                .help("Do not use system proxy settings"),
+                .about("Do not use system proxy settings"),
         );
 
     assert!(utils::compare_output(
@@ -1520,7 +1520,7 @@ fn multiple_custom_help_headers() {
             Arg::with_name("no-proxy")
                 .short('n')
                 .long("no-proxy")
-                .help("Do not use system proxy settings"),
+                .about("Do not use system proxy settings"),
         )
         .help_heading("SPECIAL")
         .arg(Arg::from(
@@ -1533,7 +1533,7 @@ fn multiple_custom_help_headers() {
                 .short('s')
                 .value_name("SPEED")
                 .possible_values(&["fast", "slow"])
-                .help("How fast?")
+                .about("How fast?")
                 .takes_value(true),
         );
 
@@ -1656,7 +1656,7 @@ fn help_required_but_not_given_for_one_of_two_arguments() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
         .arg(Arg::with_name("foo"))
-        .arg(Arg::with_name("bar").help("It does bar stuff"))
+        .arg(Arg::with_name("bar").about("It does bar stuff"))
         .get_matches();
 }
 
@@ -1664,10 +1664,10 @@ fn help_required_but_not_given_for_one_of_two_arguments() {
 fn help_required_locally_but_not_given_for_subcommand() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
-        .arg(Arg::with_name("foo").help("It does foo stuff"))
+        .arg(Arg::with_name("foo").about("It does foo stuff"))
         .subcommand(
             App::new("bar")
-                .arg(Arg::with_name("create").help("creates bar"))
+                .arg(Arg::with_name("create").about("creates bar"))
                 .arg(Arg::with_name("delete")),
         )
         .get_matches();
@@ -1679,10 +1679,10 @@ fn help_required_locally_but_not_given_for_subcommand() {
 fn help_required_globally_but_not_given_for_subcommand() {
     App::new("myapp")
         .global_setting(AppSettings::HelpRequired)
-        .arg(Arg::with_name("foo").help("It does foo stuff"))
+        .arg(Arg::with_name("foo").about("It does foo stuff"))
         .subcommand(
             App::new("bar")
-                .arg(Arg::with_name("create").help("creates bar"))
+                .arg(Arg::with_name("create").about("creates bar"))
                 .arg(Arg::with_name("delete")),
         )
         .get_matches();
@@ -1692,11 +1692,11 @@ fn help_required_globally_but_not_given_for_subcommand() {
 fn help_required_and_given_for_subcommand() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
-        .arg(Arg::with_name("foo").help("It does foo stuff"))
+        .arg(Arg::with_name("foo").about("It does foo stuff"))
         .subcommand(
             App::new("bar")
-                .arg(Arg::with_name("create").help("creates bar"))
-                .arg(Arg::with_name("delete").help("deletes bar")),
+                .arg(Arg::with_name("create").about("creates bar"))
+                .arg(Arg::with_name("delete").about("deletes bar")),
         )
         .get_matches();
 }
@@ -1705,7 +1705,7 @@ fn help_required_and_given_for_subcommand() {
 fn help_required_and_given() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
-        .arg(Arg::with_name("foo").help("It does foo stuff"))
+        .arg(Arg::with_name("foo").about("It does foo stuff"))
         .get_matches();
 }
 

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -885,14 +885,15 @@ fn final_word_wrapping() {
 
 #[test]
 fn wrapping_newline_chars() {
-    let app = App::new("ctest")
-        .version("0.1")
-        .set_term_width(60)
-        .arg(Arg::with_name("mode").about(
-            "x, max, maximum   20 characters, contains symbols.\n\
+    let app =
+        App::new("ctest")
+            .version("0.1")
+            .set_term_width(60)
+            .arg(Arg::with_name("mode").about(
+                "x, max, maximum   20 characters, contains symbols.\n\
              l, long           Copy-friendly, 14 characters, contains symbols.\n\
              m, med, medium    Copy-friendly, 8 characters, contains symbols.\n",
-        ));
+            ));
     assert!(utils::compare_output(
         app,
         "ctest --help",

--- a/tests/hidden_args.rs
+++ b/tests/hidden_args.rs
@@ -81,11 +81,11 @@ fn hidden_short_args() {
                 .short('c')
                 .long("config")
                 .hidden_short_help(true)
-                .help("Some help text describing the --config arg"),
+                .about("Some help text describing the --config arg"),
             Arg::with_name("visible")
                 .short('v')
                 .long("visible")
-                .help("This text should be visible"),
+                .about("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(
@@ -108,11 +108,11 @@ fn hidden_short_args_long_help() {
                 .short('c')
                 .long("config")
                 .hidden_short_help(true)
-                .help("Some help text describing the --config arg"),
+                .about("Some help text describing the --config arg"),
             Arg::with_name("visible")
                 .short('v')
                 .long("visible")
-                .help("This text should be visible"),
+                .about("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(
@@ -151,11 +151,11 @@ fn hidden_long_args() {
                 .short('c')
                 .long("config")
                 .hidden_long_help(true)
-                .help("Some help text describing the --config arg"),
+                .about("Some help text describing the --config arg"),
             Arg::with_name("visible")
                 .short('v')
                 .long("visible")
-                .help("This text should be visible"),
+                .about("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(
@@ -190,11 +190,11 @@ fn hidden_long_args_short_help() {
                 .short('c')
                 .long("config")
                 .hidden_long_help(true)
-                .help("Some help text describing the --config arg"),
+                .about("Some help text describing the --config arg"),
             Arg::with_name("visible")
                 .short('v')
                 .long("visible")
-                .help("This text should be visible"),
+                .about("This text should be visible"),
         ]);
 
     assert!(utils::compare_output(

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -6,7 +6,7 @@ fn option_long() {
         .arg(
             Arg::with_name("option")
                 .long("option")
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true),
         )
@@ -31,7 +31,7 @@ fn option_short() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true),
         )
@@ -55,7 +55,7 @@ fn option_mixed() {
             Arg::with_name("option")
                 .long("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true),
         )
@@ -80,7 +80,7 @@ fn option_exact_exact() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(3),
@@ -104,7 +104,7 @@ fn option_exact_exact_not_mult() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .number_of_values(3),
         )
@@ -127,7 +127,7 @@ fn option_exact_exact_mult() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(3),
@@ -153,7 +153,7 @@ fn option_exact_less() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(3),
@@ -170,7 +170,7 @@ fn option_exact_more() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(3),
@@ -189,7 +189,7 @@ fn option_min_exact() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .min_values(3),
@@ -213,7 +213,7 @@ fn option_min_less() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .min_values(3),
@@ -231,7 +231,7 @@ fn option_short_min_more_mult_occurs() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .min_values(3),
@@ -260,7 +260,7 @@ fn option_short_min_more_single_occur() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .min_values(3),
@@ -286,7 +286,7 @@ fn option_max_exact() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .max_values(3),
@@ -310,7 +310,7 @@ fn option_max_less() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .max_values(3),
@@ -334,7 +334,7 @@ fn option_max_more() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true)
                 .max_values(3),
@@ -352,7 +352,7 @@ fn positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .multiple(true),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
@@ -373,7 +373,7 @@ fn positional_exact_exact() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
@@ -394,7 +394,7 @@ fn positional_exact_less() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
@@ -408,7 +408,7 @@ fn positional_exact_more() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .number_of_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
@@ -422,7 +422,7 @@ fn positional_min_exact() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .min_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
@@ -443,7 +443,7 @@ fn positional_min_less() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .min_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
@@ -457,7 +457,7 @@ fn positional_min_more() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .min_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
@@ -478,7 +478,7 @@ fn positional_max_exact() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .max_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
@@ -499,7 +499,7 @@ fn positional_max_less() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .max_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
@@ -520,7 +520,7 @@ fn positional_max_more() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("pos")
-                .help("multiple positionals")
+                .about("multiple positionals")
                 .max_values(3),
         )
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
@@ -536,7 +536,7 @@ fn sep_long_equals() {
             Arg::with_name("option")
                 .long("option")
                 .use_delimiter(true)
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true),
         )
@@ -560,7 +560,7 @@ fn sep_long_space() {
             Arg::with_name("option")
                 .long("option")
                 .use_delimiter(true)
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .multiple(true),
         )
@@ -583,7 +583,7 @@ fn sep_short_equals() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .use_delimiter(true)
                 .takes_value(true)
                 .multiple(true),
@@ -607,7 +607,7 @@ fn sep_short_space() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .use_delimiter(true)
                 .takes_value(true)
                 .multiple(true),
@@ -631,7 +631,7 @@ fn sep_short_no_space() {
         .arg(
             Arg::with_name("option")
                 .short('o')
-                .help("multiple options")
+                .about("multiple options")
                 .use_delimiter(true)
                 .takes_value(true)
                 .multiple(true),
@@ -654,7 +654,7 @@ fn sep_positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("option")
-                .help("multiple options")
+                .about("multiple options")
                 .use_delimiter(true)
                 .multiple(true),
         )
@@ -677,7 +677,7 @@ fn different_sep() {
         .arg(
             Arg::with_name("option")
                 .long("option")
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .value_delimiter(";"),
         )
@@ -699,7 +699,7 @@ fn different_sep_positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("option")
-                .help("multiple options")
+                .about("multiple options")
                 .value_delimiter(";"),
         )
         .try_get_matches_from(vec!["", "val1;val2;val3"]);
@@ -721,7 +721,7 @@ fn no_sep() {
         .arg(
             Arg::with_name("option")
                 .long("option")
-                .help("multiple options")
+                .about("multiple options")
                 .takes_value(true)
                 .use_delimiter(false),
         )
@@ -740,7 +740,7 @@ fn no_sep_positional() {
     let m = App::new("multiple_values")
         .arg(
             Arg::with_name("option")
-                .help("multiple options")
+                .about("multiple options")
                 .use_delimiter(false),
         )
         .try_get_matches_from(vec!["", "val1,val2,val3"]);

--- a/tests/positionals.rs
+++ b/tests/positionals.rs
@@ -24,7 +24,7 @@ fn issue_946() {
             clap::Arg::with_name("filter")
                 .index(1)
                 .takes_value(true)
-                .help("filters to apply to output"),
+                .about("filters to apply to output"),
         )
         .try_get_matches_from(vec!["compiletest", "--exact"]);
     assert!(r.is_ok(), "{:#?}", r);
@@ -171,7 +171,7 @@ fn positional_possible_values() {
 #[test]
 fn create_positional() {
     let _ = App::new("test")
-        .arg(Arg::with_name("test").index(1).help("testing testing"))
+        .arg(Arg::with_name("test").index(1).about("testing testing"))
         .get_matches_from(vec![""]);
 }
 

--- a/tests/propagate_globals.rs
+++ b/tests/propagate_globals.rs
@@ -7,7 +7,7 @@ fn get_app() -> App<'static> {
         .arg(
             Arg::with_name("GLOBAL_ARG")
                 .long("global-arg")
-                .help("Specifies something needed by the subcommands")
+                .about("Specifies something needed by the subcommands")
                 .global(true)
                 .setting(ArgSettings::TakesValue)
                 .default_value("default_value"),
@@ -15,7 +15,7 @@ fn get_app() -> App<'static> {
         .arg(
             Arg::with_name("GLOBAL_FLAG")
                 .long("global-flag")
-                .help("Specifies something needed by the subcommands")
+                .about("Specifies something needed by the subcommands")
                 .global(true)
                 .setting(ArgSettings::MultipleOccurrences),
         )

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -652,7 +652,7 @@ fn require_eq() {
             .required(true)
             .require_equals(true)
             .value_name("FILE")
-            .help("some"),
+            .about("some"),
     );
     assert!(utils::compare_output(
         app,
@@ -711,7 +711,7 @@ fn issue_1643_args_mutually_require_each_other() {
     let app = App::new("test")
         .arg(
             Arg::with_name("relation_id")
-                .help("The relation id to get the data from")
+                .about("The relation id to get the data from")
                 .long("relation-id")
                 .short('r')
                 .takes_value(true)
@@ -719,7 +719,7 @@ fn issue_1643_args_mutually_require_each_other() {
         )
         .arg(
             Arg::with_name("remote_unit_name")
-                .help("The name of the remote unit to get data from")
+                .about("The name of the remote unit to get data from")
                 .long("remote-unit")
                 .short('u')
                 .takes_value(true)

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -102,7 +102,7 @@ fn subcommand() {
                     .short('t')
                     .long("test")
                     .takes_value(true)
-                    .help("testing testing"),
+                    .about("testing testing"),
             ),
         )
         .arg(Arg::with_name("other").long("other"))
@@ -123,7 +123,7 @@ fn subcommand_none_given() {
                     .short('t')
                     .long("test")
                     .takes_value(true)
-                    .help("testing testing"),
+                    .about("testing testing"),
             ),
         )
         .arg(Arg::with_name("other").long("other"))
@@ -141,7 +141,7 @@ fn subcommand_multiple() {
                     .short('t')
                     .long("test")
                     .takes_value(true)
-                    .help("testing testing"),
+                    .about("testing testing"),
             ),
             App::new("add").arg(Arg::with_name("roster").short('r')),
         ])

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -53,7 +53,7 @@ fn override_ver() {
         .about("tests stuff")
         .version("1.3")
         .mut_arg("version", |a| {
-            a.short('v').long("version").help("some version")
+            a.short('v').long("version").about("some version")
         })
         .try_get_matches_from(vec!["test", "--version"]);
 


### PR DESCRIPTION
Taking this incrementally as this is a big refactor.
Change: Updated usage of `Arg::help` with `Arg::about`, deprecating `help`

Closes #1823

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
