### PR TITLE
Move to terminal_size dep after the recent textwrap upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ strsim      = { version = "0.10",  optional = true }
 yaml-rust   = { version = "0.4.1",  optional = true }
 atty        = { version = "0.2",  optional = true }
 termcolor   = { version = "1.1", optional = true }
-term_size   = { version = "1.0.0-beta1", optional = true }
+terminal_size = { version = "0.1.12", optional = true }
 lazy_static = { version = "1", optional = true }
 clap_derive = { path = "./clap_derive", version = "3.0.0-beta.1", optional = true }
 
@@ -90,7 +90,7 @@ default     = ["suggestions", "color", "derive", "std", "cargo"]
 std         = [] # support for no_std in a backwards-compatible way
 suggestions = ["strsim"]
 color       = ["atty", "termcolor"]
-wrap_help   = ["term_size", "textwrap/terminal_size"]
+wrap_help   = ["terminal_size", "textwrap/terminal_size"]
 derive      = ["clap_derive", "lazy_static"]
 yaml        = ["yaml-rust"]
 cargo       = [] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -23,11 +23,12 @@ use crate::{
 use indexmap::IndexSet;
 use unicode_width::UnicodeWidthStr;
 
-#[cfg(not(feature = "wrap_help"))]
-mod term_size {
-    pub(crate) fn dimensions() -> Option<(usize, usize)> {
-        None
-    }
+pub(crate) fn dimensions() -> Option<(usize, usize)> {
+    #[cfg(not(feature = "wrap_help"))]
+    return None;
+
+    #[cfg(feature = "wrap_help")]
+    terminal_size::terminal_size().map(|(w, h)| (w.0.into(), h.0.into()))
 }
 
 fn str_width(s: &str) -> usize {
@@ -80,7 +81,7 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
             Some(0) => usize::MAX,
             Some(w) => w,
             None => cmp::min(
-                term_size::dimensions().map_or(100, |(w, _)| w),
+                dimensions().map_or(100, |(w, _)| w),
                 match parser.app.max_w {
                     None | Some(0) => usize::MAX,
                     Some(mw) => mw,


### PR DESCRIPTION
term_size is not maintained and we don't want to.