### PR TITLE
Refactor

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -1,6 +1,5 @@
 // Std
 use std::{
-    collections::VecDeque,
     convert::From,
     fmt::{self, Debug, Display, Formatter},
     io,
@@ -9,7 +8,7 @@ use std::{
 
 // Internal
 use crate::{
-    build::{Arg, ArgGroup},
+    build::Arg,
     output::fmt::Colorizer,
     parse::features::suggestions,
     util::{safe_exit, termcolor::ColorChoice},
@@ -375,39 +374,36 @@ pub enum ErrorKind {
 /// Command Line Argument Parser Error
 #[derive(Debug)]
 pub struct Error {
-    /// The cause of the error
-    pub cause: String,
     /// Formatted error message, enhancing the cause message with extra information
     pub(crate) message: Colorizer,
     /// The type of error
     pub kind: ErrorKind,
-    /// Any additional information passed along, such as the argument name that caused the error
-    pub info: Option<Vec<String>>,
+    /// Additional information depending on the error kind, like values and argument names.
+    /// Useful when you want to render an error of your own.
+    pub info: Vec<String>,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        self.message.fmt(f)
+        Display::fmt(&self.message, f)
     }
 }
 
-fn start_error(c: &mut Colorizer, msg: &str) -> io::Result<()> {
-    c.error("error:")?;
-    c.none(" ")?;
-    c.none(msg)
+fn start_error(c: &mut Colorizer, msg: impl Into<String>) {
+    c.error("error:");
+    c.none(" ");
+    c.none(msg);
 }
 
-fn put_usage<U>(c: &mut Colorizer, usage: U) -> io::Result<()>
-where
-    U: Display,
-{
-    c.none(&format!("\n\n{}", usage))
+fn put_usage(c: &mut Colorizer, usage: impl Into<String>) {
+    c.none("\n\n");
+    c.none(usage);
 }
 
-fn try_help(c: &mut Colorizer) -> io::Result<()> {
-    c.none("\n\nFor more information try ")?;
-    c.good("--help")?;
-    c.none("\n")
+fn try_help(c: &mut Colorizer) {
+    c.none("\n\nFor more information try ");
+    c.good("--help");
+    c.none("\n");
 }
 
 impl Error {
@@ -440,604 +436,427 @@ impl Error {
         safe_exit(0)
     }
 
-    #[allow(unused)] // requested by @pksunkara
-    pub(crate) fn group_conflict<O, U>(
-        group: &ArgGroup,
-        other: Option<O>,
-        usage: U,
-        color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        O: Into<String>,
-        U: Display,
-    {
-        let mut v = vec![group.name.to_owned()];
-        let mut c = Colorizer::new(true, color);
-
-        start_error(&mut c, "The argument '")?;
-        c.warning(group.name)?;
-        c.none("' cannot be used with ")?;
-
-        let cause = match other {
-            Some(name) => {
-                let n = name.into();
-                v.push(n.clone());
-
-                c.none("'")?;
-                c.warning(&*n)?;
-                c.none("'")?;
-
-                format!("The argument '{}' cannot be used with '{}'", group.name, n)
-            }
-            None => {
-                let n = "one or more of the other specified arguments";
-
-                c.none(n)?;
-
-                format!("The argument '{}' cannot be used with {}", group.name, n)
-            }
-        };
-
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
-
-        Ok(Error {
-            cause,
-            message: c,
-            kind: ErrorKind::ArgumentConflict,
-            info: Some(v),
-        })
-    }
-
-    pub(crate) fn argument_conflict<O, U>(
+    pub(crate) fn argument_conflict(
         arg: &Arg,
-        other: Option<O>,
-        usage: U,
+        other: Option<String>,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        O: Into<String>,
-        U: Display,
-    {
-        let mut v = vec![arg.name.to_owned()];
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
+        let arg = arg.to_string();
 
-        start_error(&mut c, "The argument '")?;
-        c.warning(&arg.to_string())?;
-        c.none("' cannot be used with ")?;
+        start_error(&mut c, "The argument '");
+        c.warning(arg.clone());
+        c.none("' cannot be used with ");
 
-        let cause = match other {
-            Some(name) => {
-                let n = name.into();
-                v.push(n.clone());
-
-                c.none("'")?;
-                c.warning(&*n)?;
-                c.none("'")?;
-
-                format!("The argument '{}' cannot be used with '{}'", arg, n)
+        match other {
+            Some(ref name) => {
+                c.none("'");
+                c.warning(name);
+                c.none("'");
             }
             None => {
-                let n = "one or more of the other specified arguments";
-
-                c.none(n)?;
-
-                format!("The argument '{}' cannot be used with {}", arg, n)
+                c.none("one or more of the other specified arguments");
             }
         };
 
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause,
+        let mut info = vec![arg];
+        if let Some(other) = other {
+            info.push(other);
+        }
+
+        Error {
             message: c,
             kind: ErrorKind::ArgumentConflict,
-            info: Some(v),
-        })
+            info,
+        }
     }
 
-    pub(crate) fn empty_value<U>(arg: &Arg, usage: U, color: ColorChoice) -> io::Result<Self>
-    where
-        U: Display,
-    {
+    pub(crate) fn empty_value(arg: &Arg, usage: String, color: ColorChoice) -> Self {
         let mut c = Colorizer::new(true, color);
+        let arg = arg.to_string();
 
-        start_error(&mut c, "The argument '")?;
-        c.warning(&arg.to_string())?;
-        c.none("' requires a value but none was supplied")?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        start_error(&mut c, "The argument '");
+        c.warning(arg.clone());
+        c.none("' requires a value but none was supplied");
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "The argument '{}' requires a value but none was supplied",
-                arg
-            ),
+        Error {
             message: c,
             kind: ErrorKind::EmptyValue,
-            info: Some(vec![arg.name.to_owned()]),
-        })
+            info: vec![arg],
+        }
     }
 
-    pub(crate) fn invalid_value<B, G, U>(
-        bad_val: B,
+    pub(crate) fn invalid_value<G>(
+        bad_val: String,
         good_vals: &[G],
         arg: &Arg,
-        usage: U,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
+    ) -> Self
     where
-        B: AsRef<str>,
         G: AsRef<str> + Display,
-        U: Display,
     {
         let mut c = Colorizer::new(true, color);
-        let suffix = suggestions::did_you_mean(bad_val.as_ref(), good_vals.iter()).pop();
+        let suffix = suggestions::did_you_mean(&bad_val, good_vals.iter()).pop();
 
         let mut sorted: Vec<String> = good_vals.iter().map(|v| v.to_string()).collect();
         sorted.sort();
 
-        start_error(&mut c, "'")?;
-        c.warning(bad_val.as_ref())?;
-        c.none("' isn't a valid value for '")?;
-        c.warning(&arg.to_string())?;
-        c.none("'\n\t[possible values: ")?;
+        start_error(&mut c, "'");
+        c.warning(bad_val.clone());
+        c.none("' isn't a valid value for '");
+        c.warning(arg.to_string());
+        c.none("'\n\t[possible values: ");
 
         if let Some((last, elements)) = sorted.split_last() {
             for v in elements {
-                c.good(v)?;
-                c.none(", ")?;
+                c.good(v);
+                c.none(", ");
             }
 
-            c.good(last)?;
+            c.good(last);
         }
 
-        c.none("]")?;
+        c.none("]");
 
         if let Some(val) = suffix {
-            c.none("\n\n\tDid you mean '")?;
-            c.good(&val)?;
-            c.none("'?")?;
+            c.none("\n\n\tDid you mean '");
+            c.good(val);
+            c.none("'?");
         }
 
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "'{}' isn't a valid value for '{}'\n\t\
-                 [possible values: {}]",
-                bad_val.as_ref(),
-                arg,
-                sorted.join(", ")
-            ),
+        let mut info = vec![arg.to_string(), bad_val];
+        info.extend(sorted);
+
+        Error {
             message: c,
             kind: ErrorKind::InvalidValue,
-            info: Some(vec![arg.name.to_owned(), bad_val.as_ref().to_owned()]),
-        })
+            info: vec![],
+        }
     }
 
-    pub(crate) fn invalid_subcommand<S, D, N, U>(
-        subcmd: S,
-        did_you_mean: D,
-        name: N,
-        usage: U,
+    pub(crate) fn invalid_subcommand(
+        subcmd: String,
+        did_you_mean: String,
+        name: String,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        S: Into<String>,
-        D: AsRef<str> + Display,
-        N: Display,
-        U: Display,
-    {
-        let s = subcmd.into();
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        start_error(&mut c, "The subcommand '")?;
-        c.warning(&*s)?;
-        c.none("' wasn't recognized\n\n\tDid you mean ")?;
-        c.good(did_you_mean.as_ref())?;
-        c.none("")?;
-        c.none(&format!(
+        start_error(&mut c, "The subcommand '");
+        c.warning(subcmd.clone());
+        c.none("' wasn't recognized\n\n\tDid you mean ");
+        c.good(did_you_mean);
+        c.none("");
+        c.none(format!(
             "?\n\nIf you believe you received this message in error, try re-running with '{} ",
             name
-        ))?;
-        c.good("--")?;
-        c.none(&format!(" {}'", &*s))?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        ));
+        c.good("--");
+        c.none(format!(" {}'", subcmd));
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!("The subcommand '{}' wasn't recognized", s),
+        Error {
             message: c,
             kind: ErrorKind::InvalidSubcommand,
-            info: Some(vec![s]),
-        })
+            info: vec![subcmd],
+        }
     }
 
-    pub(crate) fn unrecognized_subcommand<S, N>(
-        subcmd: S,
-        name: N,
+    pub(crate) fn unrecognized_subcommand(
+        subcmd: String,
+        name: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        S: Into<String>,
-        N: Display,
-    {
-        let s = subcmd.into();
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        start_error(&mut c, " The subcommand '")?;
-        c.warning(&*s)?;
-        c.none("' wasn't recognized\n\n")?;
-        c.warning("USAGE:")?;
-        c.none(&format!("\n\t{} help <subcommands>...", name))?;
-        try_help(&mut c)?;
+        start_error(&mut c, " The subcommand '");
+        c.warning(subcmd.clone());
+        c.none("' wasn't recognized\n\n");
+        c.warning("USAGE:");
+        c.none(format!("\n\t{} help <subcommands>...", name));
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!("The subcommand '{}' wasn't recognized", s),
+        Error {
             message: c,
             kind: ErrorKind::UnrecognizedSubcommand,
-            info: Some(vec![s]),
-        })
+            info: vec![subcmd],
+        }
     }
 
-    pub(crate) fn missing_required_argument<R, U>(
-        required: VecDeque<R>,
-        usage: U,
+    pub(crate) fn missing_required_argument(
+        required: Vec<String>,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        R: Display,
-        U: Display,
-    {
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
-
-        let cause = format!(
-            "The following required arguments were not provided:{}",
-            required
-                .iter()
-                .map(|x| format!("\n    {}", x))
-                .collect::<Vec<_>>()
-                .join(""),
-        );
 
         start_error(
             &mut c,
             "The following required arguments were not provided:",
-        )?;
+        );
 
         let mut info = vec![];
         for v in required {
-            c.none("\n    ")?;
-            c.good(&v.to_string())?;
+            c.none("\n    ");
+            c.good(v.to_string());
             info.push(v.to_string());
         }
 
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause,
+        Error {
             message: c,
             kind: ErrorKind::MissingRequiredArgument,
-            info: Some(info),
-        })
+            info,
+        }
     }
 
-    pub(crate) fn missing_subcommand<N, U>(
-        name: N,
-        usage: U,
-        color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        N: AsRef<str> + Display,
-        U: Display,
-    {
+    pub(crate) fn missing_subcommand(name: String, usage: String, color: ColorChoice) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        start_error(&mut c, "'")?;
-        c.warning(name.as_ref())?;
-        c.none("' requires a subcommand, but one was not provided")?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        start_error(&mut c, "'");
+        c.warning(name);
+        c.none("' requires a subcommand, but one was not provided");
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!("'{}' requires a subcommand, but one was not provided", name),
+        Error {
             message: c,
             kind: ErrorKind::MissingSubcommand,
-            info: None,
-        })
+            info: vec![],
+        }
     }
 
-    pub(crate) fn invalid_utf8<U>(usage: U, color: ColorChoice) -> io::Result<Self>
-    where
-        U: Display,
-    {
+    pub(crate) fn invalid_utf8(usage: String, color: ColorChoice) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        let cause = "Invalid UTF-8 was detected in one or more arguments";
+        start_error(
+            &mut c,
+            "Invalid UTF-8 was detected in one or more arguments",
+        );
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        start_error(&mut c, cause)?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
-
-        Ok(Error {
-            cause: cause.to_string(),
+        Error {
             message: c,
             kind: ErrorKind::InvalidUtf8,
-            info: None,
-        })
+            info: vec![],
+        }
     }
 
-    pub(crate) fn too_many_values<V, U>(
-        val: V,
+    pub(crate) fn too_many_values(
+        val: String,
         arg: &Arg,
-        usage: U,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        V: AsRef<str> + Display + ToOwned,
-        U: Display,
-    {
-        let v = val.as_ref();
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        start_error(&mut c, "The value '")?;
-        c.warning(v)?;
-        c.none("' was provided to '")?;
-        c.warning(&arg.to_string())?;
-        c.none("' but it wasn't expecting any more values")?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        start_error(&mut c, "The value '");
+        c.warning(val.clone());
+        c.none("' was provided to '");
+        c.warning(arg.to_string());
+        c.none("' but it wasn't expecting any more values");
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "The value '{}' was provided to '{}', but it wasn't expecting any more values",
-                v, arg
-            ),
+        Error {
             message: c,
             kind: ErrorKind::TooManyValues,
-            info: Some(vec![arg.name.to_owned(), v.to_owned()]),
-        })
+            info: vec![arg.to_string(), val],
+        }
     }
 
-    pub(crate) fn too_few_values<U>(
+    pub(crate) fn too_few_values(
         arg: &Arg,
         min_vals: u64,
         curr_vals: usize,
-        usage: U,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        U: Display,
-    {
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
         let verb = Error::singular_or_plural(curr_vals);
 
-        start_error(&mut c, "The argument '")?;
-        c.warning(&arg.to_string())?;
-        c.none("' requires at least ")?;
-        c.warning(&min_vals.to_string())?;
-        c.none(" values, but only ")?;
-        c.warning(&curr_vals.to_string())?;
-        c.none(&format!(" {} provided", verb))?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        start_error(&mut c, "The argument '");
+        c.warning(arg.to_string());
+        c.none("' requires at least ");
+        c.warning(min_vals.to_string());
+        c.none(" values, but only ");
+        c.warning(curr_vals.to_string());
+        c.none(format!(" {} provided", verb));
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "The argument '{}' requires at least {} values, but only {} {} provided",
-                arg, min_vals, curr_vals, verb
-            ),
+        Error {
             message: c,
             kind: ErrorKind::TooFewValues,
-            info: Some(vec![arg.name.to_owned()]),
-        })
+            info: vec![arg.to_string(), curr_vals.to_string(), min_vals.to_string()],
+        }
     }
 
     pub(crate) fn value_validation(
-        arg: Option<&Arg>,
-        err: &str,
+        arg: String,
+        val: String,
+        err: String,
         color: ColorChoice,
-    ) -> io::Result<Self> {
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        start_error(&mut c, "Invalid value")?;
+        start_error(&mut c, "Invalid value");
 
-        if let Some(a) = arg {
-            c.none(" for '")?;
-            c.warning(&a.to_string())?;
-            c.none("'")?;
-        }
+        c.none(" for '");
+        c.warning(arg.clone());
+        c.none("'");
 
-        c.none(&format!(": {}", err))?;
-        try_help(&mut c)?;
+        c.none(format!(": {}", err));
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "Invalid value{}: {}",
-                if let Some(a) = arg {
-                    format!(" for '{}'", a)
-                } else {
-                    String::new()
-                },
-                err
-            ),
+        Error {
             message: c,
             kind: ErrorKind::ValueValidation,
-            info: None,
-        })
+            info: vec![arg, val, err],
+        }
     }
 
