### PR TITLE
Fix(#1419): Consistent usage section

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -14,7 +14,6 @@ use std::{
     fmt,
     io::{self, BufRead, Write},
     ops::Index,
-    path::Path,
 };
 
 // Third Party
@@ -2127,25 +2126,12 @@ impl<'help> App<'help> {
         T: Into<OsString> + Clone,
     {
         let mut it = Input::from(itr.into_iter());
-        // Get the name of the program (argument 1 of env::args()) and determine the
-        // actual file
-        // that was used to execute the program. This is because a program called
-        // ./target/release/my_prog -a
-        // will have two arguments, './target/release/my_prog', '-a' but we don't want
-        // to display
-        // the full path when displaying help messages and such
         if !self.settings.is_set(AppSettings::NoBinaryName) {
-            if let Some((name, _)) = it.next() {
-                let p = Path::new(name);
-
-                if let Some(f) = p.file_name() {
-                    if let Some(s) = f.to_str() {
-                        if self.bin_name.is_none() {
-                            self.bin_name = Some(s.to_owned());
-                        }
-                    }
-                }
+            if self.bin_name.is_none() {
+                self.bin_name = Some(self.name.to_owned());
             }
+            // Consume the name of the program executed (argument 1 of env::args())
+            it.next();
         }
 
         self._do_parse(&mut it)

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -6,7 +6,7 @@ static REQ_GROUP_USAGE: &str = "error: The following required arguments were not
     <base|--delete>
 
 USAGE:
-    clap-test <base|--delete>
+    req_group <base|--delete>
 
 For more information try --help";
 
@@ -14,7 +14,7 @@ static REQ_GROUP_CONFLICT_USAGE: &str =
     "error: The argument '--delete' cannot be used with '<base>'
 
 USAGE:
-    clap-test <base|--delete>
+    req_group <base|--delete>
 
 For more information try --help";
 
@@ -22,7 +22,7 @@ static REQ_GROUP_CONFLICT_ONLY_OPTIONS: &str =
     "error: The argument '--delete' cannot be used with '--all'
 
 USAGE:
-    clap-test <--all|--delete>
+    req_group <--all|--delete>
 
 For more information try --help";
 
@@ -175,7 +175,7 @@ fn req_group_usage_string() {
 
     assert!(utils::compare_output(
         app,
-        "clap-test",
+        "req_group",
         REQ_GROUP_USAGE,
         true
     ));

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -344,7 +344,7 @@ Show how the about text is not
 wrapped
 
 USAGE:
-    ctest
+    test
 
 FLAGS:
     -h, --help
@@ -588,7 +588,7 @@ Will M.
 does stuff
 
 USAGE:
-    test --fake <some>:<val>
+    blorp --fake <some>:<val>
 
 FLAGS:
     -h, --help       Prints help information
@@ -603,7 +603,7 @@ NETWORKING:
 static ISSUE_1487: &str = "test 
 
 USAGE:
-    ctest <arg1|arg2>
+    test <arg1|arg2>
 
 ARGS:
     <arg1>    
@@ -1373,11 +1373,12 @@ fn issue_1046_hidden_scs() {
 #[test]
 fn issue_777_wrap_all_things() {
     let app = App::new("A app with a crazy very long long long name hahaha")
+        .bin_name("test")
         .version("1.0")
         .author("Some Very Long Name and crazy long email <email@server.com>")
         .about("Show how the about text is not wrapped")
         .term_width(35);
-    assert!(utils::compare_output(app, "ctest --help", ISSUE_777, false));
+    assert!(utils::compare_output(app, "test --help", ISSUE_777, false));
 }
 
 static OVERRIDE_HELP_SHORT: &str = "test 0.1
@@ -1801,7 +1802,7 @@ fn custom_headers_headers() {
 
     assert!(utils::compare_output(
         app,
-        "test --help",
+        "blorp --help",
         CUSTOM_HELP_SECTION,
         false
     ));
@@ -1812,7 +1813,7 @@ Will M.
 does stuff
 
 USAGE:
-    test [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
+    blorp [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
 
 FLAGS:
     -h, --help       Prints help information
@@ -1879,7 +1880,7 @@ fn multiple_custom_help_headers() {
 
     assert!(utils::compare_output(
         app,
-        "test --help",
+        "blorp --help",
         MULTIPLE_CUSTOM_HELP_SECTIONS,
         false
     ));
@@ -1966,7 +1967,7 @@ fn issue_1487() {
         .group(ArgGroup::new("group1")
             .args(&["arg1", "arg2"])
             .required(true));
-    assert!(utils::compare_output(app, "ctest -h", ISSUE_1487, false));
+    assert!(utils::compare_output(app, "test -h", ISSUE_1487, false));
 }
 
 #[cfg(debug_assertions)]

--- a/tests/possible_values.rs
+++ b/tests/possible_values.rs
@@ -9,7 +9,7 @@ static PV_ERROR: &str = "error: \"slo\" isn't a valid value for '-O <option>'
 \tDid you mean \"slow\"?
 
 USAGE:
-    clap-test -O <option>
+    test -O <option>
 
 For more information try --help";
 
@@ -18,7 +18,7 @@ static PV_ERROR: &'static str = "error: \"slo\" isn't a valid value for '-O <opt
 \t[possible values: \"ludicrous speed\", fast, slow]
 
 USAGE:
-    clap-test -O <option>
+    test -O <option>
 
 For more information try --help";
 
@@ -29,7 +29,7 @@ static PV_ERROR_ESCAPED: &str = "error: \"ludicrous\" isn't a valid value for '-
 \tDid you mean \"ludicrous speed\"?
 
 USAGE:
-    clap-test -O <option>
+    test -O <option>
 
 For more information try --help";
 
@@ -38,7 +38,7 @@ static PV_ERROR_ESCAPED: &'static str = "error: \"ludicrous\" isn't a valid valu
 \t[possible values: \"ludicrous speed\", fast, slow]
 
 USAGE:
-    clap-test -O <option>
+    test -O <option>
 
 For more information try --help";
 
@@ -188,7 +188,7 @@ fn possible_values_output() {
             "fast",
             "ludicrous speed"
         ])),
-        "clap-test -O slo",
+        "test -O slo",
         PV_ERROR,
         true
     ));
@@ -202,7 +202,7 @@ fn escaped_possible_values_output() {
             "fast",
             "ludicrous speed"
         ])),
-        "clap-test -O ludicrous",
+        "test -O ludicrous",
         PV_ERROR_ESCAPED,
         true
     ));

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -535,7 +535,7 @@ fn required_if_val_present_fail() {
 
 #[test]
 fn list_correct_required_args() {
-    let app = App::new("Test app")
+    let app = App::new("test")
         .version("1.0")
         .author("F0x06")
         .about("Arg test")
@@ -569,7 +569,7 @@ fn list_correct_required_args() {
 
 #[test]
 fn required_if_val_present_fail_error_output() {
-    let app = App::new("Test app")
+    let app = App::new("test")
         .version("1.0")
         .author("F0x06")
         .about("Arg test")


### PR DESCRIPTION
First contribution here! Do not hesitate to review my changes.

# Issue/Examples

The issue #1419 describes why usage may be inconsistent and here is an example:

The example application source code:

```
❯ tree clap_issue_1419/
clap_issue_1419/
├── Cargo.toml
└── src
    └── main.rs
```

The `main.rs` source file: 

```rust
use clap::App;

fn main() {
    let mut app = App::new("my-app");
    app.print_help().unwrap();
    app.get_matches();
}
```

With stable version `2.33.3` and beta version `3.0.0-beta.2`:

```
❯ cargo run --release --quiet -- --help
my-app

USAGE:
    my-app

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
my-app

USAGE:
    clap_issue_1419

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
```

Note the difference for the `USAGE` string. 

By default `clap` parses binary name when `App::get_matches*` is called ([source](https://github.com/clap-rs/clap/blob/97343e4cefdb40ba39d3717947ee08a71285f07e/src/build/app/mod.rs#L2137)) and uses binary name for usage string displayed when help is requested.
By contrast, the `App::new` [documentation](https://docs.rs/clap/3.0.0-beta.2/clap/struct.App.html#method.new) states that 

> It is common, but not required, to use binary name as the name. This name will only be displayed to the user when they request to print version or help and usage information.

which is not the case when the user requested help as shown in example above.

# Expected behavior

The idea is to make sure the usage string is consistent if the developer asked for displaying help with `print_help` or the user requested help with `--help` (`-h`) flag.

```
❯ cargo run --release --quiet -- --help
my-app

USAGE:
    my-app

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
my-app

USAGE:
    my-app

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
```

# Solution

Instead of parsing binary name when `get_matches*` is called, set `App::bin_name` to `App::name` if and only if the developer did not override binary name with `App::bin_name()`. 

# Problems

This change turned some tests to failure. Indeed some tests rely on this inconsistent behavior for example: 

```rust
static COND_REQ_IN_USAGE: &str = "error: The following required arguments were not provided:
    --output <output>

USAGE:
    test --target <target> --input <input> --output <output>

For more information try --help";

/* snip */

#[test]
fn required_if_val_present_fail_error_output() {
    let app = App::new("Test app")
        .version("1.0")
        .author("F0x06")
        .about("Arg test")
        .arg(
            Arg::new("target")
                .takes_value(true)
                .required(true)
                .possible_values(&["file", "stdout"])
                .long("target"),
        )
        .arg(
            Arg::new("input")
                .takes_value(true)
                .required(true)
                .long("input"),
        )
        .arg(
            Arg::new("output")
                .takes_value(true)
                .required_if_eq("target", "file")
                .long("output"),
        );
    assert!(utils::compare_output(
        app,
        "test --input somepath --target file",
        COND_REQ_IN_USAGE,
        true
    ));
```

Note that the application is named "Test App" and is called with binary name "test" without specifying binary name in `app` definition.

This PR introduces the previously described change and try to fix consistently these tests. 

Thanks! :clap: 

