### PR TITLE
Change visibility of MatchedArg

### DIFF
--- a/src/args/matched_arg.rs
+++ b/src/args/matched_arg.rs
@@ -23,6 +23,7 @@ impl Default for MatchedArg {
 }
 
 impl MatchedArg {
+    #[doc(hidden)]
     pub fn new() -> Self {
         MatchedArg::default()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,7 +561,7 @@ extern crate vec_map;
 extern crate yaml_rust;
 
 pub use app::{App, AppSettings};
-pub use args::{Arg, ArgGroup, ArgMatches, ArgSettings, OsValues, SubCommand, Values};
+pub use args::{Arg, ArgGroup, ArgMatches, ArgSettings, MatchedArg, OsValues, SubCommand, Values};
 pub use completions::Shell;
 pub use errors::{Error, ErrorKind, Result};
 pub use fmt::Format;


### PR DESCRIPTION
Issue: #1616

This is needed to write tests or benchmarks for functions that take `ArgMatches` as input. For example:

```rust
let mut args = HashMap::new();
args.insert(
    "input",
    MatchedArg {
        occurs: 1,
        indices: [1].into(),
        vals: ["test".into_os_string()].to_vec(),
    },
);

let mut matches = ArgMatches {
    args,
    subcommand: None,
    usage: None,
};

target_func(&matches);
```