### PR TITLE
Attach validation error as Error::source

### DIFF
--- a/clap_derive/examples/keyvalue.rs
+++ b/clap_derive/examples/keyvalue.rs
@@ -4,12 +4,12 @@ use clap::Clap;
 use std::error::Error;
 
 /// Parse a single key-value pair
-fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error>>
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
 where
     T: std::str::FromStr,
-    T::Err: Error + 'static,
+    T::Err: Error + Send + Sync + 'static,
     U: std::str::FromStr,
-    U::Err: Error + 'static,
+    U::Err: Error + Send + Sync + 'static,
 {
     let pos = s
         .find('=')

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -227,7 +227,6 @@ pub fn gen_app_augmentation(
                         .validator(|s| {
                             #func(s)
                             .map(|_: #convert_type| ())
-                            .map_err(|e| e.to_string())
                         })
                     },
                     ParserKind::TryFromOsStr => quote_spanned! { func.span()=>

--- a/clap_derive/tests/custom-string-parsers.rs
+++ b/clap_derive/tests/custom-string-parsers.rs
@@ -90,7 +90,15 @@ fn test_parse_hex() {
 fn custom_parser_1(_: &str) -> &'static str {
     "A"
 }
-fn custom_parser_2(_: &str) -> Result<&'static str, u32> {
+#[derive(Debug)]
+struct ErrCode(u32);
+impl std::error::Error for ErrCode {}
+impl std::fmt::Display for ErrCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+fn custom_parser_2(_: &str) -> Result<&'static str, ErrCode> {
     Ok("B")
 }
 fn custom_parser_3(_: &OsStr) -> &'static str {

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -351,7 +351,12 @@ impl ArgMatches {
                     v, name, e
                 );
 
-                Error::value_validation(name.to_string(), v.to_string(), message, ColorChoice::Auto)
+                Error::value_validation(
+                    name.to_string(),
+                    v.to_string(),
+                    message.into(),
+                    ColorChoice::Auto,
+                )
             })
         } else {
             Err(Error::argument_not_found_auto(name.to_string()))
@@ -439,7 +444,7 @@ impl ArgMatches {
                     Error::value_validation(
                         name.to_string(),
                         v.to_string(),
-                        message,
+                        message.into(),
                         ColorChoice::Auto,
                     )
                 })

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -752,6 +752,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                     message,
                     kind: ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
                     info: vec![],
+                    source: None,
                 });
             }
         }
@@ -1747,6 +1748,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                 message: c,
                 kind: ErrorKind::DisplayHelp,
                 info: vec![],
+                source: None,
             },
         }
     }
@@ -1761,6 +1763,7 @@ impl<'help, 'app> Parser<'help, 'app> {
             message: c,
             kind: ErrorKind::DisplayVersion,
             info: vec![],
+            source: None,
         }
     }
 }

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -62,6 +62,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 message,
                 kind: ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
                 info: vec![],
+                source: None,
             });
         }
         self.validate_conflicts(matcher)?;


### PR DESCRIPTION
For review on whether it makes sense to fix #2151 

One issue with this is it still retains the `error:` prefix and duplicate printing of the underlying error when you use an error reporter. I took a look at what it would take to fix this and instead have `clap` use a small internal error reporter to print the error message for functions like `App::parse`, and it seems like that needs a codebase and test-wide refactor to not assume that `impl Display for Error` will be the same as what gets written to the terminal.