### PR TITLE
the word "Subcommand" was accidentally removed

### DIFF
--- a/examples/03_args.rs
+++ b/examples/03_args.rs
@@ -3,7 +3,7 @@ use clap::{App, Arg};
 fn main() {
     // Args describe a possible valid argument which may be supplied by the user at runtime. There
     // are three different types of arguments (flags, options, and positional) as well as a fourth
-    // special type of argument, called s (which will be discussed separately).
+    // special type of argument, called Subcommands (which will be discussed separately).
     //
     // Args are described in the same manner as Apps using the "builder pattern" with multiple
     // methods describing various settings for the individual arguments. Or by supplying a "usage"

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -14,7 +14,7 @@ fn main() {
     // subcommand along with "-h" and "--help" (applies to sub-subcommands as well).
     //
     // Just like arg() and args(), subcommands can be specified one at a time via subcommand() or
-    // multiple ones at once with a Vec<Subcommand> provided to subcommands().
+    // multiple ones at once with a Vec<App> provided to subcommands().
     let matches = App::new("MyApp")
         // Normal App and Arg configuration goes here...
         // In the following example assume we wanted an application which

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -1,8 +1,8 @@
 use clap::{App, Arg};
 
 fn main() {
-    // s function exactly like sub-Apps, because that's exactly what they are. Each
-    // instance of a can have its own version, author(s), Args, and even its own
+    // Subcommands function exactly like sub-Apps, because that's exactly what they are. Each
+    // instance of a Subcommand can have its own version, author(s), Args, and even its own
     // subcommands.
     //
     // # Help and Version
@@ -14,7 +14,7 @@ fn main() {
     // subcommand along with "-h" and "--help" (applies to sub-subcommands as well).
     //
     // Just like arg() and args(), subcommands can be specified one at a time via subcommand() or
-    // multiple ones at once with a Vec<> provided to subcommands().
+    // multiple ones at once with a Vec<Subcommand> provided to subcommands().
     let matches = App::new("MyApp")
         // Normal App and Arg configuration goes here...
         // In the following example assume we wanted an application which

--- a/examples/18_builder_macro.rs
+++ b/examples/18_builder_macro.rs
@@ -14,7 +14,7 @@ fn main() {
     };
 
     // External module may contain this subcommand. If this exists in another module, a function is
-    // required to access it. Recommend `fn clap() -> Clap::`.
+    // required to access it. Recommend `fn clap() -> Clap::SubCommand`.
     let external_sub_command = clap_app!( @subcommand foo =>
         (@arg bar: -b "Bar")
     );

--- a/examples/18_builder_macro.rs
+++ b/examples/18_builder_macro.rs
@@ -14,7 +14,7 @@ fn main() {
     };
 
     // External module may contain this subcommand. If this exists in another module, a function is
-    // required to access it. Recommend `fn clap() -> Clap::SubCommand`.
+    // required to access it. Recommend `fn clap() -> clap::App`.
     let external_sub_command = clap_app!( @subcommand foo =>
         (@arg bar: -b "Bar")
     );

--- a/examples/20_subcommands.rs
+++ b/examples/20_subcommands.rs
@@ -1,5 +1,5 @@
 // Working with subcommands is simple. There are a few key points to remember when working with
-// subcommands in clap. First, s are really just Apps. This means they can have their own
+// subcommands in clap. First, Subcommands are really just Apps. This means they can have their own
 // settings, version, authors, args, and even their own subcommands. The next thing to remember is
 // that subcommands are set up in a tree like hierarchy.
 //


### PR DESCRIPTION
Was done in 03333800fe8b9056823499f20f340770994e4643

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
