### PR TITLE
docs: add back example of using non-structopt arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ fn main() {
 This second method shows a method using the 'Builder Pattern' which allows more advanced configuration options (not shown in this small example), or even dynamically generating arguments when desired. The downside is it's more verbose.
 
 ```rust,no_run
-// (Full example with detailed comments in examples/01a_quick_example.rs)
+// (Full example with detailed comments in examples/01b_quick_example.rs)
 //
 // This example demonstrates clap's "builder pattern" method of creating arguments
 // which the most flexible, but also most verbose.
@@ -239,7 +239,37 @@ fn main() {
                 .about("print debug information verbosely")))
         .get_matches();
 
-    // Same as above examples...
+    // You can check the value provided by positional arguments, or option arguments
+    if let Some(i) = matches.value_of("input") {
+        println!("Value for input: {}", i);
+    }
+
+    if let Some(c) = matches.value_of("config") {
+        println!("Value for config: {}", c);
+    }
+
+    // You can see how many times a particular flag or argument occurred
+    // Note, only flags can have multiple occurrences
+    match matches.occurrences_of("v") {
+        0 => println!("Verbose mode is off"),
+        1 => println!("Verbose mode is kind of on"),
+        2 => println!("Verbose mode is on"),
+        3 | _ => println!("Don't be crazy"),
+    }
+
+    // You can check for the existence of subcommands, and if found use their
+    // matches just as you would the top level app
+    if let Some(ref matches) = matches.subcommand_matches("test") {
+        // "$ myapp test" was run
+        if matches.is_present("debug") {
+            // "$ myapp test -d" was run
+            println!("Printing debug info...");
+        } else {
+            println!("Printing normally...");
+        }
+    }
+
+    // Continued program logic goes here...
 }
 ```
 


### PR DESCRIPTION
The 3.0 readme only shows how to use the parsed arguments with the structopt-powered API. This adds back in the usage example for the other modes of usage to the first example. Also fixes a small typo in referring to the examples. 