### PR TITLE
Option vec to vec

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -80,7 +80,7 @@ pub struct App<'b> {
     pub(crate) long_about: Option<&'b str>,
     pub(crate) before_help: Option<&'b str>,
     pub(crate) after_help: Option<&'b str>,
-    pub(crate) aliases: Option<Vec<(&'b str, bool)>>, // (name, visible)
+    pub(crate) aliases: Vec<(&'b str, bool)>, // (name, visible)
     pub(crate) usage_str: Option<&'b str>,
     pub(crate) usage: Option<String>,
     pub(crate) help_str: Option<&'b str>,
@@ -124,19 +124,13 @@ impl<'b> App<'b> {
     /// Iterate through the *visible* aliases for this subcommand.
     #[inline]
     pub fn get_visible_aliases(&self) -> impl Iterator<Item = &str> {
-        self.aliases
-            .as_ref()
-            .into_iter()
-            .flat_map(|aliases| aliases.iter().filter(|(_, vis)| *vis).map(|a| a.0))
+        self.aliases.iter().filter(|(_, vis)| *vis).map(|a| a.0)
     }
 
     /// Iterate through the set of *all* the aliases for this subcommand, both visible and hidden.
     #[inline]
     pub fn get_all_aliases(&self) -> impl Iterator<Item = &str> {
-        self.aliases
-            .as_ref()
-            .into_iter()
-            .flat_map(|aliases| aliases.iter().map(|a| a.0))
+        self.aliases.iter().map(|a| a.0)
     }
 
     /// Get the list of subcommands
@@ -164,19 +158,15 @@ impl<'b> App<'b> {
     /// Panics if the given arg conflicts with an argument that is unknown to this application
     pub fn get_arg_conflicts_with<'a, 'x, 'y>(&'a self, arg: &'x Arg<'y>) -> Vec<&Arg<'b>> // FIXME: This could probably have been an iterator
     {
-        if let Some(black_ids) = arg.blacklist.as_ref() {
-            black_ids
-                .iter()
-                .map(|id| {
-                    self.args.args.iter().find(|arg| arg.id == *id).expect(
-                        "App::get_arg_conflicts_with: \
-                        The passed arg conflicts with an arg unknown to the app",
-                    )
-                })
-                .collect()
-        } else {
-            vec![]
-        }
+        arg.blacklist
+            .iter()
+            .map(|id| {
+                self.args.args.iter().find(|arg| arg.id == *id).expect(
+                    "App::get_arg_conflicts_with: \
+                    The passed arg conflicts with an arg unknown to the app",
+                )
+            })
+            .collect()
     }
 
     /// Check if the setting was set either with [`App::setting`] or [`App::global_setting`]
@@ -770,11 +760,7 @@ impl<'b> App<'b> {
     /// ```
     /// [``]: ./struct..html
     pub fn alias<S: Into<&'b str>>(mut self, name: S) -> Self {
-        if let Some(ref mut als) = self.aliases {
-            als.push((name.into(), false));
-        } else {
-            self.aliases = Some(vec![(name.into(), false)]);
-        }
+        self.aliases.push((name.into(), false));
         self
     }
 
@@ -799,13 +785,7 @@ impl<'b> App<'b> {
     /// ```
     /// [``]: ./struct..html
     pub fn aliases(mut self, names: &[&'b str]) -> Self {
-        if let Some(ref mut als) = self.aliases {
-            for n in names {
-                als.push((n, false));
-            }
-        } else {
-            self.aliases = Some(names.iter().map(|n| (*n, false)).collect::<Vec<_>>());
-        }
+        self.aliases.extend(names.iter().map(|n| (*n, false)));
         self
     }
 
@@ -825,11 +805,7 @@ impl<'b> App<'b> {
     /// [``]: ./struct..html
     /// [`App::alias`]: ./struct.App.html#method.alias
     pub fn visible_alias<S: Into<&'b str>>(mut self, name: S) -> Self {
-        if let Some(ref mut als) = self.aliases {
-            als.push((name.into(), true));
-        } else {
-            self.aliases = Some(vec![(name.into(), true)]);
-        }
+        self.aliases.push((name.into(), true));
         self
     }
 
@@ -849,13 +825,7 @@ impl<'b> App<'b> {
     /// [``]: ./struct..html
     /// [`App::aliases`]: ./struct.App.html#method.aliases
     pub fn visible_aliases(mut self, names: &[&'b str]) -> Self {
-        if let Some(ref mut als) = self.aliases {
-            for n in names {
-                als.push((n, true));
-            }
-        } else {
-            self.aliases = Some(names.iter().map(|n| (*n, true)).collect::<Vec<_>>());
-        }
+        self.aliases.extend(names.iter().map(|n| (*n, true)));
         self
     }
 
@@ -1523,18 +1493,16 @@ impl<'b> App<'b> {
         let mut pos_counter = 1;
         for a in self.args.args.iter_mut() {
             // Fill in the groups
-            if let Some(ref grps) = a.groups {
-                for g in grps {
-                    let mut found = false;
-                    if let Some(ag) = self.groups.iter_mut().find(|grp| grp.id == *g) {
-                        ag.args.push(a.id.clone());
-                        found = true;
-                    }
-                    if !found {
-                        let mut ag = ArgGroup::_with_id(g.clone());
-                        ag.args.push(a.id.clone());
-                        self.groups.push(ag);
-                    }
+            for g in &a.groups {
+                let mut found = false;
+                if let Some(ag) = self.groups.iter_mut().find(|grp| grp.id == *g) {
+                    ag.args.push(a.id.clone());
+                    found = true;
+                }
+                if !found {
+                    let mut ag = ArgGroup::_with_id(g.clone());
+                    ag.args.push(a.id.clone());
+                    self.groups.push(ag);
                 }
             }
 
@@ -1654,46 +1622,39 @@ impl<'b> App<'b> {
             }
 
             // requires, r_if, r_unless
-            if let Some(reqs) = &arg.requires {
-                for req in reqs {
-                    assert!(
-                        self.id_exists(&req.1),
-                        "Argument or group '{:?}' specified in 'requires*' for '{}' does not exist",
-                        req.1,
-                        arg.name,
-                    );
-                }
+            for req in &arg.requires {
+                assert!(
+                    self.id_exists(&req.1),
+                    "Argument or group '{:?}' specified in 'requires*' for '{}' does not exist",
+                    req.1,
+                    arg.name,
+                );
             }
 
-            if let Some(reqs) = &arg.r_ifs {
-                for req in reqs {
-                    assert!(
-                        self.id_exists(&req.0),
-                        "Argument or group '{:?}' specified in 'required_if*' for '{}' does not exist",
-                        req.0, arg.name
-                    );
-                }
+            for req in &arg.r_ifs {
+                assert!(
+                    self.id_exists(&req.0),
+                    "Argument or group '{:?}' specified in 'required_if*' for '{}' does not exist",
+                    req.0,
+                    arg.name
+                );
             }
 
-            if let Some(reqs) = &arg.r_unless {
-                for req in reqs {
-                    assert!(
-                        self.id_exists(req),
-                        "Argument or group '{:?}' specified in 'required_unless*' for '{}' does not exist",
-                        req, arg.name,
-                    );
-                }
+            for req in &arg.r_unless {
+                assert!(
+                    self.id_exists(req),
+                    "Argument or group '{:?}' specified in 'required_unless*' for '{}' does not exist",
+                    req, arg.name,
+                );
             }
 
             // blacklist
-            if let Some(reqs) = &arg.blacklist {
-                for req in reqs {
-                    assert!(
-                        self.id_exists(req),
-                        "Argument or group '{:?}' specified in 'conflicts_with*' for '{}' does not exist",
-                        req, arg.name,
-                    );
-                }
+            for req in &arg.blacklist {
+                assert!(
+                    self.id_exists(req),
+                    "Argument or group '{:?}' specified in 'conflicts_with*' for '{}' does not exist",
+                    req, arg.name,
+                );
             }
 
             if arg.is_set(ArgSettings::Last) {
@@ -2073,15 +2034,13 @@ impl<'b> App<'b> {
             processed.push(a);
 
             if let Some(arg) = self.find(a) {
-                if let Some(ref reqs) = arg.requires {
-                    for r in reqs.iter().filter_map(requires_if_or_not) {
-                        if let Some(req) = self.find(&r) {
-                            if req.requires.is_some() {
-                                r_vec.push(&req.id)
-                            }
+                for r in arg.requires.iter().filter_map(requires_if_or_not) {
+                    if let Some(req) = self.find(&r) {
+                        if !req.requires.is_empty() {
+                            r_vec.push(&req.id)
                         }
-                        args.push(r);
                     }
+                    args.push(r);
                 }
             }
         }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -4411,7 +4411,7 @@ mod test {
     fn flag_display_single_alias() {
         let mut f = Arg::with_name("flg");
         f.long = Some("flag");
-        f.aliases = Some(vec![("als", true)]);
+        f.aliases = vec![("als", true)];
 
         assert_eq!(&*format!("{}", f), "--flag")
     }
@@ -4420,12 +4420,12 @@ mod test {
     fn flag_display_multiple_aliases() {
         let mut f = Arg::with_name("flg");
         f.short = Some('f');
-        f.aliases = Some(vec![
+        f.aliases = vec![
             ("alias_not_visible", false),
             ("f2", true),
             ("f3", true),
             ("f4", true),
-        ]);
+        ];
         assert_eq!(&*format!("{}", f), "-f");
     }
 
@@ -4543,7 +4543,7 @@ mod test {
         let mut vm = VecMap::new();
         vm.insert(0, "file1");
         vm.insert(1, "file2");
-        p2.val_names = Some(vm);
+        p2.val_names = vm;
 
         assert_eq!(&*format!("{}", p2), "<file1> <file2>");
     }
@@ -4555,7 +4555,7 @@ mod test {
         let mut vm = VecMap::new();
         vm.insert(0, "file1");
         vm.insert(1, "file2");
-        p2.val_names = Some(vm);
+        p2.val_names = vm;
 
         assert_eq!(&*format!("{}", p2), "<file1> <file2>");
     }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -825,8 +825,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::required_unless_one`]: ./struct.Arg.html#method.required_unless_one
     /// [`Arg::required_unless_all(names)`]: ./struct.Arg.html#method.required_unless_all
     pub fn required_unless_all(mut self, names: &[&str]) -> Self {
-        self.r_unless
-            .extend(names.iter().map(|name| Id::from(name)));
+        self.r_unless.extend(names.iter().map(Id::from));
         self.setting(ArgSettings::RequiredUnlessAll)
     }
 
@@ -895,8 +894,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::required_unless_one(names)`]: ./struct.Arg.html#method.required_unless_one
     /// [`Arg::required_unless_all`]: ./struct.Arg.html#method.required_unless_all
     pub fn required_unless_one(mut self, names: &[&str]) -> Self {
-        self.r_unless
-            .extend(names.iter().map(|name| Id::from(name)));
+        self.r_unless.extend(names.iter().map(Id::from));
         self
     }
 
@@ -996,8 +994,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::exclusive(true)`]: ./struct.Arg.html#method.exclusive
 
     pub fn conflicts_with_all(mut self, names: &[&str]) -> Self {
-        self.blacklist
-            .extend(names.iter().map(|name| Id::from(name)));
+        self.blacklist.extend(names.iter().map(Id::from));
         self
     }
 
@@ -1180,8 +1177,7 @@ impl<'help> Arg<'help> {
     /// assert!(!m.is_present("flag"));
     /// ```
     pub fn overrides_with_all<T: Key>(mut self, names: &[T]) -> Self {
-        self.overrides
-            .extend(names.iter().map(|name| Id::from(name)));
+        self.overrides.extend(names.iter().map(Id::from));
         self
     }
 
@@ -1871,8 +1867,7 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`ArgGroup`]: ./struct.ArgGroup.html
     pub fn groups<T: Key>(mut self, group_ids: &[T]) -> Self {
-        self.groups
-            .extend(group_ids.iter().map(|name| Id::from(name)));
+        self.groups.extend(group_ids.iter().map(Id::from));
         self
     }
 
@@ -4128,10 +4123,8 @@ impl<'help> Arg<'help> {
                 self.set_mut(ArgSettings::MultipleValues);
                 self.set_mut(ArgSettings::MultipleOccurrences);
             }
-        } else if self.is_set(ArgSettings::TakesValue) {
-            if self.val_names.len() > 1 {
-                self.num_vals = Some(self.val_names.len() as u64);
-            }
+        } else if self.is_set(ArgSettings::TakesValue) && self.val_names.len() > 1 {
+            self.num_vals = Some(self.val_names.len() as u64);
         }
     }
 

--- a/src/build/arg/tests.rs
+++ b/src/build/arg/tests.rs
@@ -8,7 +8,7 @@ fn short_flag_misspel() {
     assert_eq!(a.long.unwrap(), "flag");
     assert_eq!(a.about.unwrap(), "some flag");
     assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-    assert!(a.val_names.is_none());
+    assert!(a.val_names.is_empty());
     assert!(a.num_vals.is_none());
 }
 
@@ -20,6 +20,6 @@ fn short_flag_name_missing() {
     assert!(a.long.is_none());
     assert_eq!(a.about.unwrap(), "some flag");
     assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-    assert!(a.val_names.is_none());
+    assert!(a.val_names.is_empty());
     assert!(a.num_vals.is_none());
 }

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -517,8 +517,8 @@ mod test {
         let confs = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];
 
         assert_eq!(g.args, args);
-        assert_eq!(g.requires, Some(reqs));
-        assert_eq!(g.conflicts, Some(confs));
+        assert_eq!(g.requires, reqs);
+        assert_eq!(g.conflicts, confs);
     }
 
     #[test]
@@ -562,10 +562,7 @@ mod test {
              \trequires: {:?},\n\
              \tconflicts: {:?},\n\
              }}",
-            args,
-            true,
-            Some(reqs),
-            Some(confs)
+            args, true, reqs, confs
         );
         assert_eq!(&*format!("{:?}", g), &*debug_str);
     }
@@ -590,8 +587,8 @@ mod test {
 
         let g2 = ArgGroup::from(&g);
         assert_eq!(g2.args, args);
-        assert_eq!(g2.requires, Some(reqs));
-        assert_eq!(g2.conflicts, Some(confs));
+        assert_eq!(g2.requires, reqs);
+        assert_eq!(g2.conflicts, confs);
     }
 
     #[cfg(feature = "yaml")]
@@ -619,8 +616,8 @@ requires:
         let reqs = vec!["r1".into(), "r2".into(), "r3".into(), "r4".into()];
         let confs = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];
         assert_eq!(g.args, args);
-        assert_eq!(g.requires, Some(reqs));
-        assert_eq!(g.conflicts, Some(confs));
+        assert_eq!(g.requires, reqs);
+        assert_eq!(g.conflicts, confs);
     }
 }
 

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -80,8 +80,8 @@ pub struct ArgGroup<'a> {
     pub(crate) name: &'a str,
     pub(crate) args: Vec<Id>,
     pub(crate) required: bool,
-    pub(crate) requires: Option<Vec<Id>>,
-    pub(crate) conflicts: Option<Vec<Id>>,
+    pub(crate) requires: Vec<Id>,
+    pub(crate) conflicts: Vec<Id>,
     pub(crate) multiple: bool,
 }
 
@@ -299,12 +299,7 @@ impl<'a> ArgGroup<'a> {
     /// [required group]: ./struct.ArgGroup.html#method.required
     /// [argument requirement rules]: ./struct.Arg.html#method.requires
     pub fn requires<T: Key>(mut self, id: T) -> Self {
-        let arg_id = id.into();
-        if let Some(ref mut reqs) = self.requires {
-            reqs.push(arg_id);
-        } else {
-            self.requires = Some(vec![arg_id]);
-        }
+        self.requires.push(id.into());
         self
     }
 
@@ -375,12 +370,7 @@ impl<'a> ArgGroup<'a> {
     /// ```
     /// [argument exclusion rules]: ./struct.Arg.html#method.conflicts_with
     pub fn conflicts_with<T: Key>(mut self, id: T) -> Self {
-        let arg_id = id.into();
-        if let Some(ref mut confs) = self.conflicts {
-            confs.push(arg_id);
-        } else {
-            self.conflicts = Some(vec![arg_id]);
-        }
+        self.conflicts.push(id.into());
         self
     }
 

--- a/src/build/usage_parser.rs
+++ b/src/build/usage_parser.rs
@@ -260,7 +260,7 @@ mod test {
         assert!(a.long.is_none());
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("[flag] --flag 'some help info'");
@@ -269,7 +269,7 @@ mod test {
         assert!(a.short.is_none());
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("--flag 'some help info'");
@@ -278,7 +278,7 @@ mod test {
         assert!(a.short.is_none());
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("[flag] -f --flag 'some help info'");
@@ -287,7 +287,7 @@ mod test {
         assert_eq!(a.long.unwrap(), "flag");
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("[flag] -f... 'some help info'");
@@ -296,7 +296,7 @@ mod test {
         assert!(a.long.is_none());
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("[flag] -f --flag... 'some help info'");
@@ -305,7 +305,7 @@ mod test {
         assert_eq!(a.short.unwrap(), 'f');
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("-f --flag... 'some help info'");
@@ -314,33 +314,33 @@ mod test {
         assert_eq!(a.short.unwrap(), 'f');
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("--flags");
         assert_eq!(a.name, "flags");
         assert_eq!(a.long.unwrap(), "flags");
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("--flags...");
         assert_eq!(a.name, "flags");
         assert_eq!(a.long.unwrap(), "flags");
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("[flags] -f");
         assert_eq!(a.name, "flags");
         assert_eq!(a.short.unwrap(), 'f');
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("[flags] -f...");
         assert_eq!(a.name, "flags");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("-f 'some help info'");
@@ -349,20 +349,20 @@ mod test {
         assert!(a.long.is_none());
         assert_eq!(a.about.unwrap(), "some help info");
         assert!(!a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("-f");
         assert_eq!(a.name, "f");
         assert_eq!(a.short.unwrap(), 'f');
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
 
         let a = Arg::from("-f...");
         assert_eq!(a.name, "f");
         assert_eq!(a.short.unwrap(), 'f');
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -378,7 +378,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -393,7 +393,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -408,7 +408,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -423,7 +423,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -438,7 +438,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -452,7 +452,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -467,7 +467,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -482,7 +482,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -496,7 +496,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -511,7 +511,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -526,7 +526,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -541,10 +541,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -559,7 +556,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -574,10 +571,7 @@ mod test {
         assert!(!a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -592,7 +586,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -606,7 +600,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -621,10 +615,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -639,7 +630,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleValues));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -653,7 +644,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -669,10 +660,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -688,7 +676,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -704,10 +692,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -723,7 +708,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -739,10 +724,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -758,7 +740,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -772,7 +754,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -788,10 +770,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -807,7 +786,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -821,7 +800,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -837,10 +816,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -856,10 +832,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -875,10 +848,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -894,7 +864,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -910,10 +880,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -927,10 +894,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -946,10 +910,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -963,7 +924,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -979,10 +940,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -998,10 +956,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1017,10 +972,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1036,7 +988,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1052,10 +1004,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1069,10 +1018,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1088,10 +1034,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1105,7 +1048,7 @@ mod test {
         assert!(a.is_set(ArgSettings::MultipleOccurrences));
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(a.val_names.unwrap().values().collect::<Vec<_>>(), [&"opt"]);
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"opt"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1121,10 +1064,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"option"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"option"]);
         assert!(a.num_vals.is_none());
     }
 
@@ -1140,10 +1080,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"file", &"mode"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"file", &"mode"]);
         assert_eq!(a.num_vals.unwrap(), 2);
     }
 
@@ -1159,10 +1096,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"file", &"mode"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"file", &"mode"]);
         assert_eq!(a.num_vals.unwrap(), 2);
     }
 
@@ -1178,10 +1112,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"file", &"mode"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"file", &"mode"]);
         assert_eq!(a.num_vals.unwrap(), 2);
     }
 
@@ -1197,10 +1128,7 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"file", &"mode"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"file", &"mode"]);
         assert_eq!(a.num_vals.unwrap(), 2);
     }
 
@@ -1228,7 +1156,7 @@ mod test {
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
         assert!(!a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1241,7 +1169,7 @@ mod test {
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
         assert!(a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1254,7 +1182,7 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(!a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1267,7 +1195,7 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(!a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1280,7 +1208,7 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(!a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1296,7 +1224,7 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(!a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1312,7 +1240,7 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(!a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1325,7 +1253,7 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1337,7 +1265,7 @@ mod test {
             !(a.is_set(ArgSettings::MultipleValues) || a.is_set(ArgSettings::MultipleOccurrences))
         );
         assert!(a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1349,7 +1277,7 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(!a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
     }
 
@@ -1362,9 +1290,9 @@ mod test {
             a.is_set(ArgSettings::MultipleValues) && a.is_set(ArgSettings::MultipleOccurrences)
         );
         assert!(a.is_set(ArgSettings::Required));
-        assert!(a.val_names.is_none());
+        assert!(a.val_names.is_empty());
         assert!(a.num_vals.is_none());
-        assert_eq!(a.default_vals, Some(vec![std::ffi::OsStr::new("a")]));
+        assert_eq!(a.default_vals, vec![std::ffi::OsStr::new("a")]);
     }
 
     #[test]
@@ -1379,12 +1307,9 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"file", &"mode"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"file", &"mode"]);
         assert_eq!(a.num_vals.unwrap(), 2);
-        assert_eq!(a.default_vals, Some(vec![std::ffi::OsStr::new("a")]));
+        assert_eq!(a.default_vals, vec![std::ffi::OsStr::new("a")]);
     }
 
     #[test]
@@ -1399,12 +1324,9 @@ mod test {
         );
         assert!(a.is_set(ArgSettings::TakesValue));
         assert!(!a.is_set(ArgSettings::Required));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"file", &"mode"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"file", &"mode"]);
         assert_eq!(a.num_vals.unwrap(), 2);
-        assert_eq!(a.default_vals, Some(vec![std::ffi::OsStr::new("a")]));
+        assert_eq!(a.default_vals, vec![std::ffi::OsStr::new("a")]);
     }
 
     #[test]
@@ -1429,10 +1351,7 @@ mod test {
         let a = Arg::from("[ñämê] --ôpt=[üñíčöĐ€] 'hælp'");
         assert_eq!(a.name, "ñämê");
         assert_eq!(a.long, Some("ôpt"));
-        assert_eq!(
-            a.val_names.unwrap().values().collect::<Vec<_>>(),
-            [&"üñíčöĐ€"]
-        );
+        assert_eq!(a.val_names.values().collect::<Vec<_>>(), [&"üñíčöĐ€"]);
         assert_eq!(a.about, Some("hælp"));
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -680,8 +680,8 @@ macro_rules! names {
         $app.get_subcommands().iter().map(|s| &*s.get_name()).chain(
             $app.get_subcommands()
                 .iter()
-                .filter(|s| s.aliases.is_some())
-                .flat_map(|s| s.aliases.as_ref().unwrap().iter().map(|&(n, _)| n)),
+                .filter(|s| !s.aliases.is_empty()) // REFACTOR
+                .flat_map(|s| s.aliases.iter().map(|&(n, _)| n)),
         )
     }};
 }

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -146,14 +146,15 @@ fn _get_keys(arg: &Arg) -> Vec<KeyType> {
     if let Some(c) = arg.short {
         keys.push(KeyType::Short(c));
     }
-    if let Some(ref aliases) = arg.aliases {
-        for long in aliases
-            .iter()
-            .map(|(a, _)| KeyType::Long(OsString::from(a)))
-        {
-            keys.push(long);
-        }
+
+    for long in arg
+        .aliases
+        .iter()
+        .map(|(a, _)| KeyType::Long(OsString::from(a)))
+    {
+        keys.push(long);
     }
+
     if let Some(long) = arg.long {
         keys.push(KeyType::Long(OsString::from(long)));
     }

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -278,15 +278,15 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
             } else {
                 ' '
             };
-            if let Some(ref vec) = arg.val_names {
-                let mut it = vec.iter().peekable();
+            if !arg.val_names.is_empty() {
+                let mut it = arg.val_names.iter().peekable();
                 while let Some((_, val)) = it.next() {
                     self.good(&format!("<{}>", val))?;
                     if it.peek().is_some() {
                         self.none(&delim.to_string())?;
                     }
                 }
-                let num = vec.len();
+                let num = arg.val_names.len();
                 if mult && num == 1 {
                     self.good("...")?;
                 }
@@ -474,10 +474,14 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
             spec_vals.push(env_info);
         }
         if !a.is_set(ArgSettings::HideDefaultValue) {
-            if let Some(ref pv) = a.default_vals {
-                debug!("Help::spec_vals: Found default value...[{:?}]", pv);
+            if !a.default_vals.is_empty() {
+                debug!(
+                    "Help::spec_vals: Found default value...[{:?}]",
+                    a.default_vals
+                );
 
-                let pvs = pv
+                let pvs = a
+                    .default_vals
                     .iter()
                     .map(|&pvs| pvs.to_string_lossy())
                     .collect::<Vec<_>>()
@@ -486,10 +490,11 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
                 spec_vals.push(format!(" [default: {}]", pvs));
             }
         }
-        if let Some(ref aliases) = a.aliases {
-            debug!("Help::spec_vals: Found aliases...{:?}", aliases);
+        if !a.aliases.is_empty() {
+            debug!("Help::spec_vals: Found aliases...{:?}", a.aliases);
 
-            let als = aliases
+            let als = a
+                .aliases
                 .iter()
                 .filter(|&als| als.1) // visible
                 .map(|&als| als.0) // name
@@ -521,10 +526,16 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
         }
 
         if !self.hide_pv && !a.is_set(ArgSettings::HidePossibleValues) {
-            if let Some(ref pv) = a.possible_vals {
-                debug!("Help::spec_vals: Found possible vals...{:?}", pv);
+            if !a.possible_vals.is_empty() {
+                debug!(
+                    "Help::spec_vals: Found possible vals...{:?}",
+                    a.possible_vals
+                );
 
-                spec_vals.push(format!(" [possible values: {}]", pv.join(", ")));
+                spec_vals.push(format!(
+                    " [possible values: {}]",
+                    a.possible_vals.join(", ")
+                ));
             }
         }
         spec_vals.join(" ")
@@ -563,10 +574,11 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
     fn sc_spec_vals(&self, a: &App) -> String {
         debug!("Help::sc_spec_vals: a={}", a.name);
         let mut spec_vals = vec![];
-        if let Some(ref aliases) = a.aliases {
-            debug!("Help::spec_vals: Found aliases...{:?}", aliases);
+        if !a.aliases.is_empty() {
+            debug!("Help::spec_vals: Found aliases...{:?}", a.aliases);
 
-            let als = aliases
+            let als = a
+                .aliases
                 .iter()
                 .filter(|&als| als.1) // visible
                 .map(|&als| als.0) // name

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -473,22 +473,20 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
             let env_info = format!(" [env: {}{}]", env.0.to_string_lossy(), env_val);
             spec_vals.push(env_info);
         }
-        if !a.is_set(ArgSettings::HideDefaultValue) {
-            if !a.default_vals.is_empty() {
-                debug!(
-                    "Help::spec_vals: Found default value...[{:?}]",
-                    a.default_vals
-                );
+        if !a.is_set(ArgSettings::HideDefaultValue) && !a.default_vals.is_empty() {
+            debug!(
+                "Help::spec_vals: Found default value...[{:?}]",
+                a.default_vals
+            );
 
-                let pvs = a
-                    .default_vals
-                    .iter()
-                    .map(|&pvs| pvs.to_string_lossy())
-                    .collect::<Vec<_>>()
-                    .join(" ");
+            let pvs = a
+                .default_vals
+                .iter()
+                .map(|&pvs| pvs.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" ");
 
-                spec_vals.push(format!(" [default: {}]", pvs));
-            }
+            spec_vals.push(format!(" [default: {}]", pvs));
         }
         if !a.aliases.is_empty() {
             debug!("Help::spec_vals: Found aliases...{:?}", a.aliases);
@@ -525,18 +523,19 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
             }
         }
 
-        if !self.hide_pv && !a.is_set(ArgSettings::HidePossibleValues) {
-            if !a.possible_vals.is_empty() {
-                debug!(
-                    "Help::spec_vals: Found possible vals...{:?}",
-                    a.possible_vals
-                );
+        if !self.hide_pv
+            && !a.is_set(ArgSettings::HidePossibleValues)
+            && !a.possible_vals.is_empty()
+        {
+            debug!(
+                "Help::spec_vals: Found possible vals...{:?}",
+                a.possible_vals
+            );
 
-                spec_vals.push(format!(
-                    " [possible values: {}]",
-                    a.possible_vals.join(", ")
-                ));
-            }
+            spec_vals.push(format!(
+                " [possible values: {}]",
+                a.possible_vals.join(", ")
+            ));
         }
         spec_vals.join(" ")
     }

--- a/src/util/graph.rs
+++ b/src/util/graph.rs
@@ -1,12 +1,15 @@
 #[derive(Debug)]
 struct Child<T> {
     id: T,
-    children: Option<Vec<usize>>,
+    children: Vec<usize>,
 }
 
 impl<T> Child<T> {
     fn new(id: T) -> Self {
-        Child { id, children: None }
+        Child {
+            id,
+            children: vec![],
+        }
     }
 }
 
@@ -39,15 +42,7 @@ where
     pub(crate) fn insert_child(&mut self, parent: usize, child: T) -> usize {
         let c_idx = self.0.len();
         self.0.push(Child::new(child));
-        let parent = &mut self.0[parent];
-        if let Some(ref mut v) = parent.children {
-            v.push(c_idx);
-        } else {
-            let mut v = Vec::with_capacity(5);
-            v.push(c_idx);
-            parent.children = Some(v);
-        }
-
+        self.0[parent].children.push(c_idx);
         c_idx
     }
 


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
Our conversation about `Option<Vec>` ergonomics got me thinking: we use this pattern in clap all the time, but there isn't a single place where `None` and `Some([])` mean different things. If fact, reducing these `Option<Vec>` to `Vec` can simplify our code considerably. 

This PR replaces all internal `Option<Vec>` occurrences with plain `Vec`. -300 LOC, yay!