### PR TITLE
Idiomatic label printing

### DIFF
--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -63,7 +63,7 @@ impl Colorizer {
 impl Colorizer {
     #[cfg(feature = "color")]
     pub(crate) fn print(&self) -> io::Result<()> {
-        use termcolor::{BufferWriter, WriteColor, ColorSpec};
+        use termcolor::{BufferWriter, ColorSpec, WriteColor};
 
         let color_when = if is_a_tty(self.use_stderr) {
             self.color_when

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -126,8 +126,8 @@ impl Colorizer {
         }
     }
 
-    fn is_label(s: &String) -> bool {
-        s.ends_with(":")
+    fn is_label(s: &str) -> bool {
+        s.ends_with(':')
     }
 }
 

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "color"))]
-use crate::util::termcolor::{Color, ColorChoice, ColorSpec};
+use crate::util::termcolor::{Color, ColorChoice};
 #[cfg(feature = "color")]
-use termcolor::{Color, ColorChoice, ColorSpec};
+use termcolor::{Color, ColorChoice};
 
 use std::{
     fmt::{self, Display, Formatter},
@@ -63,7 +63,7 @@ impl Colorizer {
 impl Colorizer {
     #[cfg(feature = "color")]
     pub(crate) fn print(&self) -> io::Result<()> {
-        use termcolor::{BufferWriter, WriteColor};
+        use termcolor::{BufferWriter, WriteColor, ColorSpec};
 
         let color_when = if is_a_tty(self.use_stderr) {
             self.color_when
@@ -84,7 +84,9 @@ impl Colorizer {
                 let mut label = string.clone();
                 label.pop(); // pops off the trailing colon ":".
 
-                let mut label_spec = Colorizer::bold_with_color(color);
+                let mut label_spec = ColorSpec::new();
+                label_spec.set_fg(*color);
+                label_spec.set_bold(true);
                 buffer.set_color(&label_spec)?;
                 buffer.write_all(label.as_bytes())?;
 
@@ -126,13 +128,6 @@ impl Colorizer {
 
     fn is_label(s: &String) -> bool {
         s.ends_with(":")
-    }
-
-    fn bold_with_color(color: &Option<Color>) -> ColorSpec {
-        let mut spec = ColorSpec::new();
-        spec.set_fg(*color);
-        spec.set_bold(true);
-        spec
     }
 }
 

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "color"))]
-use crate::util::termcolor::{Color, ColorChoice};
+use crate::util::termcolor::{Color, ColorChoice, ColorSpec};
 #[cfg(feature = "color")]
-use termcolor::{Color, ColorChoice};
+use termcolor::{Color, ColorChoice, ColorSpec};
 
 use std::{
     fmt::{self, Display, Formatter},
@@ -63,7 +63,7 @@ impl Colorizer {
 impl Colorizer {
     #[cfg(feature = "color")]
     pub(crate) fn print(&self) -> io::Result<()> {
-        use termcolor::{BufferWriter, ColorSpec, WriteColor};
+        use termcolor::{BufferWriter, WriteColor};
 
         let color_when = if is_a_tty(self.use_stderr) {
             self.color_when
@@ -128,8 +128,8 @@ impl Colorizer {
         s.ends_with(":")
     }
 
-    fn bold_with_color(color: &Option<Color>) -> termcolor::ColorSpec {
-        let mut spec = termcolor::ColorSpec::new();
+    fn bold_with_color(color: &Option<Color>) -> ColorSpec {
+        let mut spec = ColorSpec::new();
         spec.set_fg(*color);
         spec.set_bold(true);
         spec

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -7,7 +7,6 @@ use std::{
     fmt::{self, Display, Formatter},
     io::{self, Write},
 };
-use termcolor::WriteColor;
 
 #[cfg(feature = "color")]
 fn is_a_tty(stderr: bool) -> bool {
@@ -64,7 +63,7 @@ impl Colorizer {
 impl Colorizer {
     #[cfg(feature = "color")]
     pub(crate) fn print(&self) -> io::Result<()> {
-        use termcolor::BufferWriter;
+        use termcolor::{BufferWriter, WriteColor};
 
         let color_when = if is_a_tty(self.use_stderr) {
             self.color_when

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "color"))]
 use crate::util::termcolor::{Color, ColorChoice};
 #[cfg(feature = "color")]
-use termcolor::{Color, ColorChoice, ColorSpec};
+use termcolor::{Color, ColorChoice};
 
 use std::{
     fmt::{self, Display, Formatter},
@@ -63,7 +63,7 @@ impl Colorizer {
 impl Colorizer {
     #[cfg(feature = "color")]
     pub(crate) fn print(&self) -> io::Result<()> {
-        use termcolor::{BufferWriter, WriteColor};
+        use termcolor::{BufferWriter, ColorSpec, WriteColor};
 
         let color_when = if is_a_tty(self.use_stderr) {
             self.color_when
@@ -128,8 +128,8 @@ impl Colorizer {
         s.ends_with(":")
     }
 
-    fn bold_with_color(color: &Option<termcolor::Color>) -> ColorSpec {
-        let mut spec = ColorSpec::new();
+    fn bold_with_color(color: &Option<Color>) -> termcolor::ColorSpec {
+        let mut spec = termcolor::ColorSpec::new();
         spec.set_fg(*color);
         spec.set_bold(true);
         spec


### PR DESCRIPTION
Closes #2294
I looked at the `Colorizer` code and included an edge case for labels (which are pretty much all strings that end with a colon like "error:"). 

Colorizer prints pieces out one by one, so this will not have any unpredictable effects. The piece is only ever considered a label if it is a string that ends with a colon (so "error:" is a label but "this didn't work. usage: bla bla bla" is not a label even though "usage:" has a colon).

I ran all tests and they all pass as well as manually checked the result:

![works](https://user-images.githubusercontent.com/23066595/104832543-b1b31700-5889-11eb-853e-a967c414ab6f.png)

It works.