### PR TITLE
Ignore extra fields in Arg yaml definitions

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -4712,10 +4712,7 @@ impl<'help> From<&'help Yaml> for Arg<'help> {
                         panic!("Failed to convert YAML value to vector")
                     }
                 }
-                s => panic!(
-                    "Unknown Arg setting '{}' in YAML file for arg '{}'",
-                    s, name_str
-                ),
+                _ => continue, // Ignore extra fields
             }
         }
 

--- a/tests/fixtures/app.yaml
+++ b/tests/fixtures/app.yaml
@@ -4,11 +4,13 @@ about: tests clap library
 author: Kevin K. <kbknapp@gmail.com>
 settings:
     - ArgRequiredElseHelp
+ignored_field: This field is ignored
 args:
     - help:
         short: h
         long: help
         about: prints help with a nonstandard description
+        ignored_field: This field is ignored
     - option:
         short: o
         long: option


### PR DESCRIPTION
Closes #2413 

When loading a `yaml` file, the presence of any extra fields in any of the `Arg`s causes the program to panic. Extra fields at the `App` level are ignored without consequence. This pull request changes the behavior of extra fields at the `Arg` level to match the `App` level, extra fields at both levels will be ignored when loading a `yaml` config.

This pull request also updates `tests/fixtures/app.yaml` with examples of ignored fields for both `App` and `Arg`s. This is checked by the `create_app_from_yaml` test in `tests/yaml.rs`.