### PR TITLE
Use `clap` instead of `::clap` in `clap_derive`

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -356,7 +356,7 @@ impl Attrs {
                         };
 
                         quote_spanned!(ident.span()=> {
-                            ::clap::lazy_static::lazy_static! {
+                            clap::lazy_static::lazy_static! {
                                 static ref DEFAULT_VALUE: &'static str = {
                                     let val = <#ty as ::std::default::Default>::default();
                                     let s = ::std::string::ToString::to_string(&val);

--- a/clap_derive/src/derives/arg_enum.rs
+++ b/clap_derive/src/derives/arg_enum.rs
@@ -63,7 +63,7 @@ pub fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStr
             clippy::cargo
         )]
         #[deny(clippy::correctness)]
-        impl ::clap::ArgEnum for #name {
+        impl clap::ArgEnum for #name {
             #variants
             #from_str
         }

--- a/clap_derive/src/derives/clap.rs
+++ b/clap_derive/src/derives/clap.rs
@@ -60,7 +60,7 @@ fn gen_for_struct(
     let from_arg_matches = from_arg_matches::gen_for_struct(name, fields, &attrs);
 
     quote! {
-        impl ::clap::Clap for #name {}
+        impl clap::Clap for #name {}
 
         #into_app
         #from_arg_matches
@@ -74,7 +74,7 @@ fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStream 
     let arg_enum = arg_enum::gen_for_enum(name, attrs, e);
 
     quote! {
-        impl ::clap::Clap for #name {}
+        impl clap::Clap for #name {}
 
         #into_app
         #from_arg_matches

--- a/clap_derive/src/derives/from_arg_matches.rs
+++ b/clap_derive/src/derives/from_arg_matches.rs
@@ -42,12 +42,12 @@ pub fn gen_for_struct(
             clippy::cargo
         )]
         #[deny(clippy::correctness)]
-        impl ::clap::FromArgMatches for #struct_name {
-            fn from_arg_matches(arg_matches: &::clap::ArgMatches) -> Self {
+        impl clap::FromArgMatches for #struct_name {
+            fn from_arg_matches(arg_matches: &clap::ArgMatches) -> Self {
                 #struct_name #constructor
             }
 
-            fn update_from_arg_matches(&mut self, arg_matches: &::clap::ArgMatches) {
+            fn update_from_arg_matches(&mut self, arg_matches: &clap::ArgMatches) {
                 #updater
             }
         }
@@ -68,12 +68,12 @@ pub fn gen_for_enum(name: &Ident) -> TokenStream {
             clippy::cargo
         )]
         #[deny(clippy::correctness)]
-        impl ::clap::FromArgMatches for #name {
-            fn from_arg_matches(arg_matches: &::clap::ArgMatches) -> Self {
-                <#name as ::clap::Subcommand>::from_subcommand(arg_matches.subcommand()).unwrap()
+        impl clap::FromArgMatches for #name {
+            fn from_arg_matches(arg_matches: &clap::ArgMatches) -> Self {
+                <#name as clap::Subcommand>::from_subcommand(arg_matches.subcommand()).unwrap()
             }
-            fn update_from_arg_matches(&mut self, arg_matches: &::clap::ArgMatches) {
-                <#name as ::clap::Subcommand>::update_from_subcommand(self, arg_matches.subcommand());
+            fn update_from_arg_matches(&mut self, arg_matches: &clap::ArgMatches) {
+                <#name as clap::Subcommand>::update_from_subcommand(self, arg_matches.subcommand());
             }
         }
     }
@@ -83,7 +83,7 @@ fn gen_arg_enum_parse(ty: &Type, attrs: &Attrs) -> TokenStream {
     let ci = attrs.case_insensitive();
 
     quote_spanned! { ty.span()=>
-        |s| <#ty as ::clap::ArgEnum>::from_str(s, #ci).unwrap()
+        |s| <#ty as clap::ArgEnum>::from_str(s, #ci).unwrap()
     }
 }
 
@@ -254,14 +254,14 @@ pub fn gen_constructor(fields: &Punctuated<Field, Comma>, parent_attribute: &Att
                 };
                 quote_spanned! { kind.span()=>
                     #field_name: {
-                        <#subcmd_type as ::clap::Subcommand>::from_subcommand(#arg_matches.subcommand())
+                        <#subcmd_type as clap::Subcommand>::from_subcommand(#arg_matches.subcommand())
                         #unwrapper
                     }
                 }
             }
 
             Kind::Flatten => quote_spanned! { kind.span()=>
-                #field_name: ::clap::FromArgMatches::from_arg_matches(#arg_matches)
+                #field_name: clap::FromArgMatches::from_arg_matches(#arg_matches)
             },
 
             Kind::Skip(val) => match val {
@@ -314,8 +314,8 @@ pub fn gen_updater(
                     _ => &field.ty,
                 };
 
-                let updater = quote_spanned!{ ty.span()=>
-                    <#subcmd_type as ::clap::Subcommand>::update_from_subcommand(#field_name, subcmd);
+                let updater = quote_spanned! { ty.span()=>
+                    <#subcmd_type as clap::Subcommand>::update_from_subcommand(#field_name, subcmd);
                 };
 
                 let updater = match **ty {
@@ -323,14 +323,14 @@ pub fn gen_updater(
                         if let Some(#field_name) = #field_name.as_mut() {
                             #updater
                         } else {
-                            *#field_name = <#subcmd_type as ::clap::Subcommand>::from_subcommand(
+                            *#field_name = <#subcmd_type as clap::Subcommand>::from_subcommand(
                                 subcmd
                             )
                         }
                     },
-                    _ => quote_spanned!{ kind.span()=>
+                    _ => quote_spanned! { kind.span()=>
                         #updater
-                    }
+                    },
                 };
 
                 quote_spanned! { kind.span()=>
@@ -344,15 +344,13 @@ pub fn gen_updater(
 
             Kind::Flatten => quote_spanned! { kind.span()=> {
                     #access
-                    ::clap::FromArgMatches::update_from_arg_matches(#field_name, #arg_matches);
+                    clap::FromArgMatches::update_from_arg_matches(#field_name, #arg_matches);
                 }
             },
 
             Kind::Skip(_) => quote!(),
 
-            Kind::Arg(ty) => {
-                gen_parsers(&attrs, ty, field_name, field, Some(&access))
-            }
+            Kind::Arg(ty) => gen_parsers(&attrs, ty, field_name, field, Some(&access)),
         }
     });
 

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -68,7 +68,7 @@ pub fn gen_for_struct(
             clippy::cargo
         )]
         #[deny(clippy::correctness)]
-        impl ::clap::IntoApp for #struct_name {
+        impl clap::IntoApp for #struct_name {
             #into_app
             #augment_clap
         }
@@ -93,24 +93,24 @@ pub fn gen_for_enum(name: &Ident) -> TokenStream {
             clippy::cargo
         )]
         #[deny(clippy::correctness)]
