### PR TITLE
feat: count chars instead of bytes in str_width

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,7 @@ maintenance = {status = "actively-developed"}
 [dependencies]
 clap_derive = { path = "./clap_derive", version = "3.0.0-beta.2", optional = true }
 bitflags = "1.2"
-textwrap = { version = "0.13", default-features = false, features = [] }
-unicode-width = { version = "0.1", optional = true }
+textwrap = { version = "0.13.3", default-features = false, features = [] }
 indexmap = "1.0"
 os_str_bytes = { version = "2.4", features = ["raw"] }
 vec_map = "0.8"
@@ -92,7 +91,7 @@ std         = [] # support for no_std in a backwards-compatible way
 suggestions = ["strsim"]
 color       = ["atty", "termcolor"]
 wrap_help   = ["terminal_size", "textwrap/terminal_size"]
-unicode_help= ["unicode-width", "textwrap/unicode-width"] # Enable if any unicode in help message
+unicode_help= ["textwrap/unicode-width"]  # Enable if any unicode in help message
 derive      = ["clap_derive", "lazy_static"]
 yaml        = ["yaml-rust"]
 cargo       = ["lazy_static"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros


### PR DESCRIPTION
feat: remove direct unicode-width dependency

This removes the direct dependency on unicode-width and delegates the complexity of computing the displayed width of text to the Textwrap crate.

The [`display_width` function](https://docs.rs/textwrap/0.13.3/textwrap/core/fn.display_width.html) handles characters like “æøå” (Danish), “äöü” (German), and “joysparklesheart_eyes” (emojis) – even if the unicode-width Cargo feature is disabled.

This is an improvement of the former `str_width` function which would over-estimate the width of emojis and non-ASCII characters (since they are several bytes wide).
