### PR TITLE
api(App): Adds help_about method to App.

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -84,6 +84,7 @@ pub struct App<'help> {
     pub(crate) about: Option<&'help str>,
     pub(crate) long_about: Option<&'help str>,
     pub(crate) help_about: Option<&'help str>,
+    pub(crate) version_about: Option<&'help str>,
     pub(crate) before_help: Option<&'help str>,
     pub(crate) before_long_help: Option<&'help str>,
     pub(crate) after_help: Option<&'help str>,
@@ -441,6 +442,27 @@ impl<'help> App<'help> {
     /// ```
     pub fn help_about<S: Into<&'help str>>(mut self, help_about: S) -> Self {
         self.help_about = Some(help_about.into());
+        self
+    }
+
+    /// Sets the help text for the auto-generated version argument.
+    ///
+    /// By default clap sets this to "Prints versoin information" but if
+    /// you're using a different convention for your help messages and
+    /// would prefer a different phrasing you can override it.
+    ///
+    /// **NOTE:** This setting propagates to subcommands.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::App;
+    /// App::new("myprog")
+    ///     .version_about("Print version information") // Impertive tone
+    /// # ;
+    /// ```
+    pub fn version_about<S: Into<&'help str>>(mut self, version_about: S) -> Self {
+        self.version_about = Some(version_about.into());
         self
     }
 
