### PR TITLE
Help & Version settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ TODO: `cargo`, `std` features
 #### Minimum Required Rust
 * As of this release, `clap` requires `rustc 1.42.0` or greater.
 
+#### BREAKING CHANGES
+
+* **Renamed Settings**
+  * `AppSettings::DisableHelpFlags` => `AppSettings::DisableHelpFlag`
+
 #### Features
 
 * **Added Methods**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,8 @@ TODO: `cargo`, `std` features
   * `App::print_help` & `App::print_long_help` now return `std::io::Result`
   * `App::write_help` & `App::write_long_help` now return `std::io::Result`
   * `Error::info` now is of type `Vec<String>` instead of `Option<Vec<String>>`
-  * `short` in `#[clap()]` now accepts `char` instead of `&str`
   * `ArgMatches::subcommand` now returns `Option<(&str, &ArgMatches)>`
+  * `short` in `#[clap()]` now accepts `char` instead of `&str`
 
 #### Features
 
@@ -71,12 +71,11 @@ TODO: `cargo`, `std` features
     * `Arg::visible_short_alias`
     * `Arg::visible_short_aliases`
     * `Arg::value_hint`
+    * `Arg::validator_regex` (gated behind `regex` feature)
   * **App**
     * `App::subcommand_placeholder`
     * `App::before_long_help`
     * `App::after_long_help`
-* **Added Settings**
-  * `AppSettings::DisableHelpFlags`
 * TODO: List App::get_* methods
 
 #### Enhancements
@@ -107,7 +106,7 @@ TODO: `cargo`, `std` features
     * `App::help_message` in favor of `App::mut_arg`
     * `App::help_short` in favor of `App::mut_arg`
     * `App::arg_from_usage` in favor of `App::arg`
-    * `App::args_from_usage` in favor of TODO: `App::args(usage.split('\n'))`
+    * `App::args_from_usage` in favor of `App::args(usage.lines().map(|l| l.trim()).filter(|l| !l.is_empty()))`
     * `App::gen_completions` in favor of TODO:
     * `App::gen_completions_to` in favor of TODO:
     * `App::settings` in favor of `App::setting(Setting1 | Setting2)`
@@ -115,18 +114,18 @@ TODO: `cargo`, `std` features
     * `App::global_settings` in favor of `App::global_setting(Setting1 | Setting2)`
   * **Arg**
     * `Arg::empty_values` in favor of TODO:
-  * `ArgMatches::usage` in favor of `App::generate_usage`
-  * **Settings**
-    * `AppSettings::PropagateGlobalValuesDown`
-    * `ArgSettings::Global` in favor of `Arg::global` method
-    * `ArgSettings::Multiple` in favor of `ArgSettings::MultipleValues` and `ArgSettings::MultipleOccurrences`
+  * **ArgMatches**
+    * `ArgMatches::usage` in favor of `App::generate_usage`
   * **Macros**
     * `arg_enum!` in favor of `ArgEnum` derive macro.
     * `value_t!` in favor of `ArgMatches::value_of_t`
     * `value_t_or_exit!` in favor of `ArgMatches::value_of_t_or_exit`
     * `values_t!` in favor of `ArgMatches::values_of_t`
     * `values_t_or_exit!` in favor of `ArgMatches::values_of_t_or_exit`
-  * Support for `{n}` in help text
+* **Removed Settings**
+  * `AppSettings::PropagateGlobalValuesDown`
+  * `ArgSettings::Global` in favor of `Arg::global` method
+  * `ArgSettings::Multiple` in favor of `ArgSettings::MultipleValues` and `ArgSettings::MultipleOccurrences`
 * **Renamed Methods**
   * **App**
     * `App::from_yaml` => `App::from`
@@ -155,6 +154,7 @@ TODO: `cargo`, `std` features
     `Fn(String) -> Result<(), String>`
   * `Arg::validator_os` now takes first argument as `Fn(&OsStr) -> Result<O, OsString>` instead of
     `Fn(&OsStr) -> Result<(), OsString>`
+* Removed support for `{n}` in help text
 * In usage parser, for options `[name]... --option [val]` results in `ArgSettings::MultipleOccurrences`
   but `--option [val]...` results in `ArgSettings::MultipleValues` *and* `ArgSettings::MultipleOccurrences`.
   Before both resulted in the same thing
