### PR TITLE
Infer long arguments

### DIFF
--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -833,7 +833,7 @@ pub enum AppSettings {
     /// match an argument named `--test`, one could use `--t`, `--te`, `--tes`, and `--test`.
     ///
     /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match
-    /// `--te` to `--test` there could not also be a subcommand or alias `--temp` because both
+    /// `--te` to `--test` there could not also be another argument or alias `--temp` because both
     /// start with `--te`
     InferLongArgs,
 

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -50,6 +50,7 @@ bitflags! {
         const DISABLE_HELP_FLAG              = 1 << 42;
         const USE_LONG_FORMAT_FOR_HELP_SC    = 1 << 43;
         const DISABLE_ENV                    = 1 << 44;
+        const INFER_LONG_ARGS                = 1 << 45;
     }
 }
 
@@ -153,7 +154,9 @@ impl_settings! { AppSettings, AppFlags,
     InferSubcommands("infersubcommands")
         => Flags::INFER_SUBCOMMANDS,
     AllArgsOverrideSelf("allargsoverrideself")
-        => Flags::ARGS_OVERRIDE_SELF
+        => Flags::ARGS_OVERRIDE_SELF,
+    InferLongArgs("inferlongargs")
+        => Flags::INFER_LONG_ARGS
 }
 
 /// Application level settings, which affect how [`App`] operates
@@ -825,6 +828,14 @@ pub enum AppSettings {
     /// [positional/free arguments]: Arg::index()
     /// [aliases]: App::alias()
     InferSubcommands,
+
+    /// Tries to match unknown args to partial long arguments or their [aliases]. For example, to
+    /// match an argument named `--test`, one could use `--t`, `--te`, `--tes`, and `--test`.
+    ///
+    /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match
+    /// `--te` to `--test` there could not also be a subcommand or alias `--temp` because both
+    /// start with `--te`
+    InferLongArgs,
 
     /// Specifies that the parser should not assume the first argument passed is the binary name.
     /// This is normally the case when using a "daemon" style mode, or an interactive CLI where one

--- a/tests/opts.rs
+++ b/tests/opts.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use clap::{App, Arg, ArgMatches, ArgSettings, ErrorKind};
+use clap::{App, AppSettings, Arg, ArgMatches, ArgSettings, ErrorKind};
 
 #[cfg(feature = "suggestions")]
 static DYM: &str =
@@ -576,4 +576,34 @@ fn issue_2279() {
         .get_matches_from(&[""]);
 
     assert_eq!(after_help_heading.value_of("foo"), Some("bar"));
+}
+
+#[test]
+fn infer_long_arg() {
+    let app = App::new("test")
+        .setting(AppSettings::InferLongArgs)
+        .arg(Arg::new("racetrack").long("racetrack").alias("autobahn"))
+        .arg(Arg::new("racecar").long("racecar").takes_value(true));
+
+    let matches = app.clone().get_matches_from(&["test", "--racec=hello"]);
+    assert!(!matches.is_present("racetrack"));
+    assert_eq!(matches.value_of("racecar"), Some("hello"));
+
+    let matches = app.clone().get_matches_from(&["test", "--racet"]);
+    assert!(matches.is_present("racetrack"));
+    assert_eq!(matches.value_of("racecar"), None);
+
+    let matches = app.clone().get_matches_from(&["test", "--auto"]);
+    assert!(matches.is_present("racetrack"));
+    assert_eq!(matches.value_of("racecar"), None);
+
+    let app = App::new("test")
+        .setting(AppSettings::InferLongArgs)
+        .arg(Arg::new("arg").long("arg"));
+
+    let matches = app.clone().get_matches_from(&["test", "--"]);
+    assert!(!matches.is_present("arg"));
+
+    let matches = app.clone().get_matches_from(&["test", "--a"]);
+    assert!(matches.is_present("arg"));
 }


### PR DESCRIPTION
Closes https://github.com/clap-rs/clap/issues/1786.

This PR add support abbreviated long options, such as writing `--test` as `--t`, `--te` or `--test` if the argument is ambiguous. It is enabled with `AppSettings::InferLongArgs`, modeled after `AppSettings::InferSubcommands`.

Also, thank you for this amazing project!