### PR TITLE
Allow visible alias(es) for args from YAML files

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -4508,6 +4508,10 @@ impl<'help> From<&'help Yaml> for Arg<'help> {
                     a.set_mut(ArgSettings::RequiredUnlessAll);
                     a
                 }
+                "visible_alias" => yaml_to_str!(a, v, visible_alias),
+                "visible_aliases" => yaml_vec_or_str!(a, v, visible_alias),
+                "visible_short_alias" => yaml_to_char!(a, v, visible_short_alias),
+                "visible_short_aliases" => yaml_to_chars!(a, v, visible_short_aliases),
                 #[cfg(feature = "regex")]
                 "validator_regex" => {
                     if let Some(vec) = v.as_vec() {

--- a/tests/fixtures/app.yaml
+++ b/tests/fixtures/app.yaml
@@ -116,6 +116,16 @@ args:
         long: value-hint
         help: Test value_hint
         value_hint: FilePath
+    - visiblealiases:
+        long: visiblealiases
+        about: Tests visible aliases
+        visible_alias: visals1
+        visible_aliases: [visals2, visals2, visals3]
+    - visibleshortaliases:
+        long: visibleshortaliases
+        about: Tests visible short aliases
+        visible_short_alias: e
+        visible_short_aliases: [l, m]
 
 arg_groups:
     - test:

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -26,7 +26,7 @@ fn help_message() {
     app.write_help(&mut help_buffer).unwrap();
     let help_string = String::from_utf8(help_buffer).unwrap();
     assert!(help_string
-        .contains("-h, --help                prints help with a nonstandard description\n"));
+        .contains("-h, --help                   prints help with a nonstandard description\n"));
 }
 
 #[test]


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->

This PR allows users to set `visible_alias`, `visible_aliases`, `visible_short_alias` and `visible_short_aliases` for args from YAML files.

Closes #1613 