@@ -178,7 +178,7 @@ TODO: `cargo`, `std` features
     * `Arg::multiple_values`
     * `Arg::multiple_occurrences`
     * `Arg::help_heading`
-* **Added Variants**
+* **Added Settings**
   * `AppSettings::HelpRequired`
   * `AppSettings::NoAutoHelp`
   * `AppSettings::NoAutoVersion`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ TODO: `cargo`, `std` features
 * **Renamed Settings**
   * `AppSettings::DisableHelpFlags` => `AppSettings::DisableHelpFlag`
   * `AppSettings::DisableVersion` => `AppSettings::DisableVersionFlag`
+  * `AppSettings::VersionlessSubcommands` => `AppSettings::DisableVersionForSubcommands`
 
 #### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ TODO: `cargo`, `std` features
 
 * **Renamed Settings**
   * `AppSettings::DisableHelpFlags` => `AppSettings::DisableHelpFlag`
+  * `AppSettings::DisableVersion` => `AppSettings::DisableVersionFlag`
 
 #### Features
 

--- a/benches/06_rustup.rs
+++ b/benches/06_rustup.rs
@@ -26,7 +26,7 @@ fn build_cli() -> App<'static> {
         .version("0.9.0") // Simulating
         .about("The Rust toolchain installer")
         .after_help(RUSTUP_HELP)
-        .setting(AppSettings::VersionlessSubcommands)
+        .setting(AppSettings::DisableVersionForSubcommands)
         .setting(AppSettings::DeriveDisplayOrder)
         // .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
