### PR TITLE
imp: Visible aliases for arguments in completions

### DIFF
--- a/clap_generate/src/generators/shells/bash.rs
+++ b/clap_generate/src/generators/shells/bash.rs
@@ -147,30 +147,34 @@ fn option_details_for_path(app: &App, path: &str) -> String {
     let mut opts = String::new();
 
     for o in p.get_opts() {
-        if let Some(l) = o.get_long() {
-            opts = format!(
-                "{}
+        if let Some(longs) = o.get_long_and_visible_aliases() {
+            for long in longs {
+                opts = format!(
+                    "{}
                 --{})
                     COMPREPLY=({})
                     return 0
                     ;;",
-                opts,
-                l,
-                vals_for(o)
-            );
+                    opts,
+                    long,
+                    vals_for(o)
+                );
+            }
         }
 
-        if let Some(s) = o.get_short() {
-            opts = format!(
-                "{}
-                    -{})
+        if let Some(shorts) = o.get_short_and_visible_aliases() {
+            for short in shorts {
+                opts = format!(
+                    "{}
+                -{})
                     COMPREPLY=({})
                     return 0
                     ;;",
-                opts,
-                s,
-                vals_for(o)
-            );
+                    opts,
+                    short,
+                    vals_for(o)
+                );
+            }
         }
     }
 

--- a/clap_generate/src/generators/shells/bash.rs
+++ b/clap_generate/src/generators/shells/bash.rs
@@ -198,7 +198,7 @@ fn all_options_for_path(app: &App, path: &str) -> String {
         shorts = Bash::shorts_and_visible_aliases(p)
             .iter()
             .fold(String::new(), |acc, s| format!("{} -{}", acc, s)),
-        longs = Bash::longs(p)
+        longs = Bash::longs_and_visible_aliases(p)
             .iter()
             .fold(String::new(), |acc, l| format!("{} --{}", acc, l)),
         pos = p

--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -97,6 +97,13 @@ fn generate_inner<'help>(
 
             completions.push_str(&preamble);
             completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
+
+            if let Some(aliases) = option.get_visible_aliases() {
+                for data in aliases {
+                    completions.push_str(&preamble);
+                    completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
+                }
+            }
         }
     }
 
@@ -120,6 +127,13 @@ fn generate_inner<'help>(
 
             completions.push_str(&preamble);
             completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
+
+            if let Some(aliases) = flag.get_visible_aliases() {
+                for data in aliases {
+                    completions.push_str(&preamble);
+                    completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
+                }
+            }
         }
     }
 

