### PR TITLE
fix(build/app): don't use long help for `print_help()

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1116,7 +1116,7 @@ impl<'b> App<'b> {
         let p = Parser::new(self);
         let mut c = Colorizer::new(false, p.color_help());
 
-        Help::new(HelpWriter::Buffer(&mut c), &p, true).write_help()?;
+        Help::new(HelpWriter::Buffer(&mut c), &p, false).write_help()?;
 
         Ok(c.print()?)
     }


### PR DESCRIPTION
For long help, there's still `print_long_help()`.

Closes #1889.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
