### PR TITLE
Relax some restrictions on validators

### DIFF
--- a/src/build/app/debug_asserts.rs
+++ b/src/build/app/debug_asserts.rs
@@ -1,0 +1,282 @@
+use crate::{App, AppSettings, ArgSettings};
+use std::cmp::Ordering;
+
+#[derive(Eq)]
+enum Flag<'a> {
+    App(String, &'a str),
+    Arg(String, &'a str),
+}
+
+impl PartialEq for Flag<'_> {
+    fn eq(&self, other: &Flag) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl PartialOrd for Flag<'_> {
+    fn partial_cmp(&self, other: &Flag) -> Option<Ordering> {
+        use Flag::*;
+
+        match (self, other) {
+            (App(s1, _), App(s2, _))
+            | (Arg(s1, _), Arg(s2, _))
+            | (App(s1, _), Arg(s2, _))
+            | (Arg(s1, _), App(s2, _)) => {
+                if s1 == s2 {
+                    Some(Ordering::Equal)
+                } else {
+                    s1.partial_cmp(s2)
+                }
+            }
+        }
+    }
+}
+
+impl Ord for Flag<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+pub(crate) fn assert_app(app: &App) {
+    debug!("App::_debug_asserts");
+
+    let mut short_flags = vec![];
+    let mut long_flags = vec![];
+
+    for sc in &app.subcommands {
+        if let Some(s) = sc.short_flag.as_ref() {
+            short_flags.push(Flag::App(format!("-{}", s), &sc.name));
+        }
+
+        for (short_alias, _) in &sc.short_flag_aliases {
+            short_flags.push(Flag::App(format!("-{}", short_alias), &sc.name));
+        }
+
+        if let Some(l) = sc.long_flag.as_ref() {
+            long_flags.push(Flag::App(format!("--{}", l), &sc.name));
+        }
+
+        for (long_alias, _) in &sc.long_flag_aliases {
+            long_flags.push(Flag::App(format!("--{}", long_alias), &sc.name));
+        }
+    }
+
+    for arg in &app.args.args {
+        arg._debug_asserts();
+
+        if let Some(s) = arg.short.as_ref() {
+            short_flags.push(Flag::Arg(format!("-{}", s), &*arg.name));
+        }
+
+        for (short_alias, _) in &arg.short_aliases {
+            short_flags.push(Flag::Arg(format!("-{}", short_alias), &arg.name));
+        }
+
+        if let Some(l) = arg.long.as_ref() {
+            long_flags.push(Flag::Arg(format!("--{}", l), &*arg.name));
+        }
+
+        for (long_alias, _) in &arg.aliases {
+            long_flags.push(Flag::Arg(format!("--{}", long_alias), &arg.name));
+        }
+
+        // Name conflicts
+        assert!(
+            app.two_args_of(|x| x.id == arg.id).is_none(),
+            "Argument names must be unique, but '{}' is in use by more than one argument or group",
+            arg.name,
+        );
+
+        // Long conflicts
+        if let Some(l) = arg.long {
+            if let Some((first, second)) = app.two_args_of(|x| x.long == Some(l)) {
+                panic!(
+                    "Long option names must be unique for each argument, \
+                        but '--{}' is in use by both '{}' and '{}'",
+                    l, first.name, second.name
+                )
+            }
+        }
+
+        // Short conflicts
+        if let Some(s) = arg.short {
+            if let Some((first, second)) = app.two_args_of(|x| x.short == Some(s)) {
+                panic!(
+                    "Short option names must be unique for each argument, \
+                        but '-{}' is in use by both '{}' and '{}'",
+                    s, first.name, second.name
+                )
+            }
+        }
+
+        // Index conflicts
+        if let Some(idx) = arg.index {
+            if let Some((first, second)) =
+                app.two_args_of(|x| x.is_positional() && x.index == Some(idx))
+            {
+                panic!(
+                    "Argument '{}' has the same index as '{}' \
+                    and they are both positional arguments\n\n\t \
+                    Use Arg::multiple_values(true) to allow one \
+                    positional argument to take multiple values",
+                    first.name, second.name
+                )
+            }
+        }
+
+        // requires, r_if, r_unless
+        for req in &arg.requires {
+            assert!(
+                app.id_exists(&req.1),
+                "Argument or group '{:?}' specified in 'requires*' for '{}' does not exist",
+                req.1,
+                arg.name,
+            );
+        }
+
+        for req in &arg.r_ifs {
+            assert!(
+                app.id_exists(&req.0),
+                "Argument or group '{:?}' specified in 'required_if*' for '{}' does not exist",
+                req.0,
+                arg.name
+            );
+        }
+
+        for req in &arg.r_unless {
+            assert!(
+                app.id_exists(req),
+                "Argument or group '{:?}' specified in 'required_unless*' for '{}' does not exist",
+                req,
+                arg.name,
+            );
+        }
+
+        // blacklist
+        for req in &arg.blacklist {
+            assert!(
+                app.id_exists(req),
+                "Argument or group '{:?}' specified in 'conflicts_with*' for '{}' does not exist",
+                req,
+                arg.name,
+            );
+        }
+
+        if arg.is_set(ArgSettings::Last) {
+            assert!(
+                arg.long.is_none(),
+                "Flags or Options cannot have last(true) set. '{}' has both a long and last(true) set.",
+                arg.name
+            );
+            assert!(
+                arg.short.is_none(),
+                "Flags or Options cannot have last(true) set. '{}' has both a short and last(true) set.",
+                arg.name
+            );
+        }
+
+        assert!(
+            !(arg.is_set(ArgSettings::Required) && arg.global),
+            "Global arguments cannot be required.\n\n\t'{}' is marked as both global and required",
+            arg.name
+        );
+
+        // validators
+        assert!(
+            arg.validator.is_none() || arg.validator_os.is_none(),
+            "Argument '{}' has both `validator` and `validator_os` set which is not allowed",
+            arg.name
+        );
+
+        if arg.value_hint == ValueHint::CommandWithArguments {
+            assert!(
+                arg.short.is_none() && arg.long.is_none(),
+                "Argument '{}' has hint CommandWithArguments and must be positional.",
+                arg.name
+            );
+
+            assert!(
+                self.is_set(AppSettings::TrailingVarArg),
+                "Positional argument '{}' has hint CommandWithArguments, so App must have TrailingVarArg set.",
+                arg.name
+            );
+        }
+    }
+
+    for group in &app.groups {
+        // Name conflicts
+        assert!(
+            app.groups.iter().filter(|x| x.id == group.id).count() < 2,
+            "Argument group name must be unique\n\n\t'{}' is already in use",
+            group.name,
+        );
+
+        // Groups should not have naming conflicts with Args
+        assert!(
+            !app.args.args.iter().any(|x| x.id == group.id),
+            "Argument group name '{}' must not conflict with argument name",
+            group.name,
+        );
+
+        // Args listed inside groups should exist
+        for arg in &group.args {
+            assert!(
+                app.args.args.iter().any(|x| x.id == *arg),
+                "Argument group '{}' contains non-existent argument '{:?}'",
+                group.name,
+                arg
+            )
+        }
+    }
+
+    // Conflicts between flags and subcommands
+
+    long_flags.sort_unstable();
+    short_flags.sort_unstable();
+
+    detect_duplicate_flags(&long_flags, "long");
+    detect_duplicate_flags(&short_flags, "short");
+
+    app._panic_on_missing_help(app.g_settings.is_set(AppSettings::HelpRequired));
+}
+
+fn detect_duplicate_flags(flags: &[Flag], short_or_long: &str) {
+    use Flag::*;
+
+    for (one, two) in find_duplicates(flags) {
+        match (one, two) {
+            (App(flag, one), App(_, another)) if one != another => panic!(
+                "the '{}' {} flag is specified for both '{}' and '{}' subcommands",
+                flag, short_or_long, one, another
+            ),
+
+            (Arg(flag, one), Arg(_, another)) if one != another => panic!(
+                "{} option names must be unique, but '{}' is in use by both '{}' and '{}'",
+                short_or_long, flag, one, another
+            ),
+
+            (Arg(flag, arg), App(_, sub)) | (App(flag, sub), Arg(_, arg)) => panic!(
+                "the '{}' {} flag for the '{}' argument conflicts with the short flag \
+                     for '{}' subcommand",
+                flag, short_or_long, arg, sub
+            ),
+
+            _ => {}
+        }
+    }
+}
+
+/// Find duplicates in a sorted array.
+///
+/// The algorithm is simple: the array is sorted, duplicates
+/// must be placed next to each other, we can check only adjacent elements.
+fn find_duplicates<T: PartialEq>(slice: &[T]) -> impl Iterator<Item = (&T, &T)> {
+    slice.windows(2).filter_map(|w| {
+        if w[0] == w[1] {
+            Some((&w[0], &w[1]))
+        } else {
+            None
+        }
+    })
+}