@@ -2274,6 +2296,9 @@ impl<'help> App<'help> {
                     if $sc.help_about.is_none() && $_self.help_about.is_some() {
                         $sc.help_about = $_self.help_about.clone();
                     }
+                    if $sc.version_about.is_none() && $_self.version_about.is_some() {
+                        $sc.version_about = $_self.version_about.clone();
+                    }
                 }
                 {
                     // FIXME: This doesn't belong here at all.
@@ -2347,7 +2372,7 @@ impl<'help> App<'help> {
             debug!("App::_create_help_and_version: Building --version");
             let mut version = Arg::new("version")
                 .long("version")
-                .about("Prints version information");
+                .about(self.version_about.unwrap_or("Prints version information"));
             if !self.args.args.iter().any(|x| x.short == Some('V')) {
                 version = version.short('V');
             }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -83,6 +83,7 @@ pub struct App<'help> {
     pub(crate) long_version: Option<&'help str>,
     pub(crate) about: Option<&'help str>,
     pub(crate) long_about: Option<&'help str>,
+    pub(crate) help_about: Option<&'help str>,
     pub(crate) before_help: Option<&'help str>,
     pub(crate) before_long_help: Option<&'help str>,
     pub(crate) after_help: Option<&'help str>,
@@ -417,6 +418,29 @@ impl<'help> App<'help> {
     /// [`App::about`]: ./struct.App.html#method.about
     pub fn long_about<S: Into<&'help str>>(mut self, about: S) -> Self {
         self.long_about = Some(about.into());
+        self
+    }
+
+    /// Sets the help text for the auto-generated help argument and subcommand.
+    ///
+    /// By default clap sets this to "Prints help information" for the help
+    /// argument and "Prints this message or the help of the given subcommand(s)"
+    /// for the help subcommand but if you're using a different convention
+    /// for your help messages and would prefer a different phrasing you can
+    /// override it.
+    ///
+    /// **NOTE:** This setting propagates to subcommands.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::App;
+    /// App::new("myprog")
+    ///     .help_about("Print help information") // Impertive tone
+    /// # ;
+    /// ```
+    pub fn help_about<S: Into<&'help str>>(mut self, help_about: S) -> Self {
+        self.help_about = Some(help_about.into());
         self
     }
 
@@ -2247,6 +2271,9 @@ impl<'help> App<'help> {
                     $sc.g_settings = $sc.g_settings | $_self.g_settings;
                     $sc.term_w = $_self.term_w;
                     $sc.max_w = $_self.max_w;
+                    if $sc.help_about.is_none() && $_self.help_about.is_some() {
+                        $sc.help_about = $_self.help_about.clone();
+                    }
                 }
                 {
                     // FIXME: This doesn't belong here at all.
@@ -2299,7 +2326,7 @@ impl<'help> App<'help> {
             debug!("App::_create_help_and_version: Building --help");
             let mut help = Arg::new("help")
                 .long("help")
-                .about("Prints help information");
+                .about(self.help_about.unwrap_or("Prints help information"));
             if !self.args.args.iter().any(|x| x.short == Some('h')) {
                 help = help.short('h');
             }
@@ -2333,8 +2360,10 @@ impl<'help> App<'help> {
         {
             debug!("App::_create_help_and_version: Building help");
             self.subcommands.push(
-                App::new("help")
-                    .about("Prints this message or the help of the given subcommand(s)"),
+                App::new("help").about(
+                    self.help_about
+                        .unwrap_or("Prints this message or the help of the given subcommand(s)"),
+                ),
             );
         }
     }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1825,3 +1825,155 @@ fn after_help_no_args() {
 
     assert_eq!(help, AFTER_HELP_NO_ARGS);
 }
+
+static HELP_ABOUT: &str = "myapp 1.0
+
+USAGE:
+    myapp
+
+FLAGS:
+    -h, --help       Print custom help about text
+    -V, --version    Prints version information";
+
+static HELP_ABOUT_MULTI_SC: &str = "myapp-subcmd-multi 1.0
+
+USAGE:
+    myapp subcmd multi
+
+FLAGS:
+    -h, --help       Print custom help about text
+    -V, --version    Prints version information";
+
+static HELP_ABOUT_MULTI_SC_OVERRIDE: &str = "myapp-subcmd-multi 1.0
+
+USAGE:
+    myapp subcmd multi
+
+FLAGS:
+    -h, --help       Print custom help about text from multi
+    -V, --version    Prints version information";
+
+#[test]
+fn help_about_short_flag() {
+    let app = App::new("myapp")
+        .version("1.0")
+        .help_about("Print custom help about text");
+
+    assert!(utils::compare_output(app, "myapp -h", HELP_ABOUT, false));
+}
+
+#[test]
+fn help_about_long_flag() {
+    let app = App::new("myapp")
+        .version("1.0")
+        .help_about("Print custom help about text");
+
+    assert!(utils::compare_output(
+        app,
+        "myapp --help",
+        HELP_ABOUT,
+        false
+    ));
+}
+
+#[test]
+fn help_about_multi_subcmd() {
+    let app = App::new("myapp")
+        .help_about("Print custom help about text")
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app,
+        "myapp help subcmd multi",
+        HELP_ABOUT_MULTI_SC,
+        false
+    ));
+}
+
+#[test]
+fn help_about_multi_subcmd_short_flag() {
+    let app = App::new("myapp")
+        .help_about("Print custom help about text")
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi -h",
+        HELP_ABOUT_MULTI_SC,
+        false
+    ));
+}
+
+#[test]
+fn help_about_multi_subcmd_long_flag() {
+    let app = App::new("myapp")
+        .help_about("Print custom help about text")
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi --help",
+        HELP_ABOUT_MULTI_SC,
+        false
+    ));
+}
+
+#[test]
+fn help_about_multi_subcmd_override() {
+    let app = App::new("myapp")
+        .help_about("Print custom help about text")
+        .subcommand(
+            App::new("subcmd").subcommand(
+                App::new("multi")
+                    .version("1.0")
+                    .help_about("Print custom help about text from multi"),
+            ),
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "myapp help subcmd multi",
+        HELP_ABOUT_MULTI_SC_OVERRIDE,
+        false
+    ));
+}
+
+#[test]
+fn help_about_multi_subcmd_override_short_flag() {
+    let app = App::new("myapp")
+        .help_about("Print custom help about text")
+        .subcommand(
+            App::new("subcmd").subcommand(
+                App::new("multi")
+                    .version("1.0")
+                    .help_about("Print custom help about text from multi"),
+            ),
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi -h",
+        HELP_ABOUT_MULTI_SC_OVERRIDE,
+        false
+    ));
+}
+
+#[test]
+fn help_about_multi_subcmd_override_long_flag() {
+    let app = App::new("myapp")
+        .help_about("Print custom help about text")
+        .subcommand(
+            App::new("subcmd").subcommand(
+                App::new("multi")
+                    .version("1.0")
+                    .help_about("Print custom help about text from multi"),
+            ),
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi --help",
+        HELP_ABOUT_MULTI_SC_OVERRIDE,
+        false
+    ));
+}

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1977,3 +1977,155 @@ fn help_about_multi_subcmd_override_long_flag() {
         false
     ));
 }
