### PR TITLE
Change how num_vals, min_vals, max_vals interacts with Multiple*

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -1867,7 +1867,7 @@ impl<'help> Arg<'help> {
     #[inline]
     pub fn number_of_values(mut self, qty: usize) -> Self {
         self.num_vals = Some(qty);
-        self.takes_value(true)
+        self.takes_value(true).multiple_values(true)
     }
 
     /// Allows one to perform a custom validation on the argument value. You provide a closure
@@ -2152,7 +2152,7 @@ impl<'help> Arg<'help> {
     #[inline]
     pub fn min_values(mut self, qty: usize) -> Self {
         self.min_vals = Some(qty);
-        self.takes_value(true)
+        self.takes_value(true).multiple_values(true)
     }
 
     /// Specifies the separator to use when values are clumped together, defaults to `,` (comma).
@@ -4347,15 +4347,10 @@ impl<'help> Arg<'help> {
         {
             self.val_delim = Some(',');
         }
-        if self.index.is_some() || (self.short.is_none() && self.long.is_none()) {
-            if self.max_vals.is_some()
-                || self.min_vals.is_some()
-                || (self.num_vals.is_some() && self.num_vals.unwrap() > 1)
-            {
-                self.settings.set(ArgSettings::MultipleValues);
-                self.settings.set(ArgSettings::MultipleOccurrences);
-            }
-        } else if self.is_set(ArgSettings::TakesValue) && self.val_names.len() > 1 {
+        if !(self.index.is_some() || (self.short.is_none() && self.long.is_none()))
+            && self.is_set(ArgSettings::TakesValue)
+            && self.val_names.len() > 1
+        {
             self.num_vals = Some(self.val_names.len());
         }
     }

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -165,10 +165,10 @@ impl ArgMatcher {
     pub(crate) fn needs_more_vals(&self, o: &Arg) -> bool {
         debug!("ArgMatcher::needs_more_vals: o={}", o.name);
         if let Some(ma) = self.get(&o.id) {
-            let current_num = ma.num_vals_last_group();
+            let current_num = ma.num_vals();
             if let Some(num) = o.num_vals {
                 debug!("ArgMatcher::needs_more_vals: num_vals...{}", num);
-                return if o.is_set(ArgSettings::MultipleValues) {
+                return if o.is_set(ArgSettings::MultipleOccurrences) {
                     (current_num % num) != 0
                 } else {
                     num != current_num

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -81,6 +81,8 @@ impl MatchedArg {
         self.vals.iter().flatten().count()
     }
 
+    // Will be used later
+    #[allow(dead_code)]
     pub(crate) fn num_vals_last_group(&self) -> usize {
         self.vals.last().map(|x| x.len()).unwrap_or(0)
     }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -348,11 +348,8 @@ impl<'help, 'app> Parser<'help, 'app> {
 
             // Has the user already passed '--'? Meaning only positional args follow
             if !self.is_set(AS::TrailingValues) {
-                let can_be_subcommand = if self.is_set(AS::SubcommandPrecedenceOverArg) {
-                    true
-                } else {
-                    !matches!(needs_val_of, ParseResult::Opt(_) | ParseResult::Pos(_))
-                };
+                let can_be_subcommand = self.is_set(AS::SubcommandPrecedenceOverArg)
+                    || !matches!(needs_val_of, ParseResult::Opt(_) | ParseResult::Pos(_));
 
                 if can_be_subcommand {
                     // Does the arg match a subcommand name, or any of its aliases (if defined)
@@ -1498,6 +1495,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         Ok(())
     }
 
+    /// Increase occurrence of specific argument and the grouped arg it's in.
     fn inc_occurrence_of_arg(&self, matcher: &mut ArgMatcher, arg: &Arg<'help>) {
         matcher.inc_occurrence_of(&arg.id);
         // Increment or create the group "args"

--- a/tests/grouped_values.rs
+++ b/tests/grouped_values.rs
@@ -153,18 +153,19 @@ fn issue_1374() {
             .takes_value(true)
             .long("input")
             .overrides_with("input")
-            .min_values(0),
+            .min_values(0)
+            .multiple_occurrences(true),
     );
     let matches = app
         .clone()
         .get_matches_from(&["MyApp", "--input", "a", "b", "c", "--input", "d"]);
     let vs = matches.values_of("input").unwrap();
-    assert_eq!(vs.collect::<Vec<_>>(), vec!["d"]);
+    assert_eq!(vs.collect::<Vec<_>>(), vec!["a", "b", "c", "d"]);
     let matches = app
         .clone()
         .get_matches_from(&["MyApp", "--input", "a", "b", "--input", "c", "d"]);
     let vs = matches.values_of("input").unwrap();
-    assert_eq!(vs.collect::<Vec<_>>(), vec!["c", "d"]);
+    assert_eq!(vs.collect::<Vec<_>>(), vec!["a", "b", "c", "d"]);
 }
 
 #[test]

--- a/tests/multiple_values.rs
+++ b/tests/multiple_values.rs
@@ -1192,3 +1192,19 @@ fn issue_1480_max_values_consumes_extra_arg_3() {
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
 }
+
+#[test]
+fn issue_2229() {
+    let m = App::new("multiple_values")
+        .arg(
+            Arg::new("pos")
+                .about("multiple positionals")
+                .number_of_values(3),
+        )
+        .try_get_matches_from(vec![
+            "myprog", "val1", "val2", "val3", "val4", "val5", "val6",
+        ]);
+
+    assert!(m.is_err()); // This panics, because `m.is_err() == false`.
+    assert_eq!(m.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+}


### PR DESCRIPTION
Fixes #2229 Fixes #1374

Let `num_vals` and etc sets `MultipleValues` with `MultipleOccurrences` left untouched, which also removes a late setting hack.