### PR TITLE
fix: Use character instead of string for Arg::Short

### DIFF
--- a/clap_derive/examples/basic.rs
+++ b/clap_derive/examples/basic.rs
@@ -30,7 +30,7 @@ struct Opt {
     // the long option will be translated by default to kebab case,
     // i.e. `--nb-cars`.
     /// Number of cars
-    #[clap(short = "c", long)]
+    #[clap(short = 'c', long)]
     nb_cars: Option<i32>,
 
     /// admin_level to consider

--- a/clap_derive/examples/keyvalue.rs
+++ b/clap_derive/examples/keyvalue.rs
@@ -26,7 +26,7 @@ struct Opt {
     // but this makes adding an argument after the values impossible:
     // my_program -D a=1 -D b=2 my_input_file
     // becomes invalid.
-    #[clap(short = "D", parse(try_from_str = parse_key_val), number_of_values = 1)]
+    #[clap(short = 'D', parse(try_from_str = parse_key_val), number_of_values = 1)]
     defines: Vec<(String, i32)>,
 }
 

--- a/clap_derive/tests/argument_naming.rs
+++ b/clap_derive/tests/argument_naming.rs
@@ -99,7 +99,7 @@ fn test_standalone_short_generates_kebab_case() {
 fn test_custom_short_overwrites_default_name() {
     #[derive(Clap, Debug, PartialEq)]
     struct Opt {
-        #[clap(short = "o")]
+        #[clap(short = 'o')]
         foo_option: bool,
     }
 

--- a/clap_derive/tests/basic.rs
+++ b/clap_derive/tests/basic.rs
@@ -18,7 +18,7 @@ use clap::Clap;
 fn basic() {
     #[derive(Clap, PartialEq, Debug)]
     struct Opt {
-        #[clap(short = "a", long = "arg")]
+        #[clap(short = 'a', long = "arg")]
         arg: Vec<i32>,
     }
     assert_eq!(Opt { arg: vec![24] }, Opt::parse_from(&["test", "-a24"]));

--- a/clap_derive/tests/custom-string-parsers.rs
+++ b/clap_derive/tests/custom-string-parsers.rs
@@ -32,7 +32,7 @@ struct PathOpt {
     #[clap(short, parse(from_os_str))]
     option_path_1: Option<PathBuf>,
 
-    #[clap(short = "q", parse(from_os_str))]
+    #[clap(short = 'q', parse(from_os_str))]
     option_path_2: Option<PathBuf>,
 }
 
@@ -179,7 +179,7 @@ struct Occurrences {
     #[clap(short, parse(from_occurrences))]
     unsigned: usize,
 
-    #[clap(short = "r", parse(from_occurrences))]
+    #[clap(short = 'r', parse(from_occurrences))]
     little_unsigned: u8,
 
     #[clap(short, long, parse(from_occurrences = foo))]

--- a/clap_derive/tests/explicit_name_no_renaming.rs
+++ b/clap_derive/tests/explicit_name_no_renaming.rs
@@ -7,7 +7,7 @@ use utils::*;
 fn explicit_short_long_no_rename() {
     #[derive(Clap, PartialEq, Debug)]
     struct Opt {
-        #[clap(short = ".", long = ".foo")]
+        #[clap(short = '.', long = ".foo")]
         foo: Vec<String>,
     }
 

--- a/clap_derive/tests/non_literal_attributes.rs
+++ b/clap_derive/tests/non_literal_attributes.rs
@@ -30,7 +30,7 @@ struct Opt {
     )]
     x: i32,
 
-    #[clap(short = "l", long = "level", aliases = &["set-level", "lvl"])]
+    #[clap(short = 'l', long = "level", aliases = &["set-level", "lvl"])]
     level: String,
 
     #[clap(long("values"))]
@@ -129,7 +129,7 @@ fn parse_hex(input: &str) -> Result<u64, ParseIntError> {
 
 #[derive(Clap, PartialEq, Debug)]
 struct HexOpt {
-    #[clap(short = "n", parse(try_from_str = parse_hex))]
+    #[clap(short, parse(try_from_str = parse_hex))]
     number: u64,
 }
 


### PR DESCRIPTION
This PR switches the Arg::Short macro to take a character instead of a string. It removes the hacky code in the Method to_token method and implements the logic for Short when parsing the clap derive arguments.

Closes #1815 