### PR TITLE
Tests possible values multiple delimiter

### DIFF
--- a/tests/possible_values.rs
+++ b/tests/possible_values.rs
@@ -208,7 +208,7 @@ fn case_insensitive() {
 }
 
 #[test]
-fn case_insensitive_faili() {
+fn case_insensitive_fail() {
     let m = App::new("pv")
         .arg(
             Arg::with_name("option")

--- a/tests/possible_values.rs
+++ b/tests/possible_values.rs
@@ -176,6 +176,50 @@ fn possible_values_of_option_multiple_fail() {
 }
 
 #[test]
+fn possible_values_of_option_multiple_with_delimiter() {
+    let m = App::new("possible_values")
+        .arg(
+            Arg::with_name("option")
+                .short("-o")
+                .long("--option")
+                .takes_value(true)
+                .possible_value("test123")
+                .possible_value("test321")
+                .use_delimiter(true)
+                .multiple(true),
+        )
+        .get_matches_from_safe(vec!["", "--option=test123,test321"]);
+
+    assert!(m.is_ok());
+    let m = m.unwrap();
+
+    assert!(m.is_present("option"));
+    assert_eq!(
+        m.values_of("option").unwrap().collect::<Vec<_>>(),
+        vec!["test123", "test321"]
+    );
+}
+
+#[test]
+fn possible_values_of_option_multiple_with_delimiter_fail() {
+    let m = App::new("possible_values")
+        .arg(
+            Arg::with_name("option")
+                .short("-o")
+                .long("--option")
+                .takes_value(true)
+                .possible_value("test123")
+                .possible_value("test321")
+                .use_delimiter(true)
+                .multiple(true),
+        )
+        .get_matches_from_safe(vec!["", "--option=test123,notest"]);
+
+    assert!(m.is_err());
+    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidValue);
+}
+
+#[test]
 fn possible_values_output() {
     assert!(test::compare_output(
         test::complex_app(),


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
I thought I found a bug but while trying to work on it, I figured I was wrong but added 2 tests that it seems were missing: using a delimiter on multiple values and possible values.
Also found a typo in a test name.