### PR TITLE
Make 2.33 examples links point to 2.33 branch, not master

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -156,8 +156,8 @@ impl<'a, 'b> App<'a, 'b> {
     /// # }
     /// ```
     /// [`App`]: ./struct.App.html
-    /// [`examples/17_yaml.rs`]: https://github.com/clap-rs/clap/blob/master/examples/17_yaml.rs
-    /// [`examples/17_yaml.yml`]: https://github.com/clap-rs/clap/blob/master/examples/17_yaml.yml
+    /// [`examples/17_yaml.rs`]: https://github.com/clap-rs/clap/blob/v2.33.1/examples/17_yaml.rs
+    /// [`examples/17_yaml.yml`]: https://github.com/clap-rs/clap/blob/v2.33.1/examples/17_yaml.yml
     /// [`panic!`]: https://doc.rust-lang.org/std/macro.panic!.html
     #[cfg(feature = "yaml")]
     pub fn from_yaml(yaml: &'a Yaml) -> App<'a, 'a> {
@@ -183,7 +183,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// # ;
     /// ```
     /// [`crate_authors!`]: ./macro.crate_authors!.html
-    /// [`examples/`]: https://github.com/clap-rs/clap/tree/master/examples
+    /// [`examples/`]: https://github.com/clap-rs/clap/tree/v2.33.1/examples
     pub fn author<S: Into<&'b str>>(mut self, author: S) -> Self {
         self.p.meta.author = Some(author.into());
         self
@@ -341,7 +341,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// # ;
     /// ```
     /// [`crate_version!`]: ./macro.crate_version!.html
-    /// [`examples/`]: https://github.com/clap-rs/clap/tree/master/examples
+    /// [`examples/`]: https://github.com/clap-rs/clap/tree/v2.33.1/examples
     /// [`App::long_version`]: ./struct.App.html#method.long_version
     pub fn version<S: Into<&'b str>>(mut self, ver: S) -> Self {
         self.p.meta.version = Some(ver.into());
@@ -372,7 +372,7 @@ impl<'a, 'b> App<'a, 'b> {
     /// # ;
     /// ```
     /// [`crate_version!`]: ./macro.crate_version!.html
-    /// [`examples/`]: https://github.com/clap-rs/clap/tree/master/examples
+    /// [`examples/`]: https://github.com/clap-rs/clap/tree/v2.33.1/examples
     /// [`App::version`]: ./struct.App.html#method.version
     pub fn long_version<S: Into<&'b str>>(mut self, ver: S) -> Self {
         self.p.meta.long_version = Some(ver.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright ⓒ 2015-2016 Kevin B. Knapp and [`clap-rs` contributors](https://github.com/clap-rs/clap/blob/master/CONTRIBUTORS.md).
+// Copyright ⓒ 2015-2016 Kevin B. Knapp and [`clap-rs` contributors](https://github.com/clap-rs/clap/blob/v2.33.1/CONTRIBUTORS.md).
 // Licensed under the MIT license
 // (see LICENSE or <http://opensource.org/licenses/MIT>) All files in the project carrying such
 // notice may not be copied, modified, or distributed except according to those terms.
@@ -366,7 +366,7 @@
 //!  * **Red** Color: **NOT** included by default (must use cargo `features` to enable)
 //!  * **Blue** Color: Dev dependency, only used while developing.
 //!
-//! ![clap dependencies](https://raw.githubusercontent.com/clap-rs/clap/master/clap_dep_graph.png)
+//! ![clap dependencies](https://github.com/clap-rs/clap/blob/v2.33.1/clap_dep_graph.png)
 //!
 //! ### More Information
 //!
@@ -391,7 +391,7 @@
 //! `clap`. You can either add it to the [examples/] directory, or file an issue and tell
 //! me. I'm all about giving credit where credit is due :)
 //!
-//! Please read [CONTRIBUTING.md](https://raw.githubusercontent.com/clap-rs/clap/master/.github/CONTRIBUTING.md) before you start contributing.
+//! Please read [CONTRIBUTING.md](https://github.com/clap-rs/clap/blob/v2.33.1/.github/CONTRIBUTING.md) before you start contributing.
 //!
 //!
 //! ### Testing Code
@@ -512,9 +512,9 @@
 //! `clap` is licensed under the MIT license. Please read the [LICENSE-MIT][license] file in
 //! this repository for more information.
 //!
-//! [examples/]: https://github.com/clap-rs/clap/tree/master/examples
+//! [examples/]: https://github.com/clap-rs/clap/tree/v2.33.1/examples
 //! [video tutorials]: https://www.youtube.com/playlist?list=PLza5oFLQGTl2Z5T8g1pRkIynR3E0_pc7U
-//! [license]: https://raw.githubusercontent.com/clap-rs/clap/master/LICENSE-MIT
+//! [license]: https://github.com/clap-rs/clap/blob/v2.33.1/LICENSE-MIT
 
 #![crate_type = "lib"]
 #![doc(html_root_url = "https://docs.rs/clap/2.33.1")]


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
**ATTENTION** This PR is against `v2-master`

This PR fixes links in 2.33 docs so they point to 2.33 examples, not master examples. Cna we have a release with this so it no longer confusers people?