### PR TITLE
Handle more edge cases for an `ArgStr` prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ bitflags              = "1.2"
 unicode-width         = "0.1"
 textwrap              = "0.11"
 indexmap              = "1.0"
-os_str_bytes          = "2.2"
+os_str_bytes = { version = "2.3", features = ["raw"] }
 vec_map               = "0.8"
 strsim      = { version = "0.10",  optional = true }
 yaml-rust   = { version = "0.4.1",  optional = true }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -817,9 +817,6 @@ where
     // Checks if the arg matches a subcommand name, or any of it's aliases (if defined)
     fn possible_subcommand(&self, arg_os: &ArgStr<'_>) -> Option<&str> {
         debug!("Parser::possible_subcommand: arg={:?}", arg_os);
-        fn starts(h: &str, n: &ArgStr<'_>) -> bool {
-            h.is_char_boundary(n.len()) && h.as_bytes().starts_with(n.as_raw_bytes())
-        }
 
         if self.is_set(AS::ArgsNegateSubcommands) && self.is_set(AS::ValidArgFound) {
             return None;
@@ -827,7 +824,7 @@ where
 
         if self.is_set(AS::InferSubcommands) {
             let v = sc_names!(self.app)
-                .filter(|s| starts(s, &*arg_os))
+                .filter(|s| arg_os.is_prefix_of(s))
                 .collect::<Vec<_>>();
 
             if v.len() == 1 {

--- a/src/util/argstr.rs
+++ b/src/util/argstr.rs
@@ -5,7 +5,7 @@ use std::{
     str,
 };
 
-use os_str_bytes::{OsStrBytes, OsStringBytes};
+use os_str_bytes::{raw, OsStrBytes, OsStringBytes};
 
 pub(crate) struct ArgStr<'a>(Cow<'a, [u8]>);
 
@@ -16,6 +16,10 @@ impl<'a> ArgStr<'a> {
 
     pub(crate) fn starts_with(&self, s: &str) -> bool {
         self.0.starts_with(s.as_bytes())
+    }
+
+    pub(crate) fn is_prefix_of(&self, s: &str) -> bool {
+        raw::starts_with(s, &self.0)
     }
 
     fn to_borrowed(&'a self) -> Self {
@@ -102,6 +106,7 @@ impl<'a> ArgStr<'a> {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn as_raw_bytes(&self) -> &[u8] {
         &self.0
     }


### PR DESCRIPTION
This filter can now catch all edge cases, instead of just UTF-8 prefixes. It uses a new function I added to os_str_bytes that can take advantage of some internal assumptions with minimal overhead.

I don't think the filter was being used for anything that would make the correctness matter, but it sets a good precedent. Plus, it removes the last use of `ArgStr::as_raw_bytes` outside of debugging code.