### PR TITLE
Unify name and arg order scheme

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1634,7 +1634,7 @@ impl<'b> App<'b> {
             for req in &arg.r_ifs {
                 assert!(
                     self.id_exists(&req.0),
-                    "Argument or group '{:?}' specified in 'required_if*' for '{}' does not exist",
+                    "Argument or group '{:?}' specified in 'required_if_eq*' for '{}' does not exist",
                     req.0,
                     arg.name
                 );

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -4284,12 +4284,12 @@ impl<'a> From<&'a Yaml> for Arg<'a> {
                 "overrides_with" => yaml_vec_or_str!(v, a, overrides_with),
                 "possible_values" => yaml_vec_or_str!(v, a, possible_value),
                 "case_insensitive" => yaml_to_bool!(a, v, case_insensitive),
-                "required_unless_eq_any" => yaml_vec_or_str!(v, a, required_unless_eq_any),
-                "required_unless_eq_all" => {
-                    a = yaml_vec_or_str!(v, a, required_unless_eq_all);
-                    a.set_mut(ArgSettings::RequiredUnlessAll);
-                    a
-                }
+                // "required_unless_eq_any" => yaml_vec_or_str!(v, a, required_unless_eq_any),
+                // "required_unless_eq_all" => {
+                //     a = yaml_vec_or_str!(v, a, required_unless_eq_all);
+                //     a.set_mut(ArgSettings::RequiredUnlessAll);
+                //     a
+                // }
                 s => panic!(
                     "Unknown Arg setting '{}' in YAML file for arg '{}'",
                     s, name_str

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -685,7 +685,7 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .required_unless_all(&["cfg", "dbg"])
+    ///     .required_unless_eq_all(&["cfg", "dbg"])
     /// # ;
     /// ```
     ///
@@ -696,7 +696,7 @@ impl<'help> Arg<'help> {
     /// # use clap::{App, Arg};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_unless_all(&["dbg", "infile"])
+    ///         .required_unless_eq_all(&["dbg", "infile"])
     ///         .takes_value(true)
     ///         .long("config"))
     ///     .arg(Arg::new("dbg")
@@ -711,14 +711,14 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok());
     /// ```
     ///
-    /// Setting [`Arg::required_unless_all(names)`] and *not* supplying
+    /// Setting [`Arg::required_unless_eq_all(names)`] and *not* supplying
     /// either *all* of `unless` args or the `self` arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_unless_all(&["dbg", "infile"])
+    ///         .required_unless_eq_all(&["dbg", "infile"])
     ///         .takes_value(true)
     ///         .long("config"))
     ///     .arg(Arg::new("dbg")
@@ -734,8 +734,8 @@ impl<'help> Arg<'help> {
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
     /// [`Arg::required_unless_eq_any`]: ./struct.Arg.html#method.required_unless_eq_any
-    /// [`Arg::required_unless_all(names)`]: ./struct.Arg.html#method.required_unless_all
-    pub fn required_unless_all(mut self, names: &[&str]) -> Self {
+    /// [`Arg::required_unless_eq_all(names)`]: ./struct.Arg.html#method.required_unless_eq_all
+    pub fn required_unless_eq_all(mut self, names: &[&str]) -> Self {
         self.r_unless.extend(names.iter().map(Id::from));
         self.setting(ArgSettings::RequiredUnlessAll)
     }
@@ -751,7 +751,7 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .required_unless_all(&["cfg", "dbg"])
+    ///     .required_unless_eq_all(&["cfg", "dbg"])
     /// # ;
     /// ```
     ///
@@ -803,7 +803,7 @@ impl<'help> Arg<'help> {
     /// ```
     /// [required]: ./struct.Arg.html#method.required
     /// [`Arg::required_unless_eq_any(names)`]: ./struct.Arg.html#method.required_unless_eq_any
-    /// [`Arg::required_unless_all`]: ./struct.Arg.html#method.required_unless_all
+    /// [`Arg::required_unless_eq_all`]: ./struct.Arg.html#method.required_unless_eq_all
     pub fn required_unless_eq_any(mut self, names: &[&str]) -> Self {
         self.r_unless.extend(names.iter().map(Id::from));
         self
@@ -4284,9 +4284,9 @@ impl<'a> From<&'a Yaml> for Arg<'a> {
                 "overrides_with" => yaml_vec_or_str!(v, a, overrides_with),
                 "possible_values" => yaml_vec_or_str!(v, a, possible_value),
                 "case_insensitive" => yaml_to_bool!(a, v, case_insensitive),
-                "required_unless_eq_any" => yaml_vec_or_str!(v, a, required_unless),
-                "required_unless_all" => {
-                    a = yaml_vec_or_str!(v, a, required_unless_present);
+                "required_unless_eq_any" => yaml_vec_or_str!(v, a, required_unless_eq_any),
+                "required_unless_eq_all" => {
+                    a = yaml_vec_or_str!(v, a, required_unless_eq_all);
                     a.set_mut(ArgSettings::RequiredUnlessAll);
                     a
                 }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -679,7 +679,7 @@ impl<'help> Arg<'help> {
     /// all these other arguments are present).
     ///
     /// **NOTE:** If you wish for this argument to only be required if *one of* these args are
-    /// present see [`Arg::required_unless_one`]
+    /// present see [`Arg::required_unless_eq_any`]
     ///
     /// # Examples
     ///
@@ -736,7 +736,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
-    /// [`Arg::required_unless_one`]: ./struct.Arg.html#method.required_unless_one
+    /// [`Arg::required_unless_eq_any`]: ./struct.Arg.html#method.required_unless_eq_any
     /// [`Arg::required_unless_all(names)`]: ./struct.Arg.html#method.required_unless_all
     pub fn required_unless_all(mut self, names: &[&str]) -> Self {
         self.r_unless.extend(names.iter().map(Id::from));
@@ -758,7 +758,7 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting [`Arg::required_unless_one(names)`] requires that the argument be used at runtime
+    /// Setting [`Arg::required_unless_eq_any(names)`] requires that the argument be used at runtime
     /// *unless* *at least one of* the args in `names` are present. In the following example, the
     /// required argument is *not* provided, but it's not an error because one the `unless` args
     /// have been supplied.
@@ -767,7 +767,7 @@ impl<'help> Arg<'help> {
     /// # use clap::{App, Arg};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_unless_one(&["dbg", "infile"])
+    ///         .required_unless_eq_any(&["dbg", "infile"])
     ///         .takes_value(true)
     ///         .long("config"))
     ///     .arg(Arg::new("dbg")
@@ -782,14 +782,14 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok());
     /// ```
     ///
-    /// Setting [`Arg::required_unless_one(names)`] and *not* supplying *at least one of* `names`
+    /// Setting [`Arg::required_unless_eq_any(names)`] and *not* supplying *at least one of* `names`
     /// or this arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_unless_one(&["dbg", "infile"])
+    ///         .required_unless_eq_any(&["dbg", "infile"])
     ///         .takes_value(true)
     ///         .long("config"))
     ///     .arg(Arg::new("dbg")
@@ -805,9 +805,9 @@ impl<'help> Arg<'help> {
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required]: ./struct.Arg.html#method.required
-    /// [`Arg::required_unless_one(names)`]: ./struct.Arg.html#method.required_unless_one
+    /// [`Arg::required_unless_eq_any(names)`]: ./struct.Arg.html#method.required_unless_eq_any
     /// [`Arg::required_unless_all`]: ./struct.Arg.html#method.required_unless_all
-    pub fn required_unless_one(mut self, names: &[&str]) -> Self {
+    pub fn required_unless_eq_any(mut self, names: &[&str]) -> Self {
         self.r_unless.extend(names.iter().map(Id::from));
         self
     }
@@ -4295,7 +4295,7 @@ impl<'a> From<&'a Yaml> for Arg<'a> {
                 "overrides_with" => yaml_vec_or_str!(v, a, overrides_with),
                 "possible_values" => yaml_vec_or_str!(v, a, possible_value),
                 "case_insensitive" => yaml_to_bool!(a, v, case_insensitive),
-                "required_unless_one" => yaml_vec_or_str!(v, a, required_unless),
+                "required_unless_eq_any" => yaml_vec_or_str!(v, a, required_unless),
                 "required_unless_all" => {
                     a = yaml_vec_or_str!(v, a, required_unless);
                     a.set_mut(ArgSettings::RequiredUnlessAll);

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -616,7 +616,7 @@ impl<'help> Arg<'help> {
 
     /// Set this arg as [required] as long as the specified argument is not present at runtime.
     ///
-    /// **Pro Tip:** Using `Arg::required_unless` implies [`Arg::required`] and is therefore not
+    /// **Pro Tip:** Using `Arg::required_unless_present` implies [`Arg::required`] and is therefore not
     /// mandatory to also set.
     ///
     /// # Examples
@@ -624,7 +624,7 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .required_unless("debug")
+    ///     .required_unless_present("debug")
     /// # ;
     /// ```
     ///
@@ -635,7 +635,7 @@ impl<'help> Arg<'help> {
     /// # use clap::{App, Arg};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_unless("dbg")
+    ///         .required_unless_present("dbg")
     ///         .takes_value(true)
     ///         .long("config"))
     ///     .arg(Arg::new("dbg")
@@ -647,13 +647,13 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok());
     /// ```
     ///
-    /// Setting `Arg::required_unless(name)` and *not* supplying `name` or this arg is an error.
+    /// Setting `Arg::required_unless_present(name)` and *not* supplying `name` or this arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_unless("dbg")
+    ///         .required_unless_present("dbg")
     ///         .takes_value(true)
     ///         .long("config"))
     ///     .arg(Arg::new("dbg")
@@ -666,7 +666,7 @@ impl<'help> Arg<'help> {
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required]: ./struct.Arg.html#method.required
-    pub fn required_unless<T: Key>(mut self, arg_id: T) -> Self {
+    pub fn required_unless_present<T: Key>(mut self, arg_id: T) -> Self {
         self.r_unless.push(arg_id.into());
         self
     }
@@ -4266,7 +4266,7 @@ impl<'a> From<&'a Yaml> for Arg<'a> {
                 "require_equals" => yaml_to_bool!(a, v, require_equals),
                 "require_delimiter" => yaml_to_bool!(a, v, require_delimiter),
                 "value_delimiter" => yaml_to_str!(a, v, value_delimiter),
-                "required_unless" => yaml_to_str!(a, v, required_unless),
+                "required_unless_present" => yaml_to_str!(a, v, required_unless_present),
                 "display_order" => yaml_to_usize!(a, v, display_order),
                 "default_value" => yaml_to_str!(a, v, default_value),
                 "default_value_if" => yaml_tuple3!(a, v, default_value_if),
@@ -4286,7 +4286,7 @@ impl<'a> From<&'a Yaml> for Arg<'a> {
                 "case_insensitive" => yaml_to_bool!(a, v, case_insensitive),
                 "required_unless_eq_any" => yaml_vec_or_str!(v, a, required_unless),
                 "required_unless_all" => {
-                    a = yaml_vec_or_str!(v, a, required_unless);
+                    a = yaml_vec_or_str!(v, a, required_unless_present);
                     a.set_mut(ArgSettings::RequiredUnlessAll);
                     a
                 }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -1361,14 +1361,14 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .required_ifs(&[
+    ///     .required_if_eq_any(&[
     ///         ("extra", "val"),
     ///         ("option", "spec")
     ///     ])
     /// # ;
     /// ```
     ///
-    /// Setting [`Arg::required_ifs(&[(arg, val)])`] makes this arg required if any of the `arg`s
+    /// Setting [`Arg::required_if_eq_any(&[(arg, val)])`] makes this arg required if any of the `arg`s
     /// are used at runtime and it's corresponding value is equal to `val`. If the `arg`'s value is
     /// anything other than `val`, this argument isn't required.
     ///
@@ -1376,7 +1376,7 @@ impl<'help> Arg<'help> {
     /// # use clap::{App, Arg};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_ifs(&[
+    ///         .required_if_eq_any(&[
     ///             ("extra", "val"),
     ///             ("option", "spec")
     ///         ])
@@ -1395,14 +1395,14 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok()); // We didn't use --option=spec, or --extra=val so "cfg" isn't required
     /// ```
     ///
-    /// Setting [`Arg::required_ifs(&[(arg, val)])`] and having any of the `arg`s used with it's
+    /// Setting [`Arg::required_if_eq_any(&[(arg, val)])`] and having any of the `arg`s used with it's
     /// value of `val` but *not* using this arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .required_ifs(&[
+    ///         .required_if_eq_any(&[
     ///             ("extra", "val"),
     ///             ("option", "spec")
     ///         ])
@@ -1424,7 +1424,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::requires(name)`]: ./struct.Arg.html#method.requires
     /// [Conflicting]: ./struct.Arg.html#method.conflicts_with
     /// [required]: ./struct.Arg.html#method.required
-    pub fn required_ifs<T: Key>(mut self, ifs: &[(T, &'help str)]) -> Self {
+    pub fn required_if_eq_any<T: Key>(mut self, ifs: &[(T, &'help str)]) -> Self {
         self.r_ifs
             .extend(ifs.iter().map(|(id, val)| (Id::from_ref(id), *val)));
         self
@@ -4260,7 +4260,7 @@ impl<'a> From<&'a Yaml> for Arg<'a> {
                 "long_help" => yaml_to_str!(a, v, long_about),
                 "required" => yaml_to_bool!(a, v, required),
                 "required_if" => yaml_tuple2!(a, v, required_if),
-                "required_ifs" => yaml_tuple2!(a, v, required_if),
+                "required_if_eq_any" => yaml_tuple2!(a, v, required_if),
                 "takes_value" => yaml_to_bool!(a, v, takes_value),
                 "index" => yaml_to_u64!(a, v, index),
                 "global" => yaml_to_bool!(a, v, global),

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -1282,7 +1282,7 @@ impl<'help> Arg<'help> {
     /// **NOTE:** If using YAML the values should be laid out as follows
     ///
     /// ```yaml
-    /// required_if:
+    /// required_if_eq:
     ///     - [arg, val]
     /// ```
     ///
@@ -1291,11 +1291,11 @@ impl<'help> Arg<'help> {
     /// ```rust
     /// # use clap::Arg;
     /// Arg::new("config")
-    ///     .required_if("other_arg", "value")
+    ///     .required_if_eq("other_arg", "value")
     /// # ;
     /// ```
     ///
-    /// Setting [`Arg::required_if(arg, val)`] makes this arg required if the `arg` is used at
+    /// Setting [`Arg::required_if_eq(arg, val)`] makes this arg required if the `arg` is used at
     /// runtime and it's value is equal to `val`. If the `arg`'s value is anything other than `val`,
     /// this argument isn't required.
     ///
@@ -1304,7 +1304,7 @@ impl<'help> Arg<'help> {
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .takes_value(true)
-    ///         .required_if("other", "special")
+    ///         .required_if_eq("other", "special")
     ///         .long("config"))
     ///     .arg(Arg::new("other")
     ///         .long("other")
@@ -1316,7 +1316,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok()); // We didn't use --other=special, so "cfg" wasn't required
     /// ```
     ///
-    /// Setting [`Arg::required_if(arg, val)`] and having `arg` used with a value of `val` but *not*
+    /// Setting [`Arg::required_if_eq(arg, val)`] and having `arg` used with a value of `val` but *not*
     /// using this arg is an error.
     ///
     /// ```rust
@@ -1324,7 +1324,7 @@ impl<'help> Arg<'help> {
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .takes_value(true)
-    ///         .required_if("other", "special")
+    ///         .required_if_eq("other", "special")
     ///         .long("config"))
     ///     .arg(Arg::new("other")
     ///         .long("other")
@@ -1339,7 +1339,7 @@ impl<'help> Arg<'help> {
     /// [`Arg::requires(name)`]: ./struct.Arg.html#method.requires
     /// [Conflicting]: ./struct.Arg.html#method.conflicts_with
     /// [required]: ./struct.Arg.html#method.required
-    pub fn required_if<T: Key>(mut self, arg_id: T, val: &'help str) -> Self {
+    pub fn required_if_eq<T: Key>(mut self, arg_id: T, val: &'help str) -> Self {
         self.r_ifs.push((arg_id.into(), val));
         self
     }
@@ -1351,7 +1351,7 @@ impl<'help> Arg<'help> {
     /// **NOTE:** If using YAML the values should be laid out as follows
     ///
     /// ```yaml
-    /// required_if:
+    /// required_if_eq:
     ///     - [arg, val]
     ///     - [arg2, val2]
     /// ```
@@ -4259,8 +4259,8 @@ impl<'a> From<&'a Yaml> for Arg<'a> {
                 "help" => yaml_to_str!(a, v, about),
                 "long_help" => yaml_to_str!(a, v, long_about),
                 "required" => yaml_to_bool!(a, v, required),
-                "required_if" => yaml_tuple2!(a, v, required_if),
-                "required_if_eq_any" => yaml_tuple2!(a, v, required_if),
+                "required_if_eq" => yaml_tuple2!(a, v, required_if_eq),
+                "required_if_eq_any" => yaml_tuple2!(a, v, required_if_eq),
                 "takes_value" => yaml_to_bool!(a, v, takes_value),
                 "index" => yaml_to_u64!(a, v, index),
                 "global" => yaml_to_bool!(a, v, global),

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -614,10 +614,9 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Sets an arg that override this arg's required setting. (i.e. this arg will be required
-    /// unless this other argument is present).
+    /// Set this arg as [required] as long as the specified argument is not present at runtime.
     ///
-    /// **Pro Tip:** Using [`Arg::required_unless`] implies [`Arg::required`] and is therefore not
+    /// **Pro Tip:** Using `Arg::required_unless` implies [`Arg::required`] and is therefore not
     /// mandatory to also set.
     ///
     /// # Examples
@@ -629,9 +628,8 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting [`Arg::required_unless(name)`] requires that the argument be used at runtime
-    /// *unless* `name` is present. In the following example, the required argument is *not*
-    /// provided, but it's not an error because the `unless` arg has been supplied.
+    /// In the following example, the required argument is *not* provided,
+    /// but it's not an error because the `unless` arg has been supplied.
     ///
     /// ```rust
     /// # use clap::{App, Arg};
@@ -649,7 +647,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok());
     /// ```
     ///
-    /// Setting [`Arg::required_unless(name)`] and *not* supplying `name` or this arg is an error.
+    /// Setting `Arg::required_unless(name)` and *not* supplying `name` or this arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
@@ -667,16 +665,17 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
-    /// [`Arg::required_unless`]: ./struct.Arg.html#method.required_unless
-    /// [`Arg::required`]: ./struct.Arg.html#method.required
-    /// [`Arg::required_unless(name)`]: ./struct.Arg.html#method.required_unless
+    /// [required]: ./struct.Arg.html#method.required
     pub fn required_unless<T: Key>(mut self, arg_id: T) -> Self {
         self.r_unless.push(arg_id.into());
         self
     }
 
-    /// Sets args that override this arg's required setting. (i.e. this arg will be required unless
-    /// all these other arguments are present).
+    /// Sets this arg as [required] unless *all* of the specified arguments are present at runtime.
+    ///
+    /// In other words, parsing will succeed only if user either
+    /// * supplies the `self` arg.
+    /// * supplies *all* of the `names` arguments.
     ///
     /// **NOTE:** If you wish for this argument to only be required if *one of* these args are
     /// present see [`Arg::required_unless_eq_any`]
@@ -690,10 +689,8 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting [`Arg::required_unless_all(names)`] requires that the argument be used at runtime
-    /// *unless* *all* the args in `names` are present. In the following example, the required
-    /// argument is *not* provided, but it's not an error because all the `unless` args have been
-    /// supplied.
+    /// In the following example, the required argument is *not* provided, but it's not an error
+    /// because *all* of the `names` args have been supplied.
     ///
     /// ```rust
     /// # use clap::{App, Arg};
@@ -714,8 +711,8 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok());
     /// ```
     ///
-    /// Setting [`Arg::required_unless_all(names)`] and *not* supplying *all* of `names` or this
-    /// arg is an error.
+    /// Setting [`Arg::required_unless_all(names)`] and *not* supplying
+    /// either *all* of `unless` args or the `self` arg is an error.
     ///
     /// ```rust
     /// # use clap::{App, Arg, ErrorKind};
@@ -743,11 +740,11 @@ impl<'help> Arg<'help> {
         self.setting(ArgSettings::RequiredUnlessAll)
     }
 
-    /// Sets args that override this arg's [required] setting. (i.e. this arg will be required
-    /// unless *at least one of* these other arguments are present).
+    /// Sets this arg as [required] unless *any* of the specified arguments are present at runtime.
     ///
-    /// **NOTE:** If you wish for this argument to only be required if *all of* these args are
-    /// present see [`Arg::required_unless_all`]
+    /// In other words, parsing will succeed only if user either
+    /// * supplies the `self` arg.
+    /// * supplies *one or more* of the `unless` arguments.
     ///
     /// # Examples
     ///
@@ -856,7 +853,6 @@ impl<'help> Arg<'help> {
     ///
     /// [`Arg::conflicts_with_all(names)`]: ./struct.Arg.html#method.conflicts_with_all
     /// [`Arg::exclusive(true)`]: ./struct.Arg.html#method.exclusive
-
     pub fn conflicts_with<T: Key>(mut self, arg_id: T) -> Self {
         self.blacklist.push(arg_id.into());
         self
@@ -906,7 +902,6 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::conflicts_with`]: ./struct.Arg.html#method.conflicts_with
     /// [`Arg::exclusive(true)`]: ./struct.Arg.html#method.exclusive
-
     pub fn conflicts_with_all(mut self, names: &[&str]) -> Self {
         self.blacklist.extend(names.iter().map(Id::from));
         self
@@ -1155,8 +1150,11 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Allows a conditional requirement. The requirement will only become valid if this arg's value
-    /// equals `val`.
+    /// Require another argument if this arg was present on runtime, and its value equals to `val`.
+    ///
+    /// This method takes `value, another_arg` pair. At runtime, clap will check
+    /// if this arg (`self`) is is present and its value equals to `val`.
+    /// If it does, `another_arg` will be marked as required.
     ///
     /// **NOTE:** If using YAML the values should be laid out as follows
     ///
@@ -1276,8 +1274,8 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Allows specifying that an argument is [required] conditionally. The requirement will only
-    /// become valid if the specified `arg`'s value equals `val`.
+    /// Allows specifying that this argument is [required] only if the specified
+    /// `arg` is present at runtime and its value equals `val`.
     ///
     /// **NOTE:** If using YAML the values should be laid out as follows
     ///
@@ -1295,12 +1293,8 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting [`Arg::required_if_eq(arg, val)`] makes this arg required if the `arg` is used at
-    /// runtime and it's value is equal to `val`. If the `arg`'s value is anything other than `val`,
-    /// this argument isn't required.
-    ///
     /// ```rust
-    /// # use clap::{App, Arg};
+    /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .takes_value(true)
@@ -1314,13 +1308,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_ok()); // We didn't use --other=special, so "cfg" wasn't required
-    /// ```
     ///
-    /// Setting [`Arg::required_if_eq(arg, val)`] and having `arg` used with a value of `val` but *not*
-    /// using this arg is an error.
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, ErrorKind};
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
     ///         .takes_value(true)
@@ -1333,6 +1321,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "--other", "special"
     ///     ]);
     ///
+    /// // We did use --other=special so "cfg" had become required but was missing.
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
     /// ```
@@ -1344,7 +1333,7 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Allows specifying that an argument is [required] based on multiple conditions. The
+    /// Allows specifying that this argument is [required] based on multiple conditions. The
     /// conditions are set up in a `(arg, val)` style tuple. The requirement will only become valid
     /// if one of the specified `arg`'s value equals it's corresponding `val`.
     ///

--- a/tests/default_vals.rs
+++ b/tests/default_vals.rs
@@ -400,7 +400,7 @@ fn conditional_reqs_fail() {
         .arg(
             Arg::new("output")
                 .takes_value(true)
-                .required_if("target", "file")
+                .required_if_eq("target", "file")
                 .long("output"),
         )
         .try_get_matches_from(vec!["test", "--input", "some"]);
@@ -431,7 +431,7 @@ fn conditional_reqs_pass() {
         .arg(
             Arg::new("output")
                 .takes_value(true)
-                .required_if("target", "file")
+                .required_if_eq("target", "file")
                 .long("output"),
         )
         .try_get_matches_from(vec!["test", "--input", "some", "--output", "other"]);

--- a/tests/fixtures/app.yml
+++ b/tests/fixtures/app.yml
@@ -77,7 +77,7 @@ args:
         long: singlealias
         about: Tests single alias
         aliases: [alias]
-        required_if:
+        required_if_eq:
             - [multvalsmo, two]
     - multaliases:
         long: multaliases
@@ -87,7 +87,7 @@ args:
         long: singleshortalias
         about: Tests single short alias
         short_aliases: [a]
-        required_if:
+        required_if_eq:
             - [multvalsmo, two]
     - multshortaliases:
         long: multshortaliases

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -496,7 +496,7 @@ fn required_if_val_present_pass() {
     let res = App::new("ri")
         .arg(
             Arg::new("cfg")
-                .required_if("extra", "val")
+                .required_if_eq("extra", "val")
                 .takes_value(true)
                 .long("config"),
         )
@@ -511,7 +511,7 @@ fn required_if_val_present_fail() {
     let res = App::new("ri")
         .arg(
             Arg::new("cfg")
-                .required_if("extra", "val")
+                .required_if_eq("extra", "val")
                 .takes_value(true)
                 .long("config"),
         )
@@ -578,7 +578,7 @@ fn required_if_val_present_fail_error_output() {
         .arg(
             Arg::new("output")
                 .takes_value(true)
-                .required_if("target", "file")
+                .required_if_eq("target", "file")
                 .long("output"),
         );
 
@@ -595,7 +595,7 @@ fn required_if_wrong_val() {
     let res = App::new("ri")
         .arg(
             Arg::new("cfg")
-                .required_if("extra", "val")
+                .required_if_eq("extra", "val")
                 .takes_value(true)
                 .long("config"),
         )
@@ -858,12 +858,12 @@ fn requires_if_invalid_arg() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Argument or group 'extra' specified in 'required_if*' for 'config' does not exist"]
+#[should_panic = "Argument or group 'extra' specified in 'required_if_eq*' for 'config' does not exist"]
 fn required_if_invalid_arg() {
     let _ = App::new("prog")
         .arg(
             Arg::new("config")
-                .required_if("extra", "val")
+                .required_if_eq("extra", "val")
                 .long("config"),
         )
         .try_get_matches_from(vec!["", "--config"]);

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -610,7 +610,7 @@ fn required_ifs_val_present_pass() {
     let res = App::new("ri")
         .arg(
             Arg::new("cfg")
-                .required_ifs(&[("extra", "val"), ("option", "spec")])
+                .required_if_eq_any(&[("extra", "val"), ("option", "spec")])
                 .takes_value(true)
                 .long("config"),
         )
@@ -626,7 +626,7 @@ fn required_ifs_val_present_fail() {
     let res = App::new("ri")
         .arg(
             Arg::new("cfg")
-                .required_ifs(&[("extra", "val"), ("option", "spec")])
+                .required_if_eq_any(&[("extra", "val"), ("option", "spec")])
                 .takes_value(true)
                 .long("config"),
         )
@@ -643,7 +643,7 @@ fn required_ifs_wrong_val() {
     let res = App::new("ri")
         .arg(
             Arg::new("cfg")
-                .required_ifs(&[("extra", "val"), ("option", "spec")])
+                .required_if_eq_any(&[("extra", "val"), ("option", "spec")])
                 .takes_value(true)
                 .long("config"),
         )
@@ -659,7 +659,7 @@ fn required_ifs_wrong_val_mult_fail() {
     let res = App::new("ri")
         .arg(
             Arg::new("cfg")
-                .required_ifs(&[("extra", "val"), ("option", "spec")])
+                .required_if_eq_any(&[("extra", "val"), ("option", "spec")])
                 .takes_value(true)
                 .long("config"),
         )

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -288,11 +288,11 @@ fn required_unless_all_err() {
 // REQUIRED_UNLESS_ONE
 
 #[test]
-fn required_unless_one() {
+fn required_unless_eq_any() {
     let res = App::new("unlessone")
         .arg(
             Arg::new("cfg")
-                .required_unless_one(&["dbg", "infile"])
+                .required_unless_eq_any(&["dbg", "infile"])
                 .takes_value(true)
                 .long("config"),
         )
@@ -307,13 +307,13 @@ fn required_unless_one() {
 }
 
 #[test]
-fn required_unless_one_2() {
-    // This tests that the required_unless_one works when the second arg in the array is used
+fn required_unless_any_2() {
+    // This tests that the required_unless_eq_any works when the second arg in the array is used
     // instead of the first.
     let res = App::new("unlessone")
         .arg(
             Arg::new("cfg")
-                .required_unless_one(&["dbg", "infile"])
+                .required_unless_eq_any(&["dbg", "infile"])
                 .takes_value(true)
                 .long("config"),
         )
@@ -328,48 +328,48 @@ fn required_unless_one_2() {
 }
 
 #[test]
-fn required_unless_one_works_with_short() {
+fn required_unless_any_works_with_short() {
     // GitHub issue: https://github.com/kbknapp/clap-rs/issues/1135
     let res = App::new("unlessone")
         .arg(Arg::new("a").conflicts_with("b").short('a'))
         .arg(Arg::new("b").short('b'))
-        .arg(Arg::new("x").short('x').required_unless_one(&["a", "b"]))
+        .arg(Arg::new("x").short('x').required_unless_eq_any(&["a", "b"]))
         .try_get_matches_from(vec!["unlessone", "-a"]);
 
     assert!(res.is_ok());
 }
 
 #[test]
-fn required_unless_one_works_with_short_err() {
+fn required_unless_any_works_with_short_err() {
     let res = App::new("unlessone")
         .arg(Arg::new("a").conflicts_with("b").short('a'))
         .arg(Arg::new("b").short('b'))
-        .arg(Arg::new("x").short('x').required_unless_one(&["a", "b"]))
+        .arg(Arg::new("x").short('x').required_unless_eq_any(&["a", "b"]))
         .try_get_matches_from(vec!["unlessone"]);
 
     assert!(!res.is_ok());
 }
 
 #[test]
-fn required_unless_one_works_without() {
+fn required_unless_any_works_without() {
     let res = App::new("unlessone")
         .arg(Arg::new("a").conflicts_with("b").short('a'))
         .arg(Arg::new("b").short('b'))
-        .arg(Arg::new("x").required_unless_one(&["a", "b"]))
+        .arg(Arg::new("x").required_unless_eq_any(&["a", "b"]))
         .try_get_matches_from(vec!["unlessone", "-a"]);
 
     assert!(res.is_ok());
 }
 
 #[test]
-fn required_unless_one_works_with_long() {
+fn required_unless_any_works_with_long() {
     let res = App::new("unlessone")
         .arg(Arg::new("a").conflicts_with("b").short('a'))
         .arg(Arg::new("b").short('b'))
         .arg(
             Arg::new("x")
                 .long("x_is_the_option")
-                .required_unless_one(&["a", "b"]),
+                .required_unless_eq_any(&["a", "b"]),
         )
         .try_get_matches_from(vec!["unlessone", "-a"]);
 
@@ -377,11 +377,11 @@ fn required_unless_one_works_with_long() {
 }
 
 #[test]
-fn required_unless_one_1() {
+fn required_unless_any_1() {
     let res = App::new("unlessone")
         .arg(
             Arg::new("cfg")
-                .required_unless_one(&["dbg", "infile"])
+                .required_unless_eq_any(&["dbg", "infile"])
                 .takes_value(true)
                 .long("config"),
         )
@@ -397,11 +397,11 @@ fn required_unless_one_1() {
 }
 
 #[test]
-fn required_unless_one_err() {
+fn required_unless_any_err() {
     let res = App::new("unlessone")
         .arg(
             Arg::new("cfg")
-                .required_unless_one(&["dbg", "infile"])
+                .required_unless_eq_any(&["dbg", "infile"])
                 .takes_value(true)
                 .long("config"),
         )

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -252,11 +252,11 @@ fn required_unless_err() {
 // REQUIRED_UNLESS_ALL
 
 #[test]
-fn required_unless_all() {
+fn required_unless_eq_all() {
     let res = App::new("unlessall")
         .arg(
             Arg::new("cfg")
-                .required_unless_all(&["dbg", "infile"])
+                .required_unless_eq_all(&["dbg", "infile"])
                 .takes_value(true)
                 .long("config"),
         )
@@ -276,7 +276,7 @@ fn required_unless_all_err() {
     let res = App::new("unlessall")
         .arg(
             Arg::new("cfg")
-                .required_unless_all(&["dbg", "infile"])
+                .required_unless_eq_all(&["dbg", "infile"])
                 .takes_value(true)
                 .long("config"),
         )

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -199,25 +199,28 @@ fn issue_753() {
         ))
         .arg(
             Arg::from("-i, --iface=[INTERFACE] 'Ethernet interface for fetching NTP packets'")
-                .required_unless("list"),
+                .required_unless_present("list"),
         )
         .arg(
             Arg::from("-f, --file=[TESTFILE] 'Fetch NTP packets from pcap file'")
                 .conflicts_with("iface")
-                .required_unless("list"),
+                .required_unless_present("list"),
         )
-        .arg(Arg::from("-s, --server=[SERVER_IP] 'NTP server IP address'").required_unless("list"))
+        .arg(
+            Arg::from("-s, --server=[SERVER_IP] 'NTP server IP address'")
+                .required_unless_present("list"),
+        )
         .arg(Arg::from("-p, --port=[SERVER_PORT] 'NTP server port'").default_value("123"))
         .try_get_matches_from(vec!["test", "--list"]);
     assert!(m.is_ok());
 }
 
 #[test]
-fn required_unless() {
+fn required_unless_present() {
     let res = App::new("unlesstest")
         .arg(
             Arg::new("cfg")
-                .required_unless("dbg")
+                .required_unless_present("dbg")
                 .takes_value(true)
                 .long("config"),
         )
@@ -235,7 +238,7 @@ fn required_unless_err() {
     let res = App::new("unlesstest")
         .arg(
             Arg::new("cfg")
-                .required_unless("dbg")
+                .required_unless_present("dbg")
                 .takes_value(true)
                 .long("config"),
         )
@@ -781,12 +784,12 @@ fn issue_1158_app() -> App<'static> {
     App::new("example")
         .arg(
             Arg::from("-c, --config [FILE] 'Custom config file.'")
-                .required_unless("ID")
+                .required_unless_present("ID")
                 .conflicts_with("ID"),
         )
         .arg(
             Arg::from("[ID] 'ID'")
-                .required_unless("config")
+                .required_unless_present("config")
                 .conflicts_with("config")
                 .requires_all(&["x", "y", "z"]),
         )
@@ -874,6 +877,10 @@ fn required_if_invalid_arg() {
 #[should_panic = "Argument or group 'extra' specified in 'required_unless*' for 'config' does not exist"]
 fn required_unless_invalid_arg() {
     let _ = App::new("prog")
-        .arg(Arg::new("config").required_unless("extra").long("config"))
+        .arg(
+            Arg::new("config")
+                .required_unless_present("extra")
+                .long("config"),
+        )
         .try_get_matches_from(vec![""]);
 }


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
I'm back with some code and sleep deprivation!

This PR does two things:
* Enforces uniform naming scheme among `require*` methods. For example, `required_if_eq_any` is much better than `required_ifs` in my humble opinion. 
* ~~Enforces `arg, value` order of arguments among `requires_if*` methods which is more intuitive. require**s**_if and require**d**_if are on the page now.~~ Postponed. I'll probably remove the at all.

TODO:

- [x] Certain docs are far from stellar. Working on it.