### PR TITLE
fix(clap_generate): zsh completion generation panic

### DIFF
--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -493,7 +493,6 @@ fn arg_conflicts(app: &App, arg: &Arg, app_global: Option<&App>) -> String {
     match (app_global, App::test_global(arg)) {
         (Some(x), true) => {
             let conflicts = x.get_global_arg_conflicts_with(arg);
-            // let conflicts = app.get_arg_conflicts_with(arg);
 
             if conflicts.is_empty() {
                 return String::new();

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -490,9 +490,9 @@ fn arg_conflicts(app: &App, arg: &Arg, app_global: Option<&App>) -> String {
     }
 
     let mut res = vec![];
-    match (app_global, App::test_global(arg)) {
+    match (app_global, arg.get_global()) {
         (Some(x), true) => {
-            let conflicts = x.get_global_arg_conflicts_with(arg);
+            let conflicts = x.get_arg_conflicts_with(arg);
 
             if conflicts.is_empty() {
                 return String::new();

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -43,7 +43,7 @@ _{name}() {{
 
 _{name} \"$@\"",
                 name = app.get_bin_name().unwrap(),
-                initial_args = get_args_of(app),
+                initial_args = get_args_of(app, None),
                 subcommands = get_subcommands_of(app),
                 subcommand_details = subcommand_details(app)
             )
@@ -225,7 +225,8 @@ fn get_subcommands_of(p: &App) -> String {
             bin_name,
         );
         let mut v = vec![format!("({})", name)];
-        let subcommand_args = get_args_of(parser_of(p, &*bin_name).expect(INTERNAL_ERROR_MSG));
+        let subcommand_args =
+            get_args_of(parser_of(p, &*bin_name).expect(INTERNAL_ERROR_MSG), Some(p));
 
         if !subcommand_args.is_empty() {
             v.push(subcommand_args);
@@ -299,12 +300,12 @@ fn parser_of<'help, 'app>(p: &'app App<'help>, bin_name: &str) -> Option<&'app A
 //    -C: modify the $context internal variable
 //    -s: Allow stacking of short args (i.e. -a -b -c => -abc)
 //    -S: Do not complete anything after '--' and treat those as argument values
-fn get_args_of(p: &App) -> String {
+fn get_args_of(p: &App, p_global: Option<&App>) -> String {
     debug!("get_args_of");
 
     let mut ret = vec![String::from("_arguments \"${_arguments_options[@]}\" \\")];
-    let opts = write_opts_of(p);
-    let flags = write_flags_of(p);
+    let opts = write_opts_of(p, p_global);
+    let flags = write_flags_of(p, p_global);
     let positionals = write_positionals_of(p);
 
     let sc_or_a = if p.has_subcommands() {
@@ -401,7 +402,7 @@ fn escape_value(string: &str) -> String {
         .replace(" ", "\\ ")
 }
 
-fn write_opts_of(p: &App) -> String {
+fn write_opts_of(p: &App, p_global: Option<&App>) -> String {
     debug!("write_opts_of");
 
     let mut ret = vec![];
@@ -410,7 +411,7 @@ fn write_opts_of(p: &App) -> String {
         debug!("write_opts_of:iter: o={}", o.get_name());
 
         let help = o.get_about().map_or(String::new(), escape_help);
-        let conflicts = arg_conflicts(p, o);
+        let conflicts = arg_conflicts(p, o, p_global);
 
         // @TODO @soundness should probably be either multiple occurrences or multiple values and
         // not both
@@ -475,28 +476,46 @@ fn write_opts_of(p: &App) -> String {
     ret.join("\n")
 }
 
-fn arg_conflicts(app: &App, arg: &Arg) -> String {
-    let conflicts = app.get_arg_conflicts_with(arg);
+fn arg_conflicts(app: &App, arg: &Arg, app_global: Option<&App>) -> String {
+    fn push_conflicts(conflicts: &[&Arg], res: &mut Vec<String>) {
+        for conflict in conflicts {
+            if let Some(s) = conflict.get_short() {
+                res.push(format!("-{}", s));
+            }
 
-    if conflicts.is_empty() {
-        return String::new();
+            if let Some(l) = conflict.get_long() {
+                res.push(format!("--{}", l));
+            }
+        }
     }
 
     let mut res = vec![];
-    for conflict in conflicts {
-        if let Some(s) = conflict.get_short() {
-            res.push(format!("-{}", s));
-        }
+    match (app_global, App::test_global(arg)) {
+        (Some(x), true) => {
+            let conflicts = x.get_global_arg_conflicts_with(arg);
+            // let conflicts = app.get_arg_conflicts_with(arg);
 
-        if let Some(l) = conflict.get_long() {
-            res.push(format!("--{}", l));
+            if conflicts.is_empty() {
+                return String::new();
+            }
+
+            push_conflicts(&conflicts, &mut res);
         }
-    }
+        (_, _) => {
+            let conflicts = app.get_arg_conflicts_with(arg);
+
+            if conflicts.is_empty() {
+                return String::new();
+            }
+
+            push_conflicts(&conflicts, &mut res);
+        }
+    };
 
     format!("({})", res.join(" "))
 }
 
-fn write_flags_of(p: &App) -> String {
+fn write_flags_of(p: &App, p_global: Option<&App>) -> String {
     debug!("write_flags_of;");
 
     let mut ret = vec![];
@@ -505,7 +524,7 @@ fn write_flags_of(p: &App) -> String {
         debug!("write_flags_of:iter: f={}", f.get_name());
 
         let help = f.get_about().map_or(String::new(), escape_help);
-        let conflicts = arg_conflicts(p, &f);
+        let conflicts = arg_conflicts(p, &f, p_global);
 
         let multiple = if f.is_set(ArgSettings::MultipleOccurrences) {
             "*"

--- a/clap_generate/tests/generate_completions.rs
+++ b/clap_generate/tests/generate_completions.rs
@@ -1,0 +1,26 @@
+use clap::{App, Arg};
+use clap_generate::{generate, generators::*};
+use std::io;
+
+#[test]
+fn generate_completions() {
+    let mut app = App::new("test_app")
+        .arg(
+            Arg::new("config")
+                .short('c')
+                .conflicts_with("v")
+                .global(true),
+        )
+        .arg(Arg::new("v").short('v'))
+        .subcommand(
+            App::new("test")
+                .about("Subcommand")
+                .arg(Arg::new("debug").short('d')),
+        );
+
+    generate::<Bash, _>(&mut app, "test_app", &mut io::sink());
+    generate::<Fish, _>(&mut app, "test_app", &mut io::sink());
+    generate::<PowerShell, _>(&mut app, "test_app", &mut io::sink());
+    generate::<Elvish, _>(&mut app, "test_app", &mut io::sink());
+    generate::<Zsh, _>(&mut app, "test_app", &mut io::sink());
+}

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -261,7 +261,15 @@ impl<'help> App<'help> {
                 .any(|ar| ar.id == arg.id)
             {
                 vec.push(&self.subcommands[idx]);
-                vec.append(&mut self.subcommands[idx].get_subcommands_containing(arg));
+                // TODO rustc >= 1.46: change  .get(dix).unwrap()  to [idx]
+                // improved readability
+                vec.append(
+                    &mut self
+                        .subcommands
+                        .get(idx)
+                        .unwrap()
+                        .get_subcommands_containing(arg),
+                );
             }
         }
         vec

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -172,6 +172,11 @@ impl<'help> Arg<'help> {
     pub fn get_value_hint(&self) -> ValueHint {
         self.value_hint
     }
+
+    /// Get information on if this argument is global or not
+    pub fn get_global(&self) -> bool {
+        self.global
+    }
 }
 
 impl<'help> Arg<'help> {


### PR DESCRIPTION
This PR fixes a panic that would occur when a zsh completion file was being generated 
for an app that contains global arguments that have conflicts with other arguments which aren't 
present in all the subcommands that the global argument would be applied to.

The added test would panic before the fix.

Only the test added without the fix to observe the problem.
git clone --branch zsh_completion_bug https://github.com/ahkrr/clap.git
cd clap/clap_generate/tests && cargo test

I haven't found an open issue regarding this panic.
