### PR TITLE
Fix completions for Elvish shell

### DIFF
--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -22,6 +22,7 @@ impl Generator for Elvish {
 
         let result = format!(
             r#"
+use str;
 edit:completion:arg-completer[{bin_name}] = [@words]{{
     fn spaces [n]{{
         repeat $n ' ' | joins ''
@@ -31,7 +32,7 @@ edit:completion:arg-completer[{bin_name}] = [@words]{{
     }}
     command = '{bin_name}'
     for word $words[1:-1] {{
-        if (has-prefix $word '-') {{
+        if (str:has-prefix $word '-') {{
             break
         }}
         command = $command';'$word

--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -22,16 +22,18 @@ impl Generator for Elvish {
 
         let result = format!(
             r#"
+use builtin;
 use str;
+
 edit:completion:arg-completer[{bin_name}] = [@words]{{
     fn spaces [n]{{
-        repeat $n ' ' | joins ''
+        builtin:repeat $n ' ' | str:join ''
     }}
     fn cand [text desc]{{
         edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
     }}
     command = '{bin_name}'
-    for word $words[1:-1] {{
+    for word $words[1..-1] {{
         if (str:has-prefix $word '-') {{
             break
         }}

--- a/clap_generate/tests/completions/elvish.rs
+++ b/clap_generate/tests/completions/elvish.rs
@@ -29,6 +29,7 @@ fn elvish() {
 }
 
 static ELVISH: &str = r#"
+use str;
 edit:completion:arg-completer[my_app] = [@words]{
     fn spaces [n]{
         repeat $n ' ' | joins ''
@@ -38,7 +39,7 @@ edit:completion:arg-completer[my_app] = [@words]{
     }
     command = 'my_app'
     for word $words[1:-1] {
-        if (has-prefix $word '-') {
+        if (str:has-prefix $word '-') {
             break
         }
         command = $command';'$word
@@ -90,6 +91,7 @@ fn build_app_special_commands() -> App<'static> {
 }
 
 static ELVISH_SPECIAL_CMDS: &str = r#"
+use str;
 edit:completion:arg-completer[my_app] = [@words]{
     fn spaces [n]{
         repeat $n ' ' | joins ''
@@ -99,7 +101,7 @@ edit:completion:arg-completer[my_app] = [@words]{
     }
     command = 'my_app'
     for word $words[1:-1] {
-        if (has-prefix $word '-') {
+        if (str:has-prefix $word '-') {
             break
         }
         command = $command';'$word
@@ -176,6 +178,7 @@ fn build_app_with_aliases() -> App<'static> {
 }
 
 static ELVISH_ALIASES: &str = r#"
+use str;
 edit:completion:arg-completer[cmd] = [@words]{
     fn spaces [n]{
         repeat $n ' ' | joins ''
@@ -185,7 +188,7 @@ edit:completion:arg-completer[cmd] = [@words]{
     }
     command = 'cmd'
     for word $words[1:-1] {
-        if (has-prefix $word '-') {
+        if (str:has-prefix $word '-') {
             break
         }
         command = $command';'$word

--- a/clap_generate/tests/completions/elvish.rs
+++ b/clap_generate/tests/completions/elvish.rs
@@ -29,16 +29,18 @@ fn elvish() {
 }
 
 static ELVISH: &str = r#"
+use builtin;
 use str;
+
 edit:completion:arg-completer[my_app] = [@words]{
     fn spaces [n]{
-        repeat $n ' ' | joins ''
+        builtin:repeat $n ' ' | str:join ''
     }
     fn cand [text desc]{
         edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
     }
     command = 'my_app'
-    for word $words[1:-1] {
+    for word $words[1..-1] {
         if (str:has-prefix $word '-') {
             break
         }
@@ -91,16 +93,18 @@ fn build_app_special_commands() -> App<'static> {
 }
 
 static ELVISH_SPECIAL_CMDS: &str = r#"
+use builtin;
 use str;
+
 edit:completion:arg-completer[my_app] = [@words]{
     fn spaces [n]{
-        repeat $n ' ' | joins ''
+        builtin:repeat $n ' ' | str:join ''
     }
     fn cand [text desc]{
         edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
     }
     command = 'my_app'
-    for word $words[1:-1] {
+    for word $words[1..-1] {
         if (str:has-prefix $word '-') {
             break
         }
@@ -178,16 +182,18 @@ fn build_app_with_aliases() -> App<'static> {
 }
 
 static ELVISH_ALIASES: &str = r#"
+use builtin;
 use str;
+
 edit:completion:arg-completer[cmd] = [@words]{
     fn spaces [n]{
-        repeat $n ' ' | joins ''
+        builtin:repeat $n ' ' | str:join ''
     }
     fn cand [text desc]{
         edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
     }
     command = 'cmd'
-    for word $words[1:-1] {
+    for word $words[1..-1] {
         if (str:has-prefix $word '-') {
             break
         }


### PR DESCRIPTION
Makes the following changes in completions for the Elvish shell:
- Changes deprecated `has-prefix` function to`str:has-prefix`
- Changes deprecated slice syntax `[1:-1]` to `[1..-1]`
- Adds `builtin` prefix to builtin functions to remove ambiguity
