### PR TITLE
fix(usage): Move positional args to end of usage string

### DIFF
--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -456,10 +456,6 @@ impl<'help, 'app, 'parser> Usage<'help, 'app, 'parser> {
             .map(|pos| (pos.index.unwrap(), pos))
             .collect::<BTreeMap<usize, &Arg>>(); // sort by index
 
-        // Only use the -- separator if we have both args and positional args.
-        if !ret_val.is_empty() && !pmap.is_empty() {
-            ret_val.push("--".to_string());
-        }
         for p in pmap.values() {
             debug!("Usage::get_required_usage_from:iter:{:?}", p.id);
             if !args_in_groups.contains(&p.id) {

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -5,14 +5,14 @@ use clap::{App, Arg, ArgGroup, ErrorKind};
 static CONFLICT_ERR: &str = "error: The argument '-F' cannot be used with '--flag'
 
 USAGE:
-    clap-test <positional> <positional2> --flag --long-option-2 <option2>
+    clap-test --flag --long-option-2 <option2> -- <positional> <positional2>
 
 For more information try --help";
 
 static CONFLICT_ERR_REV: &str = "error: The argument '--flag' cannot be used with '-F'
 
 USAGE:
-    clap-test <positional> <positional2> -F --long-option-2 <option2>
+    clap-test -F --long-option-2 <option2> -- <positional> <positional2>
 
 For more information try --help";
 

--- a/tests/conflicts.rs
+++ b/tests/conflicts.rs
@@ -5,14 +5,14 @@ use clap::{App, Arg, ArgGroup, ErrorKind};
 static CONFLICT_ERR: &str = "error: The argument '-F' cannot be used with '--flag'
 
 USAGE:
-    clap-test --flag --long-option-2 <option2> -- <positional> <positional2>
+    clap-test --flag --long-option-2 <option2> <positional> <positional2>
 
 For more information try --help";
 
 static CONFLICT_ERR_REV: &str = "error: The argument '--flag' cannot be used with '-F'
 
 USAGE:
-    clap-test -F --long-option-2 <option2> -- <positional> <positional2>
+    clap-test -F --long-option-2 <option2> <positional> <positional2>
 
 For more information try --help";
 

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -28,11 +28,12 @@ USAGE:
 For more information try --help";
 
 static MISSING_REQ: &str = "error: The following required arguments were not provided:
-    <positional2>
     --long-option-2 <option2>
+    --
+    <positional2>
 
 USAGE:
-    clap-test <positional2> --long-option-2 <option2> -F
+    clap-test --long-option-2 <option2> -F -- <positional2>
 
 For more information try --help";
 
@@ -913,7 +914,7 @@ static ISSUE_1158: &str = "error: The following required arguments were not prov
     -z <Z>
 
 USAGE:
-    example <ID> -x <X> -y <Y> -z <Z>
+    example -x <X> -y <Y> -z <Z> -- <ID>
 
 For more information try --help";
 

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -29,11 +29,10 @@ For more information try --help";
 
 static MISSING_REQ: &str = "error: The following required arguments were not provided:
     --long-option-2 <option2>
-    --
     <positional2>
 
 USAGE:
-    clap-test --long-option-2 <option2> -F -- <positional2>
+    clap-test --long-option-2 <option2> -F <positional2>
 
 For more information try --help";
 
@@ -914,7 +913,7 @@ static ISSUE_1158: &str = "error: The following required arguments were not prov
     -z <Z>
 
 USAGE:
-    example -x <X> -y <Y> -z <Z> -- <ID>
+    example -x <X> -y <Y> -z <Z> <ID>
 
 For more information try --help";
 


### PR DESCRIPTION
Fixes https://github.com/clap-rs/clap/issues/2454.

The issue was that positional arguments were being placed at the start of the usage string, rather than at the end. This poses a problem when accepting a `TrailingVarArg`.

Positional arguments should be placed at the end. For example, `git init --help` shows flags before positional arguments. I've added a `--` separator for clarity, and for correctness in the case that the last non-positional argument accepts multiple values.