### PR TITLE
Update the env var example for derive

### DIFF
--- a/clap_derive/examples/env.rs
+++ b/clap_derive/examples/env.rs
@@ -1,7 +1,7 @@
 //! How to use environment variable fallback an how it
 //! interacts with `default_value`.
 
-use clap::Clap;
+use clap::{ArgSettings, Clap};
 
 /// Example for allowing to specify options via environment variables.
 #[derive(Clap, Debug)]
@@ -18,6 +18,12 @@ struct Opt {
     /// Number of retries
     #[clap(long, env = "RETRIES", default_value = "5")]
     retries: u32,
+
+    // If an environment variable contains a sensitive value, it can be hidden
+    // from the help screen with a special setting.
+    /// Secret token
+    #[clap(long, env = "SECRET_TOKEN", setting = ArgSettings::HideEnvValues)]
+    token: String,
 }
 
 fn main() {


### PR DESCRIPTION
Updates the derive example handling environment variables to illustrate
the case where it contains a sensitive value which should not be
displayed on the help screen.

Closes https://github.com/clap-rs/clap/issues/2101

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
