### PR TITLE
Add `conflicts_with_all` note to docs

### DIFF
--- a/clap.schema.json
+++ b/clap.schema.json
@@ -69,10 +69,14 @@
           "type": "boolean"
         },
         "conflicts_with": {
-          "type": "string"
-        },
-        "conflicts_with_all": {
-          "$ref": "#/structures/arrayStrUnique"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/structures/arrayStrUnique"
+            }
+          ]
         },
         "default_value": {
           "type": "string"

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -885,7 +885,7 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// The same as [`Arg::conflicts_with`] but allows specifying multiple two-way conlicts per
+    /// The same as [`Arg::conflicts_with`] but allows specifying multiple two-way conflicts per
     /// argument.
     ///
     /// **NOTE:** Conflicting rules take precedence over being required by default. Conflict rules
@@ -894,6 +894,9 @@ impl<'help> Arg<'help> {
     /// **NOTE:** Defining a conflict is two-way, but does *not* need to defined for both arguments
     /// (i.e. if A conflicts with B, defining A.conflicts_with(B) is sufficient. You do not need
     /// need to also do B.conflicts_with(A))
+    ///
+    /// **NOTE:** This option does not exist when using a YAML configuration file. Using [`Arg::conflicts_with`]
+    /// followed by an array of strings will achieve the equivalent effect.
     ///
     /// **NOTE:** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
     ///


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Some options are missing in the `From<Yaml>` implementation for `Arg`, because the singular and plural version are merged into one via the `yaml_vec_or_str!()` macro. This PR adds a note warning about this, specifically in the `conflicts_with()` and `conflicts_with_all()` docs.

(I fixed a typo too)