### PR TITLE
setting: UseLongFormatForHelpSubcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ TODO: `cargo`, `std` features
   * **Error**
     * `Error::print`
 * **Added Settings**
+  * `AppSettings::UseLongFormatForHelpSubcommand`
   * `ArgSettings::HideEnv`
 
 #### Enhancements

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -48,6 +48,7 @@ bitflags! {
         const HELP_REQUIRED                  = 1 << 40;
         const SUBCOMMAND_PRECEDENCE_OVER_ARG = 1 << 41;
         const DISABLE_HELP_FLAG              = 1 << 42;
+        const USE_LONG_FORMAT_FOR_HELP_SC    = 1 << 43;
     }
 }
 
@@ -126,6 +127,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::SC_REQUIRED,
     SubcommandRequiredElseHelp("subcommandrequiredelsehelp")
         => Flags::SC_REQUIRED_ELSE_HELP,
+    UseLongFormatForHelpSubcommand("uselongformatforhelpsubcommand")
+        => Flags::USE_LONG_FORMAT_FOR_HELP_SC,
     TrailingVarArg("trailingvararg")
         => Flags::TRAILING_VARARG,
     UnifiedHelpMessage("unifiedhelpmessage")
@@ -904,6 +907,28 @@ pub enum AppSettings {
     /// [``]: ./struct..html
     SubcommandRequiredElseHelp,
 
+    /// Specifies that the help subcommand should print the [long format] help message.
+    ///
+    /// **NOTE:** This setting is useless if [`AppSettings::DisableHelpSubcommand`] or [`AppSettings::NoAutoHelp`] is set,
+    /// or if the app contains no subcommands at all.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg, AppSettings};
+    /// App::new("myprog")
+    ///     .setting(AppSettings::UseLongFormatForHelpSubcommand)
+    ///     .subcommand(App::new("test")
+    ///         .arg(Arg::new("foo")
+    ///             .about("short form about message")
+    ///             .long_about("long form about message")
+    ///         )
+    ///     )
+    ///     .get_matches();
+    /// ```
+    /// [long format]: App::long_about
+    UseLongFormatForHelpSubcommand,
+
     /// Specifies that any invalid UTF-8 code points should be treated as an error and fail
     /// with a [`ErrorKind::InvalidUtf8`] error.
     ///
@@ -1158,6 +1183,12 @@ mod test {
         assert_eq!(
             "subcommandrequiredelsehelp".parse::<AppSettings>().unwrap(),
             AppSettings::SubcommandRequiredElseHelp
+        );
+        assert_eq!(
+            "uselongformatforhelpsubcommand"
+                .parse::<AppSettings>()
+                .unwrap(),
+            AppSettings::UseLongFormatForHelpSubcommand
         );
         assert_eq!(
             "strictutf8".parse::<AppSettings>().unwrap(),

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -808,7 +808,7 @@ impl<'help, 'app> Parser<'help, 'app> {
             parser.app.bin_name = Some(format!("{} {}", bin_name, parser.app.name));
         }
 
-        Err(parser.help_err(false))
+        Err(parser.help_err(self.app.is_set(AS::UseLongFormatForHelpSubcommand)))
     }
 
     fn is_new_arg(&self, arg_os: &ArgStr, last_result: &ParseResult) -> bool {

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -97,6 +97,57 @@ SUBCOMMANDS:
     help    Prints this message or the help of the given subcommand(s)
     info";
 
+static LONG_FORMAT_FOR_HELP_SUBCOMMAND: &str = "myprog-test 
+
+USAGE:
+    myprog test [foo]
+
+ARGS:
+    <foo>
+            long form about message
+
+FLAGS:
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information";
+
+static LONG_FORMAT_FOR_NESTED_HELP_SUBCOMMAND: &str = "myprog-test-nested 
+
+long form about message
+
+USAGE:
+    myprog test nested
+
+FLAGS:
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information";
+
+static LONG_FORMAT_SINGLE_ARG_HELP_SUBCOMMAND: &str = "myprog 
+
+USAGE:
+    myprog [foo] [SUBCOMMAND]
+
+ARGS:
+    <foo>
+            long form about message
+
+FLAGS:
+    -h, --help
+            Prints help information
+
+    -V, --version
+            Prints version information
+
+SUBCOMMANDS:
+    help
+            Prints this message or the help of the given subcommand(s)
+    test";
+
 #[test]
 fn sub_command_negate_required() {
     App::new("sub_command_negate")
@@ -1021,4 +1072,60 @@ fn aaos_option_use_delim_false() {
         m.values_of("opt").unwrap().collect::<Vec<_>>(),
         &["one,two"]
     );
+}
+
+#[test]
+fn nested_help_subcommand_with_global_setting() {
+    let m = App::new("myprog")
+        .global_setting(AppSettings::UseLongFormatForHelpSubcommand)
+        .subcommand(
+            App::new("test").subcommand(
+                App::new("nested")
+                    .about("short form about message")
+                    .long_about("long form about message"),
+            ),
+        );
+    assert!(utils::compare_output(
+        m,
+        "myprog test help nested",
+        LONG_FORMAT_FOR_NESTED_HELP_SUBCOMMAND,
+        false
+    ));
+}
+
+#[test]
+fn single_arg_help_with_long_format_setting() {
+    let m = App::new("myprog")
+        .setting(AppSettings::UseLongFormatForHelpSubcommand)
+        .subcommand(App::new("test"))
+        .arg(
+            Arg::new("foo")
+                .about("short form about message")
+                .long_about("long form about message"),
+        );
+    assert!(utils::compare_output(
+        m,
+        "myprog help",
+        LONG_FORMAT_SINGLE_ARG_HELP_SUBCOMMAND,
+        false
+    ));
+}
+
+#[test]
+fn use_long_format_for_help_subcommand_with_setting() {
+    let m = App::new("myprog")
+        .setting(AppSettings::UseLongFormatForHelpSubcommand)
+        .subcommand(
+            App::new("test").arg(
+                Arg::new("foo")
+                    .about("short form about message")
+                    .long_about("long form about message"),
+            ),
+        );
+    assert!(utils::compare_output(
+        m,
+        "myprog help test",
+        LONG_FORMAT_FOR_HELP_SUBCOMMAND,
+        false
+    ));
 }


### PR DESCRIPTION
Closes https://github.com/clap-rs/clap/issues/2435

Specifies that the help subcommand should print the long form help message (if possible), instead of the short form.

Example:
 ```rust
let m = App::new("myprog")
     .setting(AppSettings::UseLongFormatForHelpSubcommand)
     .subcommand(App::new("test")
         .after_help("short form help msg")
         .after_long_help("long form help msg"))
     .get_matches();
 ```
Output:
```
myprog-test 

USAGE:
    myprog test

FLAGS:
    -h, --help
            Prints help information

    -V, --version
            Prints version information

long form help message
```

## TODO

- [x] Implement feature
- [x] Tests
- [x] Documentation