### PR TITLE
docs: add more explanation to #2501 fix

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -416,8 +416,9 @@ impl<'help, 'app> Parser<'help, 'app> {
                                 keep_state = !done;
                                 if keep_state {
                                     it.cursor -= 1;
-                                    self.flag_subcmd_skip =
-                                        self.cur_idx.get() - self.flag_subcmd_at.unwrap() + 1
+                                    self.flag_subcmd_skip = self.cur_idx.get()
+                                        - self.flag_subcmd_at.expect(INTERNAL_ERROR_MSG)
+                                        + 1;
                                 }
 
                                 debug!(
@@ -1121,7 +1122,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                 }
 
                 // Check for trailing concatenated value
-                let i = arg_os.split(c).next().unwrap().len() + c.len_utf8();
+                let i = arg_os.split(c).next().expect(INTERNAL_ERROR_MSG).len() + c.len_utf8();
                 debug!(
                     "Parser::parse_short_arg:iter:{}: i={}, arg_os={:?}",
                     c, i, arg_os

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1146,15 +1146,14 @@ impl<'help, 'app> Parser<'help, 'app> {
             } else if let Some(sc_name) = self.app.find_short_subcmd(c) {
                 debug!("Parser::parse_short_arg:iter:{}: subcommand={}", c, sc_name);
                 let name = sc_name.to_string();
-                let cur_idx = self.cur_idx.get();
-                let done_short_args = if let Some(at) = self.flag_subcmd_at {
+                let done_short_args = {
+                    let cur_idx = self.cur_idx.get();
+                    // Get the index of the previous flag subcommand in the group of flags.
+                    // If it is a new flag subcommand, then it should be registered.
+                    let at = *self.flag_subcmd_at.get_or_insert(cur_idx);
+                    // If we are done, then the difference of indices (cur_idx - at) should be (end - at),
+                    // where `end` is the index of the end of the group.
                     cur_idx - at == arg.len() - 1
-                } else {
-                    // This is a new flag subcommand and should be registered.
-                    self.flag_subcmd_at = Some(cur_idx);
-                    // If we have only a letter in `arg`, eg. '-S', then we are done.
-                    // Otherwise, we are not.
-                    arg.len() == 1
                 };
                 if done_short_args {
                     self.flag_subcmd_at.take();


### PR DESCRIPTION
This PR is a follow-up of #2501:
- Add more comments explaining parsing logic change in `done_short_args` and `keep_state`.
- Replace several `.unwrap()` usages with `.expect()`.
- Fix typo.