### PR TITLE
Forbid all unsafe code.

### DIFF
--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -16,6 +16,8 @@
 //! directly. See [clap documentation](https://docs.rs/clap)
 //! for the usage of `#[derive(Clap)]`.
 
+#![forbid(unsafe_code)]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -15,6 +15,7 @@
     unused_allocation,
     trivial_numeric_casts
 )]
+#![forbid(unsafe_code)]
 #![allow(clippy::needless_doctest_main)]
 
 const INTERNAL_ERROR_MSG: &str = "Fatal internal error. Please consider filing a bug \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
     unused_allocation,
     trivial_numeric_casts
 )]
+#![forbid(unsafe_code)]
 
 #[cfg(not(feature = "std"))]
 compile_error!("`std` feature is currently required to build `clap`");


### PR DESCRIPTION
This adds a `#![forbid(unsafe_code)]` to all the primary clap libraries.

Clap 3.0 has removed all unsafe code, and it should stay this way. Also makes it have a nice green in `cargo geiger` output.