-        impl ::clap::IntoApp for #name {
-            fn into_app<'b>() -> ::clap::App<'b> {
-                let app = ::clap::App::new(#app_name)
-                    .setting(::clap::AppSettings::SubcommandRequiredElseHelp);
-                <#name as ::clap::IntoApp>::augment_clap(app)
+        impl clap::IntoApp for #name {
+            fn into_app<'b>() -> clap::App<'b> {
+                let app = clap::App::new(#app_name)
+                    .setting(clap::AppSettings::SubcommandRequiredElseHelp);
+                <#name as clap::IntoApp>::augment_clap(app)
             }
 
-            fn augment_clap<'b>(app: ::clap::App<'b>) -> ::clap::App<'b> {
-                <#name as ::clap::Subcommand>::augment_subcommands(app)
+            fn augment_clap<'b>(app: clap::App<'b>) -> clap::App<'b> {
+                <#name as clap::Subcommand>::augment_subcommands(app)
             }
 
-            fn into_app_for_update<'b>() -> ::clap::App<'b> {
-                let app = ::clap::App::new(#app_name);
-                <#name as ::clap::IntoApp>::augment_clap_for_update(app)
+            fn into_app_for_update<'b>() -> clap::App<'b> {
+                let app = clap::App::new(#app_name);
+                <#name as clap::IntoApp>::augment_clap_for_update(app)
             }
 
-            fn augment_clap_for_update<'b>(app: ::clap::App<'b>) -> ::clap::App<'b> {
-                <#name as ::clap::Subcommand>::augment_subcommands_for_update(app)
+            fn augment_clap_for_update<'b>(app: clap::App<'b>) -> clap::App<'b> {
+                <#name as clap::Subcommand>::augment_subcommands_for_update(app)
             }
         }
     }
