### PR TITLE
Issue 1464

### DIFF
--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -185,10 +185,20 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         };
                         let used: Vec<Id> = matcher
                             .arg_names()
+                            .filter(|key| *key != latter)
                             .cloned()
-                            .filter(|key| key != latter)
                             .collect();
-                        let usg = Usage::new(self.p).create_usage_with_title(&used);
+                        let required: Vec<Id> = used
+                            .iter()
+                            .filter_map(|key| self.p.app.find(key))
+                            .flat_map(|key_arg| key_arg.requires.iter().map(|item| &item.1))
+                            .filter(|item| !used.contains(item))
+                            .filter(|key| *key != latter)
+                            .chain(used.iter())
+                            .cloned()
+                            .collect();
+                        println!("{:?}", required);
+                        let usg = Usage::new(self.p).create_usage_with_title(&required);
                         return Err(Error::argument_conflict(
                             former_arg,
                             Some(latter_arg.to_string()),

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -168,7 +168,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         Ok(())
     }
 
-    fn _build_conflict_err_usage(
+    fn build_conflict_err_usage(
         &self,
         matcher: &ArgMatcher,
         retained_arg: &Arg,
@@ -209,7 +209,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                                 (k, a, name, checked_arg)
                             }
                         };
-                        let usg = self._build_conflict_err_usage(matcher, former_arg, latter);
+                        let usg = self.build_conflict_err_usage(matcher, former_arg, latter);
                         return Err(Error::argument_conflict(
                             former_arg,
                             Some(latter_arg.to_string()),

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -183,18 +183,21 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                                 (k, a, name, checked_arg)
                             }
                         };
-                        let used: Vec<Id> = matcher
+                        let former_blacklist = &former_arg.blacklist;
+                        let used_filtered: Vec<Id> = matcher
                             .arg_names()
                             .filter(|key| *key != latter)
+                            .filter(|key| !former_blacklist.contains(key))
                             .cloned()
                             .collect();
-                        let required: Vec<Id> = used
+                        let required: Vec<Id> = used_filtered
                             .iter()
                             .filter_map(|key| self.p.app.find(key))
                             .flat_map(|key_arg| key_arg.requires.iter().map(|item| &item.1))
-                            .filter(|item| !used.contains(item))
+                            .filter(|item| !used_filtered.contains(item))
                             .filter(|key| *key != latter)
-                            .chain(used.iter())
+                            .filter(|key| !former_blacklist.contains(key))
+                            .chain(used_filtered.iter())
                             .cloned()
                             .collect();
                         println!("{:?}", required);

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -211,8 +211,8 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         };
                         let usg = self.build_conflict_err_usage(matcher, former_arg, latter);
                         return Err(Error::argument_conflict(
-                            former_arg,
-                            Some(latter_arg.to_string()),
+                            latter_arg,
+                            Some(former_arg.to_string()),
                             &*usg,
                             self.p.app.color(),
                         )?);

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -200,7 +200,6 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                             .chain(used_filtered.iter())
                             .cloned()
                             .collect();
