### PR TITLE
fix file include

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(feature = "doc", feature(external_doc))]
 #![doc(html_logo_url = "https://clap.rs/images/media/clap.png")]
 #![doc(html_root_url = "https://docs.rs/clap/3.0.0-beta.2")]
-#![cfg_attr(feature = "doc", doc(include = "../README.md"))]
+#![doc = include_str!("../README.md")]
 //! https://github.com/clap-rs/clap
 #![crate_type = "lib"]
 #![deny(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(feature = "doc", feature(external_doc))]
 #![doc(html_logo_url = "https://clap.rs/images/media/clap.png")]
 #![doc(html_root_url = "https://docs.rs/clap/3.0.0-beta.2")]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(feature = "doc", cfg_attr(feature = "doc", doc = include_str!("../README.md")))]
 //! https://github.com/clap-rs/clap
 #![crate_type = "lib"]
 #![deny(


### PR DESCRIPTION
compiler output

```
  warning: unknown `doc` attribute `include`
   --> /home/tshepang/clap/src/lib.rs:9:8
    |
  9 | #![doc(include = "../README.md")]
    | -------^^^^^^^^^^^^^^^^^^^^^^^^-- help: use `doc = include_str!` instead: `#![doc = include_str!("../README.md")]`
    |
    = note: `#[warn(invalid_doc_attributes)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82730 <https://github.com/rust-lang/rust/issues/82730>
