### PR TITLE
Fix various typos in docs & code

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
 If your PR closes some issues, please write `Closes #XXXX`
 where `XXXX` is the number of the issue you want to fix.
-Each issue goes on it's own line.
+Each issue goes on its own line.
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,7 @@ TODO: `cargo`, `std` features
 
 *   add debug assertion for missing args in subcommand ArgGroup ([2699d9e5](https://github.com/kbknapp/clap-rs/commit/2699d9e51e7eadc258ba64c4e347c5d1fef61343))
 *   Restore compat with Rust 1.21 ([6b263de1](https://github.com/kbknapp/clap-rs/commit/6b263de1d42ede692ec5ee55019ad2fc6386f92e))
-*   Dont mention unused subcommands ([ef92e2b6](https://github.com/kbknapp/clap-rs/commit/ef92e2b639ed305bdade4741f60fa85cb0101c5a))
+*   Don't mention unused subcommands ([ef92e2b6](https://github.com/kbknapp/clap-rs/commit/ef92e2b639ed305bdade4741f60fa85cb0101c5a))
 * **OsValues:**  Add `ExactSizeIterator` implementation ([356c69e5](https://github.com/kbknapp/clap-rs/commit/356c69e508fd25a9f0ea2d27bf80ae1d9a8d88f4))
 * **arg_enum!:**
   *  Fix comma position for valid values. ([1f1f9ff3](https://github.com/kbknapp/clap-rs/commit/1f1f9ff3fa38a43231ef8be9cfea89a32e53f518))
@@ -282,7 +282,7 @@ TODO: `cargo`, `std` features
 
 #### Bug Fixes
 
-* **Overrides Self:**  fixes a bug where options with multiple values couldnt ever have multiple values ([d95907cf](https://github.com/kbknapp/clap-rs/commit/d95907cff6d011a901fe35fa00b0f4e18547a1fb))
+* **Overrides Self:**  fixes a bug where options with multiple values couldn't ever have multiple values ([d95907cf](https://github.com/kbknapp/clap-rs/commit/d95907cff6d011a901fe35fa00b0f4e18547a1fb))
 
 
 
@@ -313,7 +313,7 @@ TODO: `cargo`, `std` features
 
 * **completions/zsh.rs:**
   *  Escape possible values for options ([25561dec](https://github.com/kbknapp/clap-rs/commit/25561decf147d329b64634a14d9695673c2fc78f))
-  *  Implement postional argument possible values completion ([f3b0afd2](https://github.com/kbknapp/clap-rs/commit/f3b0afd2bef8b7be97162f8a7802ddf7603dff36))
+  *  Implement positional argument possible values completion ([f3b0afd2](https://github.com/kbknapp/clap-rs/commit/f3b0afd2bef8b7be97162f8a7802ddf7603dff36))
   *  Complete positional arguments properly ([e39aeab8](https://github.com/kbknapp/clap-rs/commit/e39aeab8487596046fbdbc6a226e5c8820585245))
 
 #### Bug Fixes
@@ -424,7 +424,7 @@ See the commit [0c223f54](https://github.com/kbknapp/clap-rs/commit/0c223f54ed46
 
 #### Documentation
 
-*   adds addtional blurbs about using multiples with subcommands ([03455b77](https://github.com/kbknapp/clap-rs/commit/03455b7751a757e7b2f6ffaf2d16168539c99661))
+*   adds additional blurbs about using multiples with subcommands ([03455b77](https://github.com/kbknapp/clap-rs/commit/03455b7751a757e7b2f6ffaf2d16168539c99661))
 *   updates the docs to reflect changes to global args and that global args values can now be propagated back up the stack ([ead076f0](https://github.com/kbknapp/clap-rs/commit/ead076f03ada4c322bf3e34203925561ec496d87))
 *   add html_root_url attribute ([e67a061b](https://github.com/kbknapp/clap-rs/commit/e67a061bcf567c6518d6c2f58852e01f02764b22))
 *   sync README version numbers with crate version ([5536361b](https://github.com/kbknapp/clap-rs/commit/5536361bcda29887ed86bb68e43d0b603cbc423f))
@@ -469,7 +469,7 @@ See the commit [0c223f54](https://github.com/kbknapp/clap-rs/commit/0c223f54ed46
 *   avoid panic generating default help msg if term width set to 0 due to bug in textwrap 0.7.0 ([b3eadb0d](https://github.com/kbknapp/clap-rs/commit/b3eadb0de516106db4e08f078ad32e8f6d6e7a57))
 *   Change `who's` -> `whose` ([53c1ffe8](https://github.com/kbknapp/clap-rs/commit/53c1ffe87f38b05d8804a0f7832412a952845349))
 *   adds a debug assertion to ensure all args added to groups actually exist ([7ad123e2](https://github.com/kbknapp/clap-rs/commit/7ad123e2c02577e3ca30f7e205181e896b157d11), closes [#917](https://github.com/kbknapp/clap-rs/issues/917))
-*   fixes a bug where args that allow values to start with a hyphen couldnt contain a double hyphen -- as a value ([ab2f4c9e](https://github.com/kbknapp/clap-rs/commit/ab2f4c9e563e36ec739a4b55d5a5b76fdb9e9fa4), closes [#960](https://github.com/kbknapp/clap-rs/issues/960))
+*   fixes a bug where args that allow values to start with a hyphen couldn't contain a double hyphen -- as a value ([ab2f4c9e](https://github.com/kbknapp/clap-rs/commit/ab2f4c9e563e36ec739a4b55d5a5b76fdb9e9fa4), closes [#960](https://github.com/kbknapp/clap-rs/issues/960))
 *   fixes a bug where positional argument help text is misaligned ([54c16836](https://github.com/kbknapp/clap-rs/commit/54c16836dea4651806a2cfad53146a83fa3abf21))
 * **Help Message:**  fixes long_about not being usable ([a8257ea0](https://github.com/kbknapp/clap-rs/commit/a8257ea0ffb812e552aca256c4a3d2aebfd8065b), closes [#1043](https://github.com/kbknapp/clap-rs/issues/1043))
 * **Suggestions:**  output for flag after subcommand ([434ea5ba](https://github.com/kbknapp/clap-rs/commit/434ea5ba71395d8c1afcf88e69f0b0d8339b01a1))
@@ -539,7 +539,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 #### Bug Fixes
 
 *   adds a debug assertion to ensure all args added to groups actually exist ([14f6b8f3](https://github.com/kbknapp/clap-rs/commit/14f6b8f3a2f6df73aeeec9c54a54909b1acfc158), closes [#917](https://github.com/kbknapp/clap-rs/issues/917))
-*   fixes a bug where args that allow values to start with a hyphen couldnt contain a double hyphen -- as a value ([ebf73a09](https://github.com/kbknapp/clap-rs/commit/ebf73a09db6f3c03c19cdd76b1ba6113930e1643), closes [#960](https://github.com/kbknapp/clap-rs/issues/960))
+*   fixes a bug where args that allow values to start with a hyphen couldn't contain a double hyphen -- as a value ([ebf73a09](https://github.com/kbknapp/clap-rs/commit/ebf73a09db6f3c03c19cdd76b1ba6113930e1643), closes [#960](https://github.com/kbknapp/clap-rs/issues/960))
 *   fixes a bug where positional argument help text is misaligned ([54c16836](https://github.com/kbknapp/clap-rs/commit/54c16836dea4651806a2cfad53146a83fa3abf21))
 
 #### Documentation
@@ -730,7 +730,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 *   now correctly shows subcommand as required in the usage string when AppSettings::SubcommandRequiredElseHelp is used ([8f0884c1](https://github.com/kbknapp/clap-rs/commit/8f0884c1764983a49b45de52a1eddf8d721564d8))
 *   fixes some memory leaks when an error is detected and clap exits ([8c2dd287](https://github.com/kbknapp/clap-rs/commit/8c2dd28718262ace4ae0db98563809548e02a86b))
 *   fixes a trait that's marked private accidentlly, but should be crate internal public ([1ae21108](https://github.com/kbknapp/clap-rs/commit/1ae21108015cea87e5360402e1747025116c7878))
-* **Completions:**   fixes a bug that tried to propogate global args multiple times when generating multiple completion scripts ([5e9b9cf4](https://github.com/kbknapp/clap-rs/commit/5e9b9cf4dd80fa66a624374fd04e6545635c1f94), closes [#846](https://github.com/kbknapp/clap-rs/issues/846))
+* **Completions:**   fixes a bug that tried to propagate global args multiple times when generating multiple completion scripts ([5e9b9cf4](https://github.com/kbknapp/clap-rs/commit/5e9b9cf4dd80fa66a624374fd04e6545635c1f94), closes [#846](https://github.com/kbknapp/clap-rs/issues/846))
 
 #### Features
 
@@ -753,7 +753,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-* **Completions:**   fixes a bug that tried to propogate global args multiple times when generating multiple completion scripts ([5e9b9cf4](https://github.com/kbknapp/clap-rs/commit/5e9b9cf4dd80fa66a624374fd04e6545635c1f94), closes [#846](https://github.com/kbknapp/clap-rs/issues/846))
+* **Completions:**   fixes a bug that tried to propagate global args multiple times when generating multiple completion scripts ([5e9b9cf4](https://github.com/kbknapp/clap-rs/commit/5e9b9cf4dd80fa66a624374fd04e6545635c1f94), closes [#846](https://github.com/kbknapp/clap-rs/issues/846))
 
 #### Documentation
 
@@ -783,7 +783,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-*   fixes a critical bug where subcommand settings were being propogated too far ([74648c94](https://github.com/kbknapp/clap-rs/commit/74648c94b893df542bfa5bb595e68c7bb8167e36), closes [#832](https://github.com/kbknapp/clap-rs/issues/832))
+*   fixes a critical bug where subcommand settings were being propagated too far ([74648c94](https://github.com/kbknapp/clap-rs/commit/74648c94b893df542bfa5bb595e68c7bb8167e36), closes [#832](https://github.com/kbknapp/clap-rs/issues/832))
 
 
 #### Improvements
@@ -797,7 +797,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 *   allow final word to be wrapped in wrap_help ([564c5f0f](https://github.com/kbknapp/clap-rs/commit/564c5f0f1730f4a2c1cdd128664f1a981c31dcd4), closes [#828](https://github.com/kbknapp/clap-rs/issues/828))
 *   actually show character in debug output ([84d8c547](https://github.com/kbknapp/clap-rs/commit/84d8c5476de95b7f37d61888bc4f13688b712434))
-*   include final character in line lenght ([aff4ba18](https://github.com/kbknapp/clap-rs/commit/aff4ba18da8147e1259b04b0bfbc1fcb5c78a3c0))
+*   include final character in line length ([aff4ba18](https://github.com/kbknapp/clap-rs/commit/aff4ba18da8147e1259b04b0bfbc1fcb5c78a3c0))
 
 #### Improvements
 
@@ -815,7 +815,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 * **ArgsNegateSubcommands:**  disables args being allowed between subcommands ([5e2af8c9](https://github.com/kbknapp/clap-rs/commit/5e2af8c96adb5ab75fa2d1536237ebcb41869494), closes [#793](https://github.com/kbknapp/clap-rs/issues/793))
 * **DontCollapseArgsInUsage:** disables the collapsing of positional args into `[ARGS]` in the usage string  ([c2978afc](https://github.com/kbknapp/clap-rs/commit/c2978afc61fb46d5263ab3b2d87ecde1c9ce1553), closes [#769](https://github.com/kbknapp/clap-rs/issues/769))
 * **DisableHelpSubcommand:**  disables building the `help` subcommand  ([a10fc859](https://github.com/kbknapp/clap-rs/commit/a10fc859ee20159fbd9ff4337be59b76467a64f2))
-* **AllowMissingPositional:**  allows one to implement `$ prog [optional] <required>` style CLIs where the second postional argument is required, but the first is optional ([1110fdc7](https://github.com/kbknapp/clap-rs/commit/1110fdc7a345c108820dc45783a9bf893fa4c214), closes [#636](https://github.com/kbknapp/clap-rs/issues/636))
+* **AllowMissingPositional:**  allows one to implement `$ prog [optional] <required>` style CLIs where the second positional argument is required, but the first is optional ([1110fdc7](https://github.com/kbknapp/clap-rs/commit/1110fdc7a345c108820dc45783a9bf893fa4c214), closes [#636](https://github.com/kbknapp/clap-rs/issues/636))
 * **PropagateGlobalValuesDown:**  automatically propagats global arg's values down through *used* subcommands ([985536c8](https://github.com/kbknapp/clap-rs/commit/985536c8ebcc09af98aac835f42a8072ad58c262), closes [#694](https://github.com/kbknapp/clap-rs/issues/694))
 
 #### API Additions
@@ -843,7 +843,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 * **Options:**  fixes a critical bug where options weren't forced to have a value ([5a5f2b1e](https://github.com/kbknapp/clap-rs/commit/5a5f2b1e9f598a0d0280ef3e98abbbba2bc41132), closes [#665](https://github.com/kbknapp/clap-rs/issues/665))
 *   fixes a bug where calling the help of a subcommand wasn't ignoring required args of parent commands ([d3d34a2b](https://github.com/kbknapp/clap-rs/commit/d3d34a2b51ef31004055b0ab574f766d801c3adf), closes [#789](https://github.com/kbknapp/clap-rs/issues/789))
-* **Help Subcommand:**  fixes a bug where the help subcommand couldn't be overriden ([d34ec3e0](https://github.com/kbknapp/clap-rs/commit/d34ec3e032d03e402d8e87af9b2942fe2819b2da), closes [#787](https://github.com/kbknapp/clap-rs/issues/787))
+* **Help Subcommand:**  fixes a bug where the help subcommand couldn't be overridden ([d34ec3e0](https://github.com/kbknapp/clap-rs/commit/d34ec3e032d03e402d8e87af9b2942fe2819b2da), closes [#787](https://github.com/kbknapp/clap-rs/issues/787))
 * **Low Index Multiples:**  fixes a bug which caused combinations of LowIndexMultiples and `Arg::allow_hyphen_values` to fail parsing ([26c670ca](https://github.com/kbknapp/clap-rs/commit/26c670ca16d2c80dc26d5c1ce83380ace6357318))
 
 #### Improvements
@@ -896,7 +896,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Improvements
 
-* **Bash Completion:**  allows bash completion to fall back to traidtional bash completion upon no matching completing function ([b1b16d56](https://github.com/kbknapp/clap-rs/commit/b1b16d56d8fddf819bdbe24b3724bb6a9f3fa613)))
+* **Bash Completion:**  allows bash completion to fall back to traditional bash completion upon no matching completing function ([b1b16d56](https://github.com/kbknapp/clap-rs/commit/b1b16d56d8fddf819bdbe24b3724bb6a9f3fa613)))
 
 
 <a name="v2.19.0"></a>
@@ -959,7 +959,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Improvements
 
-* **Error Output:**  conflicting errors are now symetrical, meaning more consistent and less confusing ([3d37001d](https://github.com/kbknapp/clap-rs/commit/3d37001d1dc647d73cc597ff172f1072d4beb80d), closes [#718](https://github.com/kbknapp/clap-rs/issues/718))
+* **Error Output:**  conflicting errors are now symmetrical, meaning more consistent and less confusing ([3d37001d](https://github.com/kbknapp/clap-rs/commit/3d37001d1dc647d73cc597ff172f1072d4beb80d), closes [#718](https://github.com/kbknapp/clap-rs/issues/718))
 
 #### Documentation
 
@@ -1162,7 +1162,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-* **Settings:**  fixes an issue where settings weren't propogated down through grand-child subcommands ([b3efc107](https://github.com/kbknapp/clap-rs/commit/b3efc107515d78517b20798ff3890b8a2b04498e), closes [#638](https://github.com/kbknapp/clap-rs/issues/638))
+* **Settings:**  fixes an issue where settings weren't propagated down through grandchild subcommands ([b3efc107](https://github.com/kbknapp/clap-rs/commit/b3efc107515d78517b20798ff3890b8a2b04498e), closes [#638](https://github.com/kbknapp/clap-rs/issues/638))
 
 #### Features
 
@@ -1406,7 +1406,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 * **Help:**  allows wrapping at specified term width (Even on Windows!) ([1761dc0d](https://github.com/kbknapp/clap-rs/commit/1761dc0d27d0d621229d792be40c36fbf65c3014), closes [#451](https://github.com/kbknapp/clap-rs/issues/451))
 * **Settings:**
   *  adds new setting to stop delimiting values with -- or TrailingVarArg ([fc3e0f5a](https://github.com/kbknapp/clap-rs/commit/fc3e0f5afda6d24cdb3c4676614beebe13e1e870), closes [#511](https://github.com/kbknapp/clap-rs/issues/511))
-  *  one can now set an AppSetting which is propogated down through child subcommands ([e2341835](https://github.com/kbknapp/clap-rs/commit/e23418351a3b98bf08dfd7744bc14377c70d59ee), closes [#519](https://github.com/kbknapp/clap-rs/issues/519))
+  *  one can now set an AppSetting which is propagated down through child subcommands ([e2341835](https://github.com/kbknapp/clap-rs/commit/e23418351a3b98bf08dfd7744bc14377c70d59ee), closes [#519](https://github.com/kbknapp/clap-rs/issues/519))
 * **Subcommands:**  adds support for visible aliases ([7b10e7f8](https://github.com/kbknapp/clap-rs/commit/7b10e7f8937a07fdb8d16a6d8df79ce78d080cd3), closes [#522](https://github.com/kbknapp/clap-rs/issues/522))
 
 #### Bug Fixes
@@ -1609,7 +1609,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-* **From Usage:**  fixes a bug where adding empty lines werent ignored ([c5c58c86](https://github.com/kbknapp/clap-rs/commit/c5c58c86b9c503d8de19da356a5a5cffb59fbe84))
+* **From Usage:**  fixes a bug where adding empty lines weren't ignored ([c5c58c86](https://github.com/kbknapp/clap-rs/commit/c5c58c86b9c503d8de19da356a5a5cffb59fbe84))
 
 #### Documentation
 
@@ -1665,7 +1665,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-* **Multiple Values:**  fixes bug where number_of_values wasnt respected ([72c387da](https://github.com/kbknapp/clap-rs/commit/72c387da0bb8a6f526f863770f08bb8ca0d3de03))
+* **Multiple Values:**  fixes bug where number_of_values wasn't respected ([72c387da](https://github.com/kbknapp/clap-rs/commit/72c387da0bb8a6f526f863770f08bb8ca0d3de03))
 
 
 <a name="v2.0.4"></a>
@@ -1757,7 +1757,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### BREAKING CHANGES
 
-* **Fewer liftimes! Yay!**
+* **Fewer lifetimes! Yay!**
  * `App<'a, 'b, 'c, 'd, 'e, 'f>` => `App<'a, 'b>`
  * `Arg<'a, 'b, 'c, 'd, 'e, 'f>` => `Arg<'a, 'b>`
  * `ArgMatches<'a, 'b>` => `ArgMatches<'a>`
@@ -2112,7 +2112,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-* **Possible Values:**  fixes a bug where suggestions arent made when using --long=value format ([3d5e9a6c](https://github.com/kbknapp/clap-rs/commit/3d5e9a6cedb26668839b481c9978e2fbbab8be6f), closes [#192](https://github.com/kbknapp/clap-rs/issues/192))
+* **Possible Values:**  fixes a bug where suggestions aren't made when using --long=value format ([3d5e9a6c](https://github.com/kbknapp/clap-rs/commit/3d5e9a6cedb26668839b481c9978e2fbbab8be6f), closes [#192](https://github.com/kbknapp/clap-rs/issues/192))
 
 
 
@@ -2365,7 +2365,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-* **Global Args**  global arguments propogate fully now ([1f377960](https://github.com/kbknapp/clap-rs/commit/1f377960a48c82f54ca5f39eb56bcb393140b046), closes [#137](https://github.com/kbknapp/clap-rs/issues/137))
+* **Global Args**  global arguments propagate fully now ([1f377960](https://github.com/kbknapp/clap-rs/commit/1f377960a48c82f54ca5f39eb56bcb393140b046), closes [#137](https://github.com/kbknapp/clap-rs/issues/137))
 
 
 
@@ -2375,7 +2375,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 
 #### Bug Fixes
 
-* **Global Args**  global arguments propogate fully now ([8f2c0160](https://github.com/kbknapp/clap-rs/commit/8f2c0160c8d844daef375a33dbaec7d89de00a00), closes [#137](https://github.com/kbknapp/clap-rs/issues/137))
+* **Global Args**  global arguments propagate fully now ([8f2c0160](https://github.com/kbknapp/clap-rs/commit/8f2c0160c8d844daef375a33dbaec7d89de00a00), closes [#137](https://github.com/kbknapp/clap-rs/issues/137))
 
 
 
@@ -2565,7 +2565,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
   *  for possible values ([1cc2deb2](https://github.com/kbknapp/clap-rs/commit/1cc2deb29158e0e4e8b434e4ce26b3d819301a7d))
   *  for long flags (i.e. --long) ([52a0b850](https://github.com/kbknapp/clap-rs/commit/52a0b8505c99354bdf5fd1cd256cf41197ac2d81))
   *  for subcommands ([06e869b5](https://github.com/kbknapp/clap-rs/commit/06e869b5180258047ed3c60ba099de818dd25fff))
-* **Flags**  adds sugestions functionality ([8745071c](https://github.com/kbknapp/clap-rs/commit/8745071c3257dd327c497013516f12a823df9530))
+* **Flags**  adds suggestions functionality ([8745071c](https://github.com/kbknapp/clap-rs/commit/8745071c3257dd327c497013516f12a823df9530))
 * **errors**  colorizes output red on error ([f8b26b13](https://github.com/kbknapp/clap-rs/commit/f8b26b13da82ba3ba9a932d3d1ab4ea45d1ab036))
 
 #### Improvements
@@ -2768,7 +2768,7 @@ Minimum version of Rust is now v1.13.0 (Stable)
 #### Features
 
 * **macros**
-  *  add ability to get mutliple typed values or exit ([0b87251f](https://github.com/kbknapp/clap-rs/commit/0b87251fc088234bee51c323c2b652d7254f7a59))
+  *  add ability to get multiple typed values or exit ([0b87251f](https://github.com/kbknapp/clap-rs/commit/0b87251fc088234bee51c323c2b652d7254f7a59))
   *  add ability to get a typed multiple values ([e243fe38](https://github.com/kbknapp/clap-rs/commit/e243fe38ddbbf845a46c0b9baebaac3778c80927))
   *  add convenience macro to get a typed value or exit ([4b7cd3ea](https://github.com/kbknapp/clap-rs/commit/4b7cd3ea4947780d9daa39f3e1ddab53ad4c7fef))
   *  add convenience macro to get a typed value ([8752700f](https://github.com/kbknapp/clap-rs/commit/8752700fbb30e89ee68adbce24489ae9a24d33a9))

--- a/FAQ.md
+++ b/FAQ.md
@@ -16,7 +16,7 @@ First, let me say that these comparisons are highly subjective, and not meant in
 
 #### How does `clap` compare to [structopt](https://github.com/TeXitoi/structopt)?
 
-Simple! `clap` *is* `structopt`. With the 3.0 release, `clap` imported the `structopt` code into it's own codebase as the [`clap_derive`](https://github.com/clap-rs/clap/tree/master/clap_derive) crate. Since `structopt` already used `clap` under the hood, the transition was nearly painless, and is 100% feature compatible.
+Simple! `clap` *is* `structopt`. With the 3.0 release, `clap` imported the `structopt` code into its own codebase as the [`clap_derive`](https://github.com/clap-rs/clap/tree/master/clap_derive) crate. Since `structopt` already used `clap` under the hood, the transition was nearly painless, and is 100% feature compatible.
 
 If you were using `structopt` before, you have to change the attributes from `#[structopt(...)]` to `#[clap(...)]`.
 

--- a/benches/03_complex.rs
+++ b/benches/03_complex.rs
@@ -25,8 +25,8 @@ macro_rules! create_app {
                     .possible_values(&OPT3_VALS),
                 Arg::from("[positional3]... 'tests positionals with specific values'")
                     .possible_values(&POS3_VALS),
-                Arg::from("--multvals [one] [two] 'Tests mutliple values, not mult occs'"),
-                Arg::from("--multvalsmo... [one] [two] 'Tests mutliple values, not mult occs'"),
+                Arg::from("--multvals [one] [two] 'Tests multiple values, not mult occs'"),
+                Arg::from("--multvalsmo... [one] [two] 'Tests multiple values, not mult occs'"),
                 Arg::from("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
                 Arg::from("--maxvals3 [maxvals]... 'Tests 3 max vals'").max_values(3),
             ])
@@ -108,7 +108,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                 .arg(
                     Arg::new("multvals")
                         .long("multvals")
-                        .about("Tests mutliple values, not mult occs")
+                        .about("Tests multiple values, not mult occs")
                         .value_names(&["one", "two"]),
                 )
                 .arg(
@@ -116,7 +116,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .long("multvalsmo")
                         .setting(ArgSettings::MultipleValues)
                         .setting(ArgSettings::MultipleOccurrences)
-                        .about("Tests mutliple values, not mult occs")
+                        .about("Tests multiple values, not mult occs")
                         .value_names(&["one", "two"]),
                 )
                 .arg(
@@ -174,9 +174,9 @@ pub fn build_from_macros(c: &mut Criterion) {
                     (@arg positional3: index(3) ... possible_value[vi emacs]
                         "tests positionals with specific values")
                     (@arg multvals: --multvals +takes_value value_name[one two]
-                        "Tests mutliple values, not mult occs")
+                        "Tests multiple values, not mult occs")
                     (@arg multvalsmo: --multvalsmo ... +takes_value value_name[one two]
-                        "Tests mutliple values, not mult occs")
+                        "Tests multiple values, not mult occs")
                     (@arg minvals: --minvals2 min_values(1) ... +takes_value "Tests 2 min vals")
                     (@arg maxvals: --maxvals3 ... +takes_value max_values(3) "Tests 3 max vals")
                     (@subcommand subcmd =>

--- a/clap_derive/examples/README.md
+++ b/clap_derive/examples/README.md
@@ -75,4 +75,4 @@ How to express "`"true"` or `"false"` argument.
 
 ### [Author, description, and version from `Cargo.toml`](from_crate.rs)
 
-How to derive a author, description, and version from Cargo.toml
+How to derive the author, description, and version from Cargo.toml

--- a/clap_derive/examples/from_crate.rs
+++ b/clap_derive/examples/from_crate.rs
@@ -1,4 +1,4 @@
-//! How to derive a author, description, and version from Cargo.toml
+//! How to derive the author, description, and version from Cargo.toml
 
 use clap::Clap;
 

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -61,11 +61,11 @@ _{name} \"$@\"",
 //     _describe -t commands '[bin_name] commands' commands "$@"
 //
 // Where the following variables are present:
-//    [bin_name_underscore]: The full space deliniated bin_name, where spaces have been replaced by
+//    [bin_name_underscore]: The full space delineated bin_name, where spaces have been replaced by
 //                           underscore characters
 //    [arg_name]: The name of the subcommand
 //    [arg_help]: The help message of the subcommand
-//    [bin_name]: The full space deliniated bin_name
+//    [bin_name]: The full space delineated bin_name
 //
 // Here's a snippet from rustup:
 //
@@ -199,8 +199,8 @@ fn subcommands_of(p: &App) -> String {
 //
 // Where the following variables are present:
 //    [name] = The subcommand name in the form of "install" for "rustup toolchain install"
-//    [bin_name] = The full space deliniated bin_name such as "rustup toolchain install"
-//    [name_hyphen] = The full space deliniated bin_name, but replace spaces with hyphens
+//    [bin_name] = The full space delineated bin_name such as "rustup toolchain install"
+//    [name_hyphen] = The full space delineated bin_name, but replace spaces with hyphens
 //    [repeat] = From the same recursive calls, but for all subcommands
 //    [subcommand_args] = The same as zsh::get_args_of
 fn get_subcommands_of(p: &App) -> String {
@@ -263,9 +263,9 @@ fn parser_of<'b>(p: &'b App<'b>, mut sc: &str) -> &'b App<'b> {
     p.find_subcommand(sc).expect(INTERNAL_ERROR_MSG)
 }
 
-// Writes out the args section, which ends up being the flags, opts and postionals, and a jump to
+// Writes out the args section, which ends up being the flags, opts and positionals, and a jump to
 // another ZSH function if there are subcommands.
-// The structer works like this:
+// The structure works like this:
 //    ([conflicting_args]) [multiple] arg [takes_value] [[help]] [: :(possible_values)]
 //       ^-- list '-v -h'    ^--'*'          ^--'+'                   ^-- list 'one two three'
 //

--- a/examples/05_flag_args.rs
+++ b/examples/05_flag_args.rs
@@ -22,12 +22,12 @@ fn main() {
                 // occurrences such as "-aaa" or "-a -a"
                 .requires("config") // Says, "If the user uses -a, they MUST
                 // also use this other 'config' arg too"
-                // Can also specifiy a list using
+                // Can also specify a list using
                 // requires_all(Vec<&str>)
                 .conflicts_with("output"), // Opposite of requires(), says "if the
                                            // user uses -a, they CANNOT use 'output'"
                                            // also has a conflicts_with_all(Vec<&str>)
-                                           // and a exclusive(true)
+                                           // and an exclusive(true)
         )
         // NOTE: In order to compile this example, comment out requires() and
         // conflicts_with() because we have not defined an "output" or "config"
@@ -39,7 +39,7 @@ fn main() {
         println!("Awesomeness is turned on");
     }
 
-    // If we set the mutliple() option of a flag we can check how many times the user specified
+    // If we set the multiple() option of a flag we can check how many times the user specified
     //
     // Note: if we did not specify the multiple() option, and the user used "awesome" we would get
     // a 1 (no matter how many times they actually used it), or a 0 if they didn't use it at all

--- a/examples/06_positional_args.rs
+++ b/examples/06_positional_args.rs
@@ -6,7 +6,7 @@ fn main() {
     // flags, as well as a few additional ones.
     let matches = App::new("MyApp")
         // Regular App configuration goes here...
-        // We'll add two positional arguments, a input file, and a config file.
+        // We'll add two positional arguments, an input file, and a config file.
         //
         // I'll explain each possible setting that "positionals" accept. Keep in
         // mind that you DO NOT need to set each of these for every flag, only the
@@ -18,12 +18,12 @@ fn main() {
                 // specify this argument (Starts at 1)
                 .requires("config") // Says, "If the user uses "input", they MUST
                 // also use this other 'config' arg too"
-                // Can also specifiy a list using
+                // Can also specify a list using
                 // requires_all(Vec<&str>)
                 .conflicts_with("output") // Opposite of requires(), says "if the
                 // user uses -a, they CANNOT use 'output'"
                 // also has a conflicts_with_all(Vec<&str>)
-                // and a exclusive(true)
+                // and an exclusive(true)
                 .required(true), // By default this argument MUST be present
                                  // NOTE: mutual exclusions take precedence over
                                  // required arguments

--- a/examples/07_option_args.rs
+++ b/examples/07_option_args.rs
@@ -26,12 +26,12 @@ fn main() {
                 // required arguments
                 .requires("config") // Says, "If the user uses "input", they MUST
                 // also use this other 'config' arg too"
-                // Can also specifiy a list using
+                // Can also specify a list using
                 // requires_all(Vec<&str>)
                 .conflicts_with("output"), // Opposite of requires(), says "if the
                                            // user uses -a, they CANNOT use 'output'"
                                            // also has a conflicts_with_all(Vec<&str>)
-                                           // and a exclusive(true)
+                                           // and an exclusive(true)
         )
         // NOTE: In order to compile this example, comment out conflicts_with()
         // and requires() because we have not defined an "output" or "config"

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -2,11 +2,11 @@ use clap::{App, Arg};
 
 fn main() {
     // s function exactly like sub-Apps, because that's exactly what they are. Each
-    // instance of a  can have it's own version, author(s), Args, and even it's own
+    // instance of a can have its own version, author(s), Args, and even its own
     // subcommands.
     //
     // # Help and Version
-    // Just like Apps, each subcommand will get it's own "help" and "version" flags automatically
+    // Just like Apps, each subcommand will get its own "help" and "version" flags automatically
     // generated. Also, like Apps, you can override "-V" or "-h" safely and still get "--help" and
     // "--version" auto generated.
     //

--- a/examples/17_yaml.rs
+++ b/examples/17_yaml.rs
@@ -1,4 +1,4 @@
-// In order to use YAML to define your CLI you must compile clap with the "yaml" feature becasue
+// In order to use YAML to define your CLI you must compile clap with the "yaml" feature because
 // it's **not** included by default.
 //
 // In order to do this, ensure your Cargo.toml looks like one of the following:
@@ -20,7 +20,7 @@ fn main() {
 
     // To load a yaml file containing our CLI definition such as the example '17_yaml.yml' we can
     // use the convenience macro which loads the file at compile relative to the current file
-    // similiar to how modules are found.
+    // similar to how modules are found.
     //
     // Then we pass that yaml object to App to build the CLI.
     //

--- a/examples/20_subcommands.rs
+++ b/examples/20_subcommands.rs
@@ -1,7 +1,7 @@
 // Working with subcommands is simple. There are a few key points to remember when working with
 // subcommands in clap. First, s are really just Apps. This means they can have their own
 // settings, version, authors, args, and even their own subcommands. The next thing to remember is
-// that subcommands are set up in a tree like heirachy.
+// that subcommands are set up in a tree like hierarchy.
 //
 // An ASCII art depiction may help explain this better. Using a fictional version of git as the demo
 // subject. Imagine the following are all subcommands of git (note, the author is aware these aren't
@@ -30,7 +30,7 @@
 // $ git clone url push origin path
 //
 // It's also important to know that subcommands each have their own set of matches and may have args
-// with the same name as other subcommands in a different part of the tree heirachy (i.e. the arg
+// with the same name as other subcommands in a different part of the tree hierarchy (i.e. the arg
 // names aren't in a flat namespace).
 //
 // In order to use subcommands in clap, you only need to know which subcommand you're at in your
@@ -56,7 +56,7 @@ fn main() {
                 .about("pushes things")
                 .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
-                    App::new("remote") // Subcommands can have thier own subcommands,
+                    App::new("remote") // Subcommands can have their own subcommands,
                         // which in turn have their own subcommands
                         .about("pushes remote things")
                         .arg(
@@ -98,7 +98,7 @@ fn main() {
         // grandchildren, great grandchildren, etc.
         //
         // i.e. if the command `git push remove --stuff foo` was run, the above will only print out,
-        // `git push` was used. We'd need to get push's matches to see futher into the tree
+        // `git push` was used. We'd need to get push's matches to see further into the tree
     }
 
     // An alternative to checking the name is matching on known names. Again notice that only the

--- a/examples/23_flag_subcommands_pacman.rs
+++ b/examples/23_flag_subcommands_pacman.rs
@@ -38,7 +38,7 @@ fn main() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally-installed packages for matching strings")
+                        .about("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .multiple_values(true),
                 )

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -436,7 +436,7 @@ impl<'b> App<'b> {
 
     /// Allows the subcommand to be used as if it were an [`Arg::short`]
     ///
-    /// Sets the short version of the subcommand flag without the preceeding `-`.
+    /// Sets the short version of the subcommand flag without the preceding `-`.
     ///
     /// # Examples
     ///
@@ -464,7 +464,7 @@ impl<'b> App<'b> {
 
     /// Allows the subcommand to be used as if it were an [`Arg::long`]
     ///
-    /// Sets the long version of the subcommand flag without the preceeding `--`.
+    /// Sets the long version of the subcommand flag without the preceding `--`.
     ///
     /// **NOTE:** Any leading `-` characters will be stripped
     ///
@@ -648,7 +648,7 @@ impl<'b> App<'b> {
     ///     .help_template("{bin} ({version}) - {usage}")
     /// # ;
     /// ```
-    /// **NOTE:**The template system is, on purpose, very simple. Therefore the tags have to
+    /// **NOTE:**The template system is, on purpose, very simple. Therefore, the tags have to
     /// be written in the lowercase and without spacing.
     /// [`App::about`]: ./struct.App.html#method.about
     /// [`App::after_help`]: ./struct.App.html#method.after_help

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -343,7 +343,7 @@ pub enum AppSettings {
     /// assert_eq!(m.values_of("baz").unwrap().collect::<Vec<_>>(), &["baz1", "baz2", "baz3"]);
     /// ```
     ///
-    /// Now nofice if we don't specifiy `foo` or `baz` but use the `--` operator.
+    /// Now nofice if we don't specify `foo` or `baz` but use the `--` operator.
     ///
     /// ```rust
     /// # use clap::{App, Arg, AppSettings};
@@ -644,7 +644,7 @@ pub enum AppSettings {
     /// let res = App::new("myprog")
     ///     .version("v1.1")
     ///     .setting(AppSettings::DisableHelpSubcommand)
-    ///     // Normally, creating a subcommand causes a `help` subcommand to automaticaly
+    ///     // Normally, creating a subcommand causes a `help` subcommand to automatically
     ///     // be generated as well
     ///     .subcommand(App::new("test"))
     ///     .try_get_matches_from(vec![
@@ -773,7 +773,7 @@ pub enum AppSettings {
     ///```
     HelpRequired,
 
-    /// Tries to match unknown args to partial [`subcommands`] or their [aliases]. For example to
+    /// Tries to match unknown args to partial [`subcommands`] or their [aliases]. For example, to
     /// match a subcommand named `test`, one could use `t`, `te`, `tes`, and `test`.
     ///
     /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match `te`
@@ -834,7 +834,7 @@ pub enum AppSettings {
     NextLineHelp,
 
     /// Allows [``]s to override all requirements of the parent command.
-    /// For example if you had a subcommand or top level application with a required argument
+    /// For example, if you had a subcommand or top level application with a required argument
     /// that is only required as long as there is no subcommand present,
     /// using this setting would allow you to set those arguments to [`Arg::required(true)`]
     /// and yet receive no error so long as the user uses a valid subcommand instead.

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -943,7 +943,7 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Sets a overridable argument by name. I.e. this argument and the following argument
+    /// Sets an overridable argument by name. I.e. this argument and the following argument
     /// will override each other in POSIX style (whichever argument was specified at runtime
     /// **last** "wins")
     ///
@@ -990,7 +990,7 @@ impl<'help> Arg<'help> {
     /// assert!(m.is_present("flag"));
     /// assert_eq!(m.occurrences_of("flag"), 1);
     /// ```
-    /// Making a arg [`Multiple*``] and override itself is essentially meaningless. Therefore
+    /// Making an arg [`Multiple*``] and override itself is essentially meaningless. Therefore
     /// clap ignores an override of self if it's a flag and it already accepts multiple occurrences.
     ///
     /// ```
@@ -1381,7 +1381,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok()); // We didn't use --option=spec, or --extra=val so "cfg" isn't required
     /// ```
     ///
-    /// Setting [`Arg::required_ifs(&[(arg, val)])`] and having any of the `arg`s used with it's
+    /// Setting [`Arg::required_ifs(&[(arg, val)])`] and having any of the `arg`s used with its
     /// value of `val` but *not* using this arg is an error.
     ///
     /// ```rust
@@ -1821,7 +1821,7 @@ impl<'help> Arg<'help> {
     ///
     /// **NOTE:** There is a small performance hit for using validators, as they are implemented
     /// with [`Rc`] pointers. And the value to be checked will be allocated an extra time in order
-    /// to to be passed to the closure. This performance hit is extremely minimal in the grand
+    /// to be passed to the closure. This performance hit is extremely minimal in the grand
     /// scheme of things.
     ///
     /// # Examples
@@ -2986,7 +2986,7 @@ impl<'help> Arg<'help> {
     /// [`ArgSettings::MultipleOccurrences`] which only allows a single value at a time.
     ///
     /// **WARNING**: When building your CLIs, consider the effects of allowing leading hyphens and
-    /// the user passing in a value that matches a valid short. For example `prog -opt -F` where
+    /// the user passing in a value that matches a valid short. For example, `prog -opt -F` where
     /// `-F` is supposed to be a value, yet `-F` is *also* a valid short for another arg.
     /// Care should be taken when designing these args. This is compounded by the ability to "stack"
     /// short args. I.e. if `-val` is supposed to be a value, but `-v`, `-a`, and `-l` are all valid
@@ -3572,7 +3572,7 @@ impl<'help> Arg<'help> {
     /// **WARNING:**
     ///
     /// When using args with `MultipleValues` and [subcommands], one needs to consider the
-    /// posibility of an argument value being the same as a valid subcommand. By default `clap` will
+    /// possibility of an argument value being the same as a valid subcommand. By default `clap` will
     /// parse the argument in question as a value *only if* a value is possible at that moment.
     /// Otherwise it will be parsed as a subcommand. In effect, this means using `MultipleValues` with no
     /// additional parameters and a value that coincides with a subcommand name, the subcommand

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -1014,7 +1014,7 @@ impl<'b, 'c, 'd, 'w> Help<'b, 'c, 'd, 'w> {
     ///     * `{after-help}`  - Info to be displayed after the help message.
     ///     * `{before-help}` - Info to be displayed before the help message.
     ///
-    /// The template system is, on purpose, very simple. Therefore the tags have to be written
+    /// The template system is, on purpose, very simple. Therefore, the tags have to be written
     /// in the lowercase and without spacing.
     fn write_templated_help(&mut self, template: &str) -> ClapResult<()> {
         debug!("Help::write_templated_help");

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -376,7 +376,7 @@ impl<'b, 'c, 'z> Usage<'b, 'c, 'z> {
                     unrolled_reqs.push(aa);
                 }
             }
-            // alway include the required arg itself. it will not be enumerated
+            // always include the required arg itself. it will not be enumerated
             // by unroll_requirements_for_arg.
             unrolled_reqs.push(a.clone());
         }

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -560,7 +560,7 @@ impl ArgMatches {
     /// index for `val` would be recorded. This is by design.
     ///
     /// Besides the flag/option descrepancy, the primary difference between an argv index and clap
-    /// index, is that clap continues counting once all arguments have properly seperated, whereas
+    /// index, is that clap continues counting once all arguments have properly separated, whereas
     /// an argv index does not.
     ///
     /// The examples should clear this up.
@@ -571,7 +571,7 @@ impl ArgMatches {
     /// # Examples
     ///
     /// The argv indices are listed in the comments below. See how they correspond to the clap
-    /// indices. Note that if it's not listed in a clap index, this is becuase it's not saved in
+    /// indices. Note that if it's not listed in a clap index, this is because it's not saved in
     /// in an `ArgMatches` struct for querying.
     ///
     /// ```rust
@@ -927,7 +927,7 @@ impl ArgMatches {
     }
 }
 
-// The following were taken and adapated from vec_map source
+// The following were taken and adapted from vec_map source
 // repo: https://github.com/contain-rs/vec-map
 // commit: be5e1fa3c26e351761b33010ddbdaf5f05dbcc33
 // license: MIT - Copyright (c) 2015 The Rust Project Developers

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -92,7 +92,7 @@ where
 {
     pub(crate) app: &'c mut App<'b>,
     pub(crate) required: ChildGraph<Id>,
-    pub(crate) overriden: Vec<Id>,
+    pub(crate) overridden: Vec<Id>,
     pub(crate) seen: Vec<Id>,
     pub(crate) cur_idx: Cell<usize>,
     pub(crate) skip_idxs: usize,
@@ -117,7 +117,7 @@ where
         Parser {
             app,
             required: reqs,
-            overriden: Vec::new(),
+            overridden: Vec::new(),
             seen: Vec::new(),
             cur_idx: Cell::new(0),
             skip_idxs: 0,
@@ -430,7 +430,7 @@ where
 
             // Has the user already passed '--'? Meaning only positional args follow
             if !self.is_set(AS::TrailingValues) {
-                // Does the arg match a subcommand name, or any of it's aliases (if defined)
+                // Does the arg match a subcommand name, or any of its aliases (if defined)
                 match needs_val_of {
                     ParseResult::Opt(_) | ParseResult::Pos(_)
                         if !self.is_set(AS::SubcommandPrecedenceOverArg) => {}
@@ -849,7 +849,7 @@ where
         }
     }
 
-    // Checks if the arg matches a subcommand name, or any of it's aliases (if defined)
+    // Checks if the arg matches a subcommand name, or any of its aliases (if defined)
     fn possible_subcommand(&self, arg_os: &ArgStr<'_>) -> Option<&str> {
         debug!("Parser::possible_subcommand: arg={:?}", arg_os);
 
@@ -880,7 +880,7 @@ where
         None
     }
 
-    // Checks if the arg matches a long flag subcommand name, or any of it's aliases (if defined)
+    // Checks if the arg matches a long flag subcommand name, or any of its aliases (if defined)
     fn possible_long_flag_subcommand(&self, arg_os: &ArgStr<'_>) -> Option<&str> {
         debug!("Parser::possible_long_flag_subcommand: arg={:?}", arg_os);
         if self.is_set(AS::InferSubcommands) {
@@ -1570,7 +1570,7 @@ where
         for name in &to_rem {
             debug!("Parser::remove_overrides:iter:{:?}: removing", name);
             matcher.remove(name);
-            self.overriden.push(name.clone());
+            self.overridden.push(name.clone());
         }
     }
 

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -532,7 +532,7 @@ impl<'b, 'c, 'z> Validator<'b, 'c, 'z> {
 
     fn is_missing_required_ok(&self, a: &Arg<'b>, matcher: &ArgMatcher) -> bool {
         debug!("Validator::is_missing_required_ok: {}", a.name);
-        self.validate_arg_conflicts(a, matcher) || self.p.overriden.contains(&a.id)
+        self.validate_arg_conflicts(a, matcher) || self.p.overridden.contains(&a.id)
     }
 
     fn validate_arg_conflicts(&self, a: &Arg<'b>, matcher: &ArgMatcher) -> bool {

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -891,7 +891,14 @@ fn aaos_opts_mult_req_delims() {
         .setting(AppSettings::AllArgsOverrideSelf)
         .arg(Arg::from("--opt [val]... 'some option'"))
         .try_get_matches_from(vec![
-            "", "--opt", "first", "overides", "--opt", "some", "other", "val",
+            "",
+            "--opt",
+            "first",
+            "overrides",
+            "--opt",
+            "some",
+            "other",
+            "val",
         ]);
     assert!(res.is_ok());
     let m = res.unwrap();
@@ -899,7 +906,7 @@ fn aaos_opts_mult_req_delims() {
     assert_eq!(m.occurrences_of("opt"), 2);
     assert_eq!(
         m.values_of("opt").unwrap().collect::<Vec<_>>(),
-        &["first", "overides", "some", "other", "val"]
+        &["first", "overrides", "some", "other", "val"]
     );
 }
 

--- a/tests/fixtures/app.yml
+++ b/tests/fixtures/app.yml
@@ -22,7 +22,7 @@ args:
         index: 2
         default_value_if:
             - [flag, Null, some]
-            - [postional, other, something]
+            - [positional, other, something]
     - flag:
         short: f
         long: flag
@@ -59,18 +59,18 @@ args:
         possible_values: [ vi, emacs ]
     - multvals:
         long: multvals
-        about: Tests mutliple values, not mult occs
+        about: Tests multiple values, not mult occs
         value_names:
             - one
             - two
     - multvalsmo:
         long: multvalsmo
         multiple: true
-        about: Tests mutliple values, not mult occs
+        about: Tests multiple values, not mult occs
         value_names: [one, two]
     - multvalsdelim:
         long: multvalsdelim
-        about: Tests mutliple values with required delimiter
+        about: Tests multiple values with required delimiter
         multiple: true
         require_delimiter: true
     - singlealias:
@@ -81,7 +81,7 @@ args:
             - [multvalsmo, two]
     - multaliases:
         long: multaliases
-        about: Tests mutliple aliases
+        about: Tests multiple aliases
         aliases: [als1, als2, als3]
     - singleshortalias:
         long: singleshortalias
@@ -91,7 +91,7 @@ args:
             - [multvalsmo, two]
     - multshortaliases:
         long: multshortaliases
-        about: Tests mutliple short aliases
+        about: Tests multiple short aliases
         short_aliases: [a, b, c]
     - minvals2:
         long: minvals2

--- a/tests/flag_subcommands.rs
+++ b/tests/flag_subcommands.rs
@@ -419,7 +419,7 @@ FLAGS:
 
 OPTIONS:
     -i, --info <info>...        view package information
-    -s, --search <search>...    search locally-installed packages for matching strings";
+    -s, --search <search>...    search locally installed packages for matching strings";
 
 #[test]
 fn flag_subcommand_long_short_normal_usage_string() {
@@ -440,7 +440,7 @@ fn flag_subcommand_long_short_normal_usage_string() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally-installed packages for matching strings")
+                        .about("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .multiple_values(true),
                 )
@@ -473,7 +473,7 @@ FLAGS:
 
 OPTIONS:
     -i, --info <info>...        view package information
-    -s, --search <search>...    search locally-installed packages for matching strings";
+    -s, --search <search>...    search locally installed packages for matching strings";
 
 #[test]
 fn flag_subcommand_long_normal_usage_string() {
@@ -493,7 +493,7 @@ fn flag_subcommand_long_normal_usage_string() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally-installed packages for matching strings")
+                        .about("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .multiple_values(true),
                 )
@@ -526,7 +526,7 @@ FLAGS:
 
 OPTIONS:
     -i, --info <info>...        view package information
-    -s, --search <search>...    search locally-installed packages for matching strings";
+    -s, --search <search>...    search locally installed packages for matching strings";
 
 #[test]
 fn flag_subcommand_short_normal_usage_string() {
@@ -546,7 +546,7 @@ fn flag_subcommand_short_normal_usage_string() {
                     Arg::new("search")
                         .short('s')
                         .long("search")
-                        .about("search locally-installed packages for matching strings")
+                        .about("search locally installed packages for matching strings")
                         .conflicts_with("info")
                         .multiple_values(true),
                 )

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -39,8 +39,8 @@ OPTIONS:
         --long-option-2 <option2>    tests long options with exclusions
         --maxvals3 <maxvals>...      Tests 3 max vals
         --minvals2 <minvals>...      Tests 2 min vals
-        --multvals <one> <two>       Tests mutliple values, not mult occs
-        --multvalsmo <one> <two>     Tests mutliple values, and mult occs
+        --multvals <one> <two>       Tests multiple values, not mult occs
+        --multvalsmo <one> <two>     Tests multiple values, and mult occs
     -o, --option <opt>...            tests options
 
 SUBCOMMANDS:

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -43,9 +43,9 @@ fn basic() {
         (@arg positional3: index(3) ... possible_value[vi emacs]
             "tests positionals with specific values")
         (@arg multvals: --multvals +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg multvalsmo: --multvalsmo ... +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg minvals: --minvals2 min_values(1) ... +takes_value "Tests 2 min vals")
         (@arg maxvals: --maxvals3 ... +takes_value max_values(3) "Tests 3 max vals")
         (@subcommand subcmd =>
@@ -76,9 +76,9 @@ fn quoted_app_name() {
         (@arg positional3: index(3) ... possible_value[vi emacs]
             "tests positionals with specific values")
         (@arg multvals: --multvals +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg multvalsmo: --multvalsmo ... +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg minvals: --minvals2 min_values(1) ... +takes_value "Tests 2 min vals")
         (@arg maxvals: --maxvals3 ... +takes_value max_values(3) "Tests 3 max vals")
         (@subcommand subcmd =>
@@ -117,9 +117,9 @@ fn quoted_arg_long_name() {
         (@arg positional3: index(3) ... possible_value[vi emacs]
             "tests positionals with specific values")
         (@arg multvals: --multvals +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg multvalsmo: --multvalsmo ... +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg minvals: --minvals2 min_values(1) ... +takes_value "Tests 2 min vals")
         (@arg maxvals: --maxvals3 ... +takes_value max_values(3) "Tests 3 max vals")
         (@subcommand subcmd =>
@@ -155,9 +155,9 @@ fn quoted_arg_name() {
         (@arg ("positional-3"): index(3) ... possible_value[vi emacs]
             "tests positionals with specific values")
         (@arg multvals: --multvals +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg multvalsmo: --multvalsmo ... +takes_value value_name[one two]
-            "Tests mutliple values, not mult occs")
+            "Tests multiple values, not mult occs")
         (@arg minvals: --minvals2 min_values(1) ... +takes_value "Tests 2 min vals")
         (@arg maxvals: --maxvals3 ... +takes_value max_values(3) "Tests 3 max vals")
         (@subcommand subcmd =>

--- a/tests/posix_compatible.rs
+++ b/tests/posix_compatible.rs
@@ -59,7 +59,14 @@ fn mult_option_overrides_itself() {
     let res = App::new("posix")
         .arg(Arg::from("--opt [val]... 'some option'").overrides_with("opt"))
         .try_get_matches_from(vec![
-            "", "--opt", "first", "overides", "--opt", "some", "other", "val",
+            "",
+            "--opt",
+            "first",
+            "overrides",
+            "--opt",
+            "some",
+            "other",
+            "val",
         ]);
     assert!(res.is_ok());
     let m = res.unwrap();
@@ -67,7 +74,7 @@ fn mult_option_overrides_itself() {
     assert_eq!(m.occurrences_of("opt"), 2);
     assert_eq!(
         m.values_of("opt").unwrap().collect::<Vec<_>>(),
-        &["first", "overides", "some", "other", "val"]
+        &["first", "overrides", "some", "other", "val"]
     );
 }
 
@@ -206,8 +213,8 @@ fn posix_compatible_opts_short_rev() {
 }
 
 #[test]
-fn conflict_overriden() {
-    let m = App::new("conflict_overriden")
+fn conflict_overridden() {
+    let m = App::new("conflict_overridden")
         .arg(Arg::from("-f, --flag 'some flag'").conflicts_with("debug"))
         .arg(Arg::from("-d, --debug 'other flag'"))
         .arg(Arg::from("-c, --color 'third flag'").overrides_with("flag"))
@@ -218,8 +225,8 @@ fn conflict_overriden() {
 }
 
 #[test]
-fn conflict_overriden_2() {
-    let result = App::new("conflict_overriden")
+fn conflict_overridden_2() {
+    let result = App::new("conflict_overridden")
         .arg(Arg::from("-f, --flag 'some flag'").conflicts_with("debug"))
         .arg(Arg::from("-d, --debug 'other flag'"))
         .arg(Arg::from("-c, --color 'third flag'").overrides_with("flag"))
@@ -232,8 +239,8 @@ fn conflict_overriden_2() {
 }
 
 #[test]
-fn conflict_overriden_3() {
-    let result = App::new("conflict_overriden")
+fn conflict_overridden_3() {
+    let result = App::new("conflict_overridden")
         .arg(Arg::from("-f, --flag 'some flag'").conflicts_with("debug"))
         .arg(Arg::from("-d, --debug 'other flag'"))
         .arg(Arg::from("-c, --color 'third flag'").overrides_with("flag"))
@@ -244,8 +251,8 @@ fn conflict_overriden_3() {
 }
 
 #[test]
-fn conflict_overriden_4() {
-    let m = App::new("conflict_overriden")
+fn conflict_overridden_4() {
+    let m = App::new("conflict_overridden")
         .arg(Arg::from("-f, --flag 'some flag'").conflicts_with("debug"))
         .arg(Arg::from("-d, --debug 'other flag'"))
         .arg(Arg::from("-c, --color 'third flag'").overrides_with("flag"))
@@ -257,7 +264,7 @@ fn conflict_overriden_4() {
 
 #[test]
 fn pos_required_overridden_by_flag() {
-    let result = App::new("require_overriden")
+    let result = App::new("require_overridden")
         .arg(Arg::new("pos").index(1).required(true))
         .arg(Arg::from("-c, --color 'some flag'").overrides_with("pos"))
         .try_get_matches_from(vec!["", "test", "-c"]);
@@ -265,8 +272,8 @@ fn pos_required_overridden_by_flag() {
 }
 
 #[test]
-fn require_overriden_2() {
-    let m = App::new("require_overriden")
+fn require_overridden_2() {
+    let m = App::new("require_overridden")
         .arg(Arg::new("req_pos").required(true))
         .arg(Arg::from("-c, --color 'other flag'").overrides_with("req_pos"))
         .get_matches_from(vec!["", "-c", "req_pos"]);
@@ -275,8 +282,8 @@ fn require_overriden_2() {
 }
 
 #[test]
-fn require_overriden_3() {
-    let m = App::new("require_overriden")
+fn require_overridden_3() {
+    let m = App::new("require_overridden")
         .arg(Arg::from("-f, --flag 'some flag'").requires("debug"))
         .arg(Arg::from("-d, --debug 'other flag'"))
         .arg(Arg::from("-c, --color 'third flag'").overrides_with("flag"))
@@ -287,8 +294,8 @@ fn require_overriden_3() {
 }
 
 #[test]
-fn require_overriden_4() {
-    let result = App::new("require_overriden")
+fn require_overridden_4() {
+    let result = App::new("require_overridden")
         .arg(Arg::from("-f, --flag 'some flag'").requires("debug"))
         .arg(Arg::from("-d, --debug 'other flag'"))
         .arg(Arg::from("-c, --color 'third flag'").overrides_with("flag"))

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -87,8 +87,8 @@ pub fn complex_app() -> App<'static> {
             Arg::from("[positional2] 'tests positionals with exclusions'"),
             Arg::from("-O --Option [option3] 'specific vals'").possible_values(&opt3_vals),
             Arg::from("[positional3]... 'tests specific values'").possible_values(&pos3_vals),
-            Arg::from("--multvals [one] [two] 'Tests mutliple values, not mult occs'"),
-            Arg::from("--multvalsmo... [one] [two] 'Tests mutliple values, and mult occs'"),
+            Arg::from("--multvals [one] [two] 'Tests multiple values, not mult occs'"),
+            Arg::from("--multvalsmo... [one] [two] 'Tests multiple values, and mult occs'"),
             Arg::from("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
             Arg::from("--maxvals3 [maxvals]... 'Tests 3 max vals'").max_values(3),
         ])


### PR DESCRIPTION
Most errors detected and fixed with Topy (https://github.com/intgr/topy), all verified by hand.
