### PR TITLE
Refactor: Builder pattern methods receiving str array parameters to instead take ref iterators

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -1870,8 +1870,12 @@ impl<'help> Arg<'help> {
     /// ```
     /// [options]: ./struct.Arg.html#method.takes_value
     /// [positional arguments]: ./struct.Arg.html#method.index
-    pub fn possible_values(mut self, names: &[&'help str]) -> Self {
-        self.possible_vals.extend(names);
+    pub fn possible_values<T: 'help + AsRef<str>>(
+        mut self,
+        names: impl IntoIterator<Item = &'help T>,
+    ) -> Self {
+        self.possible_vals
+            .extend(names.into_iter().map(|name| name.as_ref()));
         self.takes_value(true)
     }
 


### PR DESCRIPTION
Currently, builder pattern Arg methods which allow inserting multiple values,
receive parameters of type `&[&'... str]` .  This can be an inconvenience to work with, for example -
When attempting to pass to those methods data that isn't manually hard-coded.

This PR allows utilizing these methods as usual but also allows more freedom to receive types such as `Vector<String>`.

TODO
- [ ]  Refactor all relevant methods.
- [ ] Fix issue with the refactor and derive macro styled apps (Issues can be found in the tests utilizing said pattern).