### PR TITLE
Cleanup features

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,25 +21,7 @@ Please use the following template to assist with creating an issue and to ensure
 
 ### Sample Code or Link to Sample Code
 
-
-### Debug output
-
-Compile clap with `debug` feature:
-
-```toml
-[dependencies]
-clap = { version = "*", features = ["debug"] }
+```rust
+// You code goes here. Please try to write a complete program,
+// including `fn main() { ... }`
 ```
-
-The output may be very long, so feel free to link to a gist or attach a text file
-
-<details>
-<summary> Debug Output </summary>
-<pre>
-<code>
-
-Paste Debug Output Here
-
-</code>
-</pre>
-</details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,25 +43,3 @@ I think *this* should happen instead.
 ### Additional context
 
 Add any other context about the problem here.
-
-### Debug output
-
-Compile clap with `debug` feature:
-
-```toml
-[dependencies]
-clap = { version = "*", features = ["debug"] }
-```
-
-The output may be very long, so feel free to link to a gist or attach a text file
-
-<details>
-<summary> Debug Output </summary>
-<pre>
-<code>
-
-Paste Debug Output Here
-
-</code>
-</pre>
-</details>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ derive      = ["clap_derive", "lazy_static"]
 yaml        = ["yaml-rust"]
 cargo       = [] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
 unstable    = ["clap_derive/unstable"] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
-debug       = ["clap_derive/debug"] # Enables debug messages
 
 [profile.test]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap"
-version = "3.0.0-beta.1"
+version = "3.0.0-beta.1" # remember to update html_root_url in src/lib.rs
 edition = "2018"
 authors = [
 	"Kevin K. <kbknapp@gmail.com>",
@@ -96,7 +96,6 @@ yaml        = ["yaml-rust"]
 cargo       = [] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
 unstable    = ["clap_derive/unstable"] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 debug       = ["clap_derive/debug"] # Enables debug messages
-doc         = ["yaml"] # All the features which add to documentation
 
 [profile.test]
 opt-level = 1
@@ -106,7 +105,7 @@ lto = true
 codegen-units = 1
 
 [package.metadata.docs.rs]
-features = ["doc"]
+features = ["yaml", "derive"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [workspace]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -52,8 +52,7 @@ version-sync = "0.8"
 default = []
 unstable = []
 debug = []
-doc = []
 
 [package.metadata.docs.rs]
-features = ["doc"]
+features = []
 targets = ["x86_64-unknown-linux-gnu"]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -51,7 +51,6 @@ version-sync = "0.8"
 [features]
 default = []
 unstable = []
-debug = []
 
 [package.metadata.docs.rs]
 features = []

--- a/clap_generate/Cargo.toml
+++ b/clap_generate/Cargo.toml
@@ -44,7 +44,6 @@ version-sync = "0.8"
 [features]
 default = []
 unstable = ["clap/unstable"]
-debug = ["clap/debug"]
 
 [package.metadata.docs.rs]
 features = []

--- a/clap_generate/Cargo.toml
+++ b/clap_generate/Cargo.toml
@@ -45,8 +45,7 @@ version-sync = "0.8"
 default = []
 unstable = ["clap/unstable"]
 debug = ["clap/debug"]
-doc = []
 
 [package.metadata.docs.rs]
-features = ["doc"]
+features = []
 targets = ["x86_64-unknown-linux-gnu"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,10 @@
 // (see LICENSE or <http://opensource.org/licenses/MIT>) All files in the project carrying such
 // notice may not be copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(feature = "doc", feature(external_doc))]
+#![cfg_attr(doc, feature(external_doc))]
 #![doc(html_root_url = "https://docs.rs/clap/3.0.0-beta.1")]
-#![cfg_attr(feature = "doc", doc(include = "../README.md"))]
+#![cfg_attr(doc, doc(include = "../README.md"))]
+
 //! https://github.com/clap-rs/clap
 #![crate_type = "lib"]
 #![deny(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -569,7 +569,7 @@ macro_rules! wlnerr {
     })
 }
 
-#[cfg(feature = "debug")]
+#[cfg(clap_debug)]
 macro_rules! debug {
     ($($arg:tt)*) => {
         print!("[{:>w$}] \t", module_path!(), w = 28);
@@ -577,7 +577,7 @@ macro_rules! debug {
     }
 }
 
-#[cfg(not(feature = "debug"))]
+#[cfg(not(clap_debug))]
 macro_rules! debug {
     ($($arg:tt)*) => {};
 }


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->

This PR removes two features: `doc` and `debug` .

#### **doc**

We don't need it these days anymore since we've got `#[cfg(doc)]`. Pros: we can now build clap with `--all-features` on stable instead of pichiin them one by one. Cons: `cargo doc` doesn't work on stable anymore, but this is rather good thing because it forces us to use `cargo +nightly doc`, just as docs.rs does. 

#### **debug**

This feature needs not to be user facing. I propose using env var `RUSTDOC="--cfg clap_debug" instead. Also, `--all-features` is not affected by it anymore.

---

This PR also removes `Debug output` sections from issue templates. This is fairly useless in my experience.