### PR TITLE
Add unicode_help feature, Bump textwrap to 0.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,8 @@ maintenance = {status = "actively-developed"}
 [dependencies]
 clap_derive = { path = "./clap_derive", version = "3.0.0-beta.2", optional = true }
 bitflags = "1.2"
-unicode-width = "0.1"
-textwrap = "0.12"
+textwrap = { version = "0.13", default-features = false, features = [] }
+unicode-width = { version = "0.1", optional = true }
 indexmap = "1.0"
 os_str_bytes = { version = "2.4", features = ["raw"] }
 vec_map = "0.8"
@@ -87,11 +87,12 @@ version-sync = "0.8"
 criterion = "0.3.2"
 
 [features]
-default     = ["suggestions", "color", "derive", "std", "cargo"]
+default     = ["std", "suggestions", "color", "unicode_help", "derive", "cargo"]
 std         = [] # support for no_std in a backwards-compatible way
 suggestions = ["strsim"]
 color       = ["atty", "termcolor"]
 wrap_help   = ["terminal_size", "textwrap/terminal_size"]
+unicode_help= ["unicode-width", "textwrap/unicode-width"] # Enable if any unicode in help message
 derive      = ["clap_derive", "lazy_static"]
 yaml        = ["yaml-rust"]
 cargo       = ["lazy_static"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -18,7 +18,6 @@ use crate::{
 
 // Third party
 use indexmap::IndexSet;
-use unicode_width::UnicodeWidthStr;
 
 pub(crate) fn dimensions() -> Option<(usize, usize)> {
     #[cfg(not(feature = "wrap_help"))]
@@ -29,7 +28,11 @@ pub(crate) fn dimensions() -> Option<(usize, usize)> {
 }
 
 fn str_width(s: &str) -> usize {
-    UnicodeWidthStr::width(s)
+    #[cfg(not(feature = "unicode_help"))]
+    return s.len();
+
+    #[cfg(feature = "unicode_help")]
+    unicode_width::UnicodeWidthStr::width(s)
 }
 
 const TAB: &str = "    ";
@@ -1045,9 +1048,9 @@ fn should_show_subcommand(subcommand: &App) -> bool {
 }
 
 fn text_wrapper(help: &str, width: usize) -> String {
-    let wrapper = textwrap::Wrapper::new(width).break_words(false);
+    let wrapper = textwrap::Options::new(width).break_words(false);
     help.lines()
-        .map(|line| wrapper.fill(line))
+        .map(|line| textwrap::fill(line, &wrapper))
         .collect::<Vec<String>>()
         .join("\n")
 }


### PR DESCRIPTION
cc https://github.com/clap-rs/clap/issues/1365#issuecomment-753356141

cc #1365

User now can disable unicode_help feature when their help message doesn't contain unicode characters. Which can reduce a dependency: "unicode_width".