-                        println!("{:?}", required);
                         let usg = Usage::new(self.p).create_usage_with_title(&required);
                         return Err(Error::argument_conflict(
                             former_arg,

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -2,21 +2,21 @@ mod utils;
 
 use clap::{App, Arg, ArgGroup, ErrorKind};
 
-static CONFLICT_ERR: &str = "error: The argument '--flag' cannot be used with '-F'
+static CONFLICT_ERR: &str = "error: The argument '-F' cannot be used with '--flag'
 
 USAGE:
     clap-test <positional> <positional2> --flag --long-option-2 <option2>
 
 For more information try --help";
 
-static CONFLICT_ERR_REV: &str = "error: The argument '-F' cannot be used with '--flag'
+static CONFLICT_ERR_REV: &str = "error: The argument '--flag' cannot be used with '-F'
 
 USAGE:
     clap-test <positional> <positional2> -F --long-option-2 <option2>
 
 For more information try --help";
 
-static CONFLICT_ERR_THREE: &str = "error: The argument '--one' cannot be used with '--two'
+static CONFLICT_ERR_THREE: &str = "error: The argument '--two' cannot be used with '--one'
 
 USAGE:
     three_conflicting_arguments --one
@@ -190,7 +190,7 @@ fn two_conflicting_arguments() {
     let a = a.unwrap_err();
     assert_eq!(
         a.cause,
-        "The argument \'--develop\' cannot be used with \'--production\'"
+        "The argument \'--production\' cannot be used with \'--develop\'"
     );
 }
 
@@ -218,7 +218,7 @@ fn three_conflicting_arguments() {
     let a = a.unwrap_err();
     assert_eq!(
         a.cause,
-        "The argument \'--one\' cannot be used with \'--two\'"
+        "The argument \'--two\' cannot be used with \'--one\'"
     );
 }
 

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -108,22 +108,22 @@ fn conflict_output_rev() {
 
 #[test]
 fn conflict_output_with_required() {
-    utils::compare_output(
+    assert!(utils::compare_output(
         utils::complex_app(),
         "clap-test val1 --flag --long-option-2 val2 -F",
         CONFLICT_ERR,
         true,
-    );
+    ));
 }
 
 #[test]
 fn conflict_output_rev_with_required() {
-    utils::compare_output(
+    assert!(utils::compare_output(
         utils::complex_app(),
         "clap-test val1 -F --long-option-2 val2 --flag",
         CONFLICT_ERR_REV,
         true,
-    );
+    ));
 }
 
 #[test]

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -90,7 +90,7 @@ fn group_conflict_2() {
 fn conflict_output() {
     assert!(utils::compare_output(
         utils::complex_app(),
-        "clap-test val1 --flag --long-option-2 val2 -F",
+        "clap-test val1 fa --flag --long-option-2 val2 -F",
         CONFLICT_ERR,
         true,
     ));
@@ -100,10 +100,30 @@ fn conflict_output() {
 fn conflict_output_rev() {
     assert!(utils::compare_output(
         utils::complex_app(),
-        "clap-test val1 -F --long-option-2 val2 --flag",
+        "clap-test val1 fa -F --long-option-2 val2 --flag",
         CONFLICT_ERR_REV,
         true,
     ));
+}
+
+#[test]
+fn conflict_output_with_required() {
+    utils::compare_output(
+        utils::complex_app(),
+        "clap-test val1 --flag --long-option-2 val2 -F",
+        CONFLICT_ERR,
+        true,
+    );
+}
+
+#[test]
+fn conflict_output_rev_with_required() {
+    utils::compare_output(
+        utils::complex_app(),
+        "clap-test val1 -F --long-option-2 val2 --flag",
+        CONFLICT_ERR_REV,
+        true,
+    );
 }
 
 #[test]

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -16,6 +16,13 @@ USAGE:
 
 For more information try --help";
 
+static CONFLICT_ERR_THREE: &str = "error: The argument '--one' cannot be used with '--two'
+
+USAGE:
+    three_conflicting_arguments --one
+
+For more information try --help";
+
 #[test]
 fn flag_conflict() {
     let result = App::new("flag_conflict")
@@ -127,6 +134,32 @@ fn conflict_output_rev_with_required() {
 }
 
 #[test]
+fn conflict_output_three_conflicting() {
+    let app = App::new("three_conflicting_arguments")
+        .arg(
+            Arg::new("one")
+                .long("one")
+                .conflicts_with_all(&["two", "three"]),
+        )
+        .arg(
+            Arg::new("two")
+                .long("two")
+                .conflicts_with_all(&["one", "three"]),
+        )
+        .arg(
+            Arg::new("three")
+                .long("three")
+                .conflicts_with_all(&["one", "two"]),
+        );
+    assert!(utils::compare_output(
+        app,
+        "three_conflicting_arguments --one --two --three",
+        CONFLICT_ERR_THREE,
+        true,
+    ));
+}
+
+#[test]
 fn conflict_with_unused_default_value() {
     let result = App::new("conflict")
         .arg(Arg::from("-o, --opt=[opt] 'some opt'").default_value("default"))
@@ -163,7 +196,7 @@ fn two_conflicting_arguments() {
 
 #[test]
 fn three_conflicting_arguments() {
-    let a = App::new("two_conflicting_arguments")
+    let a = App::new("three_conflicting_arguments")
         .arg(
             Arg::new("one")
                 .long("one")

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -2,14 +2,14 @@ mod utils;
 
 use clap::{App, Arg, ArgGroup, ErrorKind};
 
-static CONFLICT_ERR: &str = "error: The argument '-F' cannot be used with '--flag'
+static CONFLICT_ERR: &str = "error: The argument '--flag' cannot be used with '-F'
 
 USAGE:
     clap-test <positional> <positional2> --flag --long-option-2 <option2>
 
 For more information try --help";
 
-static CONFLICT_ERR_REV: &str = "error: The argument '--flag' cannot be used with '-F'
+static CONFLICT_ERR_REV: &str = "error: The argument '-F' cannot be used with '--flag'
 
 USAGE:
     clap-test <positional> <positional2> -F --long-option-2 <option2>
@@ -88,22 +88,22 @@ fn group_conflict_2() {
 
 #[test]
 fn conflict_output() {
-    utils::compare_output(
+    assert!(utils::compare_output(
         utils::complex_app(),
         "clap-test val1 --flag --long-option-2 val2 -F",
         CONFLICT_ERR,
         true,
-    );
+    ));
 }
 
 #[test]
 fn conflict_output_rev() {
-    utils::compare_output(
+    assert!(utils::compare_output(
         utils::complex_app(),
         "clap-test val1 -F --long-option-2 val2 --flag",
         CONFLICT_ERR_REV,
         true,
-    );
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Closes #1464 
Saw the recent reddit post and thought I'd try my hand at this issue :smile: Please let me know your thoughts and concerns.

I added tests to ensure correct output whether required argument are applied or not, as well as to ensure more than one conflicting argument is removed from the usage if needed (`conflict_output_three_conflicting`)
I edited the `CONFLICT_ERR` and `CONFLICT_ERR_REV` static strings because they did not follow the convention that other tests were following, i.e. mention the conflicting parameters in the order in which they appear (e.g. `two_conflicting_arguments` or `three_conflicting_arguments`).

- [x] tests pass locally
- [x] ran clippy and fmt
- [ ] commit messages are formatted according to CONTRIBUTING.md (I'll reformat the commit messages and squash them if desired)

I'm especially curious to see if the output in this PR for three conflicting arguments is desired, or if tacking on the required arguments in the usage based on the existing arguments is done in at least a mostly correct manner.