-    pub(crate) fn value_validation_auto(err: &str) -> io::Result<Self> {
-        let n: Option<&Arg> = None;
-        Error::value_validation(n, err, ColorChoice::Auto)
-    }
-
-    pub(crate) fn wrong_number_of_values<U>(
+    pub(crate) fn wrong_number_of_values(
         arg: &Arg,
         num_vals: u64,
         curr_vals: usize,
-        usage: U,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        U: Display,
-    {
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
         let verb = Error::singular_or_plural(curr_vals);
 
-        start_error(&mut c, "The argument '")?;
-        c.warning(&arg.to_string())?;
-        c.none("' requires ")?;
-        c.warning(&num_vals.to_string())?;
-        c.none(" values, but ")?;
-        c.warning(&curr_vals.to_string())?;
-        c.none(&format!(" {} provided", verb))?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        start_error(&mut c, "The argument '");
+        c.warning(arg.to_string());
+        c.none("' requires ");
+        c.warning(num_vals.to_string());
+        c.none(" values, but ");
+        c.warning(curr_vals.to_string());
+        c.none(format!(" {} provided", verb));
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "The argument '{}' requires {} values, but {} {} provided",
-                arg, num_vals, curr_vals, verb
-            ),
+        Error {
             message: c,
             kind: ErrorKind::WrongNumberOfValues,
-            info: Some(vec![arg.name.to_owned()]),
-        })
+            info: vec![arg.to_string(), curr_vals.to_string(), num_vals.to_string()],
+        }
     }
 
