### PR TITLE
docs(README.md): remove unused import in "Using Builder Pattern" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The next example shows a far less verbose method, but sacrifices some of the adv
 //
 // This example demonstrates clap's "usage strings" method of creating arguments
 // which is less verbose
-use clap::{Arg, App};
+use clap::App;
 
 fn main() {
     let matches = App::new("myapp")


### PR DESCRIPTION
The import `Arg` is unused, so I deleted it to make this example consistent with examples/01a_quick_example.rs.