### PR TITLE
Do not capture args meant for libtest from the integration tests

### DIFF
--- a/tests/help.rs
+++ b/tests/help.rs
@@ -608,6 +608,10 @@ fn setup() -> App<'static> {
         .version("1.3")
 }
 
+fn empty_args() -> impl IntoIterator<Item = String> {
+    std::iter::empty()
+}
+
 #[test]
 fn help_short() {
     let m = setup().try_get_matches_from(vec!["myprog", "-h"]);
@@ -1706,7 +1710,7 @@ fn help_required_but_not_given() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
         .arg(Arg::new("foo"))
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[cfg(debug_assertions)]
@@ -1716,7 +1720,7 @@ fn help_required_but_not_given_settings_after_args() {
     App::new("myapp")
         .arg(Arg::new("foo"))
         .setting(AppSettings::HelpRequired)
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[cfg(debug_assertions)]
@@ -1727,7 +1731,7 @@ fn help_required_but_not_given_for_one_of_two_arguments() {
         .setting(AppSettings::HelpRequired)
         .arg(Arg::new("foo"))
         .arg(Arg::new("bar").about("It does bar stuff"))
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[test]
@@ -1740,7 +1744,7 @@ fn help_required_locally_but_not_given_for_subcommand() {
                 .arg(Arg::new("create").about("creates bar"))
                 .arg(Arg::new("delete")),
         )
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[cfg(debug_assertions)]
@@ -1755,7 +1759,7 @@ fn help_required_globally_but_not_given_for_subcommand() {
                 .arg(Arg::new("create").about("creates bar"))
                 .arg(Arg::new("delete")),
         )
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[test]
@@ -1768,7 +1772,7 @@ fn help_required_and_given_for_subcommand() {
                 .arg(Arg::new("create").about("creates bar"))
                 .arg(Arg::new("delete").about("deletes bar")),
         )
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[test]
@@ -1776,14 +1780,14 @@ fn help_required_and_given() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
         .arg(Arg::new("foo").about("It does foo stuff"))
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[test]
 fn help_required_and_no_args() {
     App::new("myapp")
         .setting(AppSettings::HelpRequired)
-        .get_matches();
+        .get_matches_from(empty_args());
 }
 
 #[test]


### PR DESCRIPTION
Using `App::get_matches` from the integration tests meant that any CLI arguments passed to libtest would also be captured by clap, causing some of the tests to fail.

For example, running `cargo test --test help -- --nocapture` would result in several failed tests, even though `cargo test --test help` worked fine. This was very surprising/confusing.

This pull request makes the tests no longer implicitly rely on the value of `env::args_os()`, which means developers can now provide arguments to libtest without failures.