-    pub(crate) fn unexpected_multiple_usage<U>(
-        arg: &Arg,
-        usage: U,
-        color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        U: Display,
-    {
+    pub(crate) fn unexpected_multiple_usage(arg: &Arg, usage: String, color: ColorChoice) -> Self {
         let mut c = Colorizer::new(true, color);
+        let arg = arg.to_string();
 
-        start_error(&mut c, "The argument '")?;
-        c.warning(&arg.to_string())?;
-        c.none("' was provided more than once, but cannot be used multiple times")?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+        start_error(&mut c, "The argument '");
+        c.warning(arg.clone());
+        c.none("' was provided more than once, but cannot be used multiple times");
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "The argument '{}' was provided more than once, but cannot be used multiple times",
-                arg
-            ),
+        Error {
             message: c,
             kind: ErrorKind::UnexpectedMultipleUsage,
-            info: Some(vec![arg.name.to_owned()]),
-        })
+            info: vec![arg],
+        }
     }
 
-    pub(crate) fn unknown_argument<A, U>(
-        arg: A,
+    pub(crate) fn unknown_argument(
+        arg: String,
         did_you_mean: Option<(String, Option<String>)>,
-        usage: U,
+        usage: String,
         color: ColorChoice,
-    ) -> io::Result<Self>
-    where
-        A: Into<String>,
-        U: Display,
-    {
-        let a = arg.into();
+    ) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        start_error(&mut c, "Found argument '")?;
-        c.warning(&*a)?;
-        c.none("' which wasn't expected, or isn't valid in this context")?;
+        start_error(&mut c, "Found argument '");
+        c.warning(arg.clone());
+        c.none("' which wasn't expected, or isn't valid in this context");
 
         if let Some(s) = did_you_mean {
-            c.none("\n\n\tDid you mean ")?;
+            c.none("\n\n\tDid you mean ");
 
             if let Some(subcmd) = s.1 {
-                c.none("to put '")?;
-                c.good(&format!("--{}", &s.0))?;
-                c.none("' after the subcommand '")?;
-                c.good(&subcmd)?;
-                c.none("'?")?;
+                c.none("to put '");
+                c.good(format!("--{}", &s.0));
+                c.none("' after the subcommand '");
+                c.good(subcmd);
+                c.none("'?");
             } else {
-                c.none("'")?;
-                c.good(&format!("--{}", &s.0))?;
-                c.none("'?")?;
+                c.none("'");
+                c.good(format!("--{}", &s.0));
+                c.none("'?");
             }
         }
 
-        c.none(&format!(
+        c.none(format!(
             "\n\nIf you tried to supply `{}` as a PATTERN use `-- {}`",
-            a, a
-        ))?;
-        put_usage(&mut c, usage)?;
-        try_help(&mut c)?;
+            arg, arg
+        ));
+        put_usage(&mut c, usage);
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!(
-                "Found argument '{}' which wasn't expected, or isn't valid in this context",
-                a
-            ),
+        Error {
             message: c,
             kind: ErrorKind::UnknownArgument,
-            info: Some(vec![a]),
-        })
+            info: vec![arg],
+        }
     }
 
