### PR TITLE
Update dependencies for v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,27 +25,27 @@ maintenance = {status = "actively-developed"}
 [dependencies]
 bitflags              = "1.0"
 unicode-width         = "0.1.4"
-textwrap              = "0.11.0"
-strsim    = { version = "0.8",  optional = true }
-yaml-rust = { version = "0.3.5",  optional = true }
+textwrap              = "0.13.2"
+strsim    = { version = "0.10",  optional = true }
+yaml-rust = { version = "0.4.5",  optional = true }
 clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
 vec_map   = { version = "0.8", optional = true }
 term_size = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-ansi_term = { version = "0.11",  optional = true }
+ansi_term = { version = "^0.12",  optional = true }
 
 [dev-dependencies]
 regex = "1"
 lazy_static = "1.3"
-version-sync = "0.8"
+version-sync = "0.9"
 
 [features]
 default     = ["suggestions", "color", "vec_map"]
 suggestions = ["strsim"]
 color       = ["ansi_term", "atty"]
-wrap_help   = ["term_size", "textwrap/term_size"]
+wrap_help   = ["term_size", "textwrap/terminal_size"]
 yaml        = ["yaml-rust"]
 unstable    = [] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 nightly     = [] # for building with unstable Rust features (currently none)

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -1012,9 +1012,9 @@ impl<'a> Help<'a> {
 }
 
 fn wrap_help(help: &str, avail_chars: usize) -> String {
-    let wrapper = textwrap::Wrapper::new(avail_chars).break_words(false);
+    let wrapper = textwrap::Options::new(avail_chars).break_words(false);
     help.lines()
-        .map(|line| wrapper.fill(line))
+        .map(|line| textwrap::fill(line, &wrapper))
         .collect::<Vec<String>>()
         .join("\n")
 }


### PR DESCRIPTION
This PR aims to update the dependencies on the crate for version 2, the information which crates needed updated was taken from [cargo-outdated](https://github.com/kbknapp/cargo-outdated)