### PR TITLE
refactor: Implement From<Yaml> on Arg and ArgGroup

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -303,20 +303,20 @@ impl<'b> App<'b> {
     /// Sets the program's name. This will be displayed when displaying help information.
     ///
     /// **Pro-tip:** This function is particularly useful when configuring a program via
-    /// [`App::from_yaml`] in conjunction with the [`crate_name!`] macro to derive the program's
+    /// [`App::from`] in conjunction with the [`crate_name!`] macro to derive the program's
     /// name from its `Cargo.toml`.
     ///
     /// # Examples
     /// ```ignore
     /// # use clap::{App, load_yaml};
     /// let yml = load_yaml!("app.yml");
-    /// let app = App::from_yaml(yml)
+    /// let app = App::from(yml)
     ///     .name(crate_name!());
     ///
     /// // continued logic goes here, such as `app.get_matches()` etc.
     /// ```
     ///
-    /// [`App::from_yaml`]: ./struct.App.html#method.from_yaml
+    /// [`App::from`]: ./struct.App.html#method.from
     /// [`crate_name!`]: ./macro.crate_name.html
     pub fn name<S: Into<String>>(mut self, name: S) -> Self {
         self.name = name.into();
@@ -2180,7 +2180,7 @@ impl<'a> From<&'a Yaml> for App<'a> {
 
         if let Some(v) = yaml["args"].as_vec() {
             for arg_yaml in v {
-                a = a.arg(Arg::from_yaml(arg_yaml.as_hash().unwrap()));
+                a = a.arg(Arg::from(arg_yaml));
             }
         }
         if let Some(v) = yaml["subcommands"].as_vec() {

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -4,6 +4,9 @@ use std::fmt::{Debug, Formatter, Result};
 // Internal
 use crate::util::{Id, Key};
 
+#[cfg(feature = "yaml")]
+use yaml_rust::Yaml;
+
 /// `ArgGroup`s are a family of related [arguments] and way for you to express, "Any of these
 /// arguments". By placing arguments in a logical group, you can create easier requirement and
 /// exclusion rules instead of having to list each argument individually, or when you want a rule
@@ -112,21 +115,6 @@ impl<'a> ArgGroup<'a> {
             name: n,
             ..ArgGroup::default()
         }
-    }
-
-    /// Creates a new instance of `ArgGroup` from a .yml (YAML) file.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// # use clap::{ArgGroup, load_yaml};
-    /// let yml = load_yaml!("group.yml");
-    /// let ag = ArgGroup::from_yaml(yml);
-    /// ```
-    #[cfg(feature = "yaml")]
-    #[inline]
-    pub fn from_yaml(y: &'a yaml_rust::Yaml) -> ArgGroup<'a> {
-        ArgGroup::from(y.as_hash().unwrap())
     }
 
     /// Adds an [argument] to this group by name
@@ -428,6 +416,22 @@ impl<'a> Debug for ArgGroup<'a> {
     }
 }
 
+#[cfg(feature = "yaml")]
+impl<'a> From<&'a Yaml> for ArgGroup<'a> {
+    /// Creates a new instance of `ArgGroup` from a .yml (YAML) file.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// # use clap::{ArgGroup, load_yaml};
+    /// let yml = load_yaml!("group.yml");
+    /// let ag = ArgGroup::from(yml);
+    /// ```
+    fn from(y: &'a Yaml) -> Self {
+        ArgGroup::from(y.as_hash().unwrap())
+    }
+}
+
 impl<'a, 'z> From<&'z ArgGroup<'a>> for ArgGroup<'a> {
     fn from(g: &'z ArgGroup<'a>) -> Self {
         ArgGroup {
@@ -611,7 +615,7 @@ requires:
 - r3
 - r4";
         let yml = &YamlLoader::load_from_str(g_yaml).expect("failed to load YAML file")[0];
-        let g = ArgGroup::from_yaml(yml);
+        let g = ArgGroup::from(yml);
         let args = vec!["a1".into(), "a4".into(), "a2".into(), "a3".into()];
         let reqs = vec!["r1".into(), "r2".into(), "r3".into(), "r4".into()];
         let confs = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,7 +18,7 @@
 /// # use clap::App;
 /// # fn main() {
 /// let yml = load_yaml!("app.yml");
-/// let app = App::from_yaml(yml);
+/// let app = App::from(yml);
 ///
 /// // continued logic goes here, such as `app.get_matches()` etc.
 /// # }


### PR DESCRIPTION
Hi! This is my first PR to the project. I've used `clap` on projects before and wanted to give a little something back!

I'm still fairly new to Rust, so I'm hoping this change is what's needed. I also implemented `From<Yaml>` on both `Arg` and `ArgGroup` since I noticed the group was using the old way too.

I'm sure I screwed up on something though, so I'm looking forward to any feedback :smile: 

Closes #1922 