-    pub(crate) fn argument_not_found_auto<A>(arg: A) -> io::Result<Self>
-    where
-        A: Into<String>,
-    {
-        let a = arg.into();
+    pub(crate) fn argument_not_found_auto(arg: String) -> Self {
         let mut c = Colorizer::new(true, ColorChoice::Auto);
 
-        start_error(&mut c, "The argument '")?;
-        c.warning(&*a)?;
-        c.none("' wasn't found")?;
-        try_help(&mut c)?;
+        start_error(&mut c, "The argument '");
+        c.warning(arg.clone());
+        c.none("' wasn't found");
+        try_help(&mut c);
 
-        Ok(Error {
-            cause: format!("The argument '{}' wasn't found", a),
+        Error {
             message: c,
             kind: ErrorKind::ArgumentNotFound,
-            info: Some(vec![a]),
-        })
+            info: vec![arg],
+        }
     }
 
     /// Create an error with a custom description.
     ///
     /// This can be used in combination with `Error::exit` to exit your program
     /// with a custom error message.
-    pub fn with_description(description: impl Into<String>, kind: ErrorKind) -> io::Result<Self> {
+    pub fn with_description(description: String, kind: ErrorKind) -> Self {
         let mut c = Colorizer::new(true, ColorChoice::Auto);
 
-        let cause = description.into();
+        start_error(&mut c, description);
 
-        start_error(&mut c, &*cause)?;
-
-        Ok(Error {
-            cause,
+        Error {
             message: c,
             kind,
-            info: None,
-        })
+            info: vec![],
+        }
     }
 }
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
         Error::with_description(e.to_string(), ErrorKind::Io)
-            .expect("Unable to build error message")
     }
 }
 
 impl From<fmt::Error> for Error {
     fn from(e: fmt::Error) -> Self {
         Error::with_description(e.to_string(), ErrorKind::Format)
-            .expect("Unable to build error message")
     }
 }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -2,7 +2,6 @@
 use std::{
     cell::Cell,
     ffi::{OsStr, OsString},
-    io::Write,
 };
 
 // Internal
