### PR TITLE
Fix typos and grammar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ I use a [conventional](https://github.com/ajoslin/conventional-changelog/blob/a5
     - `refactor` - Code functionality doesn't change, but underlying structure may
     - `style` - Stylistic changes only, no functionality changes
     - `wip` - A work in progress commit (Should typically be `git rebase`'ed away)
-    - `chore` - Catch all or things that have to do with the build system, etc
+    - `chore` - Catch all or things that have to do with the build system, etc.
     - `examples` - Changes to existing example, or a new example
  * The `COMPONENT` is optional, and may be a single file, directory, or logical component. Parenthesis can be omitted if you are opting not to use the `COMPONENT`.
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -437,7 +437,7 @@ impl<'help> App<'help> {
     /// ```no_run
     /// # use clap::App;
     /// App::new("myprog")
-    ///     .help_about("Print help information") // Impertive tone
+    ///     .help_about("Print help information") // Imperative tone
     /// # ;
     /// ```
     pub fn help_about<S: Into<&'help str>>(mut self, help_about: S) -> Self {
@@ -447,7 +447,7 @@ impl<'help> App<'help> {
 
     /// Sets the help text for the auto-generated version argument.
     ///
-    /// By default clap sets this to "Prints versoin information" but if
+    /// By default clap sets this to "Prints version information" but if
     /// you're using a different convention for your help messages and
     /// would prefer a different phrasing you can override it.
     ///
@@ -458,7 +458,7 @@ impl<'help> App<'help> {
     /// ```no_run
     /// # use clap::App;
     /// App::new("myprog")
-    ///     .version_about("Print version information") // Impertive tone
+    ///     .version_about("Print version information") // Imperative tone
     /// # ;
     /// ```
     pub fn version_about<S: Into<&'help str>>(mut self, version_about: S) -> Self {
@@ -1381,7 +1381,7 @@ impl<'help> App<'help> {
     /// Replaces an argument or subcommand used on the CLI at runtime with other arguments or subcommands.
     ///
     /// When this method is used, `name` is removed from the CLI, and `target`
-    /// is inserted in it's place. Parsing continues as if the user typed
+    /// is inserted in its place. Parsing continues as if the user typed
     /// `target` instead of `name`.
     ///
     /// This can be used to create "shortcuts" for subcommands, or if a
@@ -2631,7 +2631,7 @@ impl<'help> App<'help> {
         // Unfortunately, that would trigger
         // https://github.com/rust-lang/rust/issues/34511#issuecomment-373423999
         //
-        // I think this "collect to vec" solution is better then the linked one
+        // I think this "collect to vec" solution is better than the linked one
         // because it's simpler and it doesn't really matter performance-wise.
         a.into_iter()
     }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -1180,7 +1180,7 @@ impl<'help> Arg<'help> {
     /// Require another argument if this arg was present on runtime, and its value equals to `val`.
     ///
     /// This method takes `value, another_arg` pair. At runtime, clap will check
-    /// if this arg (`self`) is is present and its value equals to `val`.
+    /// if this arg (`self`) is present and its value equals to `val`.
     /// If it does, `another_arg` will be marked as required.
     ///
     /// **NOTE:** If using YAML the values should be laid out as follows
@@ -1411,7 +1411,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok()); // We didn't use --option=spec, or --extra=val so "cfg" isn't required
     /// ```
     ///
-    /// Setting [`Arg::required_if_eq_any(&[(arg, val)])`] and having any of the `arg`s used with it's
+    /// Setting [`Arg::required_if_eq_any(&[(arg, val)])`] and having any of the `arg`s used with its
     /// value of `val` but *not* using this arg is an error.
     ///
     /// ```rust

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -36,7 +36,7 @@ use std::ffi::OsString;
 /// }
 /// ```
 ///
-/// The equivilant [`App`] struct + `From` implementation:
+/// The equivalent [`App`] struct + `From` implementation:
 ///
 /// ```rust
 /// # use clap::{App, Arg, ArgMatches};

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -52,7 +52,7 @@ impl PartialEq<char> for KeyType {
 }
 
 impl<'help> MKeyMap<'help> {
-    //TODO ::from(x), ::with_capacity(n) etc
+    //TODO ::from(x), ::with_capacity(n) etc.
     //? set theory ops?
 
     pub(crate) fn contains<K>(&self, key: K) -> bool

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -339,7 +339,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
         debug!("Help::val: Has switch...");
         if self.use_long {
             // long help prints messages on the next line so it don't need to align text
-            debug!("Help::val: printing long help so skip aligment");
+            debug!("Help::val: printing long help so skip alignment");
         } else if arg.has_switch() {
             debug!("Yes");
             debug!("Help::val: force_next_line...{:?}", self.force_next_line);

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -178,7 +178,7 @@ impl<'help, 'app> Parser<'help, 'app> {
             assert!(
                 ok,
                 "When using a positional argument with .multiple(true) that is *not the \
-                 last* positional argument, the last positional argument (i.e the one \
+                 last* positional argument, the last positional argument (i.e. the one \
                  with the highest index) *must* have .required(true) or .last(true) set."
             );
 

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -938,7 +938,7 @@ fn req_delimiter_complex() {
 #[test]
 #[should_panic = "When using a positional argument with \
 .multiple(true) that is *not the last* positional argument, the last \
-positional argument (i.e the one with the highest index) *must* have \
+positional argument (i.e. the one with the highest index) *must* have \
 .required(true) or .last(true) set."]
 fn low_index_positional_not_required() {
     let _ = App::new("lip")


### PR DESCRIPTION
Some more fixes in addition to #2024 (594c535ba25b343cf52901aeb96ea246ffbdfde4)
* Some I noticed manually.
* Some were found by Topy (https://github.com/intgr/topy), either new
  rules from Topy or new code in clap.
* `etc.` and `i.e.` rules were disabled during the last run.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
