### PR TITLE
setting(default_value): escape default values in help messages

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -94,6 +94,7 @@ pub struct Arg<'help> {
     pub(crate) default_vals: Vec<&'help OsStr>,
     pub(crate) default_vals_ifs: VecMap<(Id, Option<&'help OsStr>, &'help OsStr)>,
     pub(crate) default_missing_vals: Vec<&'help OsStr>,
+    pub(crate) escape_default_values: bool,
     pub(crate) env: Option<(&'help OsStr, Option<OsString>)>,
     pub(crate) terminator: Option<&'help str>,
     pub(crate) index: Option<u64>,
@@ -2369,6 +2370,16 @@ impl<'help> Arg<'help> {
     pub fn default_values_os(mut self, vals: &[&'help OsStr]) -> Self {
         self.default_vals = vals.to_vec();
         self.takes_value(true)
+    }
+
+    /// The default values for the argument should be shown in the help message as escaped strings.
+    #[inline]
+    pub fn escape_default_values(self, escape_default_values: bool) -> Self {
+        if escape_default_values {
+            self.setting(ArgSettings::EscapeDefaultValues)
+        } else {
+            self.unset_setting(ArgSettings::EscapeDefaultValues)
+        }
     }
 
     /// Specifies a value for the argument when the argument is supplied and a value is required

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -6,27 +6,28 @@ use bitflags::bitflags;
 
 bitflags! {
     struct Flags: u32 {
-        const REQUIRED         = 1;
-        const MULTIPLE_OCC     = 1 << 1;
-        const EMPTY_VALS       = 1 << 2 | Self::TAKES_VAL.bits;
-        const GLOBAL           = 1 << 3;
-        const HIDDEN           = 1 << 4;
-        const TAKES_VAL        = 1 << 5;
-        const USE_DELIM        = 1 << 6;
-        const NEXT_LINE_HELP   = 1 << 7;
-        const R_UNLESS_ALL     = 1 << 8;
-        const REQ_DELIM        = 1 << 9 | Self::TAKES_VAL.bits | Self::USE_DELIM.bits;
-        const DELIM_NOT_SET    = 1 << 10;
-        const HIDE_POS_VALS    = 1 << 11 | Self::TAKES_VAL.bits;
-        const ALLOW_TAC_VALS   = 1 << 12 | Self::TAKES_VAL.bits;
-        const REQUIRE_EQUALS   = 1 << 13 | Self::TAKES_VAL.bits;
-        const LAST             = 1 << 14 | Self::TAKES_VAL.bits;
-        const HIDE_DEFAULT_VAL = 1 << 15 | Self::TAKES_VAL.bits;
-        const CASE_INSENSITIVE = 1 << 16;
-        const HIDE_ENV_VALS    = 1 << 17;
-        const HIDDEN_SHORT_H   = 1 << 18;
-        const HIDDEN_LONG_H    = 1 << 19;
-        const MULTIPLE_VALS    = 1 << 20 | Self::TAKES_VAL.bits;
+        const REQUIRED            = 1;
+        const MULTIPLE_OCC        = 1 << 1;
+        const EMPTY_VALS          = 1 << 2 | Self::TAKES_VAL.bits;
+        const GLOBAL              = 1 << 3;
+        const HIDDEN              = 1 << 4;
+        const TAKES_VAL           = 1 << 5;
+        const USE_DELIM           = 1 << 6;
+        const NEXT_LINE_HELP      = 1 << 7;
+        const R_UNLESS_ALL        = 1 << 8;
+        const REQ_DELIM           = 1 << 9 | Self::TAKES_VAL.bits | Self::USE_DELIM.bits;
+        const DELIM_NOT_SET       = 1 << 10;
+        const HIDE_POS_VALS       = 1 << 11 | Self::TAKES_VAL.bits;
+        const ALLOW_TAC_VALS      = 1 << 12 | Self::TAKES_VAL.bits;
+        const REQUIRE_EQUALS      = 1 << 13 | Self::TAKES_VAL.bits;
+        const LAST                = 1 << 14 | Self::TAKES_VAL.bits;
+        const HIDE_DEFAULT_VAL    = 1 << 15 | Self::TAKES_VAL.bits;
+        const CASE_INSENSITIVE    = 1 << 16;
+        const HIDE_ENV_VALS       = 1 << 17;
+        const HIDDEN_SHORT_H      = 1 << 18;
+        const HIDDEN_LONG_H       = 1 << 19;
+        const MULTIPLE_VALS       = 1 << 20 | Self::TAKES_VAL.bits;
+        const ESCAPE_DEFAULT_VALS = 1 << 21;
     }
 }
 
@@ -53,7 +54,8 @@ impl_settings! { ArgSettings, ArgFlags,
     HideEnvValues("hideenvvalues") => Flags::HIDE_ENV_VALS,
     HideDefaultValue("hidedefaultvalue") => Flags::HIDE_DEFAULT_VAL,
     HiddenShortHelp("hiddenshorthelp") => Flags::HIDDEN_SHORT_H,
-    HiddenLongHelp("hiddenlonghelp") => Flags::HIDDEN_LONG_H
+    HiddenLongHelp("hiddenlonghelp") => Flags::HIDDEN_LONG_H,
+    EscapeDefaultValues("escapedefaultvalues") => Flags::ESCAPE_DEFAULT_VALS
 }
 
 impl Default for ArgFlags {
@@ -113,6 +115,8 @@ pub enum ArgSettings {
     HiddenLongHelp,
     #[doc(hidden)]
     RequiredUnlessAll,
+    /// Default values are escaped in the help message
+    EscapeDefaultValues,
 }
 
 #[cfg(test)]

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -500,7 +500,11 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
             let pvs = a
                 .default_vals
                 .iter()
-                .map(|&pvs| pvs.to_string_lossy())
+                .map(|&pvs| if a.is_set(ArgSettings::EscapeDefaultValues) {
+                    Cow::from(format!("{:?}", pvs))
+                } else {
+                    pvs.to_string_lossy()
+                })
                 .collect::<Vec<_>>()
                 .join(" ");
 

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -472,6 +472,18 @@ FLAGS:
 OPTIONS:
         --arg <argument>    Pass an argument to the program. [default: default-argument]";
 
+static ESCAPED_DEFAULT_VAL: &str = "default 0.1
+
+USAGE:
+    default [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --arg <argument>    Pass an argument to the program. [default: \"\\n\"]";
+
 static LAST_ARG_USAGE: &str = "flamegraph 0.1
 
 USAGE:
@@ -1372,6 +1384,23 @@ fn hidden_default_val() {
         app2,
         "default --help",
         HIDE_DEFAULT_VAL,
+        false
+    ));
+}
+
+#[test]
+fn escaped_default_val() {
+    let app1 = App::new("default").version("0.1").term_width(120).arg(
+        Arg::new("argument")
+            .about("Pass an argument to the program.")
+            .long("arg")
+            .default_value("\n")
+            .escape_default_values(true),
+    );
+    assert!(utils::compare_output(
+        app1,
+        "default --help",
+        ESCAPED_DEFAULT_VAL,
         false
     ));
 }


### PR DESCRIPTION
Adds a setting to allow escaping default values in the help messages.

- [ ] Add this setting to the derive as well;
- [ ] Possibly even to the parsed help (but I'm not sure that's a great idea).

Closes #1427 