### PR TITLE
Fix a few documentation typos

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -2210,9 +2210,9 @@ impl<'help> Arg<'help> {
     /// different. `Arg::default_value` *only* takes affect when the user has not provided this arg
     /// at runtime. `Arg::default_value_if` however only takes effect when the user has not provided
     /// a value at runtime **and** these other conditions are met as well. If you have set
-    /// `Arg::default_value` and `Arg::default_value_if`, and the user **did not** provide a this
-    /// arg at runtime, nor did were the conditions met for `Arg::default_value_if`, the
-    /// `Arg::default_value` will be applied.
+    /// `Arg::default_value` and `Arg::default_value_if`, and the user **did not** provide this arg
+    /// at runtime, nor were the conditions met for `Arg::default_value_if`, the `Arg::default_value`
+    /// will be applied.
     ///
     /// **NOTE:** This implicitly sets [`Arg::takes_value(true)`].
     ///
@@ -2403,9 +2403,8 @@ impl<'help> Arg<'help> {
     /// different. `Arg::default_value` *only* takes affect when the user has not provided this arg
     /// at runtime. This setting however only takes affect when the user has not provided a value at
     /// runtime **and** these other conditions are met as well. If you have set `Arg::default_value`
-    /// and `Arg::default_value_if`, and the user **did not** provide a this arg at runtime, nor did
-    /// were the conditions met for `Arg::default_value_if`, the `Arg::default_value` will be
-    /// applied.
+    /// and `Arg::default_value_if`, and the user **did not** provide this arg at runtime, nor were
+    /// the conditions met for `Arg::default_value_if`, the `Arg::default_value` will be applied.
     ///
     /// **NOTE:** This implicitly sets [`Arg::takes_value(true)`].
     ///


### PR DESCRIPTION
Fixes a few typos in the documentation for `default_value` and `default_value_if`.