### PR TITLE
Make @group accept multiple attributes

### DIFF
--- a/examples/18_builder_macro.rs
+++ b/examples/18_builder_macro.rs
@@ -28,7 +28,7 @@ fn main() {
         (@arg config: -c --config <conf> #{1, 2} {file_exists} "Sets a custom config file")
         (@arg proxyHostname: --("proxy-hostname") +takes_value "Sets the hostname of the proxy to use")
         (@arg input: * "Input file")
-        (@group test =>
+        (@group test:
             (@attributes +required)
             (@arg output: "Sets an optional output file")
             (@arg debug: -d ... "Turn debugging information on")

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -226,7 +226,7 @@ macro_rules! app_from_crate {
 ///     (@arg CONFIG: -c --config +takes_value "Sets a custom config file")
 ///     (@arg INPUT: +required "Sets the input file to use")
 ///     (@arg debug: -d ... "Sets the level of debugging information")
-///     (@group difficulty =>
+///     (@group difficulty (+required !multiple) =>
 ///         (@arg hard: -h --hard "Sets hard mode")
 ///         (@arg normal: -n --normal "Sets normal mode")
 ///         (@arg easy: -e --easy "Sets easy mode")
@@ -270,9 +270,11 @@ macro_rules! app_from_crate {
 ///
 /// # Shorthand Syntax for Groups
 ///
-/// * There are short hand syntaxes for `ArgGroup` methods that accept booleans
-///   * A plus sign will set that method to `true` such as `+required` = `ArgGroup::required(true)`
-///   * An exclamation will set that method to `false` such as `!required` = `ArgGroup::required(false)`
+/// * To set methods on a group, wrap them inside a pair of parentheses,
+/// such as `(@group group1 (+required conflicts_with("group2")) => ...)`
+/// will set `ArgGroup::required(true)` and `ArgGroup::conflicts_with("group2")`
+/// * All shorthand syntaxes for `Arg` are available for `ArgGroup`, although some may not make
+/// sense with an `ArgGroup` such as `#{min, max}` and `{fn}`
 ///
 /// # Alternative form for non-ident values
 ///
@@ -350,6 +352,13 @@ macro_rules! clap_app {
     (@app ($builder:expr) (@group $name:ident +$ident:ident => $($tail:tt)*) $($tt:tt)*) => {
         $crate::clap_app!{ @app
             ($crate::clap_app!{ @group ($builder, $crate::ArgGroup::new(stringify!($name)).$ident(true)) $($tail)* })
+            $($tt)*
+        }
+    };
+    // Handle multiple attributes in enclosing parentheses
+    (@app ($builder:expr) (@group $name:ident ($($attrs:tt)*) => $($tail:tt)*) $($tt:tt)*) => {
+        $crate::clap_app!{ @app
+            ($crate::clap_app!{ @group ($builder, $crate::ArgGroup::new(stringify!($name))) (@attributes $($attrs)*) $($tail)* })
             $($tt)*
         }
     };

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -323,8 +323,8 @@ fn group_macro_attributes_alternative() {
     );
 
     let result = app
-                .clone()
-                .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
+        .clone()
+        .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
     assert!(result.is_ok());
     let matches = result.expect("Expected to successfully match the given args.");
     assert!(matches.is_present("difficulty"));
@@ -352,8 +352,8 @@ fn group_macro_multiple_methods() {
     );
 
     let result = app
-                .clone()
-                .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
+        .clone()
+        .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
     assert!(result.is_ok());
     let matches = result.expect("Expected to successfully match the given args.");
     assert!(matches.is_present("difficulty"));
@@ -381,8 +381,8 @@ fn group_macro_multiple_methods_alternative() {
     );
 
     let result = app
-                .clone()
-                .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
+        .clone()
+        .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
     assert!(result.is_ok());
     let matches = result.expect("Expected to successfully match the given args.");
     assert!(matches.is_present("difficulty"));
@@ -412,8 +412,8 @@ fn group_macro_multiple_invokations() {
     );
 
     let result = app
-                .clone()
-                .try_get_matches_from(vec!["bin_name", "--hard", "--foo"]);
+        .clone()
+        .try_get_matches_from(vec!["bin_name", "--hard", "--foo"]);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert_eq!(err.kind, ErrorKind::ArgumentConflict);

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -322,7 +322,9 @@ fn group_macro_attributes_alternative() {
              )
     );
 
-    let result = app.clone().try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
+    let result = app
+                .clone()
+                .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
     assert!(result.is_ok());
     let matches = result.expect("Expected to successfully match the given args.");
     assert!(matches.is_present("difficulty"));
@@ -349,7 +351,9 @@ fn group_macro_multiple_methods() {
              )
     );
 
-    let result = app.clone().try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
+    let result = app
+                .clone()
+                .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
     assert!(result.is_ok());
     let matches = result.expect("Expected to successfully match the given args.");
     assert!(matches.is_present("difficulty"));
@@ -373,11 +377,12 @@ fn group_macro_multiple_methods_alternative() {
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
-             
              )
     );
 
-    let result = app.clone().try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
+    let result = app
+                .clone()
+                .try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
     assert!(result.is_ok());
     let matches = result.expect("Expected to successfully match the given args.");
     assert!(matches.is_present("difficulty"));
@@ -406,7 +411,9 @@ fn group_macro_multiple_invokations() {
              )
     );
 
-    let result = app.clone().try_get_matches_from(vec!["bin_name", "--hard", "--foo"]);
+    let result = app
+                .clone()
+                .try_get_matches_from(vec!["bin_name", "--hard", "--foo"]);
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert_eq!(err.kind, ErrorKind::ArgumentConflict);
@@ -423,7 +430,7 @@ fn literals() {
         (version: "0.1")
         (@arg "task-num": -"t-n" --"task-num" +takes_value possible_value["all" 0 1 2]
             "Task number")
-        (@group priority: 
+        (@group priority:
             (@arg "4": -4 --4 "Sets priority to 4")
             (@arg ("5"): -('5') --5 "Sets priority to 5")
             (@arg 6: -6 --6 "Sets priority to 6")

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -215,7 +215,7 @@ fn group_macro() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-             (@group difficulty =>
+             (@group difficulty:
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
@@ -235,7 +235,7 @@ fn group_macro_set_multiple() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-             (@group difficulty +multiple =>
+             (@group difficulty: +multiple
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
@@ -257,7 +257,7 @@ fn group_macro_set_not_multiple() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-             (@group difficulty !multiple =>
+             (@group difficulty: !multiple
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
@@ -276,7 +276,7 @@ fn group_macro_set_required() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-             (@group difficulty +required =>
+             (@group difficulty: +required
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
@@ -295,7 +295,7 @@ fn group_macro_set_not_required() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-             (@group difficulty !required =>
+             (@group difficulty: !required
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
@@ -309,12 +309,40 @@ fn group_macro_set_not_required() {
 }
 
 #[test]
+fn group_macro_attributes_alternative() {
+    let app = clap_app!(claptests =>
+        (version: "0.1")
+        (about: "tests clap library")
+        (author: "Kevin K. <kbknapp@gmail.com>")
+             (@group difficulty:
+                 (@attributes +multiple +required)
+                 (@arg hard: -h --hard "Sets hard mode")
+                 (@arg normal: -n --normal "Sets normal mode")
+                 (@arg easy: -e --easy "Sets easy mode")
+             )
+    );
+
+    let result = app.clone().try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
+    assert!(result.is_ok());
+    let matches = result.expect("Expected to successfully match the given args.");
+    assert!(matches.is_present("difficulty"));
+    assert!(matches.is_present("hard"));
+    assert!(matches.is_present("easy"));
+    assert!(!matches.is_present("normal"));
+
+    let result = app.try_get_matches_from(vec!["bin_name"]);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
 fn group_macro_multiple_methods() {
     let app = clap_app!(claptests =>
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-             (@group difficulty (+multiple +required) =>
+             (@group difficulty: +multiple +required
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
@@ -341,10 +369,11 @@ fn group_macro_multiple_methods_alternative() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-             (@group difficulty (* ...) =>
+             (@group difficulty: * ...
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
+             
              )
     );
 
@@ -370,7 +399,7 @@ fn group_macro_multiple_invokations() {
         (author: "Kevin K. <kbknapp@gmail.com>")
         (@arg foo: --foo)
         (@arg bar: --bar)
-             (@group difficulty (conflicts_with[foo bar]) =>
+             (@group difficulty: conflicts_with[foo bar]
                  (@arg hard: -h --hard "Sets hard mode")
                  (@arg normal: -n --normal "Sets normal mode")
                  (@arg easy: -e --easy "Sets easy mode")
@@ -394,7 +423,7 @@ fn literals() {
         (version: "0.1")
         (@arg "task-num": -"t-n" --"task-num" +takes_value possible_value["all" 0 1 2]
             "Task number")
-        (@group priority =>
+        (@group priority: 
             (@arg "4": -4 --4 "Sets priority to 4")
             (@arg ("5"): -('5') --5 "Sets priority to 5")
             (@arg 6: -6 --6 "Sets priority to 6")


### PR DESCRIPTION
This PR makes `@group` accept more than one attributes, in the same way as `@arg` does.

Now, only one attribute such as `+required` and `!multiple`, etc. is supported with a `@group`:

```
(@group difficulty +required =>
    (@arg hard: -h --hard "Sets hard mode")
    (@arg normal: -n --normal "Sets normal mode")
    (@arg easy: -e --easy "Sets easy mode")
)
```

which limits the possibility to express a `required` *and* `multiple` arg group.

This PR enables specifying multiple attributes on a group, as well as adds more possible syntaxes that are accepted by an `@arg` branch, such as:

```
(@group difficulty: +required conflicts_with[hardness]
    (@arg hard: -h --hard "Sets hard mode")
    (@arg normal: -n --normal "Sets normal mode")
    (@arg easy: -e --easy "Sets easy mode")
)
```

**EDIT**:
New syntax with `:` and without the parentheses and `=>`, similar to that of `@arg`s.
