### PR TITLE
Add hide_default_values to yaml

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -225,6 +225,7 @@ impl<'help> Arg<'help> {
                 "requires_ifs" => yaml_tuple2!(a, v, requires_if),
                 "conflicts_with" => yaml_vec_or_str!(v, a, conflicts_with),
                 "exclusive" => yaml_to_bool!(a, v, exclusive),
+                "hide_default_value" => yaml_to_bool!(a, v, hide_default_value),
                 "overrides_with" => yaml_vec_or_str!(v, a, overrides_with),
                 "possible_values" => yaml_vec_or_str!(v, a, possible_value),
                 "required_unless_one" => yaml_vec_or_str!(v, a, required_unless),

--- a/src/util/id.rs
+++ b/src/util/id.rs
@@ -49,7 +49,7 @@ impl Debug for Id {
         #[cfg(debug_assertions)]
         write!(f, "{}", self.name)?;
         #[cfg(not(debug_assertions))]
-        write!(f, "[hash: {}]", self.id)?;
+        write!(f, "[hash: {:X}]", self.id)?;
 
         Ok(())
     }


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
Closes #1359

We need to do something to make sure this won't happen again with another method. I'm not even sure we aren't missing anything else