@@ -483,11 +482,11 @@ impl<'help, 'app> Parser<'help, 'app> {
                                     || lossy_arg.parse::<f64>().is_ok())
                                 {
                                     return Err(ClapError::unknown_argument(
-                                        lossy_arg,
+                                        lossy_arg.to_string(),
                                         None,
-                                        &*Usage::new(self).create_usage_with_title(&[]),
+                                        Usage::new(self).create_usage_with_title(&[]),
                                         self.app.color(),
-                                    )?);
+                                    ));
                                 }
                             }
                             ParseResult::Opt(ref id)
@@ -537,12 +536,16 @@ impl<'help, 'app> Parser<'help, 'app> {
                         let cands: Vec<_> =
                             cands.iter().map(|cand| format!("'{}'", cand)).collect();
                         return Err(ClapError::invalid_subcommand(
-                            arg_os.to_string_lossy().into_owned(),
+                            arg_os.to_string_lossy().to_string(),
                             cands.join(" or "),
-                            self.app.bin_name.as_ref().unwrap_or(&self.app.name),
-                            &*Usage::new(self).create_usage_with_title(&[]),
+                            self.app
+                                .bin_name
+                                .as_ref()
+                                .unwrap_or(&self.app.name)
+                                .to_string(),
+                            Usage::new(self).create_usage_with_title(&[]),
                             self.app.color(),
-                        )?);
+                        ));
                     }
                 }
             }
@@ -630,11 +633,11 @@ impl<'help, 'app> Parser<'help, 'app> {
             {
                 if p.is_set(ArgSettings::Last) && !self.is_set(AS::TrailingValues) {
                     return Err(ClapError::unknown_argument(
-                        &*arg_os.to_string_lossy(),
+                        arg_os.to_string_lossy().to_string(),
                         None,
-                        &*Usage::new(self).create_usage_with_title(&[]),
+                        Usage::new(self).create_usage_with_title(&[]),
                         self.app.color(),
-                    )?);
+                    ));
                 }
 
                 if !self.is_set(AS::TrailingValues)
@@ -672,9 +675,9 @@ impl<'help, 'app> Parser<'help, 'app> {
                     None => {
                         if !self.is_set(AS::StrictUtf8) {
                             return Err(ClapError::invalid_utf8(
-                                &*Usage::new(self).create_usage_with_title(&[]),
+                                Usage::new(self).create_usage_with_title(&[]),
                                 self.app.color(),
-                            )?);
+                            ));
                         }
                         arg_os.to_string_lossy().into_owned()
                     }
@@ -686,9 +689,9 @@ impl<'help, 'app> Parser<'help, 'app> {
                 while let Some((v, _)) = it.next(None) {
                     if v.to_str().is_none() && !self.is_set(AS::StrictUtf8) {
                         return Err(ClapError::invalid_utf8(
-                            &*Usage::new(self).create_usage_with_title(&[]),
+                            Usage::new(self).create_usage_with_title(&[]),
                             self.app.color(),
-                        )?);
+                        ));
                     }
                     sc_m.add_val_to(&Id::empty_hash(), v.to_os_string(), ValueType::CommandLine);
                 }
@@ -708,11 +711,11 @@ impl<'help, 'app> Parser<'help, 'app> {
                 && !self.is_set(AS::InferSubcommands)
             {
                 return Err(ClapError::unknown_argument(
-                    &*arg_os.to_string_lossy(),
+                    arg_os.to_string_lossy().to_string(),
                     None,
-                    &*Usage::new(self).create_usage_with_title(&[]),
+                    Usage::new(self).create_usage_with_title(&[]),
                     self.app.color(),
-                )?);
+                ));
             } else if !has_args || self.is_set(AS::InferSubcommands) && self.has_subcommands() {
                 let cands = suggestions::did_you_mean(
                     &*arg_os.to_string_lossy(),
@@ -721,26 +724,34 @@ impl<'help, 'app> Parser<'help, 'app> {
                 if !cands.is_empty() {
                     let cands: Vec<_> = cands.iter().map(|cand| format!("'{}'", cand)).collect();
                     return Err(ClapError::invalid_subcommand(
-                        arg_os.to_string_lossy().into_owned(),
+                        arg_os.to_string_lossy().to_string(),
                         cands.join(" or "),
-                        self.app.bin_name.as_ref().unwrap_or(&self.app.name),
-                        &*Usage::new(self).create_usage_with_title(&[]),
+                        self.app
+                            .bin_name
+                            .as_ref()
+                            .unwrap_or(&self.app.name)
+                            .to_string(),
+                        Usage::new(self).create_usage_with_title(&[]),
                         self.app.color(),
-                    )?);
+                    ));
                 } else {
                     return Err(ClapError::unrecognized_subcommand(
-                        arg_os.to_string_lossy().into_owned(),
-                        self.app.bin_name.as_ref().unwrap_or(&self.app.name),
+                        arg_os.to_string_lossy().to_string(),
+                        self.app
+                            .bin_name
+                            .as_ref()
+                            .unwrap_or(&self.app.name)
+                            .to_string(),
                         self.app.color(),
-                    )?);
+                    ));
                 }
             } else {
                 return Err(ClapError::unknown_argument(
-                    &*arg_os.to_string_lossy(),
+                    arg_os.to_string_lossy().to_string(),
                     None,
-                    &*Usage::new(self).create_usage_with_title(&[]),
+                    Usage::new(self).create_usage_with_title(&[]),
                     self.app.color(),
-                )?);
+                ));
             }
         }
 