+
+static VERSION_ABOUT: &str = "myapp 1.0
+
+USAGE:
+    myapp
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Print custom version about text";
+
+static VERSION_ABOUT_MULTI_SC: &str = "myapp-subcmd-multi 1.0
+
+USAGE:
+    myapp subcmd multi
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Print custom version about text";
+
+static VERSION_ABOUT_MULTI_SC_OVERRIDE: &str = "myapp-subcmd-multi 1.0
+
+USAGE:
+    myapp subcmd multi
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Print custom version about text from multi";
+
+#[test]
+fn version_about_short_flag() {
+    let app = App::new("myapp")
+        .version("1.0")
+        .version_about("Print custom version about text");
+
+    assert!(utils::compare_output(app, "myapp -h", VERSION_ABOUT, false));
+}
+
+#[test]
+fn version_about_long_flag() {
+    let app = App::new("myapp")
+        .version("1.0")
+        .version_about("Print custom version about text");
+
+    assert!(utils::compare_output(
+        app,
+        "myapp --help",
+        VERSION_ABOUT,
+        false
+    ));
+}
+
+#[test]
+fn version_about_multi_subcmd() {
+    let app = App::new("myapp")
+        .version_about("Print custom version about text")
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app,
+        "myapp help subcmd multi",
+        VERSION_ABOUT_MULTI_SC,
+        false
+    ));
+}
+
+#[test]
+fn version_about_multi_subcmd_short_flag() {
+    let app = App::new("myapp")
+        .version_about("Print custom version about text")
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi -h",
+        VERSION_ABOUT_MULTI_SC,
+        false
+    ));
+}
+
+#[test]
+fn version_about_multi_subcmd_long_flag() {
+    let app = App::new("myapp")
+        .version_about("Print custom version about text")
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi --help",
+        VERSION_ABOUT_MULTI_SC,
+        false
+    ));
+}
+
+#[test]
+fn version_about_multi_subcmd_override() {
+    let app = App::new("myapp")
+        .version_about("Print custom version about text")
+        .subcommand(
+            App::new("subcmd").subcommand(
+                App::new("multi")
+                    .version("1.0")
+                    .version_about("Print custom version about text from multi"),
+            ),
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "myapp help subcmd multi",
+        VERSION_ABOUT_MULTI_SC_OVERRIDE,
+        false
+    ));
+}
+
+#[test]
+fn version_about_multi_subcmd_override_short_flag() {
+    let app = App::new("myapp")
+        .version_about("Print custom version about text")
+        .subcommand(
+            App::new("subcmd").subcommand(
+                App::new("multi")
+                    .version("1.0")
+                    .version_about("Print custom version about text from multi"),
+            ),
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi -h",
+        VERSION_ABOUT_MULTI_SC_OVERRIDE,
+        false
+    ));
+}
+
+#[test]
+fn version_about_multi_subcmd_override_long_flag() {
+    let app = App::new("myapp")
+        .version_about("Print custom version about text")
+        .subcommand(
+            App::new("subcmd").subcommand(
+                App::new("multi")
+                    .version("1.0")
+                    .version_about("Print custom version about text from multi"),
+            ),
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "myapp subcmd multi --help",
+        VERSION_ABOUT_MULTI_SC_OVERRIDE,
+        false
+    ));
+}


### PR DESCRIPTION
I saw that https://github.com/clap-rs/clap/pull/2093 went stale so I decided to try to fix this issue since it was marked with the "Good First Issue" label.

Help about text is now customizable and recursively propagates to subcommands unless the subcommand defines its own help about text in which case that is used.

Closes #2080.