--- a/src/build/app/debug_asserts.rs
+++ b/src/build/app/debug_asserts.rs
@@ -1,4 +1,4 @@
-use crate::{App, AppSettings, ArgSettings};
+use crate::{App, AppSettings, ArgSettings, ValueHint};
 use std::cmp::Ordering;
 
 #[derive(Eq)]
@@ -197,7 +197,7 @@ pub(crate) fn assert_app(app: &App) {
             );
 
             assert!(
-                self.is_set(AppSettings::TrailingVarArg),
+                app.is_set(AppSettings::TrailingVarArg),
                 "Positional argument '{}' has hint CommandWithArguments, so App must have TrailingVarArg set.",
                 arg.name
             );

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     output::{fmt::Colorizer, Help, HelpWriter, Usage},
     parse::{ArgMatcher, ArgMatches, Input, Parser},
     util::{safe_exit, termcolor::ColorChoice, ArgStr, Id, Key},
-    Result as ClapResult, ValueHint, INTERNAL_ERROR_MSG,
+    Result as ClapResult, INTERNAL_ERROR_MSG,
 };
 
 // FIXME (@CreepySkeleton): some of these variants are never constructed

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2091,7 +2091,7 @@ impl<'help> App<'help> {
     where
         F: Fn(&Arg) -> bool,
     {
-        two_elements_of(self.args.args.iter().filter(|a| condition(a)))
+        two_elements_of(self.args.args.iter().filter(|a: &&Arg| condition(a)))
     }
 
     // just in case

--- a/src/build/app/tests.rs
+++ b/src/build/app/tests.rs
@@ -44,3 +44,10 @@ fn global_settings() {
         .unwrap()
         .is_set(AppSettings::TrailingVarArg));
 }
+
+// This test will *fail to compile* if App is not Send + Sync
+#[test]
+fn app_send_sync() {
+    fn foo<T: Send + Sync>(_: T) {}
+    foo(App::new("test"))
+}

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -14,7 +14,7 @@ use std::{
     ffi::{OsStr, OsString},
     fmt::{self, Display, Formatter},
     str,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 // Third Party
@@ -30,8 +30,8 @@ use crate::{
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
 
-type Validator<'a> = dyn Fn(&str) -> Result<(), String> + Send + Sync + 'a;
-type ValidatorOs<'a> = dyn Fn(&OsStr) -> Result<(), String> + Send + Sync + 'a;
+type Validator<'a> = dyn FnMut(&str) -> Result<(), String> + Send + 'a;
+type ValidatorOs<'a> = dyn FnMut(&OsStr) -> Result<(), String> + Send + 'a;
 
 /// The abstract representation of a command line argument. Used to set all the options and
 /// relationships that define a valid argument for the program.
@@ -80,8 +80,8 @@ pub struct Arg<'help> {
     pub(crate) num_vals: Option<u64>,
     pub(crate) max_vals: Option<u64>,
     pub(crate) min_vals: Option<u64>,
-    pub(crate) validator: Option<Arc<Validator<'help>>>,
-    pub(crate) validator_os: Option<Arc<ValidatorOs<'help>>>,
+    pub(crate) validator: Option<Arc<Mutex<Validator<'help>>>>,
+    pub(crate) validator_os: Option<Arc<Mutex<ValidatorOs<'help>>>>,
     pub(crate) val_delim: Option<char>,
     pub(crate) default_vals: Vec<&'help OsStr>,
     pub(crate) default_vals_ifs: VecMap<(Id, Option<&'help OsStr>, &'help OsStr)>,
@@ -1870,14 +1870,14 @@ impl<'help> Arg<'help> {
     /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
     /// [`Err(String)`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
     /// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
-    pub fn validator<F, O, E>(mut self, f: F) -> Self
+    pub fn validator<F, O, E>(mut self, mut f: F) -> Self
     where
-        F: Fn(&str) -> Result<O, E> + Sync + Send + 'help,
+        F: FnMut(&str) -> Result<O, E> + Send + 'help,
         E: ToString,
     {
-        self.validator = Some(Arc::new(move |s| {
+        self.validator = Some(Arc::new(Mutex::new(move |s: &str| {
             f(s).map(|_| ()).map_err(|e| e.to_string())
-        }));
+        })));
         self
     }
 
@@ -1911,11 +1911,11 @@ impl<'help> Arg<'help> {
     /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
     /// [`Err(String)`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
     /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
-    pub fn validator_os<F, O>(mut self, f: F) -> Self
+    pub fn validator_os<F, O>(mut self, mut f: F) -> Self
     where
-        F: Fn(&OsStr) -> Result<O, String> + Sync + Send + 'help,
+        F: FnMut(&OsStr) -> Result<O, String> + Send + 'help,
     {
-        self.validator_os = Some(Arc::new(move |s| f(s).map(|_| ())));
+        self.validator_os = Some(Arc::new(Mutex::new(move |s: &OsStr| f(s).map(|_| ()))));
         self
     }
 
@@ -4494,11 +4494,11 @@ impl<'help> fmt::Debug for Arg<'help> {
             .field("min_vals", &self.min_vals)
             .field(
                 "validator",
-                &self.validator.as_ref().map_or("None", |_| "Some(Fn)"),
+                &self.validator.as_ref().map_or("None", |_| "Some(FnMut)"),
             )
             .field(
                 "validator_os",
-                &self.validator_os.as_ref().map_or("None", |_| "Some(Fn)"),
+                &self.validator_os.as_ref().map_or("None", |_| "Some(FnMut)"),
             )
             .field("val_delim", &self.val_delim)
             .field("default_vals", &self.default_vals)

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -13,8 +13,8 @@ use std::{
     env,
     ffi::{OsStr, OsString},
     fmt::{self, Display, Formatter},
-    rc::Rc,
     str,
+    sync::Arc,
 };
 
 // Third Party
@@ -30,8 +30,8 @@ use crate::{
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
 
-type Validator = Rc<dyn Fn(&str) -> Result<(), String>>;
-type ValidatorOs = Rc<dyn Fn(&OsStr) -> Result<(), String>>;
+type Validator<'a> = dyn Fn(&str) -> Result<(), String> + Send + Sync + 'a;
+type ValidatorOs<'a> = dyn Fn(&OsStr) -> Result<(), String> + Send + Sync + 'a;
 
 /// The abstract representation of a command line argument. Used to set all the options and
 /// relationships that define a valid argument for the program.
@@ -80,8 +80,8 @@ pub struct Arg<'help> {
     pub(crate) num_vals: Option<u64>,
     pub(crate) max_vals: Option<u64>,
     pub(crate) min_vals: Option<u64>,
-    pub(crate) validator: Option<Validator>,
-    pub(crate) validator_os: Option<ValidatorOs>,
+    pub(crate) validator: Option<Arc<Validator<'help>>>,
+    pub(crate) validator_os: Option<Arc<ValidatorOs<'help>>>,
     pub(crate) val_delim: Option<char>,
     pub(crate) default_vals: Vec<&'help OsStr>,
     pub(crate) default_vals_ifs: VecMap<(Id, Option<&'help OsStr>, &'help OsStr)>,
@@ -1844,7 +1844,7 @@ impl<'help> Arg<'help> {
     /// arg, and `<YOUR MESSAGE>` is the `String` you return as the error.
     ///
     /// **NOTE:** There is a small performance hit for using validators, as they are implemented
-    /// with [`Rc`] pointers. And the value to be checked will be allocated an extra time in order
+    /// with [`Arc`] pointers. And the value to be checked will be allocated an extra time in order
     /// to be passed to the closure. This performance hit is extremely minimal in the grand
     /// scheme of things.
     ///
@@ -1869,13 +1869,13 @@ impl<'help> Arg<'help> {
     /// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
     /// [`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html
     /// [`Err(String)`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
-    /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
+    /// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
     pub fn validator<F, O, E>(mut self, f: F) -> Self
     where
-        F: Fn(&str) -> Result<O, E> + 'static,
+        F: Fn(&str) -> Result<O, E> + Sync + Send + 'help,
         E: ToString,
     {
-        self.validator = Some(Rc::new(move |s| {
+        self.validator = Some(Arc::new(move |s| {
             f(s).map(|_| ()).map_err(|e| e.to_string())
         }));
         self
@@ -1913,9 +1913,9 @@ impl<'help> Arg<'help> {
     /// [`Rc`]: https://doc.rust-lang.org/std/rc/struct.Rc.html
     pub fn validator_os<F, O>(mut self, f: F) -> Self
     where
-        F: Fn(&OsStr) -> Result<O, String> + 'static,
+        F: Fn(&OsStr) -> Result<O, String> + Sync + Send + 'help,
     {
-        self.validator_os = Some(Rc::new(move |s| f(s).map(|_| ())));
+        self.validator_os = Some(Arc::new(move |s| f(s).map(|_| ())));
         self
     }
 

--- a/src/build/arg/tests.rs
+++ b/src/build/arg/tests.rs
@@ -23,3 +23,10 @@ fn short_flag_name_missing() {
     assert!(a.val_names.is_empty());
     assert!(a.num_vals.is_none());
 }
+
+// This test will *fail to compile* if Arg is not Send + Sync
+#[test]
+fn arg_send_sync() {
+    fn foo<T: Send + Sync>(_: T) {}
+    foo(Arg::new("test"))
+}

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -550,6 +550,13 @@ requires:
         assert_eq!(g.requires, reqs);
         assert_eq!(g.conflicts, confs);
     }
+
+    // This test will *fail to compile* if ArgGroup is not Send + Sync
+    #[test]
+    fn arg_group_send_sync() {
+        fn foo<T: Send + Sync>(_: T) {}
+        foo(ArgGroup::new("test"))
+    }
 }
 
 impl Clone for ArgGroup<'_> {

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -222,7 +222,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
     }
 
     /// Writes help for an argument to the wrapped stream.
-    fn write_arg(&mut self, arg: &Arg, prevent_nlh: bool) -> io::Result<()> {
+    fn write_arg(&mut self, arg: &Arg<'help>, prevent_nlh: bool) -> io::Result<()> {
         debug!("Help::write_arg");
         self.short(arg)?;
         self.long(arg)?;
@@ -232,7 +232,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
     }
 
     /// Writes argument's short command to the wrapped stream.
-    fn short(&mut self, arg: &Arg) -> io::Result<()> {
+    fn short(&mut self, arg: &Arg<'help>) -> io::Result<()> {
         debug!("Help::short");
 
         self.none(TAB)?;
@@ -247,7 +247,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
     }
 
     /// Writes argument's long command to the wrapped stream.
-    fn long(&mut self, arg: &Arg) -> io::Result<()> {
+    fn long(&mut self, arg: &Arg<'help>) -> io::Result<()> {
         debug!("Help::long");
         if !arg.has_switch() {
             return Ok(());

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -214,7 +214,7 @@ impl ArgMatches {
     /// ```
     /// [`Values`]: ./struct.Values.html
     /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
-    pub fn values_of<T: Key>(&self, id: T) -> Option<Values<'_>> {
+    pub fn values_of<T: Key>(&self, id: T) -> Option<Values> {
         self.args.get(&Id::from(id)).map(|arg| {
             fn to_str_slice(o: &OsString) -> &str {
                 o.to_str().expect(INVALID_UTF8)

--- a/tests/arg_aliases.rs
+++ b/tests/arg_aliases.rs
@@ -167,7 +167,7 @@ fn invisible_arg_aliases_help_output() {
                     .takes_value(true)
                     .aliases(&["invisible", "als1", "more"]),
             )
-            .arg(Arg::from("-f, --flag").aliases(&["invisible", "flg1", "anyway"])),
+            .arg(Arg::from("-f, --flag").aliases(&["unseeable", "flg1", "anyway"])),
     );
     assert!(utils::compare_output(
         app,

--- a/tests/arg_aliases_short.rs
+++ b/tests/arg_aliases_short.rs
@@ -163,7 +163,7 @@ fn invisible_short_arg_aliases_help_output() {
                     .takes_value(true)
                     .short_aliases(&['a', 'b', 'c']),
             )
-            .arg(Arg::from("-f, --flag").short_aliases(&['a', 'b', 'c'])),
+            .arg(Arg::from("-f, --flag").short_aliases(&['x', 'y', 'z'])),
     );
     assert!(utils::compare_output(
         app,

--- a/tests/fixtures/app.yaml
+++ b/tests/fixtures/app.yaml
@@ -92,7 +92,7 @@ args:
     - multshortaliases:
         long: multshortaliases
         about: Tests multiple short aliases
-        short_aliases: [a, b, c]
+        short_aliases: [b, c]
     - minvals2:
         long: minvals2
         multiple: true

--- a/tests/flag_subcommands.rs
+++ b/tests/flag_subcommands.rs
@@ -281,7 +281,7 @@ fn flag_subcommand_multiple() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Short option names must be unique for each argument, but \'-f\' is used by both an App named \'some\' and an Arg named \'test\'"]
+#[should_panic = "the \'-f\' short flag for the \'test\' argument conflicts with the short flag for \'some\' subcommand"]
 fn flag_subcommand_short_conflict_with_arg() {
     let _ = App::new("test")
         .subcommand(App::new("some").short_flag('f').long_flag("some"))
@@ -291,7 +291,7 @@ fn flag_subcommand_short_conflict_with_arg() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Short option names must be unique for each argument, but \'-f\' is used by both an App named \'some\' and an App named \'result\'"]
+#[should_panic = "the \'-f\' short flag is specified for both \'some\' and \'result\' subcommands"]
 fn flag_subcommand_short_conflict_with_alias() {
     let _ = App::new("test")
         .subcommand(App::new("some").short_flag('f').long_flag("some"))
@@ -301,7 +301,7 @@ fn flag_subcommand_short_conflict_with_alias() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Long option names must be unique for each argument, but \'--flag\' is used by both an App named \'some\' and an App named \'result\'"]
+#[should_panic = "the \'--flag\' long flag is specified for both \'some\' and \'result\' subcommands"]
 fn flag_subcommand_long_conflict_with_alias() {
     let _ = App::new("test")
         .subcommand(App::new("some").long_flag("flag"))
@@ -311,7 +311,7 @@ fn flag_subcommand_long_conflict_with_alias() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Short option names must be unique for each argument, but \'-f\' is used by both an App named \'some\' and an Arg named \'test\'"]
+#[should_panic = "the \'-f\' short flag for the \'test\' argument conflicts with the short flag for \'some\' subcommand"]
 fn flag_subcommand_short_conflict_with_arg_alias() {
     let _ = App::new("test")
         .subcommand(App::new("some").short_flag('f').long_flag("some"))
@@ -321,7 +321,7 @@ fn flag_subcommand_short_conflict_with_arg_alias() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Long option names must be unique for each argument, but \'--some\' is used by both an App named \'some\' and an Arg named \'test\'"]
+#[should_panic = "the \'--some\' long flag for the \'test\' argument conflicts with the short flag for \'some\' subcommand"]
 fn flag_subcommand_long_conflict_with_arg_alias() {
     let _ = App::new("test")
         .subcommand(App::new("some").short_flag('f').long_flag("some"))
@@ -331,7 +331,7 @@ fn flag_subcommand_long_conflict_with_arg_alias() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Long option names must be unique for each argument, but \'--flag\' is used by both an App named \'some\' and an Arg named \'flag\'"]
+#[should_panic = "the \'--flag\' long flag for the \'flag\' argument conflicts with the short flag for \'some\' subcommand"]
 fn flag_subcommand_long_conflict_with_arg() {
     let _ = App::new("test")
         .subcommand(App::new("some").short_flag('a').long_flag("flag"))

--- a/tests/validators.rs
+++ b/tests/validators.rs
@@ -48,3 +48,17 @@ fn test_validator_msg_newline() {
     let msg = format!("{}", err);
     assert!(msg.ends_with('\n'));
 }
+
+#[test]
+fn stateful_validator() {
+    let mut state = false;
+    App::new("test")
+        .arg(Arg::new("test").validator(|val| {
+            state = true;
+            val.parse::<u32>().map_err(|e| e.to_string())
+        }))
+        .try_get_matches_from(&["app", "10"])
+        .unwrap();
+
+    assert!(state);
+}


### PR DESCRIPTION
Also relaxes 'static restriction on validators.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on it's own line.
-->
Closes #1771

This PR also relaxes the `'static` restriction on the validator fn, thus allowing user to use proper closures that capture some context as validators. This should address (and potentially close) #572.