### PR TITLE
tests(validators): Add tests for `clap_app!` macro and `FromStr` trait validator

### DIFF
--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -360,3 +360,26 @@ fn multiarg() {
     assert_eq!(matches.value_of("multiarg"), Some("flag-set"));
     assert_eq!(matches.value_of("multiarg2"), Some("flag-set"));
 }
+
+#[test]
+fn validator() {
+    use std::str::FromStr;
+
+    fn validate(val: &str) -> Result<u32, String> {
+        val.parse::<u32>().map_err(|e| e.to_string())
+    }
+
+    let app = clap_app!(claptests =>
+        (@arg inline: { |val| val.parse::<u16>() })
+        (@arg func1: { validate })
+        (@arg func2: { u64::from_str })
+    );
+
+    let matches = app
+        .try_get_matches_from(&["bin", "12", "34", "56"])
+        .expect("match failed");
+
+    assert_eq!(matches.value_of_t::<u16>("inline").ok(), Some(12));
+    assert_eq!(matches.value_of_t::<u16>("func1").ok(), Some(34));
+    assert_eq!(matches.value_of_t::<u16>("func2").ok(), Some(56));
+}

--- a/tests/validators.rs
+++ b/tests/validators.rs
@@ -19,6 +19,18 @@ fn both_validator_and_validator_os() {
 }
 
 #[test]
+fn test_validator_fromstr_trait() {
+    use std::str::FromStr;
+
+    let matches = App::new("test")
+        .arg(Arg::new("from_str").validator(u32::from_str))
+        .try_get_matches_from(&["app", "1234"])
+        .expect("match failed");
+
+    assert_eq!(matches.value_of_t::<u32>("from_str").ok(), Some(1234));
+}
+
+#[test]
 fn test_validator_msg_newline() {
     let res = App::new("test")
         .arg(Arg::new("test").validator(|val| val.parse::<u32>().map_err(|e| e.to_string())))


### PR DESCRIPTION
The PR adds tests for builder macro with validators and `std::str::FromStr` as validator.