@@ -756,18 +767,17 @@ impl<'help, 'app> Parser<'help, 'app> {
             } else if self.is_set(AS::SubcommandRequired) {
                 let bn = self.app.bin_name.as_ref().unwrap_or(&self.app.name);
                 return Err(ClapError::missing_subcommand(
-                    bn,
-                    &Usage::new(self).create_usage_with_title(&[]),
+                    bn.to_string(),
+                    Usage::new(self).create_usage_with_title(&[]),
                     self.app.color(),
-                )?);
+                ));
             } else if self.is_set(AS::SubcommandRequiredElseHelp) {
                 debug!("Parser::get_matches_with: SubcommandRequiredElseHelp=true");
                 let message = self.write_help_err()?;
                 return Err(ClapError {
-                    cause: String::new(),
                     message,
                     kind: ErrorKind::MissingArgumentOrSubcommand,
-                    info: None,
+                    info: vec![],
                 });
             }
         }
@@ -941,10 +951,14 @@ impl<'help, 'app> Parser<'help, 'app> {
                     }
                 } else {
                     return Err(ClapError::unrecognized_subcommand(
-                        cmd.to_string_lossy().into_owned(),
-                        self.app.bin_name.as_ref().unwrap_or(&self.app.name),
+                        cmd.to_string_lossy().to_string(),
+                        self.app
+                            .bin_name
+                            .as_ref()
+                            .unwrap_or(&self.app.name)
+                            .to_string(),
                         self.app.color(),
-                    )?);
+                    ));
                 }
 
                 bin_name = format!("{} {}", bin_name, &sc.name);
@@ -1327,11 +1341,11 @@ impl<'help, 'app> Parser<'help, 'app> {
                 let arg = format!("-{}", c);
 
                 return Err(ClapError::unknown_argument(
-                    &*arg,
+                    arg,
                     None,
-                    &*Usage::new(self).create_usage_with_title(&[]),
+                    Usage::new(self).create_usage_with_title(&[]),
                     self.app.color(),
-                )?);
+                ));
             }
         }
         Ok(ret)
@@ -1360,9 +1374,9 @@ impl<'help, 'app> Parser<'help, 'app> {
                 debug!("Found Empty - Error");
                 return Err(ClapError::empty_value(
                     opt,
-                    &*Usage::new(self).create_usage_with_title(&[]),
+                    Usage::new(self).create_usage_with_title(&[]),
                     self.app.color(),
-                )?);
+                ));
             }
             debug!("Found - {:?}, len: {}", v, v.len());
             debug!(
@@ -1375,9 +1389,9 @@ impl<'help, 'app> Parser<'help, 'app> {
             debug!("None, but requires equals...Error");
             return Err(ClapError::empty_value(
                 opt,
-                &*Usage::new(self).create_usage_with_title(&[]),
+                Usage::new(self).create_usage_with_title(&[]),
                 self.app.color(),
-            )?);
+            ));
         } else if needs_eq && min_vals_zero {
             debug!("None and requires equals, but min_vals == 0");
             if !opt.default_missing_vals.is_empty() {
@@ -1722,24 +1736,16 @@ impl<'help, 'app> Parser<'help, 'app> {
             .collect();
 
         Err(ClapError::unknown_argument(
-            &*format!("--{}", arg),
+            format!("--{}", arg),
             did_you_mean,
-            &*Usage::new(self).create_usage_with_title(&*used),
+            Usage::new(self).create_usage_with_title(&*used),
             self.app.color(),
-        )?)
-    }
-
-    // Prints the version to the user and exits if quit=true
-    fn print_version<W: Write>(&self, w: &mut W, use_long: bool) -> ClapResult<()> {
-        self.app._write_version(w, use_long)?;
-        w.flush().map_err(ClapError::from)
+        ))
     }
 
     pub(crate) fn write_help_err(&self) -> ClapResult<Colorizer> {
         let mut c = Colorizer::new(true, self.color_help());
-
         Help::new(HelpWriter::Buffer(&mut c), self, false).write_help()?;
-
         Ok(c)
     }
 
@@ -1753,12 +1759,11 @@ impl<'help, 'app> Parser<'help, 'app> {
         let mut c = Colorizer::new(false, self.color_help());
 
         match Help::new(HelpWriter::Buffer(&mut c), self, use_long).write_help() {
-            Err(e) => e,
+            Err(e) => e.into(),
             _ => ClapError {
-                cause: String::new(),
                 message: c,
                 kind: ErrorKind::DisplayHelp,
-                info: None,
+                info: vec![],
             },
         }
     }
@@ -1766,16 +1771,13 @@ impl<'help, 'app> Parser<'help, 'app> {
     fn version_err(&self, use_long: bool) -> ClapError {
         debug!("Parser::version_err");
 
-        let mut c = Colorizer::new(false, self.app.color());
-
-        match self.print_version(&mut c, use_long) {
-            Err(e) => e,
-            _ => ClapError {
-                cause: String::new(),
-                message: c,
-                kind: ErrorKind::DisplayVersion,
-                info: None,
-            },
+        let msg = self.app._render_version(use_long);
+        let mut c = Colorizer::new(false, self.color_help());
+        c.none(msg);
+        ClapError {
+            message: c,
+            kind: ErrorKind::DisplayVersion,
+            info: vec![],
         }
     }
 }

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -47,9 +47,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             if should_err {
                 return Err(Error::empty_value(
                     o,
-                    &*Usage::new(self.p).create_usage_with_title(&[]),
+                    Usage::new(self.p).create_usage_with_title(&[]),
                     self.p.app.color(),
-                )?);
+                ));
             }
         }
 
