### PR TITLE
Hide help heading when all args are hidden

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -858,10 +858,6 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
             }
             if !custom_headings.is_empty() {
                 for heading in custom_headings {
-                    if !first {
-                        self.none("\n\n")?;
-                    }
-                    self.warning(&*format!("{}:\n", heading))?;
                     let args = self
                         .parser
                         .app
@@ -873,9 +869,17 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
                             }
                             false
                         })
+                        .filter(|arg| should_show_arg(self.use_long, arg))
                         .collect::<Vec<_>>();
-                    self.write_args(&*args)?;
-                    first = false
+
+                    if !args.is_empty() {
+                        if !first {
+                            self.none("\n\n")?;
+                        }
+                        self.warning(&*format!("{}:\n", heading))?;
+                        self.write_args(&*args)?;
+                        first = false
+                    }
                 }
             }
         }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -1944,6 +1944,64 @@ fn multiple_custom_help_headers() {
     ));
 }
 
+static CUSTOM_HELP_SECTION_HIDDEN_ARGS: &str = "blorp 1.4
+
+Will M.
+
+does stuff
+
+USAGE:
+    test --song <song> --song-volume <volume>
+
+FLAGS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SPECIAL:
+    -b, --song <song>             Change which song is played for birthdays
+    -v, --song-volume <volume>    Change the volume of the birthday song";
+
+#[test]
+fn custom_help_headers_hidden_args() {
+    let app = App::new("blorp")
+        .author("Will M.")
+        .about("does stuff")
+        .version("1.4")
+        .help_heading("NETWORKING")
+        .arg(
+            Arg::new("no-proxy")
+                .short('n')
+                .long("no-proxy")
+                .about("Do not use system proxy settings")
+                .hidden_short_help(true),
+        )
+        .help_heading("SPECIAL")
+        .arg(
+            Arg::from("-b, --song <song> 'Change which song is played for birthdays'")
+                .help_heading(Some("IGNORE THIS")),
+        )
+        .stop_custom_headings()
+        .arg(
+            Arg::from("-v --song-volume <volume> 'Change the volume of the birthday song'")
+                .help_heading(Some("SPECIAL")),
+        )
+        .arg(
+            Arg::new("server-addr")
+                .short('a')
+                .long("server-addr")
+                .about("Set server address")
+                .help_heading(Some("NETWORKING"))
+                .hidden_short_help(true),
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "test -h",
+        CUSTOM_HELP_SECTION_HIDDEN_ARGS,
+        false
+    ));
+}
+
 static ISSUE_897: &str = "ctest-foo 0.1
 
 Long about foo


### PR DESCRIPTION
Closes #2533.

Passing a closure isn't the nicest, but it avoids us having to duplicate the `args.filter(|arg| {should_show_arg(...)})` logic in multiple places.