### PR TITLE
fix: Compatibility with help2man

### DIFF
--- a/clap_derive/tests/doc-comments-help.rs
+++ b/clap_derive/tests/doc-comments-help.rs
@@ -60,7 +60,7 @@ fn empty_line_in_doc_comment_is_double_linefeed() {
     struct LoremIpsum {}
 
     let help = get_long_help::<LoremIpsum>();
-    assert!(help.starts_with("lorem-ipsum \nFoo.\n\nBar\n\nUSAGE:"));
+    assert!(help.starts_with("lorem-ipsum \n\nFoo.\n\nBar\n\nUSAGE:"));
 }
 
 #[test]

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -847,9 +847,11 @@ impl<'help> App<'help> {
     ///   * `{version}`             - Version number.
     ///   * `{author}`              - Author information.
     ///   * `{author-with-newline}` - Author followed by `\n`.
+    ///   * `{author-section}`      - Author preceded and followed by `\n`.
     ///   * `{about}`               - General description (from [`App::about`] or
     ///                               [`App::long_about`]).
     ///   * `{about-with-newline}`  - About followed by `\n`.
+    ///   * `{about-section}`       - About preceded and followed by '\n'.
     ///   * `{usage-heading}`       - Automatically generated usage heading.
     ///   * `{usage}`               - Automatically generated or given usage string.
     ///   * `{all-args}`            - Help for all arguments (options, flags, positional

--- a/tests/app_from_crate.rs
+++ b/tests/app_from_crate.rs
@@ -1,7 +1,9 @@
 use clap::{app_from_crate, ErrorKind};
 
 static EVERYTHING: &str = "clap {{version}}
+
 Kevin K. <kbknapp@gmail.com>:Clap Maintainers
+
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -38,7 +38,9 @@ OPTIONS:
     -o, --opt=<FILE>    some";
 
 static UNIFIED_HELP: &str = "test 1.3
+
 Kevin K.
+
 tests stuff
 
 USAGE:
@@ -54,7 +56,9 @@ OPTIONS:
     -V, --version         Prints version information";
 
 static SKIP_POS_VALS: &str = "test 1.3
+
 Kevin K.
+
 tests stuff
 
 USAGE:

--- a/tests/arg_aliases.rs
+++ b/tests/arg_aliases.rs
@@ -3,6 +3,7 @@ mod utils;
 use clap::{App, Arg};
 
 static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+
 Some help
 
 USAGE:
@@ -17,6 +18,7 @@ OPTIONS:
     -o, --opt <opt>    [aliases: visible]";
 
 static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+
 Some help
 
 USAGE:

--- a/tests/arg_aliases_short.rs
+++ b/tests/arg_aliases_short.rs
@@ -3,6 +3,7 @@ mod utils;
 use clap::{App, Arg};
 
 static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+
 Some help
 
 USAGE:
@@ -17,6 +18,7 @@ OPTIONS:
     -o, --opt <opt>    [short aliases: v]";
 
 static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+
 Some help
 
 USAGE:

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -1,6 +1,7 @@
 use clap::{crate_authors, crate_description, crate_name, crate_version, App, ErrorKind};
 
 static DESCRIPTION_ONLY: &str = "prog 1
+
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -12,6 +13,7 @@ FLAGS:
 ";
 
 static AUTHORS_ONLY: &str = "prog 1
+
 Kevin K. <kbknapp@gmail.com>:Clap Maintainers
 
 USAGE:

--- a/tests/flag_subcommands.rs
+++ b/tests/flag_subcommands.rs
@@ -408,6 +408,7 @@ fn flag_subcommand_long_infer_exact_match() {
 }
 
 static FLAG_SUBCOMMAND_HELP: &str = "pacman-query 
+
 Query the package database.
 
 USAGE:
@@ -462,6 +463,7 @@ fn flag_subcommand_long_short_normal_usage_string() {
 }
 
 static FLAG_SUBCOMMAND_NO_SHORT_HELP: &str = "pacman-query 
+
 Query the package database.
 
 USAGE:
@@ -515,6 +517,7 @@ fn flag_subcommand_long_normal_usage_string() {
 }
 
 static FLAG_SUBCOMMAND_NO_LONG_HELP: &str = "pacman-query 
+
 Query the package database.
 
 USAGE:

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -3,7 +3,9 @@ mod utils;
 use clap::{clap_app, App, AppSettings, Arg, ArgGroup, ArgSettings, ErrorKind};
 
 static REQUIRE_DELIM_HELP: &str = "test 1.3
+
 Kevin K.
+
 tests stuff
 
 USAGE:
@@ -17,7 +19,9 @@ OPTIONS:
     -f, --fake <some>:<val>    some help";
 
 static HELP: &str = "clap-test v1.4.8
+
 Kevin K. <kbknapp@gmail.com>
+
 tests clap library
 
 USAGE:
@@ -91,6 +95,7 @@ SUBCOMMANDS:
 static AFTER_HELP: &str = "some text that comes before the help
 
 clap-test v1.4.8
+
 tests clap library
 
 USAGE:
@@ -105,6 +110,7 @@ some text that comes after the help";
 static AFTER_LONG_HELP: &str = "some longer text that comes before the help
 
 clap-test v1.4.8
+
 tests clap library
 
 USAGE:
@@ -133,7 +139,9 @@ OPTIONS:
     -o, --opt <FILE>    tests options";
 
 static SC_HELP: &str = "clap-test-subcmd 0.1
+
 Kevin K. <kbknapp@gmail.com>
+
 tests subcommands
 
 USAGE:
@@ -194,7 +202,9 @@ FLAGS:
     -V, --version    Prints version information";
 
 static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
+
 Kevin K. <kbknapp@gmail.com>
+
 tests subcommands
 
 USAGE:
@@ -317,7 +327,9 @@ OPTIONS:
                              Gaussian, Lanczos3]";
 
 static ISSUE_702: &str = "myapp 1.0