@@ -59,10 +59,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         {
             let message = self.p.write_help_err()?;
             return Err(Error {
-                cause: String::new(),
                 message,
                 kind: ErrorKind::MissingArgumentOrSubcommand,
-                info: None,
+                info: vec![],
             });
         }
         self.validate_conflicts(matcher)?;
@@ -89,9 +88,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                     val
                 );
                 return Err(Error::invalid_utf8(
-                    &*Usage::new(self.p).create_usage_with_title(&[]),
+                    Usage::new(self.p).create_usage_with_title(&[]),
                     self.p.app.color(),
-                )?);
+                ));
             }
             if !arg.possible_vals.is_empty() {
                 debug!(
@@ -117,12 +116,12 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         .cloned()
                         .collect();
                     return Err(Error::invalid_value(
-                        val_str,
+                        val_str.to_string(),
                         &arg.possible_vals,
                         arg,
-                        &*Usage::new(self.p).create_usage_with_title(&*used),
+                        Usage::new(self.p).create_usage_with_title(&used),
                         self.p.app.color(),
-                    )?);
+                    ));
                 }
             }
             if !arg.is_set(ArgSettings::AllowEmptyValues)
@@ -132,9 +131,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 debug!("Validator::validate_arg_values: illegal empty val found");
                 return Err(Error::empty_value(
                     arg,
-                    &*Usage::new(self.p).create_usage_with_title(&[]),
+                    Usage::new(self.p).create_usage_with_title(&[]),
                     self.p.app.color(),
-                )?);
+                ));
             }
 
             // FIXME: `(&mut *vtor)(args...)` can be simplified to `vtor(args...)`
@@ -145,7 +144,12 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 let mut vtor = vtor.lock().unwrap();
                 if let Err(e) = (&mut *vtor)(&*val.to_string_lossy()) {
                     debug!("error");
-                    return Err(Error::value_validation(Some(arg), &e, self.p.app.color())?);
+                    return Err(Error::value_validation(
+                        arg.to_string(),
+                        val.to_string_lossy().to_string(),
+                        e,
+                        self.p.app.color(),
+                    ));
                 } else {
                     debug!("good");
                 }
@@ -156,10 +160,11 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 if let Err(e) = (&mut *vtor)(val) {
                     debug!("error");
                     return Err(Error::value_validation(
-                        Some(arg),
-                        &(*e).to_string(),
+                        arg.to_string(),
+                        val.to_string_lossy().into(),
+                        e,
                         self.p.app.color(),
-                    )?);
+                    ));
                 } else {
                     debug!("good");
                 }
@@ -213,9 +218,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         return Err(Error::argument_conflict(
                             latter_arg,
                             Some(former_arg.to_string()),
-                            &*usg,
+                            usg,
                             self.p.app.color(),
-                        )?);
+                        ));
                     }
                 }
             }
@@ -234,9 +239,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             return Err(Error::argument_conflict(
                 &self.p.app[first],
                 c_with,
-                &*usg,
+                usg,
                 self.p.app.color(),
-            )?);
+            ));
         }
 
         panic!(INTERNAL_ERROR_MSG);
@@ -301,7 +306,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         c_with,
                         Usage::new(self.p).create_usage_with_title(&[]),
                         self.p.app.color(),
-                    )?);
+                    ));
                 }
             }
         }
@@ -428,9 +433,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             // Not the first time, and we don't allow multiples
             return Err(Error::unexpected_multiple_usage(
                 a,
-                &*Usage::new(self.p).create_usage_with_title(&[]),
+                Usage::new(self.p).create_usage_with_title(&[]),
                 self.p.app.color(),
-            )?);
+            ));
         }
         Ok(())
     }
@@ -454,9 +459,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                     } else {
                         ma.vals.len()
                     },
-                    &*Usage::new(self.p).create_usage_with_title(&[]),
+                    Usage::new(self.p).create_usage_with_title(&[]),
                     self.p.app.color(),
-                )?);
+                ));
             }
         }
         if let Some(num) = a.max_vals {
@@ -469,11 +474,12 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         .last()
                         .expect(INTERNAL_ERROR_MSG)
                         .to_str()
-                        .expect(INVALID_UTF8),
+                        .expect(INVALID_UTF8)
+                        .to_string(),
                     a,
-                    &*Usage::new(self.p).create_usage_with_title(&[]),
+                    Usage::new(self.p).create_usage_with_title(&[]),
                     self.p.app.color(),
-                )?);
+                ));
             }
         }
         let min_vals_zero = if let Some(num) = a.min_vals {
@@ -484,9 +490,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                     a,
                     num,
                     ma.vals.len(),
-                    &*Usage::new(self.p).create_usage_with_title(&[]),
+                    Usage::new(self.p).create_usage_with_title(&[]),
                     self.p.app.color(),
-                )?);
+                ));
             }
             num == 0
         } else {
@@ -497,9 +503,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         if a.is_set(ArgSettings::TakesValue) && !min_vals_zero && ma.vals.is_empty() {
             return Err(Error::empty_value(
                 a,
-                &*Usage::new(self.p).create_usage_with_title(&[]),
+                Usage::new(self.p).create_usage_with_title(&[]),
                 self.p.app.color(),
-            )?);
+            ));
         }
         Ok(())
     }
