### PR TITLE
Change visibility of MatchedArg, ValueType and Id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,9 @@ compile_error!("`std` feature is currently required to build `clap`");
 pub use crate::{
     build::{App, AppSettings, Arg, ArgGroup, ArgSettings, ValueHint},
     parse::errors::{Error, ErrorKind, Result},
+    parse::matches::{MatchedArg, ValueType},
     parse::{ArgMatches, Indices, OsValues, Values},
+    util::Id,
 };
 
 #[cfg(feature = "derive")]

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -19,7 +19,8 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SubCommand {
+#[doc(hidden)]
+pub struct SubCommand {
     pub(crate) id: Id,
     pub(crate) name: String,
     pub(crate) matches: ArgMatches,
@@ -75,8 +76,10 @@ pub(crate) struct SubCommand {
 /// [`App::get_matches`]: ./struct.App.html#method.get_matches
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArgMatches {
-    pub(crate) args: IndexMap<Id, MatchedArg>,
-    pub(crate) subcommand: Option<Box<SubCommand>>,
+    #[doc(hidden)]
+    pub args: IndexMap<Id, MatchedArg>,
+    #[doc(hidden)]
+    pub subcommand: Option<Box<SubCommand>>,
 }
 
 impl Default for ArgMatches {

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -7,9 +7,9 @@ use std::{
 
 use crate::INTERNAL_ERROR_MSG;
 
-// TODO: Maybe make this public?
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ValueType {
+#[doc(hidden)]
+pub enum ValueType {
     Unknown,
     EnvVariable,
     CommandLine,
@@ -17,11 +17,12 @@ pub(crate) enum ValueType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct MatchedArg {
-    pub(crate) occurs: u64,
-    pub(crate) ty: ValueType,
-    indices: Vec<usize>,
-    vals: Vec<Vec<OsString>>,
+#[doc(hidden)]
+pub struct MatchedArg {
+    pub occurs: u64,
+    pub ty: ValueType,
+    pub indices: Vec<usize>,
+    pub vals: Vec<Vec<OsString>>,
 }
 
 impl Default for MatchedArg {

--- a/src/parse/matches/mod.rs
+++ b/src/parse/matches/mod.rs
@@ -1,9 +1,7 @@
 mod arg_matches;
 mod matched_arg;
 
-pub(crate) use self::{
-    arg_matches::SubCommand,
-    matched_arg::{MatchedArg, ValueType},
-};
+pub(crate) use self::arg_matches::SubCommand;
 
 pub use self::arg_matches::{ArgMatches, Indices, OsValues, Values};
+pub use self::matched_arg::{MatchedArg, ValueType};

--- a/src/util/id.rs
+++ b/src/util/id.rs
@@ -8,7 +8,8 @@ use std::{
 
 #[derive(Clone, Eq, Default)]
 #[cfg_attr(not(debug_assertions), derive(Copy), repr(transparent))]
-pub(crate) struct Id {
+#[doc(hidden)]
+pub struct Id {
     #[cfg(debug_assertions)]
     name: String,
     id: u64,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,8 +6,9 @@ mod graph;
 mod id;
 
 pub use self::fnv::Key;
+pub use self::id::Id;
 
-pub(crate) use self::{argstr::ArgStr, graph::ChildGraph, id::Id};
+pub(crate) use self::{argstr::ArgStr, graph::ChildGraph};
 pub(crate) use vec_map::VecMap;
 
 #[cfg(feature = "color")]


### PR DESCRIPTION
Close: #1616

This is needed to write tests or benchmarks for functions that take `ArgMatches` as input. For example:

```rust
let mut args = IndexMap::new();
args.insert(
    Id::from("input"),
    MatchedArg {
        occurs: 1,
        ty: ValueType::Unknown,
        indices: [1].into(),
        vals: vec![["test".into_os_string()].to_vec()],
    },
);

let mut matches = ArgMatches {
    args,
    subcommand: None,
};

target_func(&matches);
```