### PR TITLE
Bump version-sync version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ regex = { version = "1.0", optional = true }
 [dev-dependencies]
 regex = "1.0"
 lazy_static = "1"
-version-sync = "0.8"
+version-sync = "0.9"
 criterion = "0.3.2"
 
 [features]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -47,7 +47,7 @@ clap = { path = "../" }
 clap_generate = { path = "../clap_generate" }
 trybuild = "1.0"
 rustversion = "1"
-version-sync = "0.8"
+version-sync = "0.9"
 
 [features]
 default = []


### PR DESCRIPTION
Forget to bump version-sync version for clap and clap_derive(only did that for clap_generate) in #2346.😅 Now there is no check annotations from CI.