### PR TITLE
Fix name attribute being ignored on enums

### DIFF
--- a/clap_derive/src/derives/clap.rs
+++ b/clap_derive/src/derives/clap.rs
@@ -68,7 +68,7 @@ fn gen_for_struct(
 }
 
 fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStream {
-    let into_app = into_app::gen_for_enum(name);
+    let into_app = into_app::gen_for_enum(name, attrs);
     let from_arg_matches = from_arg_matches::gen_for_enum(name);
     let subcommand = subcommand::gen_for_enum(name, attrs, e);
     let arg_enum = arg_enum::gen_for_enum(name, attrs, e);


### PR DESCRIPTION
Pass the attributes slice into the `gen_for_enum` function, as is done
with the `gen_for_struct` function, and get the name from it as appears
to be intended.

I think this closes #2181?