### PR TITLE
Hint user when their small terminal width make help output wraps

### DIFF
--- a/tests/app_from_crate.rs
+++ b/tests/app_from_crate.rs
@@ -12,6 +12,8 @@ FLAGS:
     -V, --version    Prints version information
 ";
 
+/// ATTENTION!: If you see this test fails, one of the possibilities is that you
+/// enables the wrap_help feature and your terminal width is small.
 #[test]
 fn app_from_crate() {
     let res = app_from_crate!().try_get_matches_from(vec!["clap", "--help"]);
@@ -21,6 +23,8 @@ fn app_from_crate() {
     assert_eq!(err.kind, ErrorKind::DisplayHelp);
     assert_eq!(
         err.to_string(),
-        EVERYTHING.replace("{{version}}", env!("CARGO_PKG_VERSION"))
+        EVERYTHING.replace("{{version}}", env!("CARGO_PKG_VERSION")),
+        "\n\n\n\n>>>>>> ATTENTION!!!!!! <<<<<<\
+        \nThis test fails often because your terminal width is small.\n\n\n"
     );
 }


### PR DESCRIPTION
Fixes #2257

Ping @nitsky 