@@ -650,8 +656,8 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
 
         Err(Error::missing_required_argument(
             req_args,
-            &*usg.create_usage_with_title(&*used),
+            usg.create_usage_with_title(&*used),
             self.p.app.color(),
-        )?)
+        ))
     }
 }

--- a/src/util/termcolor.rs
+++ b/src/util/termcolor.rs
@@ -1,5 +1,3 @@
-use std::io::{stderr, stdout, Result, Write};
-
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub(crate) enum ColorChoice {
     Auto,
@@ -7,32 +5,9 @@ pub(crate) enum ColorChoice {
     Never,
 }
 
-pub(crate) type Buffer = Vec<u8>;
-
-pub(crate) struct BufferWriter {
-    use_stderr: bool,
-}
-
-impl BufferWriter {
-    pub(crate) fn buffer(&self) -> Buffer {
-        vec![]
-    }
-
-    pub(crate) fn stderr(_: ColorChoice) -> Self {
-        Self { use_stderr: true }
-    }
-
-    pub(crate) fn stdout(_: ColorChoice) -> Self {
-        Self { use_stderr: false }
-    }
-
-    pub(crate) fn print(&self, buf: &Buffer) -> Result<()> {
-        if self.use_stderr {
-            stderr().lock().write_all(buf)?;
-        } else {
-            stdout().lock().write_all(buf)?;
-        }
-
-        Ok(())
-    }
+#[derive(Debug)]
+pub(crate) enum Color {
+    Green,
+    Yellow,
+    Red,
 }

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -188,9 +188,11 @@ fn two_conflicting_arguments() {
 
     assert!(a.is_err());
     let a = a.unwrap_err();
-    assert_eq!(
-        a.cause,
-        "The argument \'--production\' cannot be used with \'--develop\'"
+    assert!(
+        a.to_string()
+            .contains("The argument \'--production\' cannot be used with \'--develop\'"),
+        "{}",
+        a
     );
 }
 
@@ -216,9 +218,11 @@ fn three_conflicting_arguments() {
 
     assert!(a.is_err());
     let a = a.unwrap_err();
-    assert_eq!(
-        a.cause,
-        "The argument \'--two\' cannot be used with \'--one\'"
+    assert!(
+        a.to_string()
+            .contains("The argument \'--two\' cannot be used with \'--one\'"),
+        "{}",
+        a
     );
 }
 

--- a/tests/validators.rs
+++ b/tests/validators.rs
@@ -39,9 +39,11 @@ fn test_validator_msg_newline() {
     assert!(res.is_err());
     let err = res.unwrap_err();
 
-    assert_eq!(
-        err.cause,
-        "Invalid value for \'<test>\': invalid digit found in string"
+    assert!(
+        err.to_string()
+            .contains("Invalid value for '<test>': invalid digit found in string"),
+        "{}",
+        err
     );
 
     // This message is the only thing that gets printed -- make sure it ends with a newline

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -40,9 +40,7 @@ fn complex_version_output() {
     let _ = a.try_get_matches_from_mut(vec![""]);
 
     // Now we check the output of print_version()
-    let mut ver = vec![];
-    a.write_version(&mut ver).unwrap();
-    assert_eq!(str::from_utf8(&ver).unwrap(), VERSION);
+    assert_eq!(a.render_version(), VERSION);
 }
 
 #[test]


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->

Refactor coloring/help/errors facility.

### Improvements

1. _Creation_ of of `clap::Error` is now completely separate from actual _emitting_. It cannot fail anymore.
2. Significant code bloat decrease:
   
   Before
   ``` 
    File  .text     Size Crate
    9.4%  56.8% 289.5KiB clap
    4.8%  28.7% 146.2KiB std
    1.9%  11.6%  59.1KiB [Unknown]
    0.2%   0.9%   4.8KiB indexmap
    0.1%   0.3%   1.6KiB textwrap
    0.0%   0.1%     307B probe
    0.0%   0.0%      41B os_str_bytes
   16.6% 100.0% 509.8KiB .text section size, the file size is 3.0MiB
   ```

   After
   ```
    File  .text     Size Crate
    8.6%  53.7% 262.5KiB clap
    5.0%  31.2% 152.5KiB std
    1.9%  12.1%  59.1KiB [Unknown]
    0.2%   1.0%   4.8KiB indexmap
    0.1%   0.3%   1.6KiB textwrap
    0.0%   0.1%     307B probe
    0.0%   0.0%      41B os_str_bytes
   16.1% 100.0% 489.1KiB .text section size, the file size is 3.0MiB
   ```
3. No more our own unicorn reimplementations of `str::split`. I consider this a huge improvement.

### Changes to public API
1. `App::write_[long_]version` is replaced with render version. It was necessary in order to simplify some code. I found that these methods are [very](https://github.com/Rukenshia/saml2aws-auto/blob/1b483059cc8925e98ecde5fc246b10c6088e0882/src/main.rs#L88) [rarely](https://github.com/lise-henry/crowbook/blob/464b323b4c182bcb736ebfc41d197ac0db117bfd/src/bin/helpers.rs#L271) used, and what those people really needed was `String`.

   Actually, in light of `App::get[_long]_version`, I think we could just remove it. @pksunkara Any objections?
2. `Error::cause` and `Error::info` fields are removed. I've never seen them used in practice, and they are responsible for about `10 KiB` of code bloat.
3. `print_help*` and `write_help*` now return `io::Result` instead of `clap::Result`. There's no point to convert them to clap errors.

### Performance regression

I haven't done proper benchmarking yet, but I expect certain regression in error/help rendering. I suppose the regression is negligible because printing is slow enough on it's own, but I'm open to continue working on improving it.