### PR TITLE
docs: switch debug and verbosity args in macro example

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,12 +350,12 @@ fn main() {
         (about: "Does awesome things")
         (@arg CONFIG: -c --config +takes_value "Sets a custom config file")
         (@arg INPUT: +required "Sets the input file to use")
-        (@arg debug: -d ... "Sets the level of debugging information")
+        (@arg verbose: -v --verbose "Print test information verbosely")
         (@subcommand test =>
             (about: "controls testing features")
             (version: "1.3")
             (author: "Someone E. <someone_else@other.com>")
-            (@arg verbose: -v --verbose "Print test information verbosely")
+            (@arg debug: -d ... "Sets the level of debugging information")
         )
     ).get_matches();
 


### PR DESCRIPTION
The other examples have `verbosity` as a default arg, and `debug` as a `test` subcommand arg. The macro example has these two switched up -- this corrects that.