### PR TITLE
Add a new arg option for the max_occurrences

### DIFF
--- a/clap.schema.json
+++ b/clap.schema.json
@@ -146,6 +146,9 @@
         "long_about": {
           "type": "string"
         },
+        "max_occurrences" : {
+            "type": "integer"
+        },
         "max_values": {
           "type": "integer"
         },

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -450,6 +450,23 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 self.p.app.color(),
             ));
         }
+        if let Some(max_occurs) = a.max_occurs {
+            debug!(
+                "Validator::validate_arg_num_occurs: max_occurs set...{}",
+                max_occurs
+            );
+            let occurs = ma.occurs as usize;
+            if occurs > max_occurs {
+                return Err(Error::too_many_occurrences(
+                    a,
+                    max_occurs,
+                    occurs,
+                    Usage::new(self.p).create_usage_with_title(&[]),
+                    self.p.app.color(),
+                ));
+            }
+        }
+
         Ok(())
     }
 

--- a/tests/multiple_occurrences.rs
+++ b/tests/multiple_occurrences.rs
@@ -128,3 +128,52 @@ fn multiple_occurrences_of_after_env() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     assert_eq!(m.unwrap().occurrences_of("verbose"), 3);
 }
+
+#[test]
+fn max_occurrences_implies_multiple_occurrences() {
+    let app = App::new("prog").arg(
+        Arg::new("verbose")
+            .short('v')
+            .long("verbose")
+            .max_occurrences(3),
+    );
+    let m = app.try_get_matches_from(vec!["prog", "-vvv"]);
+
+    assert!(m.is_ok(), "{}", m.unwrap_err());
+    assert_eq!(m.unwrap().occurrences_of("verbose"), 3);
+}
+
+#[test]
+fn max_occurrences_try_inputs() {
+    let app = App::new("prog").arg(
+        Arg::new("verbose")
+            .short('v')
+            .long("verbose")
+            .max_occurrences(3),
+    );
+    let m = app.clone().try_get_matches_from(vec!["prog", "-v"]);
+    assert!(m.is_ok(), "{}", m.unwrap_err());
+    assert_eq!(m.unwrap().occurrences_of("verbose"), 1);
+
+    let m = app.clone().try_get_matches_from(vec!["prog", "-vv"]);
+    assert!(m.is_ok(), "{}", m.unwrap_err());
+    assert_eq!(m.unwrap().occurrences_of("verbose"), 2);
+
+    let m = app.clone().try_get_matches_from(vec!["prog", "-vvv"]);
+    assert!(m.is_ok(), "{}", m.unwrap_err());
+    assert_eq!(m.unwrap().occurrences_of("verbose"), 3);
+
+    let m = app.clone().try_get_matches_from(vec!["prog", "-vvvv"]);
+    assert!(m.is_err(), "too many v's");
+
+    let m = app
+        .clone()
+        .try_get_matches_from(vec!["prog", "-v", "-v", "-v"]);
+    assert!(m.is_ok(), "{}", m.unwrap_err());
+    assert_eq!(m.unwrap().occurrences_of("verbose"), 3);
+
+    let m = app
+        .clone()
+        .try_get_matches_from(vec!["prog", "-v", "-vv", "-v"]);
+    assert!(m.is_err(), "{}", "too many v's");
+}

--- a/tests/multiple_occurrences.rs
+++ b/tests/multiple_occurrences.rs
@@ -152,6 +152,7 @@ fn max_occurrences_implies_multiple_occurrences() {
 
     let m = app.try_get_matches_from(vec!["prog", "-vvv"]);
 
+    assert!(m.is_err());
     assert_eq!(m.unwrap_err().kind, ErrorKind::UnexpectedMultipleUsage);
 }
 
@@ -176,6 +177,7 @@ fn max_occurrences_try_inputs() {
     assert_eq!(m.unwrap().occurrences_of("verbose"), 3);
 
     let m = app.clone().try_get_matches_from(vec!["prog", "-vvvv"]);
+    assert!(m.is_err());
     assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyOccurrences);
 
     let m = app
@@ -187,5 +189,6 @@ fn max_occurrences_try_inputs() {
     let m = app
         .clone()
         .try_get_matches_from(vec!["prog", "-v", "-vv", "-v"]);
+    assert!(m.is_err());
     assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyOccurrences);
 }

--- a/tests/multiple_occurrences.rs
+++ b/tests/multiple_occurrences.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg, ArgSettings};
+use clap::{App, Arg, ArgSettings, ErrorKind};
 
 #[test]
 fn multiple_occurrences_of_flags_long() {
@@ -141,6 +141,18 @@ fn max_occurrences_implies_multiple_occurrences() {
 
     assert!(m.is_ok(), "{}", m.unwrap_err());
     assert_eq!(m.unwrap().occurrences_of("verbose"), 3);
+
+    // One max should not imply multiple occurrences
+    let app = App::new("prog").arg(
+        Arg::new("verbose")
+            .short('v')
+            .long("verbose")
+            .max_occurrences(1),
+    );
+
+    let m = app.try_get_matches_from(vec!["prog", "-vvv"]);
+
+    assert_eq!(m.unwrap_err().kind, ErrorKind::UnexpectedMultipleUsage);
 }
 
 #[test]
@@ -164,7 +176,7 @@ fn max_occurrences_try_inputs() {
     assert_eq!(m.unwrap().occurrences_of("verbose"), 3);
 
     let m = app.clone().try_get_matches_from(vec!["prog", "-vvvv"]);
-    assert!(m.is_err(), "too many v's");
+    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyOccurrences);
 
     let m = app
         .clone()
@@ -175,5 +187,5 @@ fn max_occurrences_try_inputs() {
     let m = app
         .clone()
         .try_get_matches_from(vec!["prog", "-v", "-vv", "-v"]);
-    assert!(m.is_err(), "{}", "too many v's");
+    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyOccurrences);
 }


### PR DESCRIPTION
Closes #2520

Allows for specifying of `max_occurrences`, similar to `max_values`.
`max_occurrences` with a value of greater than 1 also specifies `multiple_occurrences`

Example:
`main.rs`
``` rust
fn main() {
    let args = App::new("foo")
        .arg(Arg::new("verbosity").short('v').max_occurrences(3))
        .get_matches();

    match args.occurrences_of("verbosity") {
        0 => println!("0"),
        1 => println!("1"),
        2 => println!("2"),
        _ =>println!("3"),
    }
}
```

The command `cargo run -- -vvv` will output:
```
3
```
whereas
`cargo run -- -vvvv` will output:
```
error: The argument '-v' allows at most 3 occurrences, but 4 were provided

USAGE:
    clap-test [FLAGS]

For more information try --help
```