@@ -129,11 +129,11 @@ fn gen_into_app_fn(attrs: &[Attribute]) -> GenOutput {
     let name = attrs.cased_name();
 
     let tokens = quote! {
-        fn into_app<'b>() -> ::clap::App<'b> {
-            Self::augment_clap(::clap::App::new(#name))
+        fn into_app<'b>() -> clap::App<'b> {
+            Self::augment_clap(clap::App::new(#name))
         }
-        fn into_app_for_update<'b>() -> ::clap::App<'b> {
-            Self::augment_clap_for_update(::clap::App::new(#name))
+        fn into_app_for_update<'b>() -> clap::App<'b> {
+            Self::augment_clap_for_update(clap::App::new(#name))
         }
     };
 
@@ -145,10 +145,10 @@ fn gen_augment_clap_fn(fields: &Punctuated<Field, Comma>, parent_attribute: &Att
     let augmentation = gen_app_augmentation(fields, &app_var, parent_attribute, false);
     let augmentation_update = gen_app_augmentation(fields, &app_var, parent_attribute, true);
     quote! {
-        fn augment_clap<'b>(#app_var: ::clap::App<'b>) -> ::clap::App<'b> {
+        fn augment_clap<'b>(#app_var: clap::App<'b>) -> clap::App<'b> {
             #augmentation
         }
-        fn augment_clap_for_update<'b>(#app_var: ::clap::App<'b>) -> ::clap::App<'b> {
+        fn augment_clap_for_update<'b>(#app_var: clap::App<'b>) -> clap::App<'b> {
             #augmentation_update
         }
     }
@@ -156,7 +156,7 @@ fn gen_augment_clap_fn(fields: &Punctuated<Field, Comma>, parent_attribute: &Att
 
 fn gen_arg_enum_possible_values(ty: &Type) -> TokenStream {
     quote_spanned! { ty.span()=>
-        .possible_values(&<#ty as ::clap::ArgEnum>::VARIANTS)
+        .possible_values(&<#ty as clap::ArgEnum>::VARIANTS)
     }
 }
 
@@ -185,7 +185,7 @@ pub fn gen_app_augmentation(
             } else {
                 quote_spanned! { kind.span()=>
                     let #app_var = #app_var.setting(
-                        ::clap::AppSettings::SubcommandRequiredElseHelp
+                        clap::AppSettings::SubcommandRequiredElseHelp
                     );
                 }
             };
@@ -193,11 +193,11 @@ pub fn gen_app_augmentation(
             let span = field.span();
             let ts = if override_required {
                 quote! {
-                    let #app_var = <#subcmd_type as ::clap::Subcommand>::augment_subcommands_for_update( #app_var );
+                    let #app_var = <#subcmd_type as clap::Subcommand>::augment_subcommands_for_update( #app_var );
                 }
             } else{
                 quote! {
-                    let #app_var = <#subcmd_type as ::clap::Subcommand>::augment_subcommands( #app_var );
+                    let #app_var = <#subcmd_type as clap::Subcommand>::augment_subcommands( #app_var );
                     #required
                 }
             };
@@ -226,7 +226,7 @@ pub fn gen_app_augmentation(
             Kind::Flatten => {
                 let ty = &field.ty;
                 Some(quote_spanned! { kind.span()=>
-                    let #app_var = <#ty as ::clap::IntoApp>::augment_clap(#app_var);
+                    let #app_var = <#ty as clap::IntoApp>::augment_clap(#app_var);
                 })
             }
             Kind::Arg(ty) => {
@@ -340,7 +340,7 @@ pub fn gen_app_augmentation(
 
                 Some(quote_spanned! { field.span()=>
                     let #app_var = #app_var.arg(
-                        ::clap::Arg::new(#name)
+                        clap::Arg::new(#name)
                             #modifier
                             #methods
                     );

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -52,7 +52,7 @@ pub fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStr
             clippy::cargo
         )]
         #[deny(clippy::correctness)]
-        impl ::clap::Subcommand for #name {
+        impl clap::Subcommand for #name {
             #augment_subcommands
             #from_subcommand
             #augment_subcommands_for_update
@@ -84,7 +84,7 @@ fn gen_augment(
             match &*kind {
                 Kind::ExternalSubcommand => {
                     quote_spanned! { kind.span()=>
-                        let app = app.setting(::clap::AppSettings::AllowExternalSubcommands);
+                        let app = app.setting(clap::AppSettings::AllowExternalSubcommands);
                     }
                 }
 
@@ -92,7 +92,7 @@ fn gen_augment(
                     Unnamed(FieldsUnnamed { ref unnamed, .. }) if unnamed.len() == 1 => {
                         let ty = &unnamed[0];
                         quote! {
-                            let app = <#ty as ::clap::Subcommand>::augment_subcommands(app);
+                            let app = <#ty as clap::Subcommand>::augment_subcommands(app);
                         }
                     }
                     _ => abort!(
@@ -115,7 +115,7 @@ fn gen_augment(
                             let ty = &unnamed[0];
                             quote_spanned! { ty.span()=>
                                 {
-                                    <#ty as ::clap::IntoApp>::augment_clap(#app_var)
+                                    <#ty as clap::IntoApp>::augment_clap(#app_var)
                                 }
                             }
                         }
@@ -129,7 +129,7 @@ fn gen_augment(
                     let version = attrs.version();
                     quote! {
                         let app = app.subcommand({
-                            let #app_var = ::clap::App::new(#name);
+                            let #app_var = clap::App::new(#name);
                             let #app_var = #arg_block;
                             #app_var#from_attrs#version
                         });
@@ -143,7 +143,7 @@ fn gen_augment(
     let version = parent_attribute.version();
     let fn_name = Ident::new(fn_name, Span::call_site());
     quote! {
-        fn #fn_name <'b>(app: ::clap::App<'b>) -> ::clap::App<'b> {
+        fn #fn_name <'b>(app: clap::App<'b>) -> clap::App<'b> {
             let app = app #app_methods;
             #( #subcommands )*;
             app #version
@@ -240,7 +240,7 @@ fn gen_from_subcommand(
             Unit => quote!(),
             Unnamed(ref fields) if fields.unnamed.len() == 1 => {
                 let ty = &fields.unnamed[0];
-                quote!( ( <#ty as ::clap::FromArgMatches>::from_arg_matches(arg_matches) ) )
+                quote!( ( <#ty as clap::FromArgMatches>::from_arg_matches(arg_matches) ) )
             }
             Unnamed(..) => abort_call_site!("{}: tuple enums are not supported", variant.ident),
         };
@@ -257,7 +257,7 @@ fn gen_from_subcommand(
             Unnamed(ref fields) if fields.unnamed.len() == 1 => {
                 let ty = &fields.unnamed[0];
                 quote! {
-                    if let Some(res) = <#ty as ::clap::Subcommand>::from_subcommand(other) {
+                    if let Some(res) = <#ty as clap::Subcommand>::from_subcommand(other) {
                         return Some(#name :: #variant_name (res));
                     }
                 }
@@ -288,7 +288,7 @@ fn gen_from_subcommand(
     };
 
     quote! {
-        fn from_subcommand(subcommand: Option<(&str, &::clap::ArgMatches)>) -> Option<Self> {
+        fn from_subcommand(subcommand: Option<(&str, &clap::ArgMatches)>) -> Option<Self> {
             match subcommand {
                 #( #match_arms, )*
                 other => {
@@ -360,7 +360,7 @@ fn gen_update_from_subcommand(
                 if fields.unnamed.len() == 1 {
                     (
                         quote!((ref mut arg)),
-                        quote!(::clap::FromArgMatches::update_from_arg_matches(
+                        quote!(clap::FromArgMatches::update_from_arg_matches(
                             arg,
                             arg_matches
                         )),
@@ -385,7 +385,7 @@ fn gen_update_from_subcommand(
                 (
                     quote!((ref mut arg)),
                     quote! {
-                        <#ty as ::clap::Subcommand>::update_from_subcommand(arg, Some((name, arg_matches)));
+                        <#ty as clap::Subcommand>::update_from_subcommand(arg, Some((name, arg_matches)));
                     },
                 )
             }
@@ -402,13 +402,13 @@ fn gen_update_from_subcommand(
     quote! {
         fn update_from_subcommand<'b>(
             &mut self,
-            subcommand: Option<(&str, &::clap::ArgMatches)>
+            subcommand: Option<(&str, &clap::ArgMatches)>
         ) {
             if let Some((name, arg_matches)) = subcommand {
                 match (name, self) {
                     #( #subcommands ),*
                     #( #child_subcommands ),*
-                    (_, s) => if let Some(sub) = <Self as ::clap::Subcommand>::from_subcommand(Some((name, arg_matches))) {
+                    (_, s) => if let Some(sub) = <Self as clap::Subcommand>::from_subcommand(Some((name, arg_matches))) {
                         *s = sub;
                     }
                 }

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -7,7 +7,7 @@ use quote::quote;
 pub fn clap_struct(name: &Ident) {
     into_app(name);
     from_arg_matches(name);
-    append_dummy(quote!( impl ::clap::Clap for #name {} ));
+    append_dummy(quote!( impl clap::Clap for #name {} ));
 }
 
 pub fn clap_enum(name: &Ident) {
@@ -15,22 +15,22 @@ pub fn clap_enum(name: &Ident) {
     from_arg_matches(name);
     subcommand(name);
     arg_enum(name);
-    append_dummy(quote!( impl ::clap::Clap for #name {} ));
+    append_dummy(quote!( impl clap::Clap for #name {} ));
 }
 
 pub fn into_app(name: &Ident) {
     append_dummy(quote! {
-        impl ::clap::IntoApp for #name {
-            fn into_app<'b>() -> ::clap::App<'b> {
+        impl clap::IntoApp for #name {
+            fn into_app<'b>() -> clap::App<'b> {
                 unimplemented!()
             }
-            fn augment_clap<'b>(_app: ::clap::App<'b>) -> ::clap::App<'b> {
+            fn augment_clap<'b>(_app: clap::App<'b>) -> clap::App<'b> {
                 unimplemented!()
             }
-            fn into_app_for_update<'b>() -> ::clap::App<'b> {
+            fn into_app_for_update<'b>() -> clap::App<'b> {
                 unimplemented!()
             }
-            fn augment_clap_for_update<'b>(_app: ::clap::App<'b>) -> ::clap::App<'b> {
+            fn augment_clap_for_update<'b>(_app: clap::App<'b>) -> clap::App<'b> {
                 unimplemented!()
             }
         }
@@ -39,11 +39,11 @@ pub fn into_app(name: &Ident) {
 
 pub fn from_arg_matches(name: &Ident) {
     append_dummy(quote! {
-        impl ::clap::FromArgMatches for #name {
-            fn from_arg_matches(_m: &::clap::ArgMatches) -> Self {
+        impl clap::FromArgMatches for #name {
+            fn from_arg_matches(_m: &clap::ArgMatches) -> Self {
                 unimplemented!()
             }
-            fn update_from_arg_matches(&mut self, matches: &::clap::ArgMatches) {
+            fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) {
                 unimplemented!()
             }
         }
@@ -52,17 +52,17 @@ pub fn from_arg_matches(name: &Ident) {
 
 pub fn subcommand(name: &Ident) {
     append_dummy(quote! {
-        impl ::clap::Subcommand for #name {
-            fn from_subcommand(_sub: Option<(&str, &::clap::ArgMatches)>) -> Option<Self> {
+        impl clap::Subcommand for #name {
+            fn from_subcommand(_sub: Option<(&str, &clap::ArgMatches)>) -> Option<Self> {
                 unimplemented!()
             }
-            fn update_from_subcommand(&mut self, _sub: Option<(&str, &::clap::ArgMatches)>) {
+            fn update_from_subcommand(&mut self, _sub: Option<(&str, &clap::ArgMatches)>) {
                 unimplemented!()
             }
-            fn augment_subcommands(_app: ::clap::App<'_>) -> ::clap::App<'_> {
+            fn augment_subcommands(_app: clap::App<'_>) -> clap::App<'_> {
                 unimplemented!()
             }
-            fn augment_subcommands_for_update(_app: ::clap::App<'_>) -> ::clap::App<'_> {
+            fn augment_subcommands_for_update(_app: clap::App<'_>) -> clap::App<'_> {
                 unimplemented!()
             }
         }
@@ -71,7 +71,7 @@ pub fn subcommand(name: &Ident) {
 
 pub fn arg_enum(name: &Ident) {
     append_dummy(quote! {
-        impl ::clap::ArgEnum for #name {
+        impl clap::ArgEnum for #name {
             const VARIANTS: &'static [&'static str] = &[];
             fn from_str(_input: &str, _case_insensitive: bool) -> Result<Self, String> {
                 unimplemented!()


### PR DESCRIPTION
This PR changes `clap_derive` to emit code that refers to clap as just `clap` instead of `::clap`. This will allow users who want to use a re-export of the clap crate to still use the derive macros. Below are some examples of this pattern used by some other prominent crates to allow re-exporting:

tokio: https://github.com/tokio-rs/tokio/blob/79d25b0a48d3e82a9d026e9cdfeef548153660ef/tokio-macros/src/entry.rs#L228

sqlx: https://github.com/launchbadge/sqlx/blob/04647ae09ae7f2d211c06e594561690ec9117acd/sqlx-macros/src/derives/encode.rs#L79
