### PR TITLE
docs(README.md): Fixes typo at line 413

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ To try out the pre-built [examples][examples], use the following steps:
 
 To test out `clap`'s default auto-generated help/version follow these steps:
 * Create a new cargo project `$ cargo new fake --bin && cd fake`
-* Writer your program as described in the quick example section.
+* Write your program as described in the quick example section.
 * Build your program `$ cargo build --release`
 * Run with help or version `$ ./target/release/fake --help` or `$ ./target/release/fake --version`
 


### PR DESCRIPTION
Closes #1984
