### PR TITLE
Eradicate remaining warnings in v2

### DIFF
--- a/src/app/parser.rs
+++ b/src/app/parser.rs
@@ -146,10 +146,10 @@ where
         assert!(self.verify_positionals());
         let should_err = self.groups.iter().all(|g| {
             g.args.iter().all(|arg| {
-                (self.flags.iter().any(|f| &f.b.name == arg)
+                self.flags.iter().any(|f| &f.b.name == arg)
                     || self.opts.iter().any(|o| &o.b.name == arg)
                     || self.positionals.values().any(|p| &p.b.name == arg)
-                    || self.groups.iter().any(|g| &g.name == arg))
+                    || self.groups.iter().any(|g| &g.name == arg)
             })
         });
         let g = self.groups.iter().find(|g| {
@@ -197,7 +197,7 @@ where
             );
         }
         let i = if a.index.is_none() {
-            (self.positionals.len() + 1)
+            self.positionals.len() + 1
         } else {
             a.index.unwrap() as usize
         };
@@ -306,7 +306,7 @@ where
         self.implied_settings(&a);
         if a.index.is_some() || (a.s.short.is_none() && a.s.long.is_none()) {
             let i = if a.index.is_none() {
-                (self.positionals.len() + 1)
+                self.positionals.len() + 1
             } else {
                 a.index.unwrap() as usize
             };
@@ -331,7 +331,7 @@ where
         self.implied_settings(a);
         if a.index.is_some() || (a.s.short.is_none() && a.s.long.is_none()) {
             let i = if a.index.is_none() {
-                (self.positionals.len() + 1)
+                self.positionals.len() + 1
             } else {
                 a.index.unwrap() as usize
             };
@@ -839,7 +839,7 @@ where
                     .iter()
                     .find(|o| o.b.name == name)
                     .expect(INTERNAL_ERROR_MSG);
-                (o.is_set(ArgSettings::AllowLeadingHyphen) || app_wide_settings)
+                o.is_set(ArgSettings::AllowLeadingHyphen) || app_wide_settings
             }
             ParseResult::Pos(name) => {
                 let p = self
@@ -847,7 +847,7 @@ where
                     .values()
                     .find(|p| p.b.name == name)
                     .expect(INTERNAL_ERROR_MSG);
-                (p.is_set(ArgSettings::AllowLeadingHyphen) || app_wide_settings)
+                p.is_set(ArgSettings::AllowLeadingHyphen) || app_wide_settings
             }
             ParseResult::ValuesDone => return true,
             _ => false,

--- a/src/app/validator.rs
+++ b/src/app/validator.rs
@@ -361,7 +361,7 @@ impl<'a, 'b, 'z> Validator<'a, 'b, 'z> {
                     a,
                     num,
                     if a.is_set(ArgSettings::Multiple) {
-                        (ma.vals.len() % num as usize)
+                        ma.vals.len() % num as usize
                     } else {
                         ma.vals.len()
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,6 +540,8 @@
 #![cfg_attr(feature = "lints", allow(cyclomatic_complexity))]
 #![cfg_attr(feature = "lints", allow(doc_markdown))]
 #![cfg_attr(feature = "lints", allow(explicit_iter_loop))]
+// Due to our "MSRV for 2.x will remain unchanged" policy, we can't fix these warnings
+#![allow(bare_trait_objects, deprecated)]
 
 #[cfg(all(feature = "color", not(target_os = "windows")))]
 extern crate ansi_term;

--- a/src/osstringext.rs
+++ b/src/osstringext.rs
@@ -112,9 +112,12 @@ impl OsStrExt2 for OsStr {
             // `clap.exe --arg=[invalid]`. Note that this entire module is
             // replaced in Clap 3.x, so this workaround is specific to the 2.x
             // branch.
-            return windows_osstr_starts_with(self, s);
+            windows_osstr_starts_with(self, s)
         }
-        self.as_bytes().starts_with(s)
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.as_bytes().starts_with(s)
+        }
     }
 
     fn contains_byte(&self, byte: u8) -> bool {


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Because why not? MSRV is preserved.

I didn't try to fix clippy warnings because they are not that apparent.