### PR TITLE
Preserve newlines in Doc comments #2389

### DIFF
--- a/clap_derive/src/utils/doc_comments.rs
+++ b/clap_derive/src/utils/doc_comments.rs
@@ -100,5 +100,9 @@ fn is_blank(s: &str) -> bool {
 }
 
 fn merge_lines(lines: &[&str]) -> String {
-    lines.iter().map(|s| s.trim()).collect::<Vec<_>>().join(" ")
+    lines
+        .iter()
+        .map(|s| s.trim())
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/clap_derive/tests/doc-comments-help.rs
+++ b/clap_derive/tests/doc-comments-help.rs
@@ -30,7 +30,8 @@ fn doc_comments() {
 
     let help = get_long_help::<LoremIpsum>();
     assert!(help.contains("Lorem ipsum"));
-    assert!(help.contains("Fooify a bar and a baz"));
+    assert!(help.contains("Fooify a bar"));
+    assert!(help.contains("and a baz"));
 }
 
 #[test]


### PR DESCRIPTION
Hello,

I am no expert. But isn't this already the fix you'd like to have to close #2389 ?

If i run your example code 
```
cargo run -- --help
```
I get the following output:
```
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/playground --help`
xh 

USAGE:
    playground [REQUEST_ITEM]...

ARGS:
    <REQUEST_ITEM>...
            Optional key-value pairs to be included in the request.
            
            - key:=value to add a complex JSON value (e.g. `numbers:=[1,2,3]`)
            - key@filename to upload a file from filename (with --form)
            - header:value to add a header
            - header: to unset a header
            - header; to add a header with an empty value
            
            A backslash can be used to escape special characters (e.g. weird\:key=value).

FLAGS:
    -h, --help
            Prints help information

    -V, --version
            Prints version information
```