### PR TITLE
Support unsetting/removing the default if an option/flag is set

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -2497,8 +2497,7 @@ impl<'help> Arg<'help> {
 
     /// Specifies the value of the argument if `arg` has been used at runtime. If `val` is set to
     /// `None`, `arg` only needs to be present. If `val` is set to `"some-val"` then `arg` must be
-    /// present at runtime **and** have the value `val`. Setting `default` to `None` removes any
-    /// existing default.
+    /// present at runtime **and** have the value `val`.
     ///
     /// **NOTE:** This setting is perfectly compatible with [`Arg::default_value`] but slightly
     /// different. `Arg::default_value` *only* takes affect when the user has not provided this arg
@@ -2590,7 +2589,7 @@ impl<'help> Arg<'help> {
     /// assert_eq!(m.value_of("other"), None);
     /// ```
     ///
-    /// We can also remove a default if the flag was set.
+    /// We can also remove a default if the flag was set by setting `default` to `None`.
     ///
     /// ```rust
     /// # use clap::{App, Arg};
@@ -2609,11 +2608,11 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
     /// [`Arg::default_value`]: ./struct.Arg.html#method.default_value
-    pub fn default_value_if<T: Key>(
+    pub fn default_value_if<T: Key, S: Into<Option<&'help str>>>(
         self,
         arg_id: T,
         val: Option<&'help str>,
-        default: impl Into<Option<&'help str>>,
+        default: S,
     ) -> Self {
         self.default_value_if_os(
             arg_id,
@@ -2627,11 +2626,11 @@ impl<'help> Arg<'help> {
     ///
     /// [`Arg::default_value_if`]: ./struct.Arg.html#method.default_value_if
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    pub fn default_value_if_os<T: Key>(
+    pub fn default_value_if_os<T: Key, S: Into<Option<&'help OsStr>>>(
         mut self,
         arg_id: T,
         val: Option<&'help OsStr>,
-        default: impl Into<Option<&'help OsStr>>,
+        default: S,
     ) -> Self {
         let l = self.default_vals_ifs.len();
         self.default_vals_ifs
@@ -2723,9 +2722,9 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::takes_value(true)`]: ./struct.Arg.html#method.takes_value
     /// [`Arg::default_value_if`]: ./struct.Arg.html#method.default_value_if
-    pub fn default_value_ifs<T: Key>(
+    pub fn default_value_ifs<T: Key, S: Into<Option<&'help str>> + Copy>(
         mut self,
-        ifs: &[(T, Option<&'help str>, impl Into<Option<&'help str>> + Copy)],
+        ifs: &[(T, Option<&'help str>, S)],
     ) -> Self {
         for (arg, val, default) in ifs {
             let default: Option<&'help str> = (*default).into();
@@ -2740,13 +2739,9 @@ impl<'help> Arg<'help> {
     ///
     /// [`Arg::default_value_ifs`]: ./struct.Arg.html#method.default_value_ifs
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    pub fn default_value_ifs_os<T: Key>(
+    pub fn default_value_ifs_os<T: Key, S: Into<Option<&'help OsStr>> + Copy>(
         mut self,
-        ifs: &[(
-            T,
-            Option<&'help OsStr>,
-            impl Into<Option<&'help OsStr>> + Copy,
-        )],
+        ifs: &[(T, Option<&'help OsStr>, S)],
     ) -> Self {
         for (arg, val, default) in ifs {
             let default: Option<&'help OsStr> = (*default).into();

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1486,7 +1486,9 @@ impl<'help, 'app> Parser<'help, 'app> {
                     };
 
                     if add {
-                        self.add_val_to_arg(arg, &ArgStr::new(default), matcher, ty)?;
+                        if let Some(default) = default {
+                            self.add_val_to_arg(arg, &ArgStr::new(default), matcher, ty)?;
+                        }
                         done = true;
                         break;
                     }

--- a/tests/default_vals.rs
+++ b/tests/default_vals.rs
@@ -338,6 +338,78 @@ fn default_if_arg_present_no_arg_with_value_with_default_user_override_fail() {
     assert_eq!(m.value_of("arg").unwrap(), "other");
 }
 
+// Unsetting the default
+
+#[test]
+fn option_default_if_arg_present_with_value_no_default() {
+    let r = App::new("df")
+        .arg(Arg::from("--opt [FILE] 'some arg'"))
+        .arg(Arg::from("[arg] 'some arg'").default_value_if("opt", Some("value"), Some("default")))
+        .try_get_matches_from(vec!["", "--opt", "value"]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(m.is_present("arg"));
+    assert_eq!(m.value_of("arg").unwrap(), "default");
+}
+
+#[test]
+fn no_default_if_arg_present_with_value_no_default() {
+    let r = App::new("df")
+        .arg(Arg::from("--opt [FILE] 'some arg'"))
+        .arg(Arg::from("[arg] 'some arg'").default_value_if("opt", Some("value"), None))
+        .try_get_matches_from(vec!["", "--opt", "value"]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(!m.is_present("arg"));
+}
+
+#[test]
+fn no_default_if_arg_present_with_value_with_default() {
+    let r = App::new("df")
+        .arg(Arg::from("--opt [FILE] 'some arg'"))
+        .arg(
+            Arg::from("[arg] 'some arg'")
+                .default_value("default")
+                .default_value_if("opt", Some("value"), None),
+        )
+        .try_get_matches_from(vec!["", "--opt", "value"]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(!m.is_present("arg"));
+}
+
+#[test]
+fn no_default_if_arg_present_with_value_with_default_user_override() {
+    let r = App::new("df")
+        .arg(Arg::from("--opt [FILE] 'some arg'"))
+        .arg(
+            Arg::from("[arg] 'some arg'")
+                .default_value("default")
+                .default_value_if("opt", Some("value"), None),
+        )
+        .try_get_matches_from(vec!["", "--opt", "value", "other"]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(m.is_present("arg"));
+    assert_eq!(m.value_of("arg").unwrap(), "other");
+}
+
+#[test]
+fn no_default_if_arg_present_no_arg_with_value_with_default() {
+    let r = App::new("df")
+        .arg(Arg::from("--opt [FILE] 'some arg'"))
+        .arg(
+            Arg::from("[arg] 'some arg'")
+                .default_value("default")
+                .default_value_if("opt", Some("value"), None),
+        )
+        .try_get_matches_from(vec!["", "--opt", "other"]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(m.is_present("arg"));
+    assert_eq!(m.value_of("arg").unwrap(), "default");
+}
+
 // Multiple conditions
 
 #[test]
@@ -355,6 +427,22 @@ fn default_ifs_arg_present() {
     let m = r.unwrap();
     assert!(m.is_present("arg"));
     assert_eq!(m.value_of("arg").unwrap(), "flg");
+}
+
+#[test]
+fn no_default_ifs_arg_present() {
+    let r = App::new("df")
+        .arg(Arg::from("--opt [FILE] 'some arg'"))
+        .arg(Arg::from("--flag 'some arg'"))
+        .arg(
+            Arg::from("[arg] 'some arg'")
+                .default_value("first")
+                .default_value_ifs(&[("opt", Some("some"), Some("default")), ("flag", None, None)]),
+        )
+        .try_get_matches_from(vec!["", "--flag"]);
+    assert!(r.is_ok());
+    let m = r.unwrap();
+    assert!(!m.is_present("arg"));
 }
 
 #[test]


### PR DESCRIPTION
For `Arg::default_vals_if` and friends, allow an `Option<&str>` as the default instead of `&str`. This allows you to unset the default if some other option/flag is set or has some specific value. To avoid breaking existing code, the modified API takes `impl Into<Option<&str>>` instead of just `Option<&str>`.

Example:
```rust
let m = App::new("prog")
    .arg(Arg::new("flag")
        .long("flag"))
    .arg(Arg::new("other")
        .long("other")
        .default_value("default")
        .default_value_if("flag", None, None))
    .get_matches_from(vec!["prog", "--flag"]);
assert_eq!(m.value_of("other"), None);
```

Closes #1406