### PR TITLE
Proposal: snapshot testing for the examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To test with all features both enabled and disabled, you can run these commands:
 $ cargo test --features "yaml unstable"
 ```
 
-Alternatively, if you have [`just`](https://github.com/casey/just) installed you can run the prebuilt recipes. _Not_ using `just` is perfectly fine as well, it simply bundles commands automatically.
+Alternatively, if you have [`just`](https://github.com/casey/just) installed you can run the prebuilt recipes. *Not* using `just` is perfectly fine as well, it simply bundles commands automatically.
 
 For example, to test the code, as above simply run:
 
@@ -39,6 +39,10 @@ There are [snapshot tests](https://sqa.stackexchange.com/q/29696) for the [examp
 ```sh
 $ cargo install cargo-insta
 $ cargo insta test --review
+
+# Or
+
+$ just review-snapshots
 ```
 
 For more details see [insta's documentation](https://docs.rs/insta).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To test with all features both enabled and disabled, you can run these commands:
 $ cargo test --features "yaml unstable"
 ```
 
-Alternatively, if you have [`just`](https://github.com/casey/just) installed you can run the prebuilt recipes. *Not* using `just` is perfectly fine as well, it simply bundles commands automatically.
+Alternatively, if you have [`just`](https://github.com/casey/just) installed you can run the prebuilt recipes. _Not_ using `just` is perfectly fine as well, it simply bundles commands automatically.
 
 For example, to test the code, as above simply run:
 
@@ -31,6 +31,17 @@ $ cargo test --test <test_name>
 
 $ just run-test <test_name>
 ```
+
+#### Snapshot Testing
+
+There are [snapshot tests](https://sqa.stackexchange.com/q/29696) for the [examples](../examples). If you've made a change that alters `clap`'s CLI output then you may need to update the snapshots. The friendliest way to do this is to install `cargo-insta` and interactively review the changes:
+
+```sh
+$ cargo install cargo-insta
+$ cargo insta test --review
+```
+
+For more details see [insta's documentation](https://docs.rs/insta).
 
 ### Linting Code
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ regex = "1.0"
 lazy_static = "1"
 version-sync = "0.8"
 criterion = "0.3.2"
+insta = "0.16.1"
 
 [features]
 default     = ["suggestions", "color", "derive", "std", "cargo"]

--- a/examples/03_args.rs
+++ b/examples/03_args.rs
@@ -41,7 +41,6 @@ fn main() {
                 .long("config"),
             Arg::new("input")
                 .about("the input file to use")
-                .index(1)
                 .required(true),
         ])
         // *Note* the following two examples are convenience methods, if you wish

--- a/examples/05_flag_args.rs
+++ b/examples/05_flag_args.rs
@@ -29,9 +29,8 @@ fn main() {
                                            // also has a conflicts_with_all(Vec<&str>)
                                            // and an exclusive(true)
         )
-        // NOTE: In order to compile this example, comment out requires() and
-        // conflicts_with() because we have not defined an "output" or "config"
-        // argument.
+        .arg("-c, --config=[FILE] 'sets a custom config file'")
+        .arg("<output> 'sets an output file'")
         .get_matches();
 
     // We can find out whether or not awesome was used

--- a/examples/06_positional_args.rs
+++ b/examples/06_positional_args.rs
@@ -33,8 +33,7 @@ fn main() {
         // requires "config"
         // Note, we also do not need to specify requires("input")
         // because requires lists are automatically two-way
-        // NOTE: In order to compile this example, comment out conflicts_with()
-        // because we have not defined an "output" argument.
+        .arg(Arg::new("output").about("the output file to use").index(3))
         .get_matches();
 
     // We can find out whether or not "input" or "config" were used

--- a/examples/07_option_args.rs
+++ b/examples/07_option_args.rs
@@ -33,9 +33,8 @@ fn main() {
                                            // also has a conflicts_with_all(Vec<&str>)
                                            // and an exclusive(true)
         )
-        // NOTE: In order to compile this example, comment out conflicts_with()
-        // and requires() because we have not defined an "output" or "config"
-        // argument.
+        .arg("-c, --config=[FILE] 'the config file to use'")
+        .arg("<output> 'the output file to use'")
         .get_matches();
 
     // We can find out whether or not "input" was used

--- a/examples/14_groups.rs
+++ b/examples/14_groups.rs
@@ -34,7 +34,7 @@ fn main() {
         .group(
             ArgGroup::new("vers")
                 .required(true)
-                .args(&["ver", "major", "minor", "patch"]),
+                .args(&["set-ver", "major", "minor", "patch"]),
         )
         // Arguments can also be added to a group individually, these two arguments
         // are part of the "input" group which is not required

--- a/justfile
+++ b/justfile
@@ -24,6 +24,10 @@ run-tests:
 @bench:
 	cargo bench
 
+review-snapshots:
+	cargo install cargo-insta
+	cargo insta test --review
+
 @lint:
 	rustup component add clippy
 	rustup component add rustfmt

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::process::{Command, Output};
 
-fn run_example<'a, S: AsRef<str>>(name: S, args: &[&str]) -> Output {
+fn run_example<S: AsRef<str>>(name: S, args: &[&str]) -> Output {
     let mut all_args = vec![
         "run",
         "--example",

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,0 +1,52 @@
+use insta;
+use std::ffi::OsStr;
+use std::fs;
+use std::process::{Command, Output};
+
+fn run_example<'a, S: AsRef<str>>(name: S, args: &[&str]) -> Output {
+    let mut all_args = vec![
+        "run",
+        "--example",
+        name.as_ref(),
+        "--features",
+        "yaml unstable",
+        "--",
+    ];
+    all_args.extend_from_slice(args);
+
+    Command::new(env!("CARGO"))
+        .args(all_args)
+        .output()
+        .expect("failed to run example")
+}
+
+#[test]
+fn examples_match_snapshots() {
+    let example_paths = fs::read_dir("examples")
+        .expect("couldn't read examples directory")
+        .map(|result| result.expect("couldn't get directory entry").path())
+        .filter(|path| path.is_file() && path.extension().and_then(OsStr::to_str) == Some("rs"));
+
+    let mut example_count = 0;
+    for path in example_paths {
+        example_count += 1;
+
+        let example_name = path
+            .file_stem()
+            .and_then(OsStr::to_str)
+            .expect("unable to determine example name");
+
+        let help = {
+            let help_output = run_example(example_name, &["--help"]);
+            assert!(
+                help_output.status.success(),
+                "{} example failed",
+                example_name
+            );
+            String::from_utf8(help_output.stdout).expect("help is not valid utf-8")
+        };
+
+        insta::assert_snapshot!(format!("{} --help", example_name), help);
+    }
+    assert!(example_count > 0);
+}

--- a/tests/snapshots/examples__01a_quick_example --help.snap
+++ b/tests/snapshots/examples__01a_quick_example --help.snap
@@ -1,0 +1,26 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 1.0
+Kevin K. <kbknapp@gmail.com>
+Does awesome things
+
+USAGE:
+    01a_quick_example [FLAGS] [OPTIONS] <output> [SUBCOMMAND]
+
+ARGS:
+    <output>    Sets an optional output file
+
+FLAGS:
+    -d               Turn debugging information on
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --config <FILE>    Sets a custom config file
+
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    test    does testing things
+

--- a/tests/snapshots/examples__01b_quick_example --help.snap
+++ b/tests/snapshots/examples__01b_quick_example --help.snap
@@ -1,0 +1,26 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 1.0
+Kevin K. <kbknapp@gmail.com>
+Does awesome things
+
+USAGE:
+    01b_quick_example [OPTIONS] [output] [SUBCOMMAND]
+
+ARGS:
+    <output>    Sets an optional output file
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --config <FILE>    Sets a custom config file
+    -d <debug>...          Turn debugging information on
+
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    test    does testing things
+

--- a/tests/snapshots/examples__01c_quick_example --help.snap
+++ b/tests/snapshots/examples__01c_quick_example --help.snap
@@ -1,0 +1,26 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 1.0
+Kevin K. <kbknapp@gmail.com>
+Does awesome things
+
+USAGE:
+    01c_quick_example [OPTIONS] <INPUT> [SUBCOMMAND]
+
+ARGS:
+    <INPUT>    Sets the input file to use
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --config <CONFIG>    Sets a custom config file
+    -d <debug>...            Sets the level of debugging information
+
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    test    controls testing features
+

--- a/tests/snapshots/examples__02_apps --help.snap
+++ b/tests/snapshots/examples__02_apps --help.snap
@@ -1,0 +1,15 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 1.0
+Kevin K. <kbknapp@gmail.com>
+Does awesome things
+
+USAGE:
+    02_apps
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+

--- a/tests/snapshots/examples__03_args --help.snap
+++ b/tests/snapshots/examples__03_args --help.snap
@@ -1,0 +1,23 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 
+
+USAGE:
+    03_args [FLAGS] [OPTIONS] <input> [output]
+
+ARGS:
+    <input>     the input file to use
+    <output>    Supply an output file to use
+
+FLAGS:
+    -d               turn on debugging information
+    -h, --help       Prints help information
+        --license    display the license file
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --config <config>    sets the config file to use
+    -i, --int <IFACE>        Set an interface to use
+

--- a/tests/snapshots/examples__04_using_matches --help.snap
+++ b/tests/snapshots/examples__04_using_matches --help.snap
@@ -1,0 +1,22 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 1.0
+Kevin K. <kbknapp@gmail.com>
+Parses an input file to do awesome things
+
+USAGE:
+    04_using_matches [FLAGS] [OPTIONS] <input>
+
+ARGS:
+    <input>    the input file to use
+
+FLAGS:
+    -d, --debug      turn on debugging information
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --config <config>    sets the config file to use
+

--- a/tests/snapshots/examples__05_flag_args --help.snap
+++ b/tests/snapshots/examples__05_flag_args --help.snap
@@ -1,0 +1,20 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 
+
+USAGE:
+    05_flag_args [OPTIONS] <output>
+
+ARGS:
+    <output>    sets an output file
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -a, --awesome <awesome>...    turns up the awesome
+    -c, --config <FILE>           sets a custom config file
+

--- a/tests/snapshots/examples__06_positional_args --help.snap
+++ b/tests/snapshots/examples__06_positional_args --help.snap
@@ -1,0 +1,18 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 
+
+USAGE:
+    06_positional_args <input> <config> [ARGS]
+
+ARGS:
+    <input>     the input file to use
+    <config>    the config file to use
+    <output>    the output file to use
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+

--- a/tests/snapshots/examples__07_option_args --help.snap
+++ b/tests/snapshots/examples__07_option_args --help.snap
@@ -1,0 +1,20 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 
+
+USAGE:
+    07_option_args [OPTIONS] <output> --input <input>... --config <FILE>
+
+ARGS:
+    <output>    the output file to use
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --config <FILE>       the config file to use
+    -i, --input <input>...    the input file to use
+

--- a/tests/snapshots/examples__08_subcommands --help.snap
+++ b/tests/snapshots/examples__08_subcommands --help.snap
@@ -1,0 +1,17 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 
+
+USAGE:
+    08_subcommands [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    add     Adds files to myapp
+    help    Prints this message or the help of the given subcommand(s)
+

--- a/tests/snapshots/examples__09_auto_version --help.snap
+++ b/tests/snapshots/examples__09_auto_version --help.snap
@@ -1,0 +1,14 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 3.0.0-beta.1
+does awesome things
+
+USAGE:
+    09_auto_version
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+

--- a/tests/snapshots/examples__10_default_values --help.snap
+++ b/tests/snapshots/examples__10_default_values --help.snap
@@ -1,0 +1,20 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+does awesome things
+
+USAGE:
+    10_default_values [OPTIONS] [INPUT]
+
+ARGS:
+    <INPUT>    The input file to use [default: input.txt]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c <CONFIG>        The config file to use (default is "config.json")
+

--- a/tests/snapshots/examples__11_only_specific_values --help.snap
+++ b/tests/snapshots/examples__11_only_specific_values --help.snap
@@ -1,0 +1,17 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+does awesome things
+
+USAGE:
+    11_only_specific_values <MODE>
+
+ARGS:
+    <MODE>    What mode to run the program in [possible values: fast, slow]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+

--- a/tests/snapshots/examples__12_typed_values --help.snap
+++ b/tests/snapshots/examples__12_typed_values --help.snap
@@ -1,0 +1,19 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+
+USAGE:
+    12_typed_values [OPTIONS] <seq>...
+
+ARGS:
+    <seq>...    A sequence of whole positive numbers, i.e. 20 25 30
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -l <len>        A length to use, defaults to 10 when omitted
+

--- a/tests/snapshots/examples__13_enum_values --help.snap
+++ b/tests/snapshots/examples__13_enum_values --help.snap
@@ -1,0 +1,16 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+
+USAGE:
+    13_enum_values <type>
+
+ARGS:
+    <type>    The type to use [possible values: Foo, Bar, Baz, Qux]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+

--- a/tests/snapshots/examples__14_groups --help.snap
+++ b/tests/snapshots/examples__14_groups --help.snap
@@ -1,0 +1,24 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+
+USAGE:
+    14_groups [OPTIONS] <--set-ver <ver>|--major|--minor|--patch> [INPUT_FILE]
+
+ARGS:
+    <INPUT_FILE>    some regular input
+
+FLAGS:
+    -h, --help       Prints help information
+        --major      auto inc major
+        --minor      auto inc minor
+        --patch      auto inc patch
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c <config>                
+        --set-ver <ver>        set version manually
+        --spec-in <SPEC_IN>    some special input argument
+

--- a/tests/snapshots/examples__15_custom_validator --help.snap
+++ b/tests/snapshots/examples__15_custom_validator --help.snap
@@ -1,0 +1,16 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+
+USAGE:
+    15_custom_validator <input>
+
+ARGS:
+    <input>    the input file to use
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+

--- a/tests/snapshots/examples__16_app_settings --help.snap
+++ b/tests/snapshots/examples__16_app_settings --help.snap
@@ -1,0 +1,21 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+
+USAGE:
+    16_app_settings <input>
+    16_app_settings <SUBCOMMAND>
+
+ARGS:
+    <input>    input file to use
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    test    does some testing
+

--- a/tests/snapshots/examples__17_yaml --help.snap
+++ b/tests/snapshots/examples__17_yaml --help.snap
@@ -1,0 +1,30 @@
+---
+source: tests/examples.rs
+expression: help
+---
+yaml_app 1.0
+Kevin K. <kbknapp@gmail.com>
+an example using a .yaml file to build a CLI
+
+USAGE:
+    17_yaml [OPTIONS] [pos] [SUBCOMMAND]
+
+ARGS:
+    <pos>    example positional argument from yaml [possible values: fast, slow]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -F <flag>...                   demo flag argument
+        --max-vals <maxvals>...    you can only supply a max of 3 values for me!
+        --min-vals <minvals>...    you must supply at least two values to satisfy me
+        --mode <mode>              shows an option with specific values [possible values: vi, emacs]
+        --mult-vals <one> <two>    demos an option which has two named values
+    -o, --option <opt>...          example option argument from yaml
+
+SUBCOMMANDS:
+    help      Prints this message or the help of the given subcommand(s)
+    subcmd    demos subcommands from yaml
+

--- a/tests/snapshots/examples__18_builder_macro --help.snap
+++ b/tests/snapshots/examples__18_builder_macro --help.snap
@@ -1,0 +1,29 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 1.0
+Alice
+Does awesome things
+
+USAGE:
+    18_builder_macro [OPTIONS] <input> --config <conf>... <output|-d <debug>...> <SUBCOMMAND>
+
+ARGS:
+    <input>     Input file
+    <output>    Sets an optional output file
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -c, --config <conf>...                  Sets a custom config file
+    -d <debug>...                           Turn debugging information on
+        --proxy-hostname <proxyHostname>    Sets the hostname of the proxy to use
+
+SUBCOMMANDS:
+    foo     
+    help    Prints this message or the help of the given subcommand(s)
+    test    does testing things
+

--- a/tests/snapshots/examples__19_auto_authors --help.snap
+++ b/tests/snapshots/examples__19_auto_authors --help.snap
@@ -1,0 +1,15 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myapp 
+Kevin K. <kbknapp@gmail.com>:Clap Maintainers
+does awesome things
+
+USAGE:
+    19_auto_authors
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+

--- a/tests/snapshots/examples__20_subcommands --help.snap
+++ b/tests/snapshots/examples__20_subcommands --help.snap
@@ -1,0 +1,21 @@
+---
+source: tests/examples.rs
+expression: help
+---
+git 1.0
+Me
+A fictional versioning CLI
+
+USAGE:
+    20_subcommands [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    add      adds things
+    clone    clones repos
+    help     Prints this message or the help of the given subcommand(s)
+    push     pushes things
+

--- a/tests/snapshots/examples__21_aliases --help.snap
+++ b/tests/snapshots/examples__21_aliases --help.snap
@@ -1,0 +1,17 @@
+---
+source: tests/examples.rs
+expression: help
+---
+MyApp 
+
+USAGE:
+    21_aliases [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    ls      Adds files to myapp
+

--- a/tests/snapshots/examples__22_stop_parsing_with_-- --help.snap
+++ b/tests/snapshots/examples__22_stop_parsing_with_-- --help.snap
@@ -1,0 +1,20 @@
+---
+source: tests/examples.rs
+expression: help
+---
+myprog 
+
+USAGE:
+    22_stop_parsing_with_-- [FLAGS] [OPTIONS] [-- <slop>...]
+
+ARGS:
+    <slop>...    
+
+FLAGS:
+    -f               
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -p <pea>        
+

--- a/tests/snapshots/examples__23_flag_subcommands_pacman --help.snap
+++ b/tests/snapshots/examples__23_flag_subcommands_pacman --help.snap
@@ -1,0 +1,20 @@
+---
+source: tests/examples.rs
+expression: help
+---
+pacman 5.2.1
+Pacman Development Team
+package manager utility
+
+USAGE:
+    23_flag_subcommands_pacman <SUBCOMMAND>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    -Q, --query, query    Query the package database.
+    -S, --sync, sync      Synchronize packages.
+    help                  Prints this message or the help of the given subcommand(s)
+


### PR DESCRIPTION
Use [insta](https://docs.rs/insta) to [snapshot](https://sqa.stackexchange.com/q/29696) the `--help` for examples, and test whether it matches previous snapshots. If the help is changed intentionally (e.g. because an example is tweaked or if there's a change to clap's behavior), insta provides [a nice workflow](https://youtu.be/rCHrMqE4JOY) to interactively review and approve the changes.

I also fixed some examples that were panicking.

This partially addresses #1652.