### PR TITLE
docs: fix links to Subcommand

### DIFF
--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -172,7 +172,7 @@ pub enum AppSettings {
     /// UTF-8 values
     ///
     /// **NOTE:** This rule only applies to  argument values, as flags, options, and
-    /// [`Subcommand`][crate::Subcommand]s themselves only allow valid UTF-8 code points.
+    /// [`Subcommand`]s themselves only allow valid UTF-8 code points.
     ///
     /// # Platform Specific
     ///
@@ -198,6 +198,7 @@ pub enum AppSettings {
     /// let m = r.unwrap();
     /// assert_eq!(m.value_of_os("arg").unwrap().as_bytes(), &[0xe9]);
     /// ```
+    /// [`Subcommand`]: crate::Subcommand
     /// [`ArgMatches::os_value_of`]: ArgMatches::os_value_of()
     /// [`ArgMatches::os_values_of`]: ArgMatches::os_values_of()
     /// [`ArgMatches::lossy_value_of`]: ArgMatches::lossy_value_of()
@@ -366,7 +367,7 @@ pub enum AppSettings {
 
     /// Specifies that an unexpected positional argument,
     /// which would otherwise cause a [`ErrorKind::UnknownArgument`] error,
-    /// should instead be treated as a [`Subcommand`][crate::Subcommand]
+    /// should instead be treated as a [`Subcommand`]
     /// within the [`ArgMatches`] struct.
     ///
     /// **NOTE:** Use this setting with caution,
@@ -396,6 +397,7 @@ pub enum AppSettings {
     ///     _ => {},
     /// }
     /// ```
+    /// [`Subcommand`]: crate::Subcommand
     AllowExternalSubcommands,
 
     /// Specifies that use of a valid [argument] negates [subcommands] being used after. By default
@@ -424,7 +426,7 @@ pub enum AppSettings {
     /// Specifies that the help text should be displayed (and then exit gracefully),
     /// if no arguments are present at runtime (i.e. an empty run such as, `$ myprog`.
     ///
-    /// **NOTE:** [`Subcommand`][crate::Subcommand]s count as arguments
+    /// **NOTE:** [`Subcommand`]s count as arguments
     ///
     /// **NOTE:** Setting [`Arg::default_value`] effectively disables this option as it will
     /// ensure that some argument is always present.
@@ -438,6 +440,7 @@ pub enum AppSettings {
     /// # ;
     /// ```
     ///
+    /// [`Subcommand`]: crate::Subcommand
     /// [`Arg::default_value`]: Arg::default_value()
     ArgRequiredElseHelp,
 
@@ -646,7 +649,7 @@ pub enum AppSettings {
     /// [`Subcommand`]: [crate:Subcommand]
     DisableHelpFlag,
 
-    /// Disables the `help` [Subcommand][crate::Subcommand]
+    /// Disables the `help` [Subcommand]
     ///
     /// # Examples
     ///
@@ -664,6 +667,7 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
+    /// [Subcommand]: crate::Subcommand
     DisableHelpSubcommand,
 
     /// Disables `-V` and `--version` for this [`App`] without affecting any of the [`Subcommand`]s
@@ -751,7 +755,7 @@ pub enum AppSettings {
     /// [`Subcommand`]: crate::Subcommand
     GlobalVersion,
 
-    /// Specifies that this [`Subcommand`][crate::Subcommand] should be hidden from help messages
+    /// Specifies that this [`Subcommand`] should be hidden from help messages
     ///
     /// # Examples
     ///
@@ -762,6 +766,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::Hidden))
     /// # ;
     /// ```
+    /// [`Subcommand`]: crate::Subcommand
     Hidden,
 
     /// Tells `clap` *not* to print possible values when displaying help information.

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -172,7 +172,7 @@ pub enum AppSettings {
     /// UTF-8 values
     ///
     /// **NOTE:** This rule only applies to  argument values, as flags, options, and
-    /// [``]s themselves only allow valid UTF-8 code points.
+    /// [`Subcommand`][crate::Subcommand]s themselves only allow valid UTF-8 code points.
     ///
     /// # Platform Specific
     ///
@@ -202,7 +202,6 @@ pub enum AppSettings {
     /// [`ArgMatches::os_values_of`]: ArgMatches::os_values_of()
     /// [`ArgMatches::lossy_value_of`]: ArgMatches::lossy_value_of()
     /// [`ArgMatches::lossy_values_of`]: ArgMatches::lossy_values_of()
-    /// [``]: ./struct..html
     AllowInvalidUtf8,
 
     /// Specifies that leading hyphens are allowed in argument *values*, such as negative numbers
@@ -367,7 +366,8 @@ pub enum AppSettings {
 
     /// Specifies that an unexpected positional argument,
     /// which would otherwise cause a [`ErrorKind::UnknownArgument`] error,
-    /// should instead be treated as a [``] within the [`ArgMatches`] struct.
+    /// should instead be treated as a [`Subcommand`][crate::Subcommand]
+    /// within the [`ArgMatches`] struct.
     ///
     /// **NOTE:** Use this setting with caution,
     /// as a truly unexpected argument (i.e. one that is *NOT* an external subcommand)
@@ -396,10 +396,9 @@ pub enum AppSettings {
     ///     _ => {},
     /// }
     /// ```
-    /// [``]: ./struct..html
     AllowExternalSubcommands,
 
-    /// Specifies that use of a valid [argument] negates [subcomands] being used after. By default
+    /// Specifies that use of a valid [argument] negates [subcommands] being used after. By default
     /// `clap` allows arguments between subcommands such as
     /// `<cmd> [cmd_args] <cmd2> [cmd2_args] <cmd3> [cmd3_args]`. This setting disables that
     /// functionality and says that arguments can only follow the *final* subcommand. For instance
@@ -417,14 +416,15 @@ pub enum AppSettings {
     ///     .setting(AppSettings::ArgsNegateSubcommands)
     /// # ;
     /// ```
-    /// [subcommands]: ./struct..html
-    /// [argument]: Arg
+    ///
+    /// [subcommands]: crate::Subcommand
+    /// [argument]: crate::Arg
     ArgsNegateSubcommands,
 
     /// Specifies that the help text should be displayed (and then exit gracefully),
     /// if no arguments are present at runtime (i.e. an empty run such as, `$ myprog`.
     ///
-    /// **NOTE:** [``]s count as arguments
+    /// **NOTE:** [`Subcommand`][crate::Subcommand]s count as arguments
     ///
     /// **NOTE:** Setting [`Arg::default_value`] effectively disables this option as it will
     /// ensure that some argument is always present.
@@ -437,7 +437,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::ArgRequiredElseHelp)
     /// # ;
     /// ```
-    /// [``]: ./struct..html
+    ///
     /// [`Arg::default_value`]: Arg::default_value()
     ArgRequiredElseHelp,
 
@@ -614,8 +614,9 @@ pub enum AppSettings {
     /// [`Arg::use_delimiter(false)`]: Arg::use_delimiter()
     DontDelimitTrailingValues,
 
-    /// Disables `-h` and `--help` [`App`] without affecting any of the [`SubCommand`]s
-    /// (Defaults to `false`; application *does* have help flags)
+    /// Disables `-h` and `--help` [`App`] without affecting any of the [`Subcommand`]s
+    ///
+    /// Defaults to `false`; application *does* have help flags.
     ///
     /// # Examples
     ///
@@ -641,9 +642,11 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::DisplayHelp);
     /// ```
+    ///
+    /// [`Subcommand`]: [crate:Subcommand]
     DisableHelpFlag,
 
-    /// Disables the `help` subcommand
+    /// Disables the `help` [Subcommand][crate::Subcommand]
     ///
     /// # Examples
     ///
@@ -661,10 +664,9 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
-    /// [``]: ./struct..html
     DisableHelpSubcommand,
 
-    /// Disables `-V` and `--version` for this [`App`] without affecting any of the [``]s
+    /// Disables `-V` and `--version` for this [`App`] without affecting any of the [`Subcommand`]s
     /// (Defaults to `false`; application *does* have a version flag)
     ///
     /// # Examples
@@ -693,7 +695,7 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::DisplayVersion);
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     DisableVersionFlag,
 
     /// Disables `-V` and `--version` for all [`subcommand`]s of this [`App`]
@@ -713,10 +715,10 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
-    /// [``]: ./struct..html
+    /// [`subcommand`]: crate::Subcommand
     DisableVersionForSubcommands,
 
-    /// Displays the arguments and [``]s in the help message in the order that they were
+    /// Displays the arguments and [`Subcommand`]s in the help message in the order that they were
     /// declared in, and not alphabetically which is the default.
     ///
     /// # Examples
@@ -727,11 +729,12 @@ pub enum AppSettings {
     ///     .setting(AppSettings::DeriveDisplayOrder)
     ///     .get_matches();
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     DeriveDisplayOrder,
 
-    /// Specifies to use the version of the current command for all child [``]s.
-    /// (Defaults to `false`; subcommands have independent version strings from their parents.)
+    /// Specifies to use the version of the current command for all child [`Subcommand`]s.
+    ///
+    /// Defaults to `false`; subcommands have independent version strings from their parents.
     ///
     /// # Examples
     ///
@@ -745,10 +748,10 @@ pub enum AppSettings {
     /// // running `$ myprog test --version` will display
     /// // "myprog-test v1.1"
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     GlobalVersion,
 
-    /// Specifies that this [``] should be hidden from help messages
+    /// Specifies that this [`Subcommand`][crate::Subcommand] should be hidden from help messages
     ///
     /// # Examples
     ///
@@ -759,7 +762,6 @@ pub enum AppSettings {
     ///     .setting(AppSettings::Hidden))
     /// # ;
     /// ```
-    /// [``]: ./struct..html
     Hidden,
 
     /// Tells `clap` *not* to print possible values when displaying help information.
@@ -821,7 +823,7 @@ pub enum AppSettings {
     ///     ]);
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
-    /// [`subcommands`]: ./struct..html
+    /// [`subcommands`]: crate::Subcommand
     /// [positional/free arguments]: Arg::index()
     /// [aliases]: App::alias()
     InferSubcommands,
@@ -856,7 +858,7 @@ pub enum AppSettings {
     /// ```
     NextLineHelp,
 
-    /// Allows [``]s to override all requirements of the parent command.
+    /// Allows [`Subcommand`]s to override all requirements of the parent command.
     /// For example, if you had a subcommand or top level application with a required argument
     /// that is only required as long as there is no subcommand present,
     /// using this setting would allow you to set those arguments to [`Arg::required(true)`]
@@ -898,11 +900,11 @@ pub enum AppSettings {
     /// # ;
     /// ```
     /// [`Arg::required(true)`]: Arg::required()
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     SubcommandsNegateReqs,
 
     /// Specifies that the help text should be displayed (before exiting gracefully) if no
-    /// [``]s are present at runtime (i.e. an empty run such as `$ myprog`).
+    /// [`Subcommand`]s are present at runtime (i.e. an empty run such as `$ myprog`).
     ///
     /// **NOTE:** This should *not* be used with [`AppSettings::SubcommandRequired`] as they do
     /// nearly same thing; this prints the help text, and the other prints an error.
@@ -919,7 +921,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::SubcommandRequiredElseHelp)
     /// # ;
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     SubcommandRequiredElseHelp,
 
     /// Specifies that the help subcommand should print the [long format] help message.
@@ -948,7 +950,7 @@ pub enum AppSettings {
     /// with a [`ErrorKind::InvalidUtf8`] error.
     ///
     /// **NOTE:** This rule only applies to argument values; Things such as flags, options, and
-    /// [``]s themselves only allow valid UTF-8 code points.
+    /// [`Subcommand`]s themselves only allow valid UTF-8 code points.
     ///
     /// # Platform Specific
     ///
@@ -973,10 +975,10 @@ pub enum AppSettings {
     /// assert!(m.is_err());
     /// assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     StrictUtf8,
 
-    /// Allows specifying that if no [``] is present at runtime,
+    /// Allows specifying that if no [`Subcommand`] is present at runtime,
     /// error and exit gracefully.
     ///
     /// **NOTE:** This defaults to `false` (subcommands do *not* need to be present)
@@ -995,7 +997,7 @@ pub enum AppSettings {
     /// assert_eq!(err.unwrap_err().kind, ErrorKind::MissingSubcommand);
     /// # ;
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     SubcommandRequired,
 
     /// Specifies that the final positional argument is a "VarArg" and that `clap` should not
@@ -1047,9 +1049,9 @@ pub enum AppSettings {
     /// Windows where a user tries to open the binary by double-clicking instead of using the
     /// command line.
     ///
-    /// **NOTE:** This setting is **not** recursive with [``]s, meaning if you wish this
+    /// **NOTE:** This setting is **not** recursive with [`Subcommand`]s, meaning if you wish this
     /// behavior for all subcommands, you must set this on each command (needing this is extremely
-    /// rare)
+    /// rare).
     ///
     /// # Examples
     ///
@@ -1059,7 +1061,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::WaitOnError)
     /// # ;
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     WaitOnError,
 
     /// @TODO-v3: @docs write them...maybe rename

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -198,6 +198,7 @@ pub enum AppSettings {
     /// let m = r.unwrap();
     /// assert_eq!(m.value_of_os("arg").unwrap().as_bytes(), &[0xe9]);
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     /// [`ArgMatches::os_value_of`]: ArgMatches::os_value_of()
     /// [`ArgMatches::os_values_of`]: ArgMatches::os_values_of()
@@ -397,6 +398,7 @@ pub enum AppSettings {
     ///     _ => {},
     /// }
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     AllowExternalSubcommands,
 
@@ -646,7 +648,7 @@ pub enum AppSettings {
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::DisplayHelp);
     /// ```
     ///
-    /// [`Subcommand`]: [crate:Subcommand]
+    /// [`Subcommand`]: crate:Subcommand
     DisableHelpFlag,
 
     /// Disables the `help` [Subcommand]
@@ -667,6 +669,7 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
+    ///
     /// [Subcommand]: crate::Subcommand
     DisableHelpSubcommand,
 
@@ -699,6 +702,7 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::DisplayVersion);
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     DisableVersionFlag,
 
@@ -719,6 +723,7 @@ pub enum AppSettings {
     /// assert!(res.is_err());
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
+    ///
     /// [`subcommand`]: crate::Subcommand
     DisableVersionForSubcommands,
 
@@ -733,6 +738,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::DeriveDisplayOrder)
     ///     .get_matches();
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     DeriveDisplayOrder,
 
@@ -752,6 +758,7 @@ pub enum AppSettings {
     /// // running `$ myprog test --version` will display
     /// // "myprog-test v1.1"
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     GlobalVersion,
 
@@ -766,6 +773,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::Hidden))
     /// # ;
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     Hidden,
 
@@ -828,6 +836,7 @@ pub enum AppSettings {
     ///     ]);
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
+    ///
     /// [`subcommands`]: crate::Subcommand
     /// [positional/free arguments]: Arg::index()
     /// [aliases]: App::alias()
@@ -904,6 +913,7 @@ pub enum AppSettings {
     /// assert!(noerr.is_ok());
     /// # ;
     /// ```
+    ///
     /// [`Arg::required(true)`]: Arg::required()
     /// [`Subcommand`]: crate::Subcommand
     SubcommandsNegateReqs,
@@ -926,6 +936,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::SubcommandRequiredElseHelp)
     /// # ;
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     SubcommandRequiredElseHelp,
 
@@ -980,6 +991,7 @@ pub enum AppSettings {
     /// assert!(m.is_err());
     /// assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     StrictUtf8,
 
@@ -1002,6 +1014,7 @@ pub enum AppSettings {
     /// assert_eq!(err.unwrap_err().kind, ErrorKind::MissingSubcommand);
     /// # ;
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     SubcommandRequired,
 
@@ -1066,6 +1079,7 @@ pub enum AppSettings {
     ///     .setting(AppSettings::WaitOnError)
     /// # ;
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     WaitOnError,
 

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -3480,7 +3480,7 @@ impl<'help> Arg<'help> {
         }
     }
 
-    /// Specifies that an argument can be matched to all child [``]s.
+    /// Specifies that an argument can be matched to all child [`Subcommand`]s.
     ///
     /// **NOTE:** Global arguments *only* propagate down, **not** up (to parent commands), however
     /// their values once a user uses them will be propagated back up to parents. In effect, this
@@ -3518,7 +3518,7 @@ impl<'help> Arg<'help> {
     /// let sub_m = m.subcommand_matches("do-stuff").unwrap();
     /// assert!(sub_m.is_present("verb"));
     /// ```
-    /// [``]: App::subcommand()
+    /// [`Subcommand`]: crate::Subcommand
     /// [required]: ArgSettings::Required
     /// [`ArgMatches::is_present("flag")`]: ArgMatches::is_present()
     #[inline]

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -3518,6 +3518,7 @@ impl<'help> Arg<'help> {
     /// let sub_m = m.subcommand_matches("do-stuff").unwrap();
     /// assert!(sub_m.is_present("verb"));
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     /// [required]: ArgSettings::Required
     /// [`ArgMatches::is_present("flag")`]: ArgMatches::is_present()

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -242,6 +242,7 @@ impl<'help> ArgGroup<'help> {
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     /// [`ArgGroup::multiple`]: ArgGroup::multiple()
     #[inline]

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -216,7 +216,7 @@ impl<'help> ArgGroup<'help> {
     /// that one argument from this group *must* be present at runtime (unless
     /// conflicting with another argument).
     ///
-    /// **NOTE:** This setting only applies to the current [`App`] / [``], and not
+    /// **NOTE:** This setting only applies to the current [`App`] / [`Subcommand`]s, and not
     /// globally.
     ///
     /// **NOTE:** By default, [`ArgGroup::multiple`] is set to `false` which when combined with
@@ -242,7 +242,7 @@ impl<'help> ArgGroup<'help> {
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     /// [`ArgGroup::multiple`]: ArgGroup::multiple()
     #[inline]
     pub fn required(mut self, r: bool) -> Self {

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -74,6 +74,7 @@ pub enum ErrorKind {
     /// assert!(result.is_err());
     /// assert_eq!(result.unwrap_err().kind, ErrorKind::InvalidSubcommand);
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     /// [`UnknownArgument`]: ErrorKind::UnknownArgument
     InvalidSubcommand,
@@ -100,6 +101,7 @@ pub enum ErrorKind {
     /// assert!(result.is_err());
     /// assert_eq!(result.unwrap_err().kind, ErrorKind::UnrecognizedSubcommand);
     /// ```
+    ///
     /// [`Subcommand`]: crate::Subcommand
     /// [`InvalidSubcommand`]: ErrorKind::InvalidSubcommand
     /// [`UnknownArgument`]: ErrorKind::UnknownArgument

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -54,7 +54,7 @@ pub enum ErrorKind {
     /// ```
     UnknownArgument,
 
-    /// Occurs when the user provides an unrecognized [``] which meets the threshold for
+    /// Occurs when the user provides an unrecognized [`Subcommand`] which meets the threshold for
     /// being similar enough to an existing subcommand.
     /// If it doesn't meet the threshold, or the 'suggestions' feature is disabled,
     /// the more general [`UnknownArgument`] error is returned.
@@ -74,11 +74,11 @@ pub enum ErrorKind {
     /// assert!(result.is_err());
     /// assert_eq!(result.unwrap_err().kind, ErrorKind::InvalidSubcommand);
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     /// [`UnknownArgument`]: ErrorKind::UnknownArgument
     InvalidSubcommand,
 
-    /// Occurs when the user provides an unrecognized [``] which either
+    /// Occurs when the user provides an unrecognized [`Subcommand`] which either
     /// doesn't meet the threshold for being similar enough to an existing subcommand,
     /// or the 'suggestions' feature is disabled.
     /// Otherwise the more detailed [`InvalidSubcommand`] error is returned.
@@ -100,7 +100,7 @@ pub enum ErrorKind {
     /// assert!(result.is_err());
     /// assert_eq!(result.unwrap_err().kind, ErrorKind::UnrecognizedSubcommand);
     /// ```
-    /// [``]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     /// [`InvalidSubcommand`]: ErrorKind::InvalidSubcommand
     /// [`UnknownArgument`]: ErrorKind::UnknownArgument
     UnrecognizedSubcommand,
@@ -334,7 +334,7 @@ pub enum ErrorKind {
     /// ```
     DisplayHelp,
 
-    /// Occurs when either an argument or a [`subcommand`] is required, as defined by
+    /// Occurs when either an argument or a [`Subcommand`] is required, as defined by
     /// [`AppSettings::ArgRequiredElseHelp`] and
     /// [`AppSettings::SubcommandRequiredElseHelp`], but the user did not provide
     /// one.
@@ -353,7 +353,8 @@ pub enum ErrorKind {
     /// assert!(result.is_err());
     /// assert_eq!(result.unwrap_err().kind, ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand);
     /// ```
-    /// [`subcommand`]: App::subcommand()
+    ///
+    /// [`Subcommand`]: crate::Subcommand
     DisplayHelpOnMissingArgumentOrSubcommand,
 
     /// Not a true "error" as it means `--version` or similar was used.

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -832,7 +832,8 @@ impl ArgMatches {
     ///     assert_eq!(sub_m.value_of("opt"), Some("val"));
     /// }
     /// ```
-    /// [`Subcommand`]: ./struct..html
+    ///
+    /// [`Subcommand`]: crate::Subcommand
     pub fn subcommand_matches<T: Key>(&self, id: T) -> Option<&ArgMatches> {
         if let Some(ref s) = self.subcommand {
             if s.id == id.into() {
@@ -897,7 +898,7 @@ impl ArgMatches {
     ///     _              => {}, // Either no subcommand or one not tested for...
     /// }
     /// ```
-    /// [`Subcommand`]: ./struct..html
+    /// [`Subcommand`]: crate::Subcommand
     #[inline]
     pub fn subcommand_name(&self) -> Option<&str> {
         self.subcommand.as_ref().map(|sc| &*sc.name)


### PR DESCRIPTION
These were broken by 03333800fe8b9056823499f20f340770994e4643