--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -78,61 +78,37 @@ fn generate_inner<'help>(
     let preamble = String::from("\n            cand ");
 
     for option in p.get_opts() {
-        if let Some(data) = option.get_short() {
-            let tooltip = get_tooltip(option.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(format!("-{} '{}'", data, tooltip).as_str());
-
-            if let Some(short_aliases) = option.get_visible_short_aliases() {
-                for data in short_aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(format!("-{} '{}'", data, tooltip).as_str());
-                }
+        if let Some(shorts) = option.get_short_and_visible_aliases() {
+            let tooltip = get_tooltip(option.get_about(), shorts[0]);
+            for short in shorts {
+                completions.push_str(&preamble);
+                completions.push_str(format!("-{} '{}'", short, tooltip).as_str());
             }
         }
 
-        if let Some(data) = option.get_long() {
-            let tooltip = get_tooltip(option.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
-
-            if let Some(aliases) = option.get_visible_aliases() {
-                for data in aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
-                }
+        if let Some(longs) = option.get_long_and_visible_aliases() {
+            let tooltip = get_tooltip(option.get_about(), longs[0]);
+            for long in longs {
+                completions.push_str(&preamble);
+                completions.push_str(format!("--{} '{}'", long, tooltip).as_str());
             }
         }
     }
 
     for flag in Elvish::flags(p) {
-        if let Some(data) = flag.get_short() {
-            let tooltip = get_tooltip(flag.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(format!("-{} '{}'", data, tooltip).as_str());
-
-            if let Some(short_aliases) = flag.get_visible_short_aliases() {
-                for data in short_aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(format!("-{} '{}'", data, tooltip).as_str());
-                }
+        if let Some(shorts) = flag.get_short_and_visible_aliases() {
+            let tooltip = get_tooltip(flag.get_about(), shorts[0]);
+            for short in shorts {
+                completions.push_str(&preamble);
+                completions.push_str(format!("-{} '{}'", short, tooltip).as_str());
             }
         }
 
-        if let Some(data) = flag.get_long() {
-            let tooltip = get_tooltip(flag.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
-
-            if let Some(aliases) = flag.get_visible_aliases() {
-                for data in aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(format!("--{} '{}'", data, tooltip).as_str());
-                }
+        if let Some(longs) = flag.get_long_and_visible_aliases() {
+            let tooltip = get_tooltip(flag.get_about(), longs[0]);
+            for long in longs {
+                completions.push_str(&preamble);
+                completions.push_str(format!("--{} '{}'", long, tooltip).as_str());
             }
         }
     }

--- a/clap_generate/src/generators/shells/fish.rs
+++ b/clap_generate/src/generators/shells/fish.rs
@@ -71,6 +71,12 @@ fn gen_fish_inner(root_command: &str, app: &App, buffer: &mut String) {
 
         if let Some(data) = option.get_long() {
             template.push_str(format!(" -l {}", data).as_str());
+
+            if let Some(aliases) = option.get_visible_aliases() {
+                for data in aliases {
+                    template.push_str(format!(" -l {}", data).as_str());
+                }
+            }
         }
 
         if let Some(data) = option.get_about() {
@@ -98,6 +104,12 @@ fn gen_fish_inner(root_command: &str, app: &App, buffer: &mut String) {
 
         if let Some(data) = flag.get_long() {
             template.push_str(format!(" -l {}", data).as_str());
+
+            if let Some(aliases) = flag.get_visible_aliases() {
+                for data in aliases {
+                    template.push_str(format!(" -l {}", data).as_str());
+                }
+            }
         }
 
         if let Some(data) = flag.get_about() {

--- a/clap_generate/src/generators/shells/fish.rs
+++ b/clap_generate/src/generators/shells/fish.rs
@@ -59,23 +59,15 @@ fn gen_fish_inner(root_command: &str, app: &App, buffer: &mut String) {
     for option in app.get_opts() {
         let mut template = basic_template.clone();
 
-        if let Some(data) = option.get_short() {
-            template.push_str(format!(" -s {}", data).as_str());
-
-            if let Some(short_aliases) = option.get_visible_short_aliases() {
-                for data in short_aliases {
-                    template.push_str(format!(" -s {}", data).as_str());
-                }
+        if let Some(shorts) = option.get_short_and_visible_aliases() {
+            for short in shorts {
+                template.push_str(format!(" -s {}", short).as_str());
             }
         }
 
-        if let Some(data) = option.get_long() {
-            template.push_str(format!(" -l {}", data).as_str());
-
-            if let Some(aliases) = option.get_visible_aliases() {
-                for data in aliases {
-                    template.push_str(format!(" -l {}", data).as_str());
-                }
+        if let Some(longs) = option.get_long_and_visible_aliases() {
+            for long in longs {
+                template.push_str(format!(" -l {}", escape_string(long)).as_str());
             }
         }
 
@@ -92,23 +84,15 @@ fn gen_fish_inner(root_command: &str, app: &App, buffer: &mut String) {
     for flag in Fish::flags(app) {
         let mut template = basic_template.clone();
 
-        if let Some(data) = flag.get_short() {
-            template.push_str(format!(" -s {}", data).as_str());
-
-            if let Some(short_aliases) = flag.get_visible_short_aliases() {
-                for data in short_aliases {
-                    template.push_str(format!(" -s {}", data).as_str());
-                }
+        if let Some(shorts) = flag.get_short_and_visible_aliases() {
+            for short in shorts {
+                template.push_str(format!(" -s {}", short).as_str());
             }
         }
 
-        if let Some(data) = flag.get_long() {
-            template.push_str(format!(" -l {}", data).as_str());
-
-            if let Some(aliases) = flag.get_visible_aliases() {
-                for data in aliases {
-                    template.push_str(format!(" -l {}", data).as_str());
-                }
+        if let Some(longs) = flag.get_long_and_visible_aliases() {
+            for long in longs {
+                template.push_str(format!(" -l {}", escape_string(long)).as_str());
             }
         }
 

--- a/clap_generate/src/generators/shells/powershell.rs
+++ b/clap_generate/src/generators/shells/powershell.rs
@@ -122,6 +122,19 @@ fn generate_inner<'help>(
                 )
                 .as_str(),
             );
+
+            if let Some(aliases) = option.get_visible_aliases() {
+                for data in aliases {
+                    completions.push_str(&preamble);
+                    completions.push_str(
+                        format!(
+                            "'--{}', '{}', {}, '{}')",
+                            data, data, "[CompletionResultType]::ParameterName", tooltip
+                        )
+                        .as_str(),
+                    );
+                }
+            }
         }
     }
 
@@ -163,6 +176,19 @@ fn generate_inner<'help>(
                 )
                 .as_str(),
             );
+
+            if let Some(aliases) = flag.get_visible_aliases() {
+                for data in aliases {
+                    completions.push_str(&preamble);
+                    completions.push_str(
+                        format!(
+                            "'--{}', '{}', {}, '{}')",
+                            data, data, "[CompletionResultType]::ParameterName", tooltip
+                        )
+                        .as_str(),
+                    );
+                }
+            }
         }
     }
 

--- a/clap_generate/src/generators/shells/powershell.rs
+++ b/clap_generate/src/generators/shells/powershell.rs
@@ -85,109 +85,61 @@ fn generate_inner<'help>(
     let preamble = String::from("\n            [CompletionResult]::new(");
 
     for option in p.get_opts() {
-        if let Some(data) = option.get_short() {
-            let tooltip = get_tooltip(option.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(
-                format!(
-                    "'-{}', '{}', {}, '{}')",
-                    data, data, "[CompletionResultType]::ParameterName", tooltip
-                )
-                .as_str(),
-            );
-
-            if let Some(short_aliases) = option.get_visible_short_aliases() {
-                for data in short_aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(
-                        format!(
-                            "'-{}', '{}', {}, '{}')",
-                            data, data, "[CompletionResultType]::ParameterName", tooltip
-                        )
-                        .as_str(),
-                    );
-                }
+        if let Some(shorts) = option.get_short_and_visible_aliases() {
+            let tooltip = get_tooltip(option.get_about(), shorts[0]);
+            for short in shorts {
+                completions.push_str(&preamble);
+                completions.push_str(
+                    format!(
+                        "'-{}', '{}', {}, '{}')",
+                        short, short, "[CompletionResultType]::ParameterName", tooltip
+                    )
+                    .as_str(),
+                );
             }
         }
 
-        if let Some(data) = option.get_long() {
-            let tooltip = get_tooltip(option.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(
-                format!(
-                    "'--{}', '{}', {}, '{}')",
-                    data, data, "[CompletionResultType]::ParameterName", tooltip
-                )
-                .as_str(),
-            );
-
-            if let Some(aliases) = option.get_visible_aliases() {
-                for data in aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(
-                        format!(
-                            "'--{}', '{}', {}, '{}')",
-                            data, data, "[CompletionResultType]::ParameterName", tooltip
-                        )
-                        .as_str(),
-                    );
-                }
+        if let Some(longs) = option.get_long_and_visible_aliases() {
+            let tooltip = get_tooltip(option.get_about(), longs[0]);
+            for long in longs {
+                completions.push_str(&preamble);
+                completions.push_str(
+                    format!(
+                        "'--{}', '{}', {}, '{}')",
+                        long, long, "[CompletionResultType]::ParameterName", tooltip
+                    )
+                    .as_str(),
+                );
             }
         }
     }
 
     for flag in PowerShell::flags(p) {
-        if let Some(data) = flag.get_short() {
-            let tooltip = get_tooltip(flag.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(
-                format!(
-                    "'-{}', '{}', {}, '{}')",
-                    data, data, "[CompletionResultType]::ParameterName", tooltip
-                )
-                .as_str(),
-            );
-
-            if let Some(short_aliases) = flag.get_visible_short_aliases() {
-                for data in short_aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(
-                        format!(
-                            "'-{}', '{}', {}, '{}')",
-                            data, data, "[CompletionResultType]::ParameterName", tooltip
-                        )
-                        .as_str(),
-                    );
-                }
+        if let Some(shorts) = flag.get_short_and_visible_aliases() {
+            let tooltip = get_tooltip(flag.get_about(), shorts[0]);
+            for short in shorts {
+                completions.push_str(&preamble);
+                completions.push_str(
+                    format!(
+                        "'-{}', '{}', {}, '{}')",
+                        short, short, "[CompletionResultType]::ParameterName", tooltip
+                    )
+                    .as_str(),
+                );
             }
         }
 
-        if let Some(data) = flag.get_long() {
-            let tooltip = get_tooltip(flag.get_about(), data);
-
-            completions.push_str(&preamble);
-            completions.push_str(
-                format!(
-                    "'--{}', '{}', {}, '{}')",
-                    data, data, "[CompletionResultType]::ParameterName", tooltip
-                )
-                .as_str(),
-            );
-
-            if let Some(aliases) = flag.get_visible_aliases() {
-                for data in aliases {
-                    completions.push_str(&preamble);
-                    completions.push_str(
-                        format!(
-                            "'--{}', '{}', {}, '{}')",
-                            data, data, "[CompletionResultType]::ParameterName", tooltip
-                        )
-                        .as_str(),
-                    );
-                }
+        if let Some(longs) = flag.get_long_and_visible_aliases() {
+            let tooltip = get_tooltip(flag.get_about(), longs[0]);
+            for long in longs {
+                completions.push_str(&preamble);
+                completions.push_str(
+                    format!(
+                        "'--{}', '{}', {}, '{}')",
+                        long, long, "[CompletionResultType]::ParameterName", tooltip
+                    )
+                    .as_str(),
+                );
             }
         }
     }

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -464,6 +464,22 @@ fn write_opts_of(p: &App, p_global: Option<&App>) -> String {
 
             debug!("write_opts_of:iter: Wrote...{}", &*l);
             ret.push(l);
+
+            if let Some(aliases) = o.get_visible_aliases() {
+                for alias in aliases {
+                    let l = format!(
+                        "'{conflicts}{multiple}--{arg}=[{help}]{value_completion}' \\",
+                        conflicts = conflicts,
+                        multiple = multiple,
+                        arg = alias,
+                        value_completion = vc,
+                        help = help
+                    );
+
+                    debug!("write_opts_of:iter: Wrote...{}", &*l);
+                    ret.push(l);
+                }
+            }
         }
     }
 
@@ -567,6 +583,22 @@ fn write_flags_of(p: &App, p_global: Option<&App>) -> String {
             debug!("write_flags_of:iter: Wrote...{}", &*l);
 
             ret.push(l);
+
+            if let Some(aliases) = f.get_visible_aliases() {
+                for alias in aliases {
+                    let l = format!(
+                        "'{conflicts}{multiple}--{arg}[{help}]' \\",
+                        conflicts = conflicts,
+                        multiple = multiple,
+                        arg = alias,
+                        help = help
+                    );
+
+                    debug!("write_flags_of:iter: Wrote...{}", &*l);
+
+                    ret.push(l);
+                }
+            }
         }
     }
 

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -422,63 +422,34 @@ fn write_opts_of(p: &App, p_global: Option<&App>) -> String {
             None => "".to_string(),
         };
 
-        if let Some(short) = o.get_short() {
-            let s = format!(
-                "'{conflicts}{multiple}-{arg}+[{help}]{value_completion}' \\",
-                conflicts = conflicts,
-                multiple = multiple,
-                arg = short,
-                value_completion = vc,
-                help = help
-            );
+        if let Some(shorts) = o.get_short_and_visible_aliases() {
+            for short in shorts {
+                let s = format!(
+                    "'{conflicts}{multiple}-{arg}+[{help}]{value_completion}' \\",
+                    conflicts = conflicts,
+                    multiple = multiple,
+                    arg = short,
+                    value_completion = vc,
+                    help = help
+                );
 
-            debug!("write_opts_of:iter: Wrote...{}", &*s);
-            ret.push(s);
-
-            if let Some(short_aliases) = o.get_visible_short_aliases() {
-                for alias in short_aliases {
-                    let s = format!(
-                        "'{conflicts}{multiple}-{arg}+[{help}]{value_completion}' \\",
-                        conflicts = conflicts,
-                        multiple = multiple,
-                        arg = alias,
-                        value_completion = vc,
-                        help = help
-                    );
-
-                    debug!("write_opts_of:iter: Wrote...{}", &*s);
-                    ret.push(s);
-                }
+                debug!("write_opts_of:iter: Wrote...{}", &*s);
+                ret.push(s);
             }
         }
+        if let Some(longs) = o.get_long_and_visible_aliases() {
+            for long in longs {
+                let l = format!(
+                    "'{conflicts}{multiple}--{arg}=[{help}]{value_completion}' \\",
+                    conflicts = conflicts,
+                    multiple = multiple,
+                    arg = long,
+                    value_completion = vc,
+                    help = help
+                );
 
-        if let Some(long) = o.get_long() {
-            let l = format!(
-                "'{conflicts}{multiple}--{arg}=[{help}]{value_completion}' \\",
-                conflicts = conflicts,
-                multiple = multiple,
-                arg = long,
-                value_completion = vc,
-                help = help
-            );
-
-            debug!("write_opts_of:iter: Wrote...{}", &*l);
-            ret.push(l);
-
-            if let Some(aliases) = o.get_visible_aliases() {
-                for alias in aliases {
-                    let l = format!(
-                        "'{conflicts}{multiple}--{arg}=[{help}]{value_completion}' \\",
-                        conflicts = conflicts,
-                        multiple = multiple,
-                        arg = alias,
-                        value_completion = vc,
-                        help = help
-                    );
-
-                    debug!("write_opts_of:iter: Wrote...{}", &*l);
-                    ret.push(l);
-                }
+                debug!("write_opts_of:iter: Wrote...{}", &*l);
+                ret.push(l);
             }
         }
     }

--- a/clap_generate/tests/completions/bash.rs
+++ b/clap_generate/tests/completions/bash.rs
@@ -252,3 +252,83 @@ static BASH_SPECIAL_CMDS: &str = r#"_my_app() {
 
 complete -F _my_app -o bashdefault -o default my_app
 "#;
+
+#[test]
+fn bash_with_aliases() {
+    let mut app = build_app_with_aliases();
+    common::<Bash>(&mut app, "cmd", BASH_ALIASES);
+}
+
+fn build_app_with_aliases() -> App<'static> {
+    App::new("cmd")
+        .about("testing bash completions")
+        .arg(
+            Arg::new("flag")
+                .short('f')
+                .visible_short_alias('F')
+                .long("flag")
+                .visible_alias("flg")
+                .about("cmd flag"),
+        )
+        .arg(
+            Arg::new("option")
+                .short('o')
+                .visible_short_alias('O')
+                .long("option")
+                .visible_alias("opt")
+                .about("cmd option")
+                .takes_value(true),
+        )
+        .arg(Arg::new("positional"))
+}
+
+static BASH_ALIASES: &str = r#"_cmd() {
+    local i cur prev opts cmds
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    cmd=""
+    opts=""
+
+    for i in ${COMP_WORDS[@]}
+    do
+        case "${i}" in
+            cmd)
+                cmd="cmd"
+                ;;
+            
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        cmd)
+            opts=" -h -V -F -f -O -o  --help --version --flg --flag --opt --option  <positional> "
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                
+                --option)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                    -o)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        
+    esac
+}
+
+complete -F _cmd -o bashdefault -o default cmd
+"#;

--- a/clap_generate/tests/completions/bash.rs
+++ b/clap_generate/tests/completions/bash.rs
@@ -315,7 +315,15 @@ static BASH_ALIASES: &str = r#"_cmd() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
-                    -o)
+                --opt)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -O)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/clap_generate/tests/completions/fish.rs
+++ b/clap_generate/tests/completions/fish.rs
@@ -121,3 +121,38 @@ complete -c my_app -n "__fish_use_subcommand" -l backslash -d 'Avoid \'\\n\''
 complete -c my_app -n "__fish_use_subcommand" -l brackets -d 'List packages [filter]'
 complete -c my_app -n "__fish_use_subcommand" -l expansions -d 'Execute the shell command with $SHELL'
 "#;
+
+#[test]
+fn fish_with_aliases() {
+    let mut app = build_app_with_aliases();
+    common::<Fish>(&mut app, "cmd", FISH_ALIASES);
+}
+
+fn build_app_with_aliases() -> App<'static> {
+    App::new("cmd")
+        .about("testing bash completions")
+        .arg(
+            Arg::new("flag")
+                .short('f')
+                .visible_short_alias('F')
+                .long("flag")
+                .visible_alias("flg")
+                .about("cmd flag"),
+        )
+        .arg(
+            Arg::new("option")
+                .short('o')
+                .visible_short_alias('O')
+                .long("option")
+                .visible_alias("opt")
+                .about("cmd option")
+                .takes_value(true),
+        )
+        .arg(Arg::new("positional"))
+}
+
+static FISH_ALIASES: &str = r#"complete -c cmd -n "__fish_use_subcommand" -s o -s O -l option -l opt -d 'cmd option' -r
+complete -c cmd -n "__fish_use_subcommand" -s h -l help -d 'Prints help information'
+complete -c cmd -n "__fish_use_subcommand" -s V -l version -d 'Prints version information'
+complete -c cmd -n "__fish_use_subcommand" -s f -s F -l flag -l flg -d 'cmd flag'
+"#;

--- a/clap_generate/tests/completions/powershell.rs
+++ b/clap_generate/tests/completions/powershell.rs
@@ -12,6 +12,14 @@ fn build_app_with_name(s: &'static str) -> App<'static> {
                 .value_hint(ValueHint::FilePath)
                 .about("some input file"),
         )
+        .arg(
+            Arg::new("config")
+                .about("some config file")
+                .short('c')
+                .visible_short_alias('C')
+                .long("config")
+                .visible_alias("conf"),
+        )
         .subcommand(
             App::new("test").about("tests things").arg(
                 Arg::new("case")
@@ -54,6 +62,10 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'some config file')
+            [CompletionResult]::new('-C', 'C', [CompletionResultType]::ParameterName, 'some config file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'some config file')
+            [CompletionResult]::new('--conf', 'conf', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('test', 'test', [CompletionResultType]::ParameterValue, 'tests things')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Prints this message or the help of the given subcommand(s)')
             break
@@ -125,6 +137,10 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'some config file')
+            [CompletionResult]::new('-C', 'C', [CompletionResultType]::ParameterName, 'some config file')
+            [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'some config file')
+            [CompletionResult]::new('--conf', 'conf', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('test', 'test', [CompletionResultType]::ParameterValue, 'tests things')
             [CompletionResult]::new('some_cmd', 'some_cmd', [CompletionResultType]::ParameterValue, 'tests other things')
             [CompletionResult]::new('some-cmd-with-hypens', 'some-cmd-with-hypens', [CompletionResultType]::ParameterValue, 'some-cmd-with-hypens')
@@ -159,6 +175,78 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            break
+        }
+    })
+
+    $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
+        Sort-Object -Property ListItemText
+}
+"#;
+
+#[test]
+fn powershell_with_aliases() {
+    let mut app = build_app_with_aliases();
+    common::<PowerShell>(&mut app, "cmd", POWERSHELL_ALIASES);
+}
+
+fn build_app_with_aliases() -> App<'static> {
+    App::new("cmd")
+        .about("testing bash completions")
+        .arg(
+            Arg::new("flag")
+                .short('f')
+                .visible_short_alias('F')
+                .long("flag")
+                .visible_alias("flg")
+                .about("cmd flag"),
+        )
+        .arg(
+            Arg::new("option")
+                .short('o')
+                .visible_short_alias('O')
+                .long("option")
+                .visible_alias("opt")
+                .about("cmd option")
+                .takes_value(true),
+        )
+        .arg(Arg::new("positional"))
+}
+
+static POWERSHELL_ALIASES: &str = r#"
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+
+Register-ArgumentCompleter -Native -CommandName 'cmd' -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+
+    $commandElements = $commandAst.CommandElements
+    $command = @(
+        'cmd'
+        for ($i = 1; $i -lt $commandElements.Count; $i++) {
+            $element = $commandElements[$i]
+            if ($element -isnot [StringConstantExpressionAst] -or
+                $element.StringConstantType -ne [StringConstantType]::BareWord -or
+                $element.Value.StartsWith('-')) {
+                break
+        }
+        $element.Value
+    }) -join ';'
+
+    $completions = @(switch ($command) {
+        'cmd' {
+            [CompletionResult]::new('-o', 'o', [CompletionResultType]::ParameterName, 'cmd option')
+            [CompletionResult]::new('-O', 'O', [CompletionResultType]::ParameterName, 'cmd option')
+            [CompletionResult]::new('--option', 'option', [CompletionResultType]::ParameterName, 'cmd option')
+            [CompletionResult]::new('--opt', 'opt', [CompletionResultType]::ParameterName, 'cmd option')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'cmd flag')
+            [CompletionResult]::new('-F', 'F', [CompletionResultType]::ParameterName, 'cmd flag')
+            [CompletionResult]::new('--flag', 'flag', [CompletionResultType]::ParameterName, 'cmd flag')
+            [CompletionResult]::new('--flg', 'flg', [CompletionResultType]::ParameterName, 'cmd flag')
             break
         }
     })

--- a/clap_generate/tests/completions/zsh.rs
+++ b/clap_generate/tests/completions/zsh.rs
@@ -422,3 +422,74 @@ _my_app__second__third_commands() {
 }
 
 _my_app "$@""#;
+
+#[test]
+fn zsh_with_aliases() {
+    let mut app = build_app_with_aliases();
+    common::<Zsh>(&mut app, "cmd", ZSH_ALIASES);
+}
+
+fn build_app_with_aliases() -> App<'static> {
+    App::new("cmd")
+        .about("testing bash completions")
+        .arg(
+            Arg::new("flag")
+                .short('f')
+                .visible_short_alias('F')
+                .long("flag")
+                .visible_alias("flg")
+                .about("cmd flag"),
+        )
+        .arg(
+            Arg::new("option")
+                .short('o')
+                .visible_short_alias('O')
+                .long("option")
+                .visible_alias("opt")
+                .about("cmd option")
+                .takes_value(true),
+        )
+        .arg(Arg::new("positional"))
+}
+
+static ZSH_ALIASES: &str = r#"#compdef cmd
+
+autoload -U is-at-least
+
+_cmd() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" \
+'-o+[cmd option]' \
+'-O+[cmd option]' \
+'--option=[cmd option]' \
+'--opt=[cmd option]' \
+'-h[Prints help information]' \
+'--help[Prints help information]' \
+'-V[Prints version information]' \
+'--version[Prints version information]' \
+'-f[cmd flag]' \
+'-F[cmd flag]' \
+'--flag[cmd flag]' \
+'--flg[cmd flag]' \
+'::positional:' \
+&& ret=0
+    
+}
+
+(( $+functions[_cmd_commands] )) ||
+_cmd_commands() {
+    local commands; commands=()
+    _describe -t commands 'cmd commands' commands "$@"
+}
+
+_cmd "$@""#;

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -160,6 +160,19 @@ impl<'help> Arg<'help> {
         }
     }
 
+    /// Get the short option name and its visible aliases, if any
+    #[inline]
+    pub fn get_short_and_visible_aliases(&self) -> Option<Vec<char>> {
+        let mut shorts = match self.short {
+            Some(short) => vec![short],
+            None => return None,
+        };
+        if let Some(aliases) = self.get_visible_short_aliases() {
+            shorts.extend(aliases);
+        }
+        Some(shorts)
+    }
+
     /// Get the long option name for this argument, if any
     #[inline]
     pub fn get_long(&self) -> Option<&str> {
@@ -180,6 +193,19 @@ impl<'help> Arg<'help> {
                     .collect(),
             )
         }
+    }
+
+    /// Get the long option name and its visible aliases, if any
+    #[inline]
+    pub fn get_long_and_visible_aliases(&self) -> Option<Vec<&str>> {
+        let mut longs = match self.long {
+            Some(long) => vec![long],
+            None => return None,
+        };
+        if let Some(aliases) = self.get_visible_aliases() {
+            longs.extend(aliases);
+        }
+        Some(longs)
     }
 
     /// Get the list of the possible values for this argument, if any

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -166,6 +166,22 @@ impl<'help> Arg<'help> {
         self.long
     }
 
+    /// Get visible aliases for this argument, if any
+    #[inline]
+    pub fn get_visible_aliases(&self) -> Option<Vec<&str>> {
+        if self.aliases.is_empty() {
+            None
+        } else {
+            Some(
+                self.aliases
+                    .iter()
+                    .filter_map(|(s, v)| if *v { Some(s) } else { None })
+                    .copied()
+                    .collect(),
+            )
+        }
+    }
+
     /// Get the list of the possible values for this argument, if any
     #[inline]
     pub fn get_possible_values(&self) -> Option<&[&str]> {


### PR DESCRIPTION
Closes #2335 

# Summary

This pull request implements completion for long visible aliases added with `App::visible_alias` or `App::visible_aliases`.

# Examples

```rust
use clap::App;
use clap::Arg;
use clap_generate::generate;
use clap_generate::generators::Bash;

fn main() {
    let mut app = App::new("foo")
        .arg(
            Arg::new("bar")
                .short('b')
                .visible_short_alias('q')
                .long("bar")
                .visible_alias("qux"),
        );
    generate::<Bash, _>(&mut app, "foo", &mut std::io::stdout());
}
```

With version `3.0.0-beta.2` generated completions are:
```
❯ cargo run --quiet > completions.bash && source completions.bash
❯ foo --
--bar      --help     --version
```

With this PR generated completions are: 
```
❯ cargo run --quiet > completions.bash && source completions.bash
❯ foo --
--bar      --help     --qux      --version
```

Note that visible alias `qux` is now available for completions.

# Feedback request

I am new to clap source code can you please review my changes?

Thanks!

