### PR TITLE
Fix YAML's default_value_if handling

### DIFF
--- a/src/build/macros.rs
+++ b/src/build/macros.rs
@@ -65,7 +65,7 @@ macro_rules! yaml_vec_or_str {
 #[cfg(feature = "yaml")]
 macro_rules! yaml_opt_str {
     ($v:expr) => {{
-        if $v.is_null() {
+        if !$v.is_null() {
             Some(
                 $v.as_str()
                     .unwrap_or_else(|| panic!("failed to convert YAML {:?} value to a string", $v)),

--- a/tests/fixtures/app.yaml
+++ b/tests/fixtures/app.yaml
@@ -21,7 +21,7 @@ args:
         about: tests positionals with exclusions
         index: 2
         default_value_if:
-            - [flag, Null, some]
+            - [flag, null, some]
             - [positional, other, something]
     - flag:
         short: f

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -54,3 +54,48 @@ fn value_hint() {
         .unwrap();
     assert_eq!(arg.get_value_hint(), ValueHint::FilePath);
 }
+
+#[test]
+fn default_value_if_not_triggered_by_argument() {
+    let yml = load_yaml!("fixtures/app.yaml");
+    let app = App::from(yml);
+
+    // Fixtures use "other" as value
+    let matches = app.try_get_matches_from(vec!["prog", "wrong"]).unwrap();
+
+    assert!(matches.value_of("positional2").is_none());
+}
+
+#[test]
+fn default_value_if_triggered_by_matching_argument() {
+    let yml = load_yaml!("fixtures/app.yaml");
+    let app = App::from(yml);
+
+    let matches = app.try_get_matches_from(vec!["prog", "other"]).unwrap();
+    assert_eq!(matches.value_of("positional2").unwrap(), "something");
+}
+
+#[test]
+fn default_value_if_triggered_by_flag() {
+    let yml = load_yaml!("fixtures/app.yaml");
+    let app = App::from(yml);
+
+    let matches = app
+        .try_get_matches_from(vec!["prog", "--flag", "flagvalue"])
+        .unwrap();
+
+    assert_eq!(matches.value_of("positional2").unwrap(), "some");
+}
+
+#[test]
+fn default_value_if_triggered_by_flag_and_argument() {
+    let yml = load_yaml!("fixtures/app.yaml");
+    let app = App::from(yml);
+
+    let matches = app
+        .try_get_matches_from(vec!["prog", "--flag", "flagvalue", "other"])
+        .unwrap();
+
+    // First condition triggers, therefore "some"
+    assert_eq!(matches.value_of("positional2").unwrap(), "some");
+}


### PR DESCRIPTION
While working on another issue I was completely puzzled by the `yaml_opt_str!`, as it immediately starts with `$v.is_null()` and then uses `as_str()` on a `YAML::Null` value. While trying to get to the root of the issue, I've noticed that this bug will only manifest itself in `default_value_if` when compiled with `yaml` support.

I've added some integration tests for the YAML part and also noticed that `null` was misspelled in the fixture, which kept the bug hidden. If you don't apply `e20cc1c` from the set of commits, you'll notice that *all* `yaml` tests break down due to `[flag, null, some]`.

**Please note that this is my first non-documentation Rust pull request ever and I'm happy about any feedback and criticism.**

I wasn't sure about the commit message style, as the recent commits didn't use the style mentioned in the contributing guide. I've tried to emulate the style from the recent commits. Also wasn't sure whether you want to have a single squashed commit, or three atomic changes/additions, but I'll happily change the messages/squash the commits if necessary.