### PR TITLE
Propagate before completion generation.

### DIFF
--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -182,6 +182,7 @@ where
     app.set_bin_name(bin_name);
 
     if !app.is_set(clap::AppSettings::Built) {
+        app._full_propagate();
         app._build();
         app._build_bin_names();
     }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2220,6 +2220,12 @@ impl<'help> App<'help> {
         two_elements_of(self.groups.iter().filter(|a| condition(a)))
     }
 
+    // used in clap_generate (https://github.com/clap-rs/clap_generate)
+    #[doc(hidden)]
+    pub fn _full_propagate(&mut self) {
+        self._propagate(Propagation::Full)
+    }
+
     pub(crate) fn _propagate(&mut self, prop: Propagation) {
         macro_rules! propagate_subcmd {
             ($_self:expr, $sc:expr) => {{


### PR DESCRIPTION
Closes #2090 

This propagates app settings before generation.  This fixes a bug where auto-completion options for version would appear on sub-commands when the parent disables them with `global_setting(AppSettings::DisableVersion)`.

I added one hidden public method to accomplish this, I chose to add a new method instead of using `_propagate(Propagation::Full)` because that would also require leaking the `Propagation` and `Id` types.
