### PR TITLE
fix: detect if space should be added before spec_vals

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -568,9 +568,10 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
 
             spec_vals.push(format!("[possible values: {}]", a.possible_vals.join(", ")));
         }
-        let prefix = match !spec_vals.is_empty() && !a.get_about().unwrap_or("").is_empty() {
-            true => " ",
-            false => "",
+        let prefix = if !spec_vals.is_empty() && !a.get_about().unwrap_or("").is_empty() {
+            " "
+        } else {
+            ""
         };
         prefix.to_string() + &spec_vals.join(" ")
     }

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -504,7 +504,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
             } else {
                 String::new()
             };
-            let env_info = format!(" [env: {}{}]", env.0.to_string_lossy(), env_val);
+            let env_info = format!("[env: {}{}]", env.0.to_string_lossy(), env_val);
             spec_vals.push(env_info);
         }
         if !a.is_set(ArgSettings::HideDefaultValue) && !a.default_vals.is_empty() {
@@ -520,7 +520,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
                 .collect::<Vec<_>>()
                 .join(" ");
 
-            spec_vals.push(format!(" [default: {}]", pvs));
+            spec_vals.push(format!("[default: {}]", pvs));
         }
         if !a.aliases.is_empty() {
             debug!("Help::spec_vals: Found aliases...{:?}", a.aliases);
@@ -534,7 +534,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
                 .join(", ");
 
             if !als.is_empty() {
-                spec_vals.push(format!(" [aliases: {}]", als));
+                spec_vals.push(format!("[aliases: {}]", als));
             }
         }
 
@@ -566,12 +566,13 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
                 a.possible_vals
             );
 
-            spec_vals.push(format!(
-                " [possible values: {}]",
-                a.possible_vals.join(", ")
-            ));
+            spec_vals.push(format!("[possible values: {}]", a.possible_vals.join(", ")));
         }
-        spec_vals.join(" ")
+        let prefix = match !spec_vals.is_empty() && !a.get_about().unwrap_or("").is_empty() {
+            true => " ",
+            false => "",
+        };
+        prefix.to_string() + &spec_vals.join(" ")
     }
 }
 

--- a/tests/arg_aliases.rs
+++ b/tests/arg_aliases.rs
@@ -9,12 +9,12 @@ USAGE:
     ct test [FLAGS] [OPTIONS]
 
 FLAGS:
-    -f, --flag        [aliases: v_flg, flag2, flg3]
+    -f, --flag       [aliases: v_flg, flag2, flg3]
     -h, --help       Prints help information
     -V, --version    Prints version information
 
 OPTIONS:
-    -o, --opt <opt>     [aliases: visible]";
+    -o, --opt <opt>    [aliases: visible]";
 
 static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help

--- a/tests/arg_aliases_short.rs
+++ b/tests/arg_aliases_short.rs
@@ -9,7 +9,7 @@ USAGE:
     ct test [FLAGS] [OPTIONS]
 
 FLAGS:
-    -f, --flag        [aliases: flag1] [short aliases: a, b, 🦆]
+    -f, --flag       [aliases: flag1] [short aliases: a, b, 🦆]
     -h, --help       Prints help information
     -V, --version    Prints version information
 


### PR DESCRIPTION
Here I check for situation when there's no `about` available about the argument, but there're some `spec_vals` to be printed. If that's the case, We don't need the separator (" ") between about section and those values, so it should be omitted.

Closes #2040 