### PR TITLE
Test README code examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ regex = "1.0"
 lazy_static = "1"
 version-sync = "0.9"
 criterion = "0.3.2"
+doc-comment = "0.3"
 
 [features]
 default     = ["std", "suggestions", "color", "unicode_help", "derive", "cargo"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@
 #[cfg(not(feature = "std"))]
 compile_error!("`std` feature is currently required to build `clap`");
 
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");
+
 pub use crate::{
     build::{App, AppSettings, Arg, ArgGroup, ArgSettings, ValueHint},
     parse::errors::{Error, ErrorKind, Result},


### PR DESCRIPTION
This is a reopening of #1462. It allows to test README code examples without needing external tools and only relying on a lightweight dev-dependency.