### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://clap.rs/sponsorship/"]


### PR DESCRIPTION
I recently released [`cargo-fund`](https://users.rust-lang.org/t/cargo-fund-discover-funding-links-for-your-projects-dependencies/43251?u=acfoltzer), and noticed that while there is sponsorship information in this repo, but it's not yet encoded in a machine-readable way. Adding this metadata will add a "Sponsor" button to the repo, and allow `cargo-fund` to show the project's sponsorship link. For more about this file format, see the [Github docs](https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository).

I also noticed that this URL doesn't appear to work currently, but there is still sponsor information on the front page of clap.rs. Feel free to modify this if there's now a more appropriate URL.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
