### PR TITLE
Custom subcommand placeholders

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1466,7 +1466,7 @@ impl<'b> App<'b> {
     ///
     /// ```text
     /// myprog
-    /// 
+    ///
     /// USAGE:
     ///     myprog [SUBCOMMAND]
     ///
@@ -1493,7 +1493,7 @@ impl<'b> App<'b> {
     /// will produce
     ///
     /// ```text
-    /// myprog 
+    /// myprog
     ///
     /// USAGE:
     ///     myprog [THING]
@@ -1509,7 +1509,7 @@ impl<'b> App<'b> {
     pub fn subcommand_placeholder<S, T>(mut self, placeholder: S, header: T) -> Self
     where
         S: Into<&'b str>,
-        T: Into<&'b str>
+        T: Into<&'b str>,
     {
         self.subcommand_placeholder = Some(placeholder.into());
         self.subcommand_header = Some(header.into());

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -96,6 +96,7 @@ pub struct App<'b> {
     pub(crate) groups: Vec<ArgGroup<'b>>,
     pub(crate) current_help_heading: Option<&'b str>,
     pub(crate) subcommand_placeholder: Option<&'b str>,
+    pub(crate) subcommand_header: Option<&'b str>,
 }
 
 impl<'b> App<'b> {
@@ -1448,19 +1449,70 @@ impl<'b> App<'b> {
         self._do_parse(&mut it)
     }
 
-    /// Sets the placeholder text used for subcommands when printing usage.
-    /// By default, this is "SUBCOMMAND".
+    /// Sets the placeholder text used for subcommands when printing usage and help.
+    /// By default, this is "SUBCOMMAND" with a header of "SUBCOMMANDS"
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use clap::{App, Arg};
     /// App::new("myprog")
-    ///     .subcommand_placeholder("THING")
+    ///     .subcommand(App::new("sub1"))
+    ///     .print_help()
     /// # ;
     /// ```
-    pub fn subcommand_placeholder<S: Into<&'b str>>(mut self, placeholder: S) -> Self {
+    ///
+    /// will produce
+    ///
+    /// ```text
+    /// myprog
+    /// 
+    /// USAGE:
+    ///     myprog [SUBCOMMAND]
+    ///
+    /// FLAGS:
+    ///     -h, --help       Prints help information
+    ///     -V, --version    Prints version information
+    ///
+    /// SUBCOMMANDS:
+    ///     help    Prints this message or the help of the given subcommand(s)
+    ///     sub1    
+    /// ```
+    ///
+    /// but usage of `subcommand_placeholder`
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .subcommand(App::new("sub1"))
+    ///     .subcommand_placeholder("THING", "THINGS")
+    ///     .print_help()
+    /// # ;
+    /// ```
+    ///
+    /// will produce
+    ///
+    /// ```text
+    /// myprog 
+    ///
+    /// USAGE:
+    ///     myprog [THING]
+    ///
+    /// FLAGS:
+    ///     -h, --help       Prints help information
+    ///     -V, --version    Prints version information
+    ///
+    /// THINGS:
+    ///     help    Prints this message or the help of the given subcommand(s)
+    ///     sub1    
+    /// ```
+    pub fn subcommand_placeholder<S, T>(mut self, placeholder: S, header: T) -> Self
+    where
+        S: Into<&'b str>,
+        T: Into<&'b str>
+    {
         self.subcommand_placeholder = Some(placeholder.into());
+        self.subcommand_header = Some(header.into());
         self
     }
 }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -95,6 +95,7 @@ pub struct App<'b> {
     pub(crate) replacers: HashMap<&'b str, &'b [&'b str]>,
     pub(crate) groups: Vec<ArgGroup<'b>>,
     pub(crate) current_help_heading: Option<&'b str>,
+    pub(crate) subcommand_placeholder: Option<&'b str>,
 }
 
 impl<'b> App<'b> {
@@ -1445,6 +1446,22 @@ impl<'b> App<'b> {
         }
 
         self._do_parse(&mut it)
+    }
+
+    /// Sets the placeholder text used for subcommands when printing usage.
+    /// By default, this is "SUBCOMMAND".
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .subcommand_placeholder("THING")
+    /// # ;
+    /// ```
+    pub fn subcommand_placeholder<S: Into<&'b str>>(mut self, placeholder: S) -> Self {
+        self.subcommand_placeholder = Some(placeholder.into());
+        self
     }
 }
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -751,15 +751,7 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
                 self.none("\n\n")?;
             }
 
