### PR TITLE
Automatically read license field from Cargo.toml

### DIFF
--- a/examples/01a_quick_example.rs
+++ b/examples/01a_quick_example.rs
@@ -33,6 +33,7 @@ fn main() {
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
+        .license("MIT OR Apache-2.0")
         .arg("-c, --config=[FILE] 'Sets a custom config file'")
         .arg("<output> 'Sets an optional output file'")
         .arg("-d..., --debug... 'Turn debugging information on'")

--- a/examples/01b_quick_example.rs
+++ b/examples/01b_quick_example.rs
@@ -35,6 +35,7 @@ fn main() {
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
+        .license("MIT OR Apache-2.0")
         .arg(
             Arg::new("config")
                 .short('c')

--- a/examples/01c_quick_example.rs
+++ b/examples/01c_quick_example.rs
@@ -32,6 +32,7 @@ fn main() {
         (version: "1.0")
         (author: "Kevin K. <kbknapp@gmail.com>")
         (about: "Does awesome things")
+        (license: "MIT OR Apache-2.0")
         (@arg CONFIG: -c --config +takes_value "Sets a custom config file")
         (@arg INPUT: +required "Sets the input file to use")
         (@arg debug: -d ... "Sets the level of debugging information")

--- a/examples/02_apps.rs
+++ b/examples/02_apps.rs
@@ -20,6 +20,7 @@ fn main() {
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
+        .license("MIT OR Apache-2.0")
         .get_matches();
 
     // This example doesn't do much, but it *does* give automatic -h, --help, -V, and --version functionality ;)

--- a/examples/04_using_matches.rs
+++ b/examples/04_using_matches.rs
@@ -16,6 +16,7 @@ fn main() {
     // argument.
     let matches = App::new("MyApp")
         .about("Parses an input file to do awesome things")
+        .license("MIT OR Apache-2.0")
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .arg(

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -24,6 +24,7 @@ fn main() {
             App::new("add") // The name we call argument with
                 .about("Adds files to myapp") // The message displayed in "myapp -h"
                 // or "myapp help"
+                .license("MIT OR Apache-2.0")
                 .version("0.1") // Subcommands can have independent version
                 .author("Kevin K.") // And authors
                 .arg(

--- a/examples/18_builder_macro.rs
+++ b/examples/18_builder_macro.rs
@@ -23,6 +23,7 @@ fn main() {
         (@setting SubcommandRequiredElseHelp)
         (version: "1.0")
         (author: "Alice")
+        (license: "MIT OR Apache-2.0")
         (about: "Does awesome things")
         (@arg config: -c --config <conf> #{1, 2} {file_exists} "Sets a custom config file")
         (@arg proxyHostname: --("proxy-hostname") +takes_value "Sets the hostname of the proxy to use")

--- a/examples/20_subcommands.rs
+++ b/examples/20_subcommands.rs
@@ -49,6 +49,7 @@ fn main() {
         .subcommand(
             App::new("clone")
                 .about("clones repos")
+                .license("MIT OR Apache-2.0")
                 .arg(Arg::new("repo").about("The repo to clone").required(true)),
         )
         .subcommand(

--- a/examples/21_aliases.rs
+++ b/examples/21_aliases.rs
@@ -6,6 +6,7 @@ fn main() {
             App::new("ls")
                 .aliases(&["list", "dir"])
                 .about("Adds files to myapp")
+                .license("MIT OR Apache-2.0")
                 .version("0.1")
                 .author("Kevin K.")
                 .arg(

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -81,6 +81,7 @@ pub struct App<'help> {
     pub(crate) author: Option<&'help str>,
     pub(crate) version: Option<&'help str>,
     pub(crate) long_version: Option<&'help str>,
+    pub(crate) license: Option<&'help str>,
     pub(crate) about: Option<&'help str>,
     pub(crate) long_about: Option<&'help str>,
     pub(crate) help_about: Option<&'help str>,
@@ -785,6 +786,27 @@ impl<'help> App<'help> {
     /// [`App::version`]: ./struct.App.html#method.version
     pub fn long_version<S: Into<&'help str>>(mut self, ver: S) -> Self {
         self.long_version = Some(ver.into());
+        self
+    }
+
+    /// Sets a string of the license to be displayed when displaying help information.
+    ///
+    /// **Pro-tip:** Use `clap`s convenience macro [`crate_license!`] to automatically set your
+    /// application's license to the same thing as your crate at compile time. See the
+    /// [`examples/`] directory for more information
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .license("MIT OR Apache-2.0")
+    /// # ;
+    /// ```
+    /// [`crate_license!`]: ./macro.crate_license!.html
+    /// [`examples/`]: https://github.com/clap-rs/clap/tree/master/examples
+    pub fn license<S: Into<&'help str>>(mut self, license: S) -> Self {
+        self.license = Some(license.into());
         self
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,6 +32,37 @@ macro_rules! load_yaml {
     };
 }
 
+/// Allows you to pull the licence from your Cargo.toml at compile time. If the `license` field is
+/// empty, then the `licence-field` is read. If both fields are empty, then an empty string is
+/// returned.
+///
+/// # Examples
+///
+/// ```no_run
+/// # #[macro_use]
+/// # extern crate clap;
+/// # use clap::App;
+/// # fn main() {
+/// let m = App::new("app")
+///             .version(crate_license!())
+///             .get_matches();
+/// # }
+/// ```
+#[cfg(feature = "cargo")]
+#[macro_export]
+macro_rules! crate_license {
+    () => {{
+        let mut license = env!("CARGO_PKG_LICENSE");
+        if license.is_empty() {
+            license = env!("CARGO_PKG_LICENSE_FILE");
+        }
+        if license.is_empty() {
+            license = "";
+        }
+        license
+    }};
+}
+
 /// Allows you to pull the version from your Cargo.toml at compile time as
 /// `MAJOR.MINOR.PATCH_PKGVERSION_PRE`
 ///
@@ -166,12 +197,14 @@ macro_rules! app_from_crate {
             .version($crate::crate_version!())
             .author($crate::crate_authors!())
             .about($crate::crate_description!())
+            .license($crate::crate_license!())
     };
     ($sep:expr) => {
         $crate::App::new($crate::crate_name!())
             .version($crate::crate_version!())
             .author($crate::crate_authors!($sep))
             .about($crate::crate_description!())
+            .license($crate::crate_license!())
     };
 }
 


### PR DESCRIPTION
Note: this is my first time contributing to clap, and I'm not familiar with the codebase. Please review that I didn't forgot anything.

I recently added [support](https://github.com/rust-lang/cargo/pull/8387) in Cargo for the environment variable CARGO_PKG_LICENSE_FILE in addition to the recently added CARGO_PKG_LICENSE. This commit automatically populate the `license` field by reading those environment variable.

If both of the environment variable are empty, should we `panic!()` instead of just returning an empty string? I don't think that panicking is a good idea, since it would possibly break crates that are using the `app_from_crate!` macro, but I don't know of a better way to add a warning.

This may help a bit with #1768.