### PR TITLE
fix(errors): incorrect missing argument error messages

### DIFF
--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -332,10 +332,16 @@ impl<'b, 'c, 'z> Usage<'b, 'c, 'z> {
                 for aa in self.p.app.unroll_requirements_for_arg(a, m) {
                     unrolled_reqs.push(aa);
                 }
-            } else {
-                unrolled_reqs.push(a.clone());
             }
+            // alway include the required arg itself. it will not be enumerated
+            // by unroll_requirements_for_arg.
+            unrolled_reqs.push(a.clone());
         }
+
+        debug!(
+            "Usage::get_required_usage_from: unrolled_reqs={:?}",
+            unrolled_reqs
+        );
 
         let args_in_groups = self
             .p
@@ -396,6 +402,19 @@ impl<'b, 'c, 'z> Usage<'b, 'c, 'z> {
             .iter()
             .filter(|n| self.p.app.groups.iter().any(|g| g.id == **n))
         {
+            // don't print requirement for required groups that have an arg.
+            if let Some(m) = matcher {
+                let have_group_entry = self
+                    .p
+                    .app
+                    .unroll_args_in_group(&g)
+                    .iter()
+                    .any(|arg| m.contains(&arg));
+                if have_group_entry {
+                    continue;
+                }
+            }
+
             let elem = self.p.app.format_group(g);
             if !g_vec.contains(&elem) {
                 g_vec.push(elem);

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -594,7 +594,7 @@ impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
         let req_args = if let Some(x) = incl {
             usg.get_required_usage_from(&[x.clone()], Some(matcher), true)
         } else {
-            usg.get_required_usage_from(&[], None, true)
+            usg.get_required_usage_from(&[], Some(matcher), true)
         };
 
         debug!(

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -529,20 +529,20 @@ fn list_correct_required_args() {
         .author("F0x06")
         .about("Arg test")
         .arg(
-            Arg::with_name("target")
+            Arg::new("target")
                 .takes_value(true)
                 .required(true)
                 .possible_values(&["file", "stdout"])
                 .long("target"),
         )
         .arg(
-            Arg::with_name("input")
+            Arg::new("input")
                 .takes_value(true)
                 .required(true)
                 .long("input"),
         )
         .arg(
-            Arg::with_name("output")
+            Arg::new("output")
                 .takes_value(true)
                 .required(true)
                 .long("output"),
@@ -695,7 +695,7 @@ fn require_eq_filtered() {
     let app = App::new("clap-test")
         .version("v1.4.8")
         .arg(
-            Arg::with_name("opt")
+            Arg::new("opt")
                 .long("opt")
                 .short('o')
                 .required(true)
@@ -704,7 +704,7 @@ fn require_eq_filtered() {
                 .about("some"),
         )
         .arg(
-            Arg::with_name("foo")
+            Arg::new("foo")
                 .long("foo")
                 .short('f')
                 .required(true)
@@ -725,7 +725,7 @@ fn require_eq_filtered_group() {
     let app = App::new("clap-test")
         .version("v1.4.8")
         .arg(
-            Arg::with_name("opt")
+            Arg::new("opt")
                 .long("opt")
                 .short('o')
                 .required(true)
@@ -734,7 +734,7 @@ fn require_eq_filtered_group() {
                 .about("some"),
         )
         .arg(
-            Arg::with_name("foo")
+            Arg::new("foo")
                 .long("foo")
                 .short('f')
                 .required(true)
@@ -743,19 +743,19 @@ fn require_eq_filtered_group() {
                 .about("some other arg"),
         )
         .arg(
-            Arg::with_name("g1")
+            Arg::new("g1")
                 .long("g1")
                 .require_equals(true)
                 .value_name("FILE"),
         )
         .arg(
-            Arg::with_name("g2")
+            Arg::new("g2")
                 .long("g2")
                 .require_equals(true)
                 .value_name("FILE"),
         )
         .group(
-            ArgGroup::with_name("test_group")
+            ArgGroup::new("test_group")
                 .args(&["g1", "g2"])
                 .required(true),
         );


### PR DESCRIPTION
correctly filter the suggestion arguments returned by the missing_required_argument error.
- a simple argument has been supplied, don't include it
- if a required group has been satisfied, don't include it
- add test for these cases.