### PR TITLE
Parser refactor

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2555,11 +2555,6 @@ impl<'help> App<'help> {
     }
 
     #[inline]
-    pub(crate) fn unset(&mut self, s: AppSettings) {
-        self.settings.unset(s)
-    }
-
-    #[inline]
     pub(crate) fn has_args(&self) -> bool {
         !self.args.is_empty()
     }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2086,7 +2086,7 @@ impl<'help> App<'help> {
         // to display
         // the full path when displaying help messages and such
         if !self.settings.is_set(AppSettings::NoBinaryName) {
-            if let Some((name, _)) = it.next(None) {
+            if let Some((name, _)) = it.next() {
                 let p = Path::new(name);
 
                 if let Some(f) = p.file_name() {

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -40,7 +40,6 @@ bitflags! {
         const PROPAGATE_VALS_DOWN            = 1 << 31;
         const ALLOW_MISSING_POS              = 1 << 32;
         const TRAILING_VALUES                = 1 << 33;
-        const VALID_NEG_NUM_FOUND            = 1 << 34;
         const BUILT                          = 1 << 35;
         const VALID_ARG_FOUND                = 1 << 36;
         const INFER_SUBCOMMANDS              = 1 << 37;
@@ -141,8 +140,6 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::WAIT_ON_ERROR,
     TrailingValues("trailingvalues")
         => Flags::TRAILING_VALUES,
-    ValidNegNumFound("validnegnumfound")
-        => Flags::VALID_NEG_NUM_FOUND,
     Built("built")
         => Flags::BUILT,
     ValidArgFound("validargfound")
@@ -1052,9 +1049,6 @@ pub enum AppSettings {
     TrailingValues,
 
     #[doc(hidden)]
-    ValidNegNumFound,
-
-    #[doc(hidden)]
     Built,
 
     #[doc(hidden)]
@@ -1202,10 +1196,6 @@ mod test {
         assert_eq!(
             "waitonerror".parse::<AppSettings>().unwrap(),
             AppSettings::WaitOnError
-        );
-        assert_eq!(
-            "validnegnumfound".parse::<AppSettings>().unwrap(),
-            AppSettings::ValidNegNumFound
         );
         assert_eq!(
             "validargfound".parse::<AppSettings>().unwrap(),

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1178,8 +1178,6 @@ impl<'help, 'app> Parser<'help, 'app> {
             return Ok(ParseResult::FlagSubCommand(sc_name.to_string()));
         } else if self.is_set(AS::AllowLeadingHyphen) {
             return Ok(ParseResult::MaybeHyphenValue);
-        } else if self.is_set(AS::ValidNegNumFound) {
-            return Ok(ParseResult::MaybeNegNum);
         }
 
         debug!("Parser::parse_long_arg: Didn't match anything");


### PR DESCRIPTION
1. More readable replacment recovering.

2. Simplify `is_new_arg()`.

3. Remove `ValidNegNumFound` parser state.