### PR TITLE
Fix part of the non_fmt_panic warnings, bump version-sync to 0.9.2

### DIFF
--- a/clap_derive/tests/custom-string-parsers.rs
+++ b/clap_derive/tests/custom-string-parsers.rs
@@ -83,6 +83,7 @@ fn test_parse_hex() {
     let err = HexOpt::try_parse_from(&["test", "-n", "gg"]).unwrap_err();
     assert!(
         err.to_string().contains("invalid digit found in string"),
+        "{}",
         err
     );
 }

--- a/clap_derive/tests/non_literal_attributes.rs
+++ b/clap_derive/tests/non_literal_attributes.rs
@@ -149,6 +149,7 @@ fn test_parse_hex_function_path() {
     let err = HexOpt::try_parse_from(&["test", "-n", "gg"]).unwrap_err();
     assert!(
         err.to_string().contains("invalid digit found in string"),
+        "{}",
         err
     );
 }

--- a/clap_generate/Cargo.toml
+++ b/clap_generate/Cargo.toml
@@ -39,7 +39,7 @@ clap = { path = "../", version = "3.0.0-beta.2" }
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-version-sync = "0.8"
+version-sync = "0.9"
 
 [features]
 default = []

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2318,11 +2318,11 @@ impl<'help> App<'help> {
                 .collect();
 
             if !args_missing_help.is_empty() {
-                panic!(format!(
+                panic!(
                     "AppSettings::HelpRequired is enabled for the App {}, but at least one of its arguments does not have either `help` or `long_help` set. List of such arguments: {}",
                     self.name,
                     args_missing_help.join(", ")
-                ));
+                );
             }
         }
 

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -242,7 +242,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             ));
         }
 
-        panic!(INTERNAL_ERROR_MSG);
+        panic!("{}", INTERNAL_ERROR_MSG);
     }
 
     fn validate_conflicts(&mut self, matcher: &mut ArgMatcher) -> ClapResult<()> {


### PR DESCRIPTION
Remove recent nightly test warnings, some of the warnings originates from version-sync.

Related: https://github.com/mgeisler/version-sync/issues/103, https://github.com/rust-lang/rust/pull/81645