### PR TITLE
refactor(validator): cleanup code

### DIFF
--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -180,17 +180,18 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         let retained_blacklist = &retained_arg.blacklist;
         let used_filtered: Vec<Id> = matcher
             .arg_names()
-            .filter(|key| *key != conflicting_key)
-            .filter(|key| !retained_blacklist.contains(key))
+            .filter(|key| *key != conflicting_key && !retained_blacklist.contains(key))
             .cloned()
             .collect();
         let required: Vec<Id> = used_filtered
             .iter()
             .filter_map(|key| self.p.app.find(key))
             .flat_map(|key_arg| key_arg.requires.iter().map(|item| &item.1))
-            .filter(|item| !used_filtered.contains(item))
-            .filter(|key| *key != conflicting_key)
-            .filter(|key| !retained_blacklist.contains(key))
+            .filter(|key| {
+                !used_filtered.contains(key)
+                    && *key != conflicting_key
+                    && !retained_blacklist.contains(key)
+            })
             .chain(used_filtered.iter())
             .cloned()
             .collect();


### PR DESCRIPTION
This PR tries to make some parts of `validator` code more readable mainly by:

- Using aliases when appropriate, which reduces the number of lines.
- Using functional style to remove some of the global variables in the function scope.

PS: I understand that the functional style might not look good to everyone :)