### PR TITLE
Bump textwrap to 0.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,14 @@ maintenance = {status = "actively-developed"}
 
 [dependencies]
 bitflags              = "1.0"
-unicode-width         = "0.1.4"
-textwrap              = "0.11.0"
+unicode-width = { version = "0.1", optional = true }
+textwrap  = { version = "0.13", default-features = false, features = [] }
 strsim    = { version = "0.8",  optional = true }
 yaml-rust = { version = "0.3.5",  optional = true }
 clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
 vec_map   = { version = "0.8", optional = true }
-term_size = { version = "0.3.0", optional = true }
+terminal_size = { version = "0.1.12", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 ansi_term = { version = "0.11",  optional = true }
@@ -45,7 +45,8 @@ version-sync = "0.8"
 default     = ["suggestions", "color", "vec_map"]
 suggestions = ["strsim"]
 color       = ["ansi_term", "atty"]
-wrap_help   = ["term_size", "textwrap/term_size"]
+wrap_help   = ["terminal_size", "textwrap/terminal_size"]
+unicode_help= ["unicode-width", "textwrap/unicode-width"] # Enable if any unicode in help message
 yaml        = ["yaml-rust"]
 unstable    = [] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 nightly     = [] # for building with unstable Rust features (currently none)

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -20,7 +20,6 @@ use INTERNAL_ERROR_MSG;
 #[cfg(feature = "wrap_help")]
 use term_size;
 use textwrap;
-use unicode_width::UnicodeWidthStr;
 
 #[cfg(not(feature = "wrap_help"))]
 mod term_size {
@@ -30,6 +29,10 @@ mod term_size {
 }
 
 fn str_width(s: &str) -> usize {
+    #[cfg(not(feature = "unicode_help"))]
+    return s.len();
+
+    #[cfg(feature = "unicode_help")]
     UnicodeWidthStr::width(s)
 }
 
@@ -1012,9 +1015,9 @@ impl<'a> Help<'a> {
 }
 
 fn wrap_help(help: &str, avail_chars: usize) -> String {
-    let wrapper = textwrap::Wrapper::new(avail_chars).break_words(false);
+    let wrapper = textwrap::Options::new(avail_chars).break_words(false);
     help.lines()
-        .map(|line| wrapper.fill(line))
+        .map(|line| textwrap::fill(line, &wrapper))
         .collect::<Vec<String>>()
         .join("\n")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,7 +554,6 @@ extern crate strsim;
 #[cfg(feature = "wrap_help")]
 extern crate term_size;
 extern crate textwrap;
-extern crate unicode_width;
 #[cfg(feature = "vec_map")]
 extern crate vec_map;
 #[cfg(feature = "yaml")]


### PR DESCRIPTION
Update textwrap dependency for the v2 branch. This is a cherry-pick of c6da968ec79b49108ff0507fbf09f6ce8bd3f890.