### PR TITLE
api: Add clap_generate::Shell enum

### DIFF
--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -28,6 +28,8 @@ mod macros;
 
 /// Contains some popular generators
 pub mod generators;
+/// Contains supported shells for auto-completion scripts
+pub mod shell;
 
 use std::ffi::OsString;
 use std::fs::File;
@@ -36,21 +38,8 @@ use std::path::PathBuf;
 
 #[doc(inline)]
 pub use generators::Generator;
-
-/// Shell with auto-generated completion script available.
-#[non_exhaustive]
-pub enum Shell {
-    /// Bash shell
-    Bash,
-    /// Elvish shell
-    Elvish,
-    /// Fish shell
-    Fish,
-    /// PowerShell
-    PowerShell,
-    /// Zsh shell
-    Zsh,
-}
+#[doc(inline)]
+pub use shell::Shell;
 
 /// Generate a file for a specified generator at compile time.
 ///

--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -37,6 +37,21 @@ use std::path::PathBuf;
 #[doc(inline)]
 pub use generators::Generator;
 
+/// Shell with auto-generated completion script available.
+#[non_exhaustive]
+pub enum Shell {
+    /// Bash shell
+    Bash,
+    /// Elvish shell
+    Elvish,
+    /// Fish shell
+    Fish,
+    /// PowerShell
+    PowerShell,
+    /// Zsh shell
+    Zsh,
+}
+
 /// Generate a file for a specified generator at compile time.
 ///
 /// **NOTE:** to generate the file at compile time you must use a `build.rs` "Build Script"

--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -29,7 +29,7 @@ mod macros;
 /// Contains some popular generators
 pub mod generators;
 /// Contains supported shells for auto-completion scripts
-pub mod shell;
+mod shell;
 
 use std::ffi::OsString;
 use std::fs::File;

--- a/clap_generate/src/shell.rs
+++ b/clap_generate/src/shell.rs
@@ -1,0 +1,54 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// Shell with auto-generated completion script available.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub enum Shell {
+    /// Bourne Again SHell (bash)
+    Bash,
+    /// Elvish shell
+    Elvish,
+    /// Friendly Interactive SHell (fish)
+    Fish,
+    /// PowerShell
+    PowerShell,
+    /// Z SHell (zsh)
+    Zsh,
+}
+
+impl Shell {
+    /// A list of supported shells in `[&'static str]` form.
+    pub fn variants() -> [&'static str; 5] {
+        ["bash", "elvish", "fish", "powershell", "zsh"]
+    }
+}
+
+impl Display for Shell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Shell::Bash => write!(f, "bash"),
+            Shell::Elvish => write!(f, "elvish"),
+            Shell::Fish => write!(f, "fish"),
+            Shell::PowerShell => write!(f, "powershell"),
+            Shell::Zsh => write!(f, "zsh"),
+        }
+    }
+}
+
+impl FromStr for Shell {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "bash" => Ok(Shell::Bash),
+            "elvish" => Ok(Shell::Elvish),
+            "fish" => Ok(Shell::Fish),
+            "powershell" => Ok(Shell::PowerShell),
+            "zsh" => Ok(Shell::Zsh),
+            _ => Err(String::from(
+                "[valid values: bash, elvish, fish, powershell, zsh]",
+            )),
+        }
+    }
+}


### PR DESCRIPTION
Closes #1900

Back to my workstation, here is the pull request for the easy one.

# API

This pull request adds `clap_generate::Shell` (non-exhaustive) enum with all currently supported shells.

```rust
pub enum Shell {
    Bash,
    Elvish,
    Fish,
    PowerShell,
    Zsh,
}
```