### PR TITLE
Don't use default value when option is passed

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1612,23 +1612,8 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         if !arg.default_vals.is_empty() {
             debug!("Parser::add_value:iter:{}: has default vals", arg.name);
-            if matcher
-                .get(&arg.id)
-                .map(|ma| ma.vals.len())
-                .map(|len| len == 0)
-                .unwrap_or(false)
-            {
-                debug!(
-                    "Parser::add_value:iter:{}: has no user defined vals",
-                    arg.name
-                );
-
-                for val in &arg.default_vals {
-                    self.add_val_to_arg(arg, &ArgStr::new(val), matcher, ty)?;
-                }
-            } else if matcher.get(&arg.id).is_some() {
-                debug!("Parser::add_value:iter:{}: has user defined vals", arg.name);
-
+            if matcher.get(&arg.id).is_some() {
+                debug!("Parser::add_value:iter:{}: was used", arg.name);
             // do nothing
             } else {
                 debug!("Parser::add_value:iter:{}: wasn't used", arg.name);
@@ -1640,6 +1625,39 @@ impl<'help, 'app> Parser<'help, 'app> {
         } else {
             debug!(
                 "Parser::add_value:iter:{}: doesn't have default vals",
+                arg.name
+            );
+
+            // do nothing
+        }
+
+        if !arg.default_missing_vals.is_empty() {
+            debug!(
+                "Parser::add_value:iter:{}: has default missing vals",
+                arg.name
+            );
+            match matcher.get(&arg.id) {
+                Some(ma) if ma.vals.is_empty() => {
+                    debug!(
+                        "Parser::add_value:iter:{}: has no user defined vals",
+                        arg.name
+                    );
+                    for val in &arg.default_missing_vals {
+                        self.add_val_to_arg(arg, &ArgStr::new(val), matcher, ty)?;
+                    }
+                }
+                None => {
+                    debug!("Parser::add_value:iter:{}: wasn't used", arg.name);
+                    // do nothing
+                }
+                _ => {
+                    debug!("Parser::add_value:iter:{}: has user defined vals", arg.name);
+                    // do nothing
+                }
+            }
+        } else {
+            debug!(
+                "Parser::add_value:iter:{}: doesn't have default missing vals",
                 arg.name
             );
 

--- a/tests/default_vals.rs
+++ b/tests/default_vals.rs
@@ -12,6 +12,19 @@ fn opts() {
 }
 
 #[test]
+fn opt_without_value_fail() {
+    let r = App::new("df")
+        .arg(Arg::from("-o [opt] 'some opt'").default_value("default"))
+        .try_get_matches_from(vec!["", "-o"]);
+    assert!(r.is_err());
+    let err = r.unwrap_err();
+    assert_eq!(err.kind, ErrorKind::EmptyValue);
+    assert!(err
+        .to_string()
+        .contains("The argument '-o <opt>' requires a value but none was supplied"));
+}
+
+#[test]
 fn opt_user_override() {
     let r = App::new("df")
         .arg(Arg::from("--opt [FILE] 'some arg'").default_value("default"))

--- a/tests/opts.rs
+++ b/tests/opts.rs
@@ -402,7 +402,7 @@ fn issue_1047_min_zero_vals_default_val() {
                 .long("del")
                 .setting(ArgSettings::RequireEquals)
                 .min_values(0)
-                .default_value("default"),
+                .default_missing_value("default"),
         )
         .get_matches_from(vec!["foo", "-d"]);
     assert_eq!(m.occurrences_of("del"), 1);


### PR DESCRIPTION
This PR changes `default_value` so that it does not apply for an option when the user passes the flag without a corresponding value. This case is now handled by `default_missing_value`.

(See also my discussion question https://github.com/clap-rs/clap/discussions/2083 where I understood that this is the expected behaviour.)

Consider this sample program:

```
#[derive(Clap, Debug)]
struct Opts {
    #[clap(long, default_value = "5")]
    batch_size: usize
}
```

With the current master, I get the following results of execution:

```
cargo run                    // OK
batch_size = 5

cargo run -- --batch-size    // <---This should not succeed, as default_missing_value is not set
batch_size = 5

cargo run -- --batch-size 6  // OK
batch_size = 6
```

After this patch, everything works as expected:

```
cargo run
batch_size = 5

cargo run -- --batch-size
error: The argument '--batch-size <batch-size>' requires a value but none was supplied

cargo run -- --batch-size 6
batch_size = 6
```