-            let subcommand_string = self.parser.app.subcommand_placeholder.unwrap_or("SUBCOMMAND");
-            self.warning(subcommand_string)?;
-            // TODO: simply appending an 's' doesn't work for every string.
-            let pluralizer = if subcommand_string.chars().last().unwrap_or('D').is_lowercase() {
-                "s"
-            } else {
-                "S"
-            };
-            self.warning(pluralizer)?;
+            self.warning(self.parser.app.subcommand_header.unwrap_or("SUBCOMMANDS"))?;
             self.warning(":\n")?;
 
             self.write_subcommands(&self.parser.app)?;

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -750,7 +750,18 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
             if !first {
                 self.none("\n\n")?;
             }
-            self.warning("SUBCOMMANDS:\n")?;
+
+            let subcommand_string = self.parser.app.subcommand_placeholder.unwrap_or("SUBCOMMAND");
+            self.warning(subcommand_string)?;
+            // TODO: simply appending an 's' doesn't work for every string.
+            let pluralizer = if subcommand_string.chars().last().unwrap_or('D').is_lowercase() {
+                "s"
+            } else {
+                "S"
+            };
+            self.warning(pluralizer)?;
+            self.warning(":\n")?;
+
             self.write_subcommands(&self.parser.app)?;
         }
 

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -131,18 +131,28 @@ impl<'b, 'c, 'z> Usage<'b, 'c, 'z> {
                 if !self.p.is_set(AS::ArgsNegateSubcommands) {
                     usage.push_str("\n    ");
                     usage.push_str(&*self.create_help_usage(false));
-                    usage.push_str(" <SUBCOMMAND>");
+
+                    usage.push_str(" <");
+                    usage.push_str(self.p.app.subcommand_placeholder.unwrap_or("SUBCOMMAND"));
+                    usage.push_str(">");
                 } else {
                     usage.push_str("\n    ");
                     usage.push_str(&*name);
-                    usage.push_str(" <SUBCOMMAND>");
+
+                    usage.push_str(" <");
+                    usage.push_str(self.p.app.subcommand_placeholder.unwrap_or("SUBCOMMAND"));
+                    usage.push_str(">");
                 }
             } else if self.p.is_set(AS::SubcommandRequired)
                 || self.p.is_set(AS::SubcommandRequiredElseHelp)
             {
-                usage.push_str(" <SUBCOMMAND>");
+                usage.push_str(" <");
+                usage.push_str(self.p.app.subcommand_placeholder.unwrap_or("SUBCOMMAND"));
+                usage.push_str(">");
             } else {
-                usage.push_str(" [SUBCOMMAND]");
+                usage.push_str(" [");
+                usage.push_str(self.p.app.subcommand_placeholder.unwrap_or("SUBCOMMAND"));
+                usage.push_str("]");
             }
         }
         usage.shrink_to_fit();
