### PR TITLE
docs(README.md): fix a broken link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ These videos slowly trickle out as I finish them and currently a work in progres
 
 ## How to Contribute
 
-Details on how to contribute can be found in the [CONTRIBUTING.md](.github/CONTRIBUTING.md) file.
+Details on how to contribute can be found in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 ### Compatibility Policy
 


### PR DESCRIPTION
Hi,

I found a broken link in README.md.
Since this is a very minor issue due to a wrong path of CONTRIBUTING.md, I have created a PR here directly without reporting an issue.
Could you please find and check it?

Many thanks,

noritada