### PR TITLE
Change the ret tyte of Argmatches::subcommand

### DIFF
--- a/clap_derive/src/derives/from_arg_matches.rs
+++ b/clap_derive/src/derives/from_arg_matches.rs
@@ -65,9 +65,7 @@ pub fn gen_for_enum(name: &Ident) -> TokenStream {
         #[deny(clippy::correctness)]
         impl ::clap::FromArgMatches for #name {
             fn from_arg_matches(matches: &::clap::ArgMatches) -> Self {
-                let (name, subcmd) = matches.subcommand();
-                <#name as ::clap::Subcommand>::from_subcommand(name, subcmd)
-                    .unwrap()
+                <#name as ::clap::Subcommand>::from_subcommand(matches.subcommand()).unwrap()
             }
         }
     }
@@ -107,11 +105,7 @@ pub fn gen_constructor(fields: &Punctuated<Field, Comma>, parent_attribute: &Att
                 };
                 quote_spanned! { kind.span()=>
                     #field_name: {
-                        let (name, subcmd) = matches.subcommand();
-                        <#subcmd_type as ::clap::Subcommand>::from_subcommand(
-                            name,
-                            subcmd
-                        )
+                        <#subcmd_type as ::clap::Subcommand>::from_subcommand(matches.subcommand())
                         #unwrapper
                     }
                 }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -280,7 +280,7 @@ fn gen_from_subcommand(
     };
 
     quote! {
-        fn from_subcommand<'b>(subcommand: Option<(&'b str, &'b ::clap::ArgMatches)>) -> Option<Self> {
+        fn from_subcommand(subcommand: Option<(&str, &::clap::ArgMatches)>) -> Option<Self> {
             match subcommand {
                 #( #match_arms, )*
                 other => {

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -44,7 +44,7 @@ pub fn from_arg_matches(name: &Ident) {
 pub fn subcommand(name: &Ident) {
     append_dummy(quote! {
         impl ::clap::Subcommand for #name {
-            fn from_subcommand<'b>(_sub: Option<(&'b str, &'b ::clap::ArgMatches)>) -> Option<Self> {
+            fn from_subcommand(_sub: Option<(&str, &::clap::ArgMatches)>) -> Option<Self> {
                 unimplemented!()
             }
             fn augment_subcommands(_app: ::clap::App<'_>) -> ::clap::App<'_> {

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -44,7 +44,7 @@ pub fn from_arg_matches(name: &Ident) {
 pub fn subcommand(name: &Ident) {
     append_dummy(quote! {
         impl ::clap::Subcommand for #name {
-            fn from_subcommand(_name: &str, _matches: Option<&::clap::ArgMatches>) -> Option<Self> {
+            fn from_subcommand<'b>(_sub: Option<(&'b str, &'b ::clap::ArgMatches)>) -> Option<Self> {
                 unimplemented!()
             }
             fn augment_subcommands(_app: ::clap::App<'_>) -> ::clap::App<'_> {

--- a/examples/16_app_settings.rs
+++ b/examples/16_app_settings.rs
@@ -28,8 +28,8 @@ fn main() {
         println!("The input file is: {}", inp);
     }
 
-    match matches.subcommand() {
-        ("test", _) => println!("The 'test' subcommand was used"),
+    match matches.subcommand_name() {
+        Some("test") => println!("The 'test' subcommand was used"),
         _ => unreachable!(),
     }
 }

--- a/examples/20_subcommands.rs
+++ b/examples/20_subcommands.rs
@@ -120,24 +120,24 @@ fn main() {
     // The most common way to handle subcommands is via a combined approach using
     // `ArgMatches::subcommand` which returns a tuple of both the name and matches
     match matches.subcommand() {
-        ("clone", Some(clone_matches)) => {
+        Some(("clone", clone_matches)) => {
             // Now we have a reference to clone's matches
             println!("Cloning {}", clone_matches.value_of("repo").unwrap());
         }
-        ("push", Some(push_matches)) => {
+        Some(("push", push_matches)) => {
             // Now we have a reference to push's matches
             match push_matches.subcommand() {
-                ("remote", Some(remote_matches)) => {
+                Some(("remote", remote_matches)) => {
                     // Now we have a reference to remote's matches
                     println!("Pushing to {}", remote_matches.value_of("repo").unwrap());
                 }
-                ("local", Some(_)) => {
+                Some(("local", _)) => {
                     println!("'git push local' was used");
                 }
                 _ => unreachable!(),
             }
         }
-        ("add", Some(add_matches)) => {
+        Some(("add", add_matches)) => {
             // Now we have a reference to add's matches
             println!(
                 "Adding {}",
@@ -148,7 +148,7 @@ fn main() {
                     .join(", ")
             );
         }
-        ("", None) => println!("No subcommand was used"), // If no subcommand was usd it'll match the tuple ("", None)
+        None => println!("No subcommand was used"), // If no subcommand was used it'll match the tuple ("", None)
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachabe!()
     }
 

--- a/examples/23_flag_subcommands_pacman.rs
+++ b/examples/23_flag_subcommands_pacman.rs
@@ -86,7 +86,7 @@ fn main() {
         .get_matches();
 
     match matches.subcommand() {
-        ("sync", Some(sync_matches)) => {
+        Some(("sync", sync_matches)) => {
             if sync_matches.is_present("search") {
                 let packages: Vec<_> = sync_matches.values_of("search").unwrap().collect();
                 let values = packages.join(", ");
@@ -103,7 +103,7 @@ fn main() {
                 println!("Installing {}...", values);
             }
         }
-        ("query", Some(query_matches)) => {
+        Some(("query", query_matches)) => {
             if let Some(packages) = query_matches.values_of("info") {
                 let comma_sep = packages.collect::<Vec<_>>().join(", ");
                 println!("Retrieving info for {}...", comma_sep);

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -387,7 +387,7 @@ pub enum AppSettings {
     /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
     /// // string argument name
     /// match m.subcommand() {
-    ///     (external, Some(ext_m)) => {
+    ///     Some((external, ext_m)) => {
     ///          let ext_args: Vec<&str> = ext_m.values_of("").unwrap().collect();
     ///          assert_eq!(external, "subcmd");
     ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -60,7 +60,7 @@ pub trait FromArgMatches: Sized {
 /// @TODO @release @docs
 pub trait Subcommand: Sized {
     /// @TODO @release @docs
-    fn from_subcommand(name: &str, matches: Option<&ArgMatches>) -> Option<Self>;
+    fn from_subcommand(subcommand: Option<(&str, &ArgMatches)>) -> Option<Self>;
     /// @TODO @release @docs
     fn augment_subcommands(app: App<'_>) -> App<'_>;
 }
@@ -118,8 +118,8 @@ impl<T: FromArgMatches> FromArgMatches for Box<T> {
 }
 
 impl<T: Subcommand> Subcommand for Box<T> {
-    fn from_subcommand(name: &str, matches: Option<&ArgMatches>) -> Option<Self> {
-        <T as Subcommand>::from_subcommand(name, matches).map(Box::new)
+    fn from_subcommand(subcommand: Option<(&str, &ArgMatches)>) -> Option<Self> {
+        <T as Subcommand>::from_subcommand(subcommand).map(Box::new)
     }
     fn augment_subcommands(app: App<'_>) -> App<'_> {
         <T as Subcommand>::augment_subcommands(app)

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -886,9 +886,9 @@ impl ArgMatches {
     ///      .get_matches();
     ///
     /// match app_m.subcommand() {
-    ///     ("clone",  Some(sub_m)) => {}, // clone was used
-    ///     ("push",   Some(sub_m)) => {}, // push was used
-    ///     ("commit", Some(sub_m)) => {}, // commit was used
+    ///     Some(("clone",  sub_m)) => {}, // clone was used
+    ///     Some(("push",   sub_m)) => {}, // push was used
+    ///     Some(("commit", sub_m)) => {}, // commit was used
     ///     _                       => {}, // Either no subcommand or one not tested for...
     /// }
     /// ```
@@ -909,7 +909,7 @@ impl ArgMatches {
     /// // All trailing arguments will be stored under the subcommand's sub-matches using an empty
     /// // string argument name
     /// match app_m.subcommand() {
-    ///     (external, Some(sub_m)) => {
+    ///     Some((external, sub_m)) => {
     ///          let ext_args: Vec<&str> = sub_m.values_of("").unwrap().collect();
     ///          assert_eq!(external, "subcmd");
     ///          assert_eq!(ext_args, ["--option", "value", "-fff", "--flag"]);
@@ -920,10 +920,8 @@ impl ArgMatches {
     /// [`ArgMatches::subcommand_matches`]: ./struct.ArgMatches.html#method.subcommand_matches
     /// [`ArgMatches::subcommand_name`]: ./struct.ArgMatches.html#method.subcommand_name
     #[inline]
-    pub fn subcommand(&self) -> (&str, Option<&ArgMatches>) {
-        self.subcommand
-            .as_ref()
-            .map_or(("", None), |sc| (&sc.name[..], Some(&sc.matches)))
+    pub fn subcommand(&self) -> Option<(&str, &ArgMatches)> {
+        self.subcommand.as_ref().map(|sc| (&*sc.name, &sc.matches))
     }
 }
 

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -735,7 +735,7 @@ fn allow_ext_sc_when_sc_required() {
     assert!(res.is_ok());
 
     match res.unwrap().subcommand() {
-        (name, Some(args)) => {
+        Some((name, args)) => {
             assert_eq!(name, "external-cmd");
             assert_eq!(args.values_of_lossy(""), Some(vec!["foo".to_string()]));
         }
@@ -753,7 +753,7 @@ fn external_subcommand_looks_like_built_in() {
     assert!(res.is_ok());
     let m = res.unwrap();
     match m.subcommand() {
-        (name, Some(args)) => {
+        Some((name, args)) => {
             assert_eq!(name, "install-update");
             assert_eq!(args.values_of_lossy(""), Some(vec!["foo".to_string()]));
         }


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
The question was raised in https://github.com/clap-rs/clap/discussions/2047. And indeed, having both the name and the matches wrapped in `Option` feels more fitting.