@@ -171,7 +181,9 @@ impl<'b, 'c, 'z> Usage<'b, 'c, 'z> {
         );
         usage.push_str(&*r_string);
         if self.p.is_set(AS::SubcommandRequired) {
-            usage.push_str(" <SUBCOMMAND>");
+            usage.push_str(" <");
+            usage.push_str(self.p.app.subcommand_placeholder.unwrap_or("SUBCOMMAND"));
+            usage.push_str(">");
         }
         usage.shrink_to_fit();
         usage

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -367,12 +367,12 @@ fn issue_1722_not_emit_error_when_arg_follows_similar_to_a_subcommand() {
 fn subcommand_placeholder_test() {
     let mut app = App::new("myprog")
         .subcommand(App::new("subcommand"))
-        .subcommand_placeholder("TEST_PLACEHOLDER");
+        .subcommand_placeholder("TEST_PLACEHOLDER", "TEST_HEADER");
 
     assert_eq!(&app.generate_usage(), "USAGE:\n    myprog [TEST_PLACEHOLDER]");
 
     let mut help_text = Vec::new();
     app.write_help(&mut help_text).expect("Failed to write to internal buffer");
 
-    assert!(String::from_utf8(help_text).unwrap().contains("TEST_PLACEHOLDERS:"));
+    assert!(String::from_utf8(help_text).unwrap().contains("TEST_HEADER:"));
 }

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -369,10 +369,16 @@ fn subcommand_placeholder_test() {
         .subcommand(App::new("subcommand"))
         .subcommand_placeholder("TEST_PLACEHOLDER", "TEST_HEADER");
 
-    assert_eq!(&app.generate_usage(), "USAGE:\n    myprog [TEST_PLACEHOLDER]");
+    assert_eq!(
+        &app.generate_usage(),
+        "USAGE:\n    myprog [TEST_PLACEHOLDER]"
+    );
 
     let mut help_text = Vec::new();
-    app.write_help(&mut help_text).expect("Failed to write to internal buffer");
+    app.write_help(&mut help_text)
+        .expect("Failed to write to internal buffer");
 
-    assert!(String::from_utf8(help_text).unwrap().contains("TEST_HEADER:"));
+    assert!(String::from_utf8(help_text)
+        .unwrap()
+        .contains("TEST_HEADER:"));
 }

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -365,10 +365,14 @@ fn issue_1722_not_emit_error_when_arg_follows_similar_to_a_subcommand() {
 
 #[test]
 fn subcommand_placeholder_test() {
-    let usage = App::new("myprog")
+    let mut app = App::new("myprog")
         .subcommand(App::new("subcommand"))
-        .subcommand_placeholder("TEST_PLACEHOLDER")
-        .generate_usage();
+        .subcommand_placeholder("TEST_PLACEHOLDER");
 
-    assert_eq!(&usage, "USAGE:\n    myprog [TEST_PLACEHOLDER]");
+    assert_eq!(&app.generate_usage(), "USAGE:\n    myprog [TEST_PLACEHOLDER]");
+
+    let mut help_text = Vec::new();
+    app.write_help(&mut help_text).expect("Failed to write to internal buffer");
+
+    assert!(String::from_utf8(help_text).unwrap().contains("TEST_PLACEHOLDERS:"));
 }

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -362,3 +362,13 @@ fn issue_1722_not_emit_error_when_arg_follows_similar_to_a_subcommand() {
         .try_get_matches_from(vec!["myprog", "--", "subcommand"]);
     assert_eq!(m.unwrap().value_of("argument"), Some("subcommand"));
 }
+
+#[test]
+fn subcommand_placeholder_test() {
+    let usage = App::new("myprog")
+        .subcommand(App::new("subcommand"))
+        .subcommand_placeholder("TEST_PLACEHOLDER")
+        .generate_usage();
+
+    assert_eq!(&usage, "USAGE:\n    myprog [TEST_PLACEHOLDER]");
+}


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->

This PR lets you change the "SUBCOMMAND" placeholder in usage text to text of your choosing.

Closes #1597.

There are a few questions I have about how this should be implemented:
 - In the full help text, there is a section labeled "SUBCOMMANDS".
   - Should this also change?
   - Should there be a separate option for that?
 - How's the naming? "subcommand_placeholder" is long but descriptive -- to me, at least.
 - The current implementation does repeat some logic a bit, I could factor that into a private helper on App if you like.
 - I suspect the documentation I wrote could use some work.
 - ... I just read the contribution guidelines, I can redo the commit messages before this gets merged.