### PR TITLE
Don't print spaces in long help

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -353,7 +353,10 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
             && h_w > (self.term_w - taken);
 
         debug!("Help::val: Has switch...");
-        if arg.has_switch() {
+        if self.use_long {
+            // long help prints messages on the next line so it don't need to align text
+            debug!("Help::val: printing long help so skip aligment");
+        } else if arg.has_switch() {
             debug!("Yes");
             debug!("Help::val: force_next_line...{:?}", self.force_next_line);
             debug!("Help::val: nlh...{:?}", nlh);

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -111,10 +111,10 @@ USAGE:
     clap-test
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information
 
 
@@ -361,16 +361,16 @@ USAGE:
     prog [FLAGS]
 
 FLAGS:
-        --config     
+        --config
             The config file used by the myprog must be in JSON format
             with only valid keys and may not contain other nonsense
             that cannot be read by this program. Obviously I'm going on
             and on, so I'll stop now.
 
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information";
 
 static CUSTOM_VERSION_AND_HELP: &str = "customize 0.1
@@ -522,14 +522,14 @@ USAGE:
     myapp [arg1]
 
 ARGS:
-    <arg1>    
+    <arg1>
             some option
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information";
 
 static HIDE_ENV_VALS: &str = "ctest 0.1
@@ -1626,10 +1626,10 @@ USAGE:
     ctest foo
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information";
 
 #[test]

--- a/tests/hidden_args.rs
+++ b/tests/hidden_args.rs
@@ -57,16 +57,16 @@ USAGE:
     test [FLAGS]
 
 FLAGS:
-    -c, --config     
+    -c, --config
             Some help text describing the --config arg
 
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information
 
-    -v, --visible    
+    -v, --visible
             This text should be visible";
 
 /// Ensure hidden with short option
@@ -131,13 +131,13 @@ USAGE:
     test [FLAGS]
 
 FLAGS:
-    -h, --help       
+    -h, --help
             Prints help information
 
-    -V, --version    
+    -V, --version
             Prints version information
 
-    -v, --visible    
+    -v, --visible
             This text should be visible";
 
 #[test]


### PR DESCRIPTION
Closes #1094


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1094: -h, --help generate trailing spaces](https://issuehunt.io/repos/31315121/issues/1094)
---
</details>
<!-- /Issuehunt content-->