@@ -107,7 +107,7 @@ fn build_cli() -> App<'static> {
         .subcommand(
             App::new("target")
                 .about("Modify a toolchain's supported targets")
-                .setting(AppSettings::VersionlessSubcommands)
+                .setting(AppSettings::DisableVersionForSubcommands)
                 .setting(AppSettings::DeriveDisplayOrder)
                 // .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
@@ -163,7 +163,7 @@ fn build_cli() -> App<'static> {
         .subcommand(
             App::new("component")
                 .about("Modify a toolchain's installed components")
-                .setting(AppSettings::VersionlessSubcommands)
+                .setting(AppSettings::DisableVersionForSubcommands)
                 .setting(AppSettings::DeriveDisplayOrder)
                 // .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
@@ -210,7 +210,7 @@ fn build_cli() -> App<'static> {
             App::new("override")
                 .about("Modify directory toolchain overrides")
                 .after_help(OVERRIDE_HELP)
-                .setting(AppSettings::VersionlessSubcommands)
+                .setting(AppSettings::DisableVersionForSubcommands)
                 .setting(AppSettings::DeriveDisplayOrder)
                 // .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(App::new("list").about("List directory toolchain overrides"))
@@ -302,7 +302,7 @@ fn build_cli() -> App<'static> {
         .subcommand(
             App::new("self")
                 .about("Modify the rustup installation")
-                .setting(AppSettings::VersionlessSubcommands)
+                .setting(AppSettings::DisableVersionForSubcommands)
                 .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(App::new("update").about("Download and install updates to rustup"))
                 .subcommand(
@@ -316,7 +316,7 @@ fn build_cli() -> App<'static> {
             App::new("telemetry")
                 .about("rustup telemetry commands")
                 .setting(AppSettings::Hidden)
-                .setting(AppSettings::VersionlessSubcommands)
+                .setting(AppSettings::DisableVersionForSubcommands)
                 .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(App::new("enable").about("Enable rustup telemetry"))
                 .subcommand(App::new("disable").about("Disable rustup telemetry"))

--- a/clap_derive/examples/value_hints_derive.rs
+++ b/clap_derive/examples/value_hints_derive.rs
@@ -34,7 +34,7 @@ enum GeneratorChoice {
     name = "value_hints_derive",
     // AppSettings::TrailingVarArg is required to use ValueHint::CommandWithArguments
     setting = AppSettings::TrailingVarArg,
-    setting = AppSettings::DisableVersion
+    setting = AppSettings::DisableVersionFlag
 )]
 struct Opt {
     /// If provided, outputs the completion file for given shell

--- a/clap_generate/examples/value_hints.rs
+++ b/clap_generate/examples/value_hints.rs
@@ -19,7 +19,7 @@ use std::io;
 
 fn build_cli() -> App<'static> {
     App::new("value_hints")
-        .setting(AppSettings::DisableVersion)
+        .setting(AppSettings::DisableVersionFlag)
         // AppSettings::TrailingVarArg is required to use ValueHint::CommandWithArguments
         .setting(AppSettings::TrailingVarArg)
         .arg(Arg::new("generator").long("generate").possible_values(&[

--- a/clap_generate/src/generators/mod.rs
+++ b/clap_generate/src/generators/mod.rs
@@ -144,7 +144,7 @@ pub trait Generator {
             shorts_and_visible_aliases.push('h');
         }
 
-        if !p.is_set(AppSettings::DisableVersion)
+        if !p.is_set(AppSettings::DisableVersionFlag)
             && !shorts_and_visible_aliases.iter().any(|&x| x == 'V')
         {
             shorts_and_visible_aliases.push('V');
@@ -173,7 +173,7 @@ pub trait Generator {
             longs.push(String::from("help"));
         }
 
-        if !p.is_set(AppSettings::DisableVersion) && !longs.iter().any(|x| *x == "version") {
+        if !p.is_set(AppSettings::DisableVersionFlag) && !longs.iter().any(|x| *x == "version") {
             longs.push(String::from("version"));
         }
 
@@ -196,7 +196,7 @@ pub trait Generator {
             );
         }
 
-        if !p.is_set(AppSettings::DisableVersion)
+        if !p.is_set(AppSettings::DisableVersionFlag)
             && !flags.iter().any(|x| x.get_name() == "version")
         {
             flags.push(

--- a/clap_generate/tests/value_hints.rs
+++ b/clap_generate/tests/value_hints.rs
@@ -6,7 +6,7 @@ mod completions;
 
 pub fn build_app_with_value_hints() -> App<'static> {
     App::new("my_app")
-        .setting(AppSettings::DisableVersion)
+        .setting(AppSettings::DisableVersionFlag)
         .setting(AppSettings::TrailingVarArg)
         .arg(
             Arg::new("choice")

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2293,7 +2293,9 @@ impl<'help> App<'help> {
                 // We have to create a new scope in order to tell rustc the borrow of `sc` is
                 // done and to recursively call this method
                 {
-                    let vsc = $_self.settings.is_set(AppSettings::VersionlessSubcommands);
+                    let vsc = $_self
+                        .settings
+                        .is_set(AppSettings::DisableVersionForSubcommands);
                     let gv = $_self.settings.is_set(AppSettings::GlobalVersion);
 
                     if vsc {

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2353,50 +2353,58 @@ impl<'help> App<'help> {
     pub(crate) fn _create_help_and_version(&mut self) {
         debug!("App::_create_help_and_version");
 
-        if !(self
-            .args
-            .args
-            .iter()
-            .any(|x| x.long == Some("help") || x.id == Id::help_hash())
-            || self.is_set(AppSettings::DisableHelpFlag)
+        if !(self.is_set(AppSettings::DisableHelpFlag)
+            || self
+                .args
+                .args
+                .iter()
+                .any(|x| x.long == Some("help") || x.id == Id::help_hash())
             || self
                 .subcommands
                 .iter()
-                .any(|sc| sc.short_flag == Some('h') || sc.long_flag == Some("help")))
+                .any(|sc| sc.long_flag == Some("help")))
         {
             debug!("App::_create_help_and_version: Building --help");
             let mut help = Arg::new("help")
                 .long("help")
                 .about(self.help_about.unwrap_or("Prints help information"));
-            if !self.args.args.iter().any(|x| x.short == Some('h')) {
+
+            if !(self.args.args.iter().any(|x| x.short == Some('h'))
+                || self.subcommands.iter().any(|sc| sc.short_flag == Some('h')))
+            {
                 help = help.short('h');
             }
 
             self.args.push(help);
         }
-        if !(self
-            .args
-            .args
-            .iter()
-            .any(|x| x.long == Some("version") || x.id == Id::version_hash())
-            || self.is_set(AppSettings::DisableVersionFlag)
+
+        if !(self.is_set(AppSettings::DisableVersionFlag)
+            || self
+                .args
+                .args
+                .iter()
+                .any(|x| x.long == Some("version") || x.id == Id::version_hash())
             || self
                 .subcommands
                 .iter()
-                .any(|sc| sc.short_flag == Some('V') || sc.long_flag == Some("version")))
+                .any(|sc| sc.long_flag == Some("version")))
         {
             debug!("App::_create_help_and_version: Building --version");
             let mut version = Arg::new("version")
                 .long("version")
                 .about(self.version_about.unwrap_or("Prints version information"));
-            if !self.args.args.iter().any(|x| x.short == Some('V')) {
+
+            if !(self.args.args.iter().any(|x| x.short == Some('V'))
+                || self.subcommands.iter().any(|sc| sc.short_flag == Some('V')))
+            {
                 version = version.short('V');
             }
 
             self.args.push(version);
         }
-        if self.has_subcommands()
-            && !self.is_set(AppSettings::DisableHelpSubcommand)
+
+        if !self.is_set(AppSettings::DisableHelpSubcommand)
+            && self.has_subcommands()
             && !self.subcommands.iter().any(|s| s.id == Id::help_hash())
         {
             debug!("App::_create_help_and_version: Building help");

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2356,7 +2356,7 @@ impl<'help> App<'help> {
             .args
             .iter()
             .any(|x| x.long == Some("help") || x.id == Id::help_hash())
-            || self.is_set(AppSettings::DisableHelpFlags)
+            || self.is_set(AppSettings::DisableHelpFlag)
             || self
                 .subcommands
                 .iter()

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2297,7 +2297,7 @@ impl<'help> App<'help> {
                     let gv = $_self.settings.is_set(AppSettings::GlobalVersion);
 
                     if vsc {
-                        $sc.set(AppSettings::DisableVersion);
+                        $sc.set(AppSettings::DisableVersionFlag);
                     }
                     if gv && $sc.version.is_none() && $_self.version.is_some() {
                         $sc.set(AppSettings::GlobalVersion);
@@ -2377,7 +2377,7 @@ impl<'help> App<'help> {
             .args
             .iter()
             .any(|x| x.long == Some("version") || x.id == Id::version_hash())
-            || self.is_set(AppSettings::DisableVersion)
+            || self.is_set(AppSettings::DisableVersionFlag)
             || self
                 .subcommands
                 .iter()

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -10,7 +10,7 @@ bitflags! {
         const SC_REQUIRED                    = 1 << 1;
         const A_REQUIRED_ELSE_HELP           = 1 << 2;
         const GLOBAL_VERSION                 = 1 << 3;
-        const VERSIONLESS_SC                 = 1 << 4;
+        const DISABLE_VERSION_FOR_SC         = 1 << 4;
         const UNIFIED_HELP                   = 1 << 5;
         const WAIT_ON_ERROR                  = 1 << 6;
         const SC_REQUIRED_ELSE_HELP          = 1 << 7;
@@ -135,8 +135,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::UNIFIED_HELP,
     NextLineHelp("nextlinehelp")
         => Flags::NEXT_LINE_HELP,
-    VersionlessSubcommands("versionlesssubcommands")
-        => Flags::VERSIONLESS_SC,
+    DisableVersionForSubcommands("disableversionforsubcommands")
+        => Flags::DISABLE_VERSION_FOR_SC,
     WaitOnError("waitonerror")
         => Flags::WAIT_ON_ERROR,
     TrailingValues("trailingvalues")
@@ -657,7 +657,7 @@ pub enum AppSettings {
     /// [``]: ./struct..html
     DisableHelpSubcommand,
 
-    /// Disables `-V` and `--version` [`App`] without affecting any of the [``]s
+    /// Disables `-V` and `--version` for this [`App`] without affecting any of the [``]s
     /// (Defaults to `false`; application *does* have a version flag)
     ///
     /// # Examples
@@ -690,6 +690,27 @@ pub enum AppSettings {
     /// [`App`]: ./struct.App.html
     DisableVersionFlag,
 
+    /// Disables `-V` and `--version` for all [`subcommand`]s of this [`App`]
+    /// (Defaults to `false`; subcommands *do* have version flags.)
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, AppSettings, ErrorKind};
+    /// let res = App::new("myprog")
+    ///     .version("v1.1")
+    ///     .setting(AppSettings::DisableVersionForSubcommands)
+    ///     .subcommand(App::new("test"))
+    ///     .try_get_matches_from(vec![
+    ///         "myprog", "test", "-V"
+    ///     ]);
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// ```
+    /// [`App`]: ./struct.App.html
+    /// [``]: ./struct..html
+    DisableVersionForSubcommands,
+
     /// Displays the arguments and [``]s in the help message in the order that they were
     /// declared in, and not alphabetically which is the default.
     ///
@@ -706,9 +727,6 @@ pub enum AppSettings {
 
     /// Specifies to use the version of the current command for all child [``]s.
     /// (Defaults to `false`; subcommands have independent version strings from their parents.)
-    ///
-    /// **NOTE:** The version for the current command **and** this setting must be set **prior** to
-    /// adding any child subcommands
     ///
     /// # Examples
     ///
@@ -999,28 +1017,6 @@ pub enum AppSettings {
     /// ```
     UnifiedHelpMessage,
 
-    /// Disables `-V` and `--version` for all [``]s
-    /// (Defaults to `false`; subcommands *do* have version flags.)
-    ///
-    /// **NOTE:** This setting must be set **prior** to adding any subcommands.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, AppSettings, ErrorKind};
-    /// let res = App::new("myprog")
-    ///     .version("v1.1")
-    ///     .setting(AppSettings::VersionlessSubcommands)
-    ///     .subcommand(App::new("test"))
-    ///     .try_get_matches_from(vec![
-    ///         "myprog", "test", "-V"
-    ///     ]);
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
-    /// ```
-    /// [``]: ./struct..html
-    VersionlessSubcommands,
-
     /// Will display a message "Press \[ENTER\]/\[RETURN\] to continue..." and wait for user before
     /// exiting
     ///
@@ -1198,8 +1194,10 @@ mod test {
             AppSettings::UnifiedHelpMessage
         );
         assert_eq!(
-            "versionlesssubcommands".parse::<AppSettings>().unwrap(),
-            AppSettings::VersionlessSubcommands
+            "disableversionforsubcommands"
+                .parse::<AppSettings>()
+                .unwrap(),
+            AppSettings::DisableVersionForSubcommands
         );
         assert_eq!(
             "waitonerror".parse::<AppSettings>().unwrap(),

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -16,7 +16,7 @@ bitflags! {
         const SC_REQUIRED_ELSE_HELP          = 1 << 7;
         const NO_AUTO_HELP                   = 1 << 8;
         const NO_AUTO_VERSION                = 1 << 9;
-        const DISABLE_VERSION                = 1 << 10;
+        const DISABLE_VERSION_FLAG           = 1 << 10;
         const HIDDEN                         = 1 << 11;
         const TRAILING_VARARG                = 1 << 12;
         const NO_BIN_NAME                    = 1 << 13;
@@ -103,8 +103,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::DISABLE_HELP_SC,
     DisableHelpFlag("disablehelpflag")
         => Flags::DISABLE_HELP_FLAG,
-    DisableVersion("disableversion")
-        => Flags::DISABLE_VERSION,
+    DisableVersionFlag("disableversionflag")
+        => Flags::DISABLE_VERSION_FLAG,
     GlobalVersion("globalversion")
         => Flags::GLOBAL_VERSION,
     HidePossibleValuesInHelp("hidepossiblevaluesinhelp")
@@ -666,7 +666,7 @@ pub enum AppSettings {
     /// # use clap::{App, AppSettings, ErrorKind};
     /// let res = App::new("myprog")
     ///     .version("v1.1")
-    ///     .setting(AppSettings::DisableVersion)
+    ///     .setting(AppSettings::DisableVersionFlag)
     ///     .try_get_matches_from(vec![
     ///         "myprog", "-V"
     ///     ]);
@@ -678,7 +678,7 @@ pub enum AppSettings {
     /// # use clap::{App, AppSettings, ErrorKind};
     /// let res = App::new("myprog")
     ///     .version("v1.1")
-    ///     .setting(AppSettings::DisableVersion)
+    ///     .setting(AppSettings::DisableVersionFlag)
     ///     .subcommand(App::new("test"))
     ///     .try_get_matches_from(vec![
     ///         "myprog", "test", "-V"
@@ -688,7 +688,7 @@ pub enum AppSettings {
     /// ```
     /// [``]: ./struct..html
     /// [`App`]: ./struct.App.html
-    DisableVersion,
+    DisableVersionFlag,
 
     /// Displays the arguments and [``]s in the help message in the order that they were
     /// declared in, and not alphabetically which is the default.
@@ -1130,8 +1130,8 @@ mod test {
             AppSettings::DisableHelpSubcommand
         );
         assert_eq!(
-            "disableversion".parse::<AppSettings>().unwrap(),
-            AppSettings::DisableVersion
+            "disableversionflag".parse::<AppSettings>().unwrap(),
+            AppSettings::DisableVersionFlag
         );
         assert_eq!(
             "dontcollapseargsinusage".parse::<AppSettings>().unwrap(),

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -48,7 +48,7 @@ bitflags! {
         const ARGS_OVERRIDE_SELF             = 1 << 39;
         const HELP_REQUIRED                  = 1 << 40;
         const SUBCOMMAND_PRECEDENCE_OVER_ARG = 1 << 41;
-        const DISABLE_HELP_FLAGS             = 1 << 42;
+        const DISABLE_HELP_FLAG              = 1 << 42;
     }
 }
 
@@ -101,8 +101,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::DERIVE_DISP_ORDER,
     DisableHelpSubcommand("disablehelpsubcommand")
         => Flags::DISABLE_HELP_SC,
-    DisableHelpFlags("disablehelpflags")
-        => Flags::DISABLE_HELP_FLAGS,
+    DisableHelpFlag("disablehelpflag")
+        => Flags::DISABLE_HELP_FLAG,
     DisableVersion("disableversion")
         => Flags::DISABLE_VERSION,
     GlobalVersion("globalversion")
@@ -613,7 +613,7 @@ pub enum AppSettings {
     /// ```rust
     /// # use clap::{App, AppSettings, ErrorKind};
     /// let res = App::new("myprog")
-    ///     .setting(AppSettings::DisableHelpFlags)
+    ///     .setting(AppSettings::DisableHelpFlag)
     ///     .try_get_matches_from(vec![
     ///         "myprog", "-h"
     ///     ]);
@@ -624,7 +624,7 @@ pub enum AppSettings {
     /// ```rust
     /// # use clap::{App, AppSettings, ErrorKind};
     /// let res = App::new("myprog")
-    ///     .setting(AppSettings::DisableHelpFlags)
+    ///     .setting(AppSettings::DisableHelpFlag)
     ///     .subcommand(App::new("test"))
     ///     .try_get_matches_from(vec![
     ///         "myprog", "test", "-h"
@@ -634,7 +634,7 @@ pub enum AppSettings {
     /// ```
     /// [`SubCommand`]: ./struct.SubCommand.html
     /// [`App`]: ./struct.App.html
-    DisableHelpFlags,
+    DisableHelpFlag,
 
     /// Disables the `help` subcommand
     ///
@@ -1076,8 +1076,8 @@ mod test {
     #[test]
     fn app_settings_fromstr() {
         assert_eq!(
-            "disablehelpflags".parse::<AppSettings>().unwrap(),
-            AppSettings::DisableHelpFlags
+            "disablehelpflag".parse::<AppSettings>().unwrap(),
+            AppSettings::DisableHelpFlag
         );
         assert_eq!(
             "argsnegatesubcommands".parse::<AppSettings>().unwrap(),

--- a/src/build/app/tests.rs
+++ b/src/build/app/tests.rs
@@ -55,9 +55,9 @@ fn app_send_sync() {
 #[test]
 fn issue_2090() {
     let mut app = App::new("app")
-        .global_setting(AppSettings::DisableVersion)
+        .global_setting(AppSettings::DisableVersionFlag)
         .subcommand(App::new("sub"));
     app._build();
 
-    assert!(app.subcommands[0].is_set(AppSettings::DisableVersion));
+    assert!(app.subcommands[0].is_set(AppSettings::DisableVersionFlag));
 }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1118,18 +1118,25 @@ impl<'help, 'app> Parser<'help, 'app> {
             arg
         );
 
-        // Needs to use app.settings.is_set instead of just is_set() because is_set() checks
-        // both global and local settings, we only want to check local
-        if arg == "help" && !self.app.settings.is_set(AS::NoAutoHelp) {
-            debug!("Help");
-            return Err(self.help_err(true));
+        if let Some(help) = self.app.find(&Id::help_hash()) {
+            if let Some(h) = help.long {
+                if arg == h && !self.is_set(AS::NoAutoHelp) {
+                    debug!("Help");
+                    return Err(self.help_err(true));
+                }
+            }
         }
-        if arg == "version" && !self.app.settings.is_set(AS::NoAutoVersion) {
-            debug!("Version");
-            return Err(self.version_err(true));
-        }
-        debug!("Neither");
 
+        if let Some(version) = self.app.find(&Id::version_hash()) {
+            if let Some(v) = version.long {
+                if arg == v && !self.is_set(AS::NoAutoVersion) {
+                    debug!("Version");
+                    return Err(self.version_err(true));
+                }
+            }
+        }
+
+        debug!("Neither");
         Ok(())
     }
 
@@ -1139,24 +1146,25 @@ impl<'help, 'app> Parser<'help, 'app> {
             "Parser::check_for_help_and_version_char: Checking if -{} is help or version...",
             arg
         );
-        // Needs to use app.settings.is_set instead of just is_set() because is_set() checks
-        // both global and local settings, we only want to check local
+
         if let Some(help) = self.app.find(&Id::help_hash()) {
             if let Some(h) = help.short {
-                if arg == h && !self.app.settings.is_set(AS::NoAutoHelp) {
+                if arg == h && !self.is_set(AS::NoAutoHelp) {
                     debug!("Help");
                     return Err(self.help_err(false));
                 }
             }
         }
+
         if let Some(version) = self.app.find(&Id::version_hash()) {
             if let Some(v) = version.short {
-                if arg == v && !self.app.settings.is_set(AS::NoAutoVersion) {
+                if arg == v && !self.is_set(AS::NoAutoVersion) {
                     debug!("Version");
                     return Err(self.version_err(false));
                 }
             }
         }
+
         debug!("Neither");
         Ok(())
     }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1448,8 +1448,6 @@ fn escaped_whitespace_values() {
 
 fn issue_1112_setup() -> App<'static> {
     App::new("test")
-        .author("Kevin K.")
-        .about("tests stuff")
         .version("1.3")
         .global_setting(AppSettings::NoAutoHelp)
         .arg(Arg::from("-h, --help 'some help'"))

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1919,7 +1919,7 @@ This is after help.
 fn after_help_no_args() {
     let mut app = App::new("myapp")
         .version("1.0")
-        .setting(AppSettings::DisableHelpFlags)
+        .setting(AppSettings::DisableHelpFlag)
         .setting(AppSettings::DisableVersion)
         .after_help("This is after help.");
 

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1920,7 +1920,7 @@ fn after_help_no_args() {
     let mut app = App::new("myapp")
         .version("1.0")
         .setting(AppSettings::DisableHelpFlag)
-        .setting(AppSettings::DisableVersion)
+        .setting(AppSettings::DisableVersionFlag)
         .after_help("This is after help.");
 
     let help = {

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -29,7 +29,7 @@ fn basic() {
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
         (@global_setting ColorNever)
-        (@setting VersionlessSubcommands)
+        (@setting DisableVersionForSubcommands)
         (@arg opt: -o --option +takes_value ... "tests options")
         (@arg positional: index(1) "tests positionals")
         (@arg flag: -f --flag ... +global "tests flags")


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->

I am wondering which is better, `DisableVersionFlagForSubcommands` or `DisableVersionForSubcommands`. Because if we ever have version subcommand, then we would want to disable even that for subcommands, so, thinking about the `Flag` in that name.
