### PR TITLE
Fix unset_setting()

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -947,7 +947,6 @@ impl<'help> App<'help> {
     #[inline]
     pub fn unset_setting(mut self, setting: AppSettings) -> Self {
         self.settings.unset(setting);
-        self.g_settings.unset(setting);
         self
     }
 

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -542,8 +542,8 @@ fn unset_settings() {
     assert!(&m.is_set(AppSettings::ColorAuto));
 
     let m = m
-        .unset_setting(AppSettings::AllowInvalidUtf8)
-        .unset_setting(AppSettings::ColorAuto);
+        .unset_global_setting(AppSettings::AllowInvalidUtf8)
+        .unset_global_setting(AppSettings::ColorAuto);
     assert!(!m.is_set(AppSettings::AllowInvalidUtf8), "{:#?}", m);
     assert!(!m.is_set(AppSettings::ColorAuto), "{:#?}", m);
 }


### PR DESCRIPTION
`unset_setting()` accidentally changes global setting, which makes it's behaviour the same as `unset_global_setting`. This PR fixes it. 