### PR TITLE
Modify debug option to conform to specification.

### DIFF
--- a/examples/01b_quick_example.rs
+++ b/examples/01b_quick_example.rs
@@ -51,7 +51,8 @@ fn main() {
         .arg(
             Arg::new("debug")
                 .short('d')
-                .multiple(true)
+                .long("debug")
+                .multiple_occurrences(true)
                 .about("Turn debugging information on"),
         )
         .subcommand(


### PR DESCRIPTION
Modified the `debug` option in example `examples/01b_quick_example.rs` to conform to the specification in the earlier comments:

```
    //    - A debug flag
    //        + Uses "-d" or "--debug"
    //        + Allows multiple occurrences of such as "-dd" (for vary levels of debugging, as an example)
```