### PR TITLE
feat(macros): Add `@global $setting` to set global settings

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -312,6 +312,13 @@ macro_rules! clap_app {
             $($tt)*
         }
     };
+    // Global Settings
+    (@app ($builder:expr) (@global_setting $setting:ident) $($tt:tt)*) => {
+        $crate::clap_app!{ @app
+            ($builder.global_setting($crate::AppSettings::$setting))
+            $($tt)*
+        }
+    };
     // Settings
     (@app ($builder:expr) (@setting $setting:ident) $($tt:tt)*) => {
         $crate::clap_app!{ @app

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -28,6 +28,8 @@ fn basic() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
+        (@global_setting ColorNever)
+        (@setting VersionlessSubcommands)
         (@arg opt: -o --option +takes_value ... "tests options")
         (@arg positional: index(1) "tests positionals")
         (@arg flag: -f --flag ... +global "tests flags")


### PR DESCRIPTION
This PR adds the ability to set global settings with `@global $setting` just like `@setting`.
```rust
let app = clap_app!(claptest =>
    (@global ColorNever)
    (@global DisableVersion)
);
```
instead of
```rust
let app = clap_app!(claptest =>
    (global_setting: AppSettings::ColorNever)
    (global_setting: AppSettings::DisableVersion)
);
```

I also added the attributes to the basic macro test.