### PR TITLE
fix(justfile): rustup uses 'component add' instead of 'add component'

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,8 +25,8 @@ run-tests:
 	cargo bench
 
 @lint:
-	rustup add component clippy
-	rustup add component rustfmt
+	rustup component add clippy
+	rustup component add rustfmt
 	cargo clippy --lib --features "yaml unstable" -- -D warnings
 	cargo clippy --tests --examples --features "yaml unstable"
 	cargo fmt -- --check


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->

This fixes usage of `just lint` on my computer. Did the syntax of rustup change or something?