### PR TITLE
Lazy propagation and _build cleaning

### DIFF
--- a/clap_generate/src/generators/mod.rs
+++ b/clap_generate/src/generators/mod.rs
@@ -117,7 +117,7 @@ pub trait Generator {
 
     /// Gets all the short options, their visible aliases and flags of a [`clap::App`](../clap/struct.App.html).
     /// Includes `h` and `V` depending on the [`clap::AppSettings`](../clap/enum.AppSettings.html).
-    fn shorts_and_visible_aliases<'help>(p: &App<'help>) -> Vec<char> {
+    fn shorts_and_visible_aliases(p: &App) -> Vec<char> {
         debug!("shorts: name={}", p.get_name());
 
         let mut shorts_and_visible_aliases: Vec<char> = p
@@ -155,7 +155,7 @@ pub trait Generator {
 
     /// Gets all the long options and flags of a [`clap::App`](../clap/struct.App.html).
     /// Includes `help` and `version` depending on the [`clap::AppSettings`](../clap/enum.AppSettings.html).
-    fn longs<'help>(p: &App<'help>) -> Vec<String> {
+    fn longs(p: &App) -> Vec<String> {
         debug!("longs: name={}", p.get_name());
 
         let mut longs: Vec<String> = p

--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -181,10 +181,8 @@ where
 {
     app.set_bin_name(bin_name);
 
-    if !app.is_set(clap::AppSettings::Built) {
-        app._build();
-        app._build_bin_names();
-    }
+    app._build();
+    app._build_bin_names();
 
     G::generate(app, buf)
 }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2512,30 +2512,35 @@ impl<'help> App<'help> {
     pub fn _build_bin_names(&mut self) {
         debug!("App::_build_bin_names");
 
-        for mut sc in &mut self.subcommands {
-            debug!("App::_build_bin_names:iter: bin_name set...");
+        if !self.is_set(AppSettings::BinNameBuilt) {
+            for mut sc in &mut self.subcommands {
+                debug!("App::_build_bin_names:iter: bin_name set...");
 
-            if sc.bin_name.is_none() {
-                debug!("No");
-                let bin_name = format!(
-                    "{}{}{}",
-                    self.bin_name.as_ref().unwrap_or(&self.name.clone()),
-                    if self.bin_name.is_some() { " " } else { "" },
-                    &*sc.name
-                );
+                if sc.bin_name.is_none() {
+                    debug!("No");
+                    let bin_name = format!(
+                        "{}{}{}",
+                        self.bin_name.as_ref().unwrap_or(&self.name.clone()),
+                        if self.bin_name.is_some() { " " } else { "" },
+                        &*sc.name
+                    );
+                    debug!(
+                        "App::_build_bin_names:iter: Setting bin_name of {} to {}",
+                        self.name, bin_name
+                    );
+                    sc.bin_name = Some(bin_name);
+                } else {
+                    debug!("yes ({:?})", sc.bin_name);
+                }
                 debug!(
-                    "App::_build_bin_names:iter: Setting bin_name of {} to {}",
-                    self.name, bin_name
+                    "App::_build_bin_names:iter: Calling build_bin_names from...{}",
+                    sc.name
                 );
-                sc.bin_name = Some(bin_name);
-            } else {
-                debug!("yes ({:?})", sc.bin_name);
+                sc._build_bin_names();
             }
-            debug!(
-                "App::_build_bin_names:iter: Calling build_bin_names from...{}",
-                sc.name
-            );
-            sc._build_bin_names();
+            self.set(AppSettings::BinNameBuilt);
+        } else {
+            debug!("App::_build_bin_names: already built");
         }
     }
 

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -39,7 +39,8 @@ bitflags! {
         const PROPAGATE_VALS_DOWN            = 1 << 31;
         const ALLOW_MISSING_POS              = 1 << 32;
         const TRAILING_VALUES                = 1 << 33;
-        const BUILT                          = 1 << 35;
+        const BUILT                          = 1 << 34;
+        const BIN_NAME_BUILT                 = 1 << 35;
         const VALID_ARG_FOUND                = 1 << 36;
         const INFER_SUBCOMMANDS              = 1 << 37;
         const CONTAINS_LAST                  = 1 << 38;
@@ -139,6 +140,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::TRAILING_VALUES,
     Built("built")
         => Flags::BUILT,
+    BinNameBuilt("binnamebuilt")
+        => Flags::BIN_NAME_BUILT,
     ValidArgFound("validargfound")
         => Flags::VALID_ARG_FOUND,
     InferSubcommands("infersubcommands")
@@ -1046,6 +1049,9 @@ pub enum AppSettings {
     Built,
 
     #[doc(hidden)]
+    BinNameBuilt,
+
+    #[doc(hidden)]
     ValidArgFound,
 
     #[doc(hidden)]
@@ -1192,6 +1198,10 @@ mod test {
             AppSettings::ValidArgFound
         );
         assert_eq!("built".parse::<AppSettings>().unwrap(), AppSettings::Built);
+        assert_eq!(
+            "binnamebuilt".parse::<AppSettings>().unwrap(),
+            AppSettings::BinNameBuilt
+        );
         assert_eq!(
             "trailingvalues".parse::<AppSettings>().unwrap(),
             AppSettings::TrailingValues

--- a/src/build/app/tests.rs
+++ b/src/build/app/tests.rs
@@ -1,4 +1,4 @@
-use crate::{build::app::Propagation, App, AppSettings};
+use crate::{App, AppSettings};
 
 #[test]
 fn global_version() {
@@ -6,7 +6,7 @@ fn global_version() {
         .setting(AppSettings::GlobalVersion)
         .version("1.1")
         .subcommand(App::new("sub1"));
-    app._propagate(Propagation::NextLevel);
+    app._propagate();
     assert_eq!(app.subcommands[0].version, Some("1.1"));
 }
 
@@ -15,7 +15,7 @@ fn global_setting() {
     let mut app = App::new("test")
         .global_setting(AppSettings::ColoredHelp)
         .subcommand(App::new("subcmd"));
-    app._propagate(Propagation::NextLevel);
+    app._propagate();
     assert!(app
         .subcommands
         .iter()
@@ -30,7 +30,7 @@ fn global_settings() {
         .global_setting(AppSettings::ColoredHelp)
         .global_setting(AppSettings::TrailingVarArg)
         .subcommand(App::new("subcmd"));
-    app._propagate(Propagation::NextLevel);
+    app._propagate();
     assert!(app
         .subcommands
         .iter()

--- a/src/build/usage_parser.rs
+++ b/src/build/usage_parser.rs
@@ -44,9 +44,11 @@ impl<'help> UsageParser<'help> {
 
     pub(crate) fn parse(mut self) -> Arg<'help> {
         debug!("UsageParser::parse");
-        let mut arg = Arg::default();
-        arg.disp_ord = 999;
-        arg.unified_ord = 999;
+        let mut arg = Arg {
+            disp_ord: 999,
+            unified_ord: 999,
+            ..Default::default()
+        };
         loop {
             debug!("UsageParser::parse:iter: pos={}", self.pos);
             self.stop_at(token);

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -6,7 +6,6 @@ use std::{
 
 // Internal
 use crate::{
-    build::app::Propagation,
     build::AppSettings as AS,
     build::{App, Arg, ArgSettings},
     mkeymap::KeyType,
@@ -865,9 +864,6 @@ impl<'help, 'app> Parser<'help, 'app> {
                     help_help = true;
                     break; // Maybe?
                 }
-                if let Some(id) = sc.find_subcommand(cmd).map(|x| x.id.clone()) {
-                    sc._propagate(Propagation::To(id));
-                }
 
                 if let Some(mut c) = sc.find_subcommand(cmd).cloned() {
                     c._build();
@@ -973,11 +969,6 @@ impl<'help, 'app> Parser<'help, 'app> {
             for s in &reqs {
                 write!(&mut mid_string, "{} ", s).expect(INTERNAL_ERROR_MSG);
             }
-        }
-
-        if let Some(x) = self.app.find_subcommand(sc_name) {
-            let id = x.id.clone();
-            self.app._propagate(Propagation::To(id));
         }
 
         if let Some(sc) = self.app.subcommands.iter_mut().find(|s| s.name == sc_name) {


### PR DESCRIPTION
Speed up?
And resolve a fixme (now the propagation affects next level of subcommand).

The old behaviour of propagation is when `App` building begins, propagating global args recursively. But we will also build our subcommand app, which makes this "recursive" non-sense. And also, the subcommands are "built lazilly", which makes propagating to unused subcommand even more non-sense.

Now we only propagates the global argument for one level. Since the `_build` is already lazy, and propagation happens in build process, now propagation is also lazy.

This PR also move the is built checking into `_build` function. Which will speed up the multiple _build() calls on an `App`.