### PR TITLE
Bump ansi_term, strsim, and textwrap to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ maintenance = {status = "actively-developed"}
 [dependencies]
 bitflags              = "1.0"
 unicode-width         = "0.1.4"
-textwrap              = "0.11.0"
-strsim    = { version = "0.8",  optional = true }
+textwrap              = "0.14.2"
+strsim    = { version = "0.10.0",  optional = true }
 yaml-rust = { version = "0.3.5",  optional = true }
 clippy    = { version = "~0.0.166", optional = true }
 atty      = { version = "0.2.2",  optional = true }
@@ -34,7 +34,7 @@ vec_map   = { version = "0.8", optional = true }
 term_size = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-ansi_term = { version = "0.11",  optional = true }
+ansi_term = { version = "0.12.1",  optional = true }
 
 [dev-dependencies]
 regex = "1"
@@ -45,7 +45,7 @@ version-sync = "0.8"
 default     = ["suggestions", "color", "vec_map"]
 suggestions = ["strsim"]
 color       = ["ansi_term", "atty"]
-wrap_help   = ["term_size", "textwrap/term_size"]
+wrap_help   = ["term_size", "textwrap/terminal_size"]
 yaml        = ["yaml-rust"]
 unstable    = [] # for building with unstable clap features (doesn't require nightly Rust) (currently none)
 nightly     = [] # for building with unstable Rust features (currently none)

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -1012,9 +1012,9 @@ impl<'a> Help<'a> {
 }
 
 fn wrap_help(help: &str, avail_chars: usize) -> String {
-    let wrapper = textwrap::Wrapper::new(avail_chars).break_words(false);
+    let options = textwrap::Options::new(avail_chars).break_words(false);
     help.lines()
-        .map(|line| wrapper.fill(line))
+        .map(|line| textwrap::fill(line, &options))
         .collect::<Vec<String>>()
         .join("\n")
 }


### PR DESCRIPTION
@pksunkara, a new patch release of v2 with these changes would be _hugely_ helpful for us at @MaterializeInc in removing some duplicate dependencies. (We'd be eager to upgrade to v3 instead, but it seems like that is still a while out.) Any chance you could consider this?