### PR TITLE
imp(errors): Provide the missing required arguments as info

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -708,9 +708,11 @@ impl Error {
             "The following required arguments were not provided:",
         )?;
 
+        let mut info = vec![];
         for v in required {
             c.none("\n    ")?;
             c.good(&v.to_string())?;
+            info.push(v.to_string());
         }
 
         put_usage(&mut c, usage)?;
@@ -720,7 +722,7 @@ impl Error {
             cause,
             message: c,
             kind: ErrorKind::MissingRequiredArgument,
-            info: None,
+            info: Some(info),
         })
     }
 


### PR DESCRIPTION
Collect the missing required arguments for `Error::info`.

### Code
```rust
use clap::clap_app;

fn main() {
    let app = clap_app!(prog =>
        (@arg arg1: +required)
        (@arg arg2: -o +required)
    );
    let m = app.try_get_matches();
    dbg!(m);
}
```
### `cargo r` Output
```
[src/prog.rs:9] m = Err(
    Error {
        cause: "The following required arguments were not provided:\n    <arg1>\n    -o",
        message: error: The following required arguments were not provided:
            <arg1>
            -o
        
        USAGE:
            prog [FLAGS] <arg1> -o
        
        For more information try --help
        ,
        kind: MissingRequiredArgument,
        info: Some(
            [
                "<arg1>",
                "-o",
            ],
        ),
    },
)

```