### PR TITLE
makes validators opt-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ Cargo.lock
 .vscode/*
 .idea/*
 clap-rs.iml
+*.vi
+*.emacs
 
 # Auxiliary files
 test-results.test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ version-sync = "0.8"
 criterion = "0.3.2"
 
 [features]
-default     = ["suggestions", "color", "derive", "std", "cargo"]
+default     = ["suggestions", "color", "derive", "std", "cargo", "validators"]
 std         = [] # support for no_std in a backwards-compatible way
 suggestions = ["strsim"]
 color       = ["atty", "termcolor"]
@@ -97,6 +97,7 @@ cargo       = [] # Disable if you're not using Cargo, enables Cargo-env-var-depe
 unstable    = ["clap_derive/unstable"] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 debug       = ["clap_derive/debug"] # Enables debug messages
 doc         = ["yaml"] # All the features which add to documentation
+validators  = [] # support for validators
 
 [profile.test]
 opt-level = 1

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -4,14 +4,17 @@ pub mod features;
 mod arg_matcher;
 pub mod matches;
 mod parser;
+#[cfg(feature = "validators")]
 mod validator;
 
 pub(crate) use self::{
     arg_matcher::ArgMatcher,
     matches::{MatchedArg, SubCommand, ValueType},
     parser::{Input, ParseResult, Parser},
-    validator::Validator,
 };
+
+#[cfg(feature = "validators")]
+pub(crate) use self::validator::Validator;
 
 pub use self::matches::ArgMatches;
 pub use self::matches::{OsValues, Values};

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -6,6 +6,8 @@ use std::{
 };
 
 // Internal
+#[cfg(feature = "validators")]
+use crate::parse::Validator;
 use crate::{
     build::app::Propagation,
     build::AppSettings as AS,
@@ -16,8 +18,7 @@ use crate::{
     parse::errors::ErrorKind,
     parse::errors::Result as ClapResult,
     parse::features::suggestions,
-    parse::{ArgMatcher, SubCommand},
-    parse::{Validator, ValueType},
+    parse::{ArgMatcher, SubCommand, ValueType},
     util::{termcolor::ColorChoice, ArgStr, ChildGraph, Id},
     INTERNAL_ERROR_MSG, INVALID_UTF8,
 };
@@ -745,7 +746,11 @@ where
 
         self.remove_overrides(matcher);
 
-        Validator::new(self).validate(needs_val_of, subcmd_name.is_some(), matcher)
+        // explicit return is required here to satisfy the lexer due to cfg'ed returns
+        #[cfg(feature = "validators")]
+        return Validator::new(self).validate(needs_val_of, subcmd_name.is_some(), matcher);
+        #[cfg(not(feature = "validators"))]
+        return Ok(());
     }
 
     // Should we color the help?

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -221,6 +221,7 @@ fn not_possible_value() {
     assert!(r.is_err());
 }
 
+#[cfg(feature = "validators")]
 #[test]
 fn validator() {
     env::set_var("CLP_TEST_ENV_VDOR", "env");
@@ -246,6 +247,7 @@ fn validator() {
     assert_eq!(m.value_of("arg").unwrap(), "env");
 }
 
+#[cfg(feature = "validators")]
 #[test]
 fn validator_output() {
     env::set_var("CLP_TEST_ENV_VO", "42");
@@ -261,6 +263,7 @@ fn validator_output() {
     assert_eq!(m.value_of("arg").unwrap().parse(), Ok(42));
 }
 
+#[cfg(feature = "validators")]
 #[test]
 fn validator_invalid() {
     env::set_var("CLP_TEST_ENV_IV", "env");

--- a/tests/validators.rs
+++ b/tests/validators.rs
@@ -1,5 +1,6 @@
 use clap::{App, Arg};
 
+#[cfg(feature = "validators")]
 #[cfg(debug_assertions)]
 #[test]
 #[should_panic = "Argument 'test' has both `validator` and `validator_os` set which is not allowed"]
@@ -18,6 +19,7 @@ fn both_validator_and_validator_os() {
         .try_get_matches_from(&["app", "1"]);
 }
 
+#[cfg(feature = "validators")]
 #[test]
 fn test_validator_msg_newline() {
     let res = App::new("test")


### PR DESCRIPTION
Validators are not always used, in fact it *might* be fair to say they're rarely used. However they make up a large portion of the binary size. This PR feature gates them with a new feature `validators` which is part of the default feature set.

## Setup

```rust
// src/main.rs
use clap::{App, Arg};
fn main() {
    let matches = App::new("test")
        .arg(Arg::new("foo").short('f').long("foo").default_value("99"))
        .arg(Arg::new("bar").short('b').long("bar"))
        .get_matches();

    let foo = matches.value_of("foo").unwrap();
    println!("foo: {}", foo);
}
```

## Before

**NOTE:**  this is without the `derive` feature

```
cargo bloat --release --crates | head
    Finished release [optimized] target(s) in 0.01s
    Analyzing target/release/fake

 File  .text     Size Crate
 9.3%  58.0% 327.3KiB clap
 4.5%  28.1% 158.4KiB std
 1.7%  10.3%  58.3KiB [Unknown]
 0.1%   0.6%   3.3KiB indexmap
 0.1%   0.5%   3.1KiB strsim
 0.1%   0.3%   1.8KiB termcolor
 0.0%   0.3%   1.6KiB textwrap
 0.0%   0.3%   1.5KiB fake
 0.0%   0.0%      41B os_str_bytes
```
Top 5 largest functions:

```
cargo bloat --release -n 5 | head
    Finished release [optimized] target(s) in 0.01s
    Analyzing target/release/fake

 File  .text     Size     Crate Name
 1.0%   6.2%  35.3KiB      clap clap::parse::parser::Parser::get_matches_with
 0.5%   3.3%  18.4KiB      clap clap::parse::validator::Validator::validate
 0.5%   3.0%  17.1KiB      clap clap::output::help::Help::write_help
 0.5%   3.0%  17.0KiB      clap clap::output::help::Help::write_arg
 0.3%   1.9%  10.7KiB [Unknown] add_ranges
13.0%  80.9% 456.8KiB           And 1216 smaller methods. Use -n N to show more.
16.0% 100.0% 564.6KiB           .text section size, the file size is 3.4MiB
```

## After (when opt-ing out of validators)

```
cargo bloat --release --crates | head
    Finished release [optimized] target(s) in 0.01s
    Analyzing target/release/fake

 File  .text     Size Crate
 7.7%  52.5% 265.4KiB clap
 4.7%  31.9% 161.2KiB std
 1.7%  11.5%  58.3KiB [Unknown]
 0.1%   0.6%   3.3KiB indexmap
 0.1%   0.6%   3.1KiB strsim
 0.1%   0.4%   1.8KiB termcolor
 0.0%   0.3%   1.6KiB textwrap
 0.0%   0.3%   1.5KiB fake
 0.0%   0.0%      41B os_str_bytes
```

Top 5 largest functions:

```
cargo bloat --release -n 5 | head
   Compiling clap v3.0.0-beta.1 (/storage/Projects/clap)
   Compiling fake v0.1.0 (/storage/Projects/fake)
    Finished release [optimized] target(s) in 4.97s
    Analyzing target/release/fake

 File  .text     Size     Crate Name
 1.0%   7.1%  35.8KiB      clap clap::parse::parser::Parser::get_matches_with
 0.5%   3.4%  17.1KiB      clap clap::output::help::Help::write_help
 0.5%   3.4%  17.0KiB      clap clap::output::help::Help::write_arg
 0.3%   2.1%  10.7KiB [Unknown] add_ranges
 0.3%   2.0%  10.3KiB [Unknown] read_line_info
11.8%  80.2% 405.3KiB           And 1157 smaller methods. Use -n N to show more.
14.7% 100.0% 505.0KiB           .text section size, the file size is 3.4MiB
```

Relates to #1365