+
 foo
+
 bar
 
 USAGE:
@@ -338,8 +350,10 @@ OPTIONS:
 
 static ISSUE_777: &str = "A app with a crazy very long long
 long name hahaha 1.0
+
 Some Very Long Name and crazy long
 email <email@server.com>
+
 Show how the about text is not
 wrapped
 
@@ -514,7 +528,9 @@ FLAGS:
     -V, --version    Prints version information";
 
 static LONG_ABOUT: &str = "myapp 1.0
+
 foo
+
 something really really long, with
 multiple lines of text
 that should be displayed
@@ -584,7 +600,9 @@ OPTIONS:
     -p, --pos <VAL>      Some vals [possible values: fast, slow]";
 
 static CUSTOM_HELP_SECTION: &str = "blorp 1.4
+
 Will M.
+
 does stuff
 
 USAGE:
@@ -1806,7 +1824,9 @@ fn custom_headers_headers() {
 }
 
 static MULTIPLE_CUSTOM_HELP_SECTIONS: &str = "blorp 1.4
+
 Will M.
+
 does stuff
 
 USAGE:
@@ -1884,6 +1904,7 @@ fn multiple_custom_help_headers() {
 }
 
 static ISSUE_897: &str = "ctest-foo 0.1
+
 Long about foo
 
 USAGE:
@@ -1913,6 +1934,7 @@ fn show_long_about_issue_897() {
 }
 
 static ISSUE_897_SHORT: &str = "ctest-foo 0.1
+
 About foo
 
 USAGE:

--- a/tests/hidden_args.rs
+++ b/tests/hidden_args.rs
@@ -3,7 +3,9 @@ mod utils;
 use clap::{App, AppSettings, Arg};
 
 static HIDDEN_ARGS: &str = "test 1.4
+
 Kevin K.
+
 tests stuff
 
 USAGE:
@@ -38,7 +40,9 @@ fn hidden_args() {
 }
 
 static HIDDEN_SHORT_ARGS: &str = "test 2.31.2
+
 Steve P.
+
 hides short args
 
 USAGE:
@@ -50,7 +54,9 @@ FLAGS:
     -V, --version    Prints version information";
 
 static HIDDEN_SHORT_ARGS_LONG_HELP: &str = "test 2.31.2
