### PR TITLE
Fix issue #2181

### DIFF
--- a/clap_derive/src/derives/clap.rs
+++ b/clap_derive/src/derives/clap.rs
@@ -68,7 +68,7 @@ fn gen_for_struct(
 }
 
 fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStream {
-    let into_app = into_app::gen_for_enum(name);
+    let into_app = into_app::gen_for_enum(name, attrs);
     let from_arg_matches = from_arg_matches::gen_for_enum(name);
     let subcommand = subcommand::gen_for_enum(name, attrs, e);
     let arg_enum = arg_enum::gen_for_enum(name, attrs, e);

--- a/clap_derive/tests/app_name.rs
+++ b/clap_derive/tests/app_name.rs
@@ -1,0 +1,97 @@
+use clap::Clap;
+use clap::IntoApp;
+#[test]
+fn app_name_in_short_help_from_struct() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    struct MyApp {}
+
+    let mut help = Vec::new();
+    MyApp::into_app().write_help(&mut help).unwrap();
+    let help = String::from_utf8(help).unwrap();
+
+    assert!(help.contains("my-app"));
+}
+
+#[test]
+fn app_name_in_long_help_from_struct() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    struct MyApp {}
+
+    let mut help = Vec::new();
+    MyApp::into_app().write_long_help(&mut help).unwrap();
+    let help = String::from_utf8(help).unwrap();
+
+    assert!(help.contains("my-app"));
+}
+
+#[test]
+fn app_name_in_short_help_from_enum() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    enum MyApp {}
+
+    let mut help = Vec::new();
+    MyApp::into_app().write_help(&mut help).unwrap();
+    let help = String::from_utf8(help).unwrap();
+
+    assert!(help.contains("my-app"));
+}
+
+#[test]
+fn app_name_in_long_help_from_enum() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    enum MyApp {}
+
+    let mut help = Vec::new();
+    MyApp::into_app().write_long_help(&mut help).unwrap();
+    let help = String::from_utf8(help).unwrap();
+
+    assert!(help.contains("my-app"));
+}
+
+#[test]
+fn app_name_in_short_version_from_struct() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    struct MyApp {}
+
+    let version = MyApp::into_app().render_version();
+
+    assert!(version.contains("my-app"));
+}
+
+#[test]
+fn app_name_in_long_version_from_struct() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    struct MyApp {}
+
+    let version = MyApp::into_app().render_long_version();
+
+    assert!(version.contains("my-app"));
+}
+
+#[test]
+fn app_name_in_short_version_from_enum() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    enum MyApp {}
+
+    let version = MyApp::into_app().render_version();
+
+    assert!(version.contains("my-app"));
+}
+
+#[test]
+fn app_name_in_long_version_from_enum() {
+    #[derive(Clap)]
+    #[clap(name = "my-app")]
+    enum MyApp {}
+
+    let version = MyApp::into_app().render_long_version();
+
+    assert!(version.contains("my-app"));
+}


### PR DESCRIPTION
Closes #2181 

# Summary 

This PR propose a fix for issue #2181.

# Issue/Examples

Example application source code: 

```
❯ tree clap_issue_2181/
clap_issue_2181/
├── Cargo.lock
├── Cargo.toml
└── src
    └── main.rs

1 directory, 3 files
```

`main.rs` source file: 

```rust
use clap::Clap;

#[derive(Clap)]
#[clap(name = "my-bin", version = clap::crate_version!())]
enum Opts {}

fn main() {
    Opts::parse();
}
```

With beta version:

```
❯ cargo run --quiet -- -V
clap_issue_2181 0.1.0

❯ cargo run --quiet -- --version
clap_issue_2181 0.1.0

❯ cargo run --quiet -- --help
clap_issue_2181 0.1.0

USAGE:
    clap_issue_2181

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

❯ cargo run --quiet -- -h
clap_issue_2181 0.1.0

USAGE:
    clap_issue_2181

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
```

Note application name in version string and help string (`clap_issue_2181` instead of `my-bin`).

With this PR:
```
❯ cargo run --quiet -- -V
my-bin 0.1.0

❯ cargo run --quiet -- --version
my-bin 0.1.0

❯ cargo run --quiet -- --help
my-bin 0.1.0

USAGE:
    clap_issue_2181

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

❯ cargo run --quiet -- -h
my-bin 0.1.0

USAGE:
    clap_issue_2181

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
```

# Solution

The current implementation matches the expected behavior when `#[derive(Clap)]` is used on structs. This PR just ports `struct` solution to `enum` and add unit tests for testing this behavior.