### PR TITLE
Fix parser skipping options without heading set

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -214,18 +214,26 @@ impl<'help> App<'help> {
         self.get_arguments().filter(|a| a.is_positional())
     }
 
-    /// Iterate through the *flags* that don't have custom heading.
-    pub fn get_flags_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
+    /// Iterate through the *flags*.
+    pub fn get_flags(&self) -> impl Iterator<Item = &Arg<'help>> {
         self.get_arguments()
             .filter(|a| !a.is_set(ArgSettings::TakesValue) && a.get_index().is_none())
-            .filter(|a| a.get_help_heading().is_none())
+    }
+
+    /// Iterate through the *options*.
+    pub fn get_opts(&self) -> impl Iterator<Item = &Arg<'help>> {
+        self.get_arguments()
+            .filter(|a| a.is_set(ArgSettings::TakesValue) && a.get_index().is_none())
+    }
+
+    /// Iterate through the *flags* that don't have custom heading.
+    pub fn get_flags_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
+        self.get_flags().filter(|a| a.get_help_heading().is_none())
     }
 
     /// Iterate through the *options* that don't have custom heading.
     pub fn get_opts_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
-        self.get_arguments()
-            .filter(|a| a.is_set(ArgSettings::TakesValue) && a.get_index().is_none())
-            .filter(|a| a.get_help_heading().is_none())
+        self.get_opts().filter(|a| a.get_help_heading().is_none())
     }
 
     /// Get a list of all arguments the given argument conflicts with.

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1562,7 +1562,7 @@ impl<'help, 'app> Parser<'help, 'app> {
     pub(crate) fn add_defaults(&mut self, matcher: &mut ArgMatcher) -> ClapResult<()> {
         debug!("Parser::add_defaults");
 
-        for o in self.app.get_opts_with_no_heading() {
+        for o in self.app.get_opts() {
             debug!("Parser::add_defaults:iter:{}:", o.name);
             self.add_value(o, matcher, ValueType::DefaultValue)?;
         }

--- a/tests/opts.rs
+++ b/tests/opts.rs
@@ -510,3 +510,12 @@ fn long_eq_val_starts_with_eq() {
 
     assert_eq!("=value", matches.value_of("opt").unwrap());
 }
+
+#[test]
+fn issue_2022_get_flags_misuse() {
+    let app = App::new("test")
+        .help_heading("test")
+        .arg(Arg::new("a").long("a").default_value("32"));
+    let matches = app.get_matches_from(&[""]);
+    assert!(matches.value_of("a").is_some())
+}


### PR DESCRIPTION
Also fixes more places where `get_opts_with_no_heading` is misused, i.e `has_opts`

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->

Closes #2022