### PR TITLE
Fix the error logic and error message for suggesting `--` before a flag

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -798,26 +798,32 @@ impl Error {
         c.warning(arg.clone());
         c.none("' which wasn't expected, or isn't valid in this context");
 
-        if let Some(s) = did_you_mean {
+        if let Some((flag, subcmd)) = did_you_mean {
+            let flag = format!("--{}", flag);
             c.none("\n\n\tDid you mean ");
 
-            if let Some(subcmd) = s.1 {
+            if let Some(subcmd) = subcmd {
                 c.none("to put '");
-                c.good(format!("--{}", &s.0));
+                c.good(flag);
                 c.none("' after the subcommand '");
                 c.good(subcmd);
                 c.none("'?");
             } else {
                 c.none("'");
-                c.good(format!("--{}", &s.0));
+                c.good(flag);
                 c.none("'?");
             }
         }
 
-        c.none(format!(
-            "\n\nIf you tried to supply `{}` as a PATTERN use `-- {}`",
-            arg, arg
-        ));
+        // If the user wants to supply things like `--a-flag` or `-b` as a value,
+        // suggest `--` for disambiguation.
+        if arg.starts_with('-') {
+            c.none(format!(
+                "\n\nIf you tried to supply `{}` as a value rather than a flag, use `-- {}`",
+                arg, arg
+            ));
+        }
+
         put_usage(&mut c, usage);
         try_help(&mut c);
 

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -1,4 +1,15 @@
+mod utils;
 use clap::{App, Arg};
+
+const USE_FLAG_AS_ARGUMENT: &str =
+    "error: Found argument '--another-flag' which wasn't expected, or isn't valid in this context
+
+If you tried to supply `--another-flag` as a value rather than a flag, use `-- --another-flag`
+
+USAGE:
+    mycat [FLAGS] [filename]
+
+For more information try --help";
 
 #[test]
 fn flag_using_short() {
@@ -109,4 +120,29 @@ fn multiple_flags_in_single() {
     assert!(m.is_present("flag"));
     assert!(m.is_present("color"));
     assert!(m.is_present("debug"));
+}
+
+#[test]
+fn issue_1284_argument_in_flag_style() {
+    let app = App::new("mycat")
+        .arg(Arg::new("filename"))
+        .arg(Arg::new("a-flag").long("a-flag"));
+
+    let m = app
+        .clone()
+        .get_matches_from(vec!["", "--", "--another-flag"]);
+    assert_eq!(m.value_of("filename"), Some("--another-flag"));
+
+    let m = app.clone().get_matches_from(vec!["", "--a-flag"]);
+    assert!(m.is_present("a-flag"));
+
+    let m = app.clone().get_matches_from(vec!["", "--", "--a-flag"]);
+    assert_eq!(m.value_of("filename"), Some("--a-flag"));
+
+    assert!(utils::compare_output(
+        app,
+        "mycat --another-flag",
+        USE_FLAG_AS_ARGUMENT,
+        true
+    ));
 }

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -29,7 +29,7 @@ For more information try --help";
 static REQ_GROUP_CONFLICT_ONLY_OPTIONS: &str =
     "error: Found argument '--all' which wasn't expected, or isn't valid in this context
 
-If you tried to supply `--all` as a PATTERN use `-- --all`
+If you tried to supply `--all` as a value rather than a flag, use `-- --all`
 
 USAGE:
     clap-test <-a|--delete>
@@ -40,8 +40,6 @@ For more information try --help";
 //        Need to roll back somehow.
 static REQ_GROUP_CONFLICT_REV_DEGRADED: &str =
     "error: Found argument 'base' which wasn't expected, or isn't valid in this context
-
-If you tried to supply `base` as a PATTERN use `-- base`
 
 USAGE:
     clap-test <base|--delete>

--- a/tests/opts.rs
+++ b/tests/opts.rs
@@ -8,7 +8,7 @@ static DYM: &str =
 
 \tDid you mean '--option'?
 
-If you tried to supply `--optio` as a PATTERN use `-- --optio`
+If you tried to supply `--optio` as a value rather than a flag, use `-- --optio`
 
 USAGE:
     clap-test --option <opt>...
@@ -21,7 +21,7 @@ static DYM_ISSUE_1073: &str =
 
 \tDid you mean '--files-without-match'?
 
-If you tried to supply `--files-without-matches` as a PATTERN use `-- --files-without-matches`
+If you tried to supply `--files-without-matches` as a value rather than a flag, use `-- --files-without-matches`
 
 USAGE:
     ripgrep-616 --files-without-match

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -86,7 +86,7 @@ static DYM_ARG: &str =
 
 	Did you mean to put '--subcmdarg' after the subcommand 'subcmd'?
 
-If you tried to supply `--subcm` as a PATTERN use `-- --subcm`
+If you tried to supply `--subcm` as a value rather than a flag, use `-- --subcm`
 
 USAGE:
     dym [SUBCOMMAND]


### PR DESCRIPTION
Closes #1284 BurntSushi/ripgrep#936
Related: #1744 #1943
The features disgussed in this issue was already implemented. However the error message emission introduced by #1514 is misleading.

The word `PATTERN` in the current error message comes from ripgrep-specific usage information, which is misleading in other applications. 

The error message should only be emitted when the argument looks like a flag(which is the only way the argument can be processed counterintuitively). 

This is also the first step on solving #1744 #1943.