+
 Steve P.
+
 hides short args
 
 USAGE:
@@ -124,7 +130,9 @@ fn hidden_short_args_long_help() {
 }
 
 static HIDDEN_LONG_ARGS: &str = "test 2.31.2
+
 Steve P.
+
 hides long args
 
 USAGE:
@@ -167,7 +175,9 @@ fn hidden_long_args() {
 }
 
 static HIDDEN_LONG_ARGS_SHORT_HELP: &str = "test 2.31.2
+
 Steve P.
+
 hides long args
 
 USAGE:

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -12,6 +12,7 @@ fn version_short() {
         .author("Kevin K.")
         .about("tests stuff")
         .version("1.3")
+        .long_version("1.3 (abcdef12)")
         .try_get_matches_from(vec!["myprog", "-V"]);
 
     assert!(m.is_err());
@@ -26,12 +27,13 @@ fn version_long() {
         .author("Kevin K.")
         .about("tests stuff")
         .version("1.3")
+        .long_version("1.3 (abcdef12)")
         .try_get_matches_from(vec!["myprog", "--version"]);
 
     assert!(m.is_err());
     let err = m.unwrap_err();
     assert_eq!(err.kind, ErrorKind::DisplayVersion);
-    assert_eq!(err.to_string(), "test 1.3\n");
+    assert_eq!(err.to_string(), "test 1.3 (abcdef12)\n");
 }
 
 #[test]


### PR DESCRIPTION
Fix compatibility with help2man output (see #1432)

- Change default help template:
  The new template introduce new lines before and after
  author/about sections.
- Add help template placeholders:
  - `about-section`
  - `author-section`
- Documentation of new placeholders in `clap::App::help_template`
- Update all unit tests by incorporating new lines

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Closes #1432

# Issue

When [help2man](https://www.gnu.org/software/help2man/) parses standard clap help template, the generated man page unwraps `{binary_name} {version} {author} {about}` placeholders.

## Source code

```
❯ tree clap_issue_1432
clap_issue_1432
├── Cargo.lock
├── Cargo.toml
├── src
|   └── main.rs
└── test.man

1 directory, 4 files
```

The `main.rs` source file:

```rust
use clap::App;
use clap::AppSettings;
use clap::Arg;

fn main() {
    let app = App::new("command")
        .author("command author")
        .version("1.2.3")
        .about("command about")
        .setting(AppSettings::DisableHelpSubcommand)
        .arg(
            Arg::new("flag")
                .about("command flag")
                .short('f')
                .long("flag"),
        )
        .arg(
            Arg::new("option")
                .about("command option")
                .short('o')
                .long("option")
                .takes_value(true),
        )
        .arg(
            Arg::new("positional")
                .about("command positional")
                .takes_value(true),
        )
        .subcommand(
            App::new("subcommand")
            .about("subcommand")
        );
    app.get_matches();
}
```

## With version `3.0.0-beta.2`

```
❯ cargo run --quiet -- --help
command 1.2.3
command author
command about

USAGE:
    clap_issue_1432 [FLAGS] [OPTIONS] [positional] [SUBCOMMAND]

ARGS:
    <positional>    command positional

FLAGS:
    -f, --flag       command flag
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -o, --option <option>    command option

SUBCOMMANDS:
    subcommand    subcommand

❯ cargo run --quiet -- --version
command 1.2.3

❯ help2man -N 'cargo run --' > test.man

❯ cat test.man
.\" DO NOT MODIFY THIS FILE!  It was generated by help2man 1.48.1.
.TH COMMAND "1" "February 2021" "command 1.2.3" "User Commands"
.SH NAME
command \- manual page for command 1.2.3
.SH DESCRIPTION
command 1.2.3
command author
command about
.SS "USAGE:"
.IP
clap_issue_1432 [FLAGS] [OPTIONS] [positional] [SUBCOMMAND]
.SS "ARGS:"
.TP
<positional>
command positional
.SS "FLAGS:"
.TP
\fB\-f\fR, \fB\-\-flag\fR
command flag
.TP
\fB\-h\fR, \fB\-\-help\fR
Prints help information
.TP
\fB\-V\fR, \fB\-\-version\fR
Prints version information
.SS "OPTIONS:"
.TP
\fB\-o\fR, \fB\-\-option\fR <option>
command option
.SS "SUBCOMMANDS:"
.TP
subcommand
subcommand

❯ man ./test.man
```

The man page:

```
COMMAND(1)                                                                           User Commands                                                                           COMMAND(1)

NAME
       command - manual page for command 1.2.3

DESCRIPTION
       command 1.2.3 command author command about

   USAGE:
              clap_issue_1432 [FLAGS] [OPTIONS] [positional] [SUBCOMMAND]

   ARGS:
       <positional>
              command positional

   FLAGS:
       -f, --flag
              command flag

       -h, --help
              Prints help information

       -V, --version
              Prints version information

   OPTIONS:
       -o, --option <option>
              command option

   SUBCOMMANDS:
       subcommand
              subcommand

command 1.2.3                                                                        February 2021                                                                           COMMAND(1)
```

Note the description in the man page.

## With this pull request

```
❯ cargo run --quiet -- --help
command 1.2.3

command author

command about

USAGE:
    clap_issue_1432 [FLAGS] [OPTIONS] [positional] [SUBCOMMAND]

ARGS:
    <positional>    command positional

FLAGS:
    -f, --flag       command flag
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -o, --option <option>    command option

SUBCOMMANDS:
    subcommand    subcommand

❯ cargo run --quiet -- --version
command 1.2.3

❯ help2man -N 'cargo run --' > test.man

❯ cat test.man
.\" DO NOT MODIFY THIS FILE!  It was generated by help2man 1.48.1.
.TH COMMAND "1" "February 2021" "command 1.2.3" "User Commands"
.SH NAME
command \- manual page for command 1.2.3
.SH DESCRIPTION
command 1.2.3
.PP
command author
.PP
command about
.SS "USAGE:"
.IP
clap_issue_1432 [FLAGS] [OPTIONS] [positional] [SUBCOMMAND]
.SS "ARGS:"
.TP
<positional>
command positional
.SS "FLAGS:"
.TP
\fB\-f\fR, \fB\-\-flag\fR
command flag
.TP
\fB\-h\fR, \fB\-\-help\fR
Prints help information
.TP
\fB\-V\fR, \fB\-\-version\fR
Prints version information
.SS "OPTIONS:"
.TP
\fB\-o\fR, \fB\-\-option\fR <option>
command option
.SS "SUBCOMMANDS:"
.TP
subcommand
subcommand

❯ man ./test.man
```

The man page: 

```
COMMAND(1)                                                                           User Commands                                                                           COMMAND(1)

NAME
       command - manual page for command 1.2.3

DESCRIPTION
       command 1.2.3

       command author

       command about

   USAGE:
              clap_issue_1432 [FLAGS] [OPTIONS] [positional] [SUBCOMMAND]

   ARGS:
       <positional>
              command positional

   FLAGS:
       -f, --flag
              command flag

       -h, --help
              Prints help information

       -V, --version
              Prints version information

   OPTIONS:
       -o, --option <option>
              command option

   SUBCOMMANDS:
       subcommand
              subcommand

command 1.2.3                                                                        February 2021                                                                           COMMAND(1)
```

Note:
- new lines appeared in `--help` output and it is the same for `-h` flag
- `version` output is unchanged
- the generated man page output include paragraph separators between command version, command authors and command about (`.PP`)
- the generated man page is correctly formatted

# Solution

Following changes were included in this pull request:

- Change default template:

from:
```
{before-help}{bin} {version}\n\
{author-with-newline}{about-with-newline}\n\
{usage-heading}\n    {usage}\n\
\n\
{all-args}{after-help}\
```

to 
```
{before-help}{bin} {version}\n\
{author-section}\
{about-section}\n\
{usage-heading}\n    {usage}\n\
\n\
{all-args}{after-help}\
```

- Following help template placeholders were added and documented during development:
  - `{author-section}`
  - `{about-section}`
 
- All unit tests relying on `--help` format were edited to include new lines.

