### PR TITLE
feat(help): Add flag to recursively print help of all subcommands

### DIFF
--- a/clap_generate/tests/completions.rs
+++ b/clap_generate/tests/completions.rs
@@ -61,7 +61,7 @@ static BASH: &str = r#"_myapp() {
             ;;
         
         myapp__help)
-            opts=" -h -V  --help --version  "
+            opts=" -r -h -V  --recursive --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -142,6 +142,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
+'-r[Recursively print the help of all subcommand(s)]' \
+'--recursive[Recursively print the help of all subcommand(s)]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -185,6 +187,7 @@ complete -c myapp -n "__fish_use_subcommand" -f -a "help" -d 'Prints this messag
 complete -c myapp -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
 complete -c myapp -n "__fish_seen_subcommand_from test" -s h -l help -d 'Prints help information'
 complete -c myapp -n "__fish_seen_subcommand_from test" -s V -l version -d 'Prints version information'
+complete -c myapp -n "__fish_seen_subcommand_from help" -s r -l recursive -d 'Recursively print the help of all subcommand(s)'
 complete -c myapp -n "__fish_seen_subcommand_from help" -s h -l help -d 'Prints help information'
 complete -c myapp -n "__fish_seen_subcommand_from help" -s V -l version -d 'Prints version information'
 "#;
@@ -228,6 +231,8 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             break
         }
         'my_app;help' {
+            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'Recursively print the help of all subcommand(s)')
+            [CompletionResult]::new('--recursive', 'recursive', [CompletionResultType]::ParameterName, 'Recursively print the help of all subcommand(s)')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
@@ -273,6 +278,8 @@ edit:completion:arg-completer[my_app] = [@words]{
             cand --version 'Prints version information'
         }
         &'my_app;help'= {
+            cand -r 'Recursively print the help of all subcommand(s)'
+            cand --recursive 'Recursively print the help of all subcommand(s)'
             cand -h 'Prints help information'
             cand --help 'Prints help information'
             cand -V 'Prints version information'
@@ -330,6 +337,8 @@ edit:completion:arg-completer[my_app] = [@words]{
             cand --version 'Prints version information'
         }
         &'my_app;help'= {
+            cand -r 'Recursively print the help of all subcommand(s)'
+            cand --recursive 'Recursively print the help of all subcommand(s)'
             cand -h 'Prints help information'
             cand --help 'Prints help information'
             cand -V 'Prints version information'
@@ -396,6 +405,8 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             break
         }
         'my_app;help' {
+            [CompletionResult]::new('-r', 'r', [CompletionResultType]::ParameterName, 'Recursively print the help of all subcommand(s)')
+            [CompletionResult]::new('--recursive', 'recursive', [CompletionResultType]::ParameterName, 'Recursively print the help of all subcommand(s)')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
@@ -468,6 +479,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
+'-r[Recursively print the help of all subcommand(s)]' \
+'--recursive[Recursively print the help of all subcommand(s)]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \
@@ -534,6 +547,7 @@ complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Pr
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Prints version information'
 complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hypens" -s h -l help -d 'Prints help information'
 complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hypens" -s V -l version -d 'Prints version information'
+complete -c my_app -n "__fish_seen_subcommand_from help" -s r -l recursive -d 'Recursively print the help of all subcommand(s)'
 complete -c my_app -n "__fish_seen_subcommand_from help" -s h -l help -d 'Prints help information'
 complete -c my_app -n "__fish_seen_subcommand_from help" -s V -l version -d 'Prints version information'
 "#;
@@ -588,7 +602,7 @@ static BASH_SPECIAL_CMDS: &str = r#"_my_app() {
             ;;
         
         my_app__help)
-            opts=" -h -V  --help --version  "
+            opts=" -r -h -V  --recursive --help --version  "
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -771,6 +785,8 @@ esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
+'-r[Recursively print the help of all subcommand(s)]' \
+'--recursive[Recursively print the help of all subcommand(s)]' \
 '-h[Prints help information]' \
 '--help[Prints help information]' \
 '-V[Prints version information]' \

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2385,10 +2385,18 @@ impl<'help> App<'help> {
         {
             debug!("App::_create_help_and_version: Building help");
             self.subcommands.push(
-                App::new("help").about(
-                    self.help_about
-                        .unwrap_or("Prints this message or the help of the given subcommand(s)"),
-                ),
+                App::new("help")
+                    .about(
+                        self.help_about.unwrap_or(
+                            "Prints this message or the help of the given subcommand(s)",
+                        ),
+                    )
+                    .arg(
+                        Arg::new("recursive")
+                            .long("recursive")
+                            .short('r')
+                            .about("Recursively print the help of all subcommand(s)"),
+                    ),
             );
         }
     }

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -57,6 +57,20 @@ impl Colorizer {
     pub(crate) fn none(&mut self, msg: impl Into<String>) {
         self.pieces.push((msg.into(), None));
     }
+
+    pub(crate) fn extend(&mut self, other: Colorizer) {
+        self.pieces.extend(other.pieces);
+    }
+
+    pub(crate) fn nest(&mut self, nesting_level: usize) {
+        let line_seperator = String::from("\n") + &". ".repeat(nesting_level);
+        let mut new_pieces = self
+            .pieces
+            .iter()
+            .map(|(s, c)| (s.replace('\n', &line_seperator), *c))
+            .collect();
+        std::mem::swap(&mut self.pieces, &mut new_pieces);
+    }
 }
 
 /// Printing methods.

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -93,6 +93,64 @@ USAGE:
 
 For more information try --help";
 
+static RECURSIVE_HELP: &str = "clap-test 2.6
+
+USAGE:
+    clap-test [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help           Prints this message or the help of the given subcommand(s)
+    subcommand1    Some help
+    subcommand2    Another subcommand
+
+. clap-test-subcommand1 
+. Some help
+. 
+. USAGE:
+.     clap-test subcommand1 [SUBCOMMAND]
+. 
+. SUBCOMMANDS:
+.     nested-subcommand    Subcommand below subcommand1
+. 
+. . clap-test-nested-subcommand 
+. . Subcommand below subcommand1
+. . 
+. . USAGE:
+. .     clap-test nested-subcommand [FLAGS] [some-arg]
+. . 
+. . ARGS:
+. .         
+. . 
+. . FLAGS:
+. .         
+. . 
+. clap-test-subcommand2 
+. Another subcommand
+. 
+. USAGE:
+.     clap-test subcommand2 [FLAGS] [argument]
+. 
+. ARGS:
+.         
+. 
+. FLAGS:
+.         
+. 
+. clap-test-help 
+. Prints this message or the help of the given subcommand(s)
+. 
+. USAGE:
+.     clap-test help [FLAGS]
+. 
+. FLAGS:
+.     -r, --recursive    Recursively print the help of all subcommand(s)
+.
+";
+
 #[test]
 fn subcommand() {
     let m = App::new("test")
@@ -261,6 +319,30 @@ fn visible_aliases_help_output() {
         app,
         "clap-test --help",
         VISIBLE_ALIAS_HELP,
+        false
+    ));
+}
+
+#[test]
+fn recursive_subcommand_help() {
+    let app = App::new("clap-test")
+        .version("2.6")
+        .subcommand(
+            App::new("subcommand1").about("Some help").subcommand(
+                App::new("nested-subcommand")
+                    .about("Subcommand below subcommand1")
+                    .arg(Arg::new("some-arg")),
+            ),
+        )
+        .subcommand(
+            App::new("subcommand2")
+                .about("Another subcommand")
+                .arg(Arg::new("argument")),
+        );
+    assert!(utils::compare_output(
+        app,
+        "clap-test help -r",
+        RECURSIVE_HELP,
         false
     ));
 }


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Closes #1535 

Add the flag `--recursive` (`-r` short) to the help subcommand for printing the help of all subcommands. See the test in `tests/subcommands.rs` for an example of how the subcommand helps are indented.
