### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ fn main() {
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
-        .arg("-c, --config=[FILE] 'Sets a custom config file'")
-        .arg("<INPUT>              'Sets the input file to use'")
-        .arg("-v...                'Sets the level of verbosity'")
+        .arg(Arg::from_usage("-c, --config=[FILE] 'Sets a custom config file'"))
+        .arg(Arg::from_usage("<INPUT>              'Sets the input file to use'"))
+        .arg(Arg::from_usage("-v...                'Sets the level of verbosity'"))
         .subcommand(App::new("test")
             .about("controls testing features")
             .version("1.3")
             .author("Someone E. <someone_else@other.com>")
-            .arg("-d, --debug 'Print debug information'"))
+            .arg(Arg::from_usage("-d, --debug 'Print debug information'")))
         .get_matches();
 
     // Same as previous example...


### PR DESCRIPTION
According to the latest documentation here https://docs.rs/clap/2.33.1/clap/struct.App.html#method.arg it seems these examples doesn't compile. Indeed on my project it didn't.
