### PR TITLE
bump 'ansi_term', 'yaml-rust' deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,14 @@ bitflags              = "1.0"
 unicode-width         = "0.1.4"
 textwrap              = "0.11.0"
 strsim    = { version = "0.8",  optional = true }
-yaml-rust = { version = "0.3.5",  optional = true }
+yaml-rust = { version = "0.4",  optional = true }
 clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
 vec_map   = { version = "0.8", optional = true }
 term_size = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-ansi_term = { version = "0.11",  optional = true }
+ansi_term = { version = "0.12",  optional = true }
 
 [dev-dependencies]
 regex = "1"


### PR DESCRIPTION
I'm currently using clap v2 and these dependencies were incompatible with some others, causing duplicate packages to be checked+built