### PR TITLE
fix: Corrected assertion arguments

### DIFF
--- a/clap_derive/src/utils/spanned.rs
+++ b/clap_derive/src/utils/spanned.rs
@@ -83,7 +83,7 @@ impl<T: ToTokens> ToTokens for Sp<T> {
         // this is the simplest way out of correct ones to change span on
         // arbitrary token tree I could come up with
         let tt = self.val.to_token_stream().into_iter().map(|mut tt| {
-            tt.set_span(self.span.clone());
+            tt.set_span(self.span);
             tt
         });
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1577,7 +1577,7 @@ impl<'b> App<'b> {
 
             // Name conflicts
             assert!(
-                self.two_args_of(|x| x.name == arg.name).is_none(),
+                self.two_args_of(|x| x.id == arg.id).is_none(),
                 "Argument names must be unique, but '{}' is in use by more than one argument or group",
                 arg.name,
             );


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #1965 `
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
Fixes for the assertion parameters of `build::App::two_args_of()`for name conflicts described in Issue #1965 

 `Closes #1965 `