### PR TITLE
fix(derive)!: Rename `Clap` to `Parser`.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -20,7 +20,7 @@ Simple! `clap` *is* `structopt`. With the 3.0 release, `clap` imported the `stru
 
 If you were using `structopt` before, you have to change the attributes from `#[structopt(...)]` to `#[clap(...)]`.
 
-Also the derive statements changed from `#[derive(Structopt)]` to `#[derive(Clap)]`. There is also some additional functionality and breaking changes that's been added to the `clap_derive` crate. See the documentation for that crate, for more details.
+Also the derive statements changed from `#[derive(Structopt)]` to `#[derive(Parser)]`. There is also some additional functionality and breaking changes that's been added to the `clap_derive` crate. See the documentation for that crate, for more details.
 
 #### How does `clap` compare to [getopts](https://github.com/rust-lang-nursery/getopts)?
 

--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ The first example shows the simplest way to use `clap`, by defining a struct. If
 //
 // This example demonstrates clap's full 'custom derive' style of creating arguments which is the
 // simplest method of use, but sacrifices some flexibility.
-use clap::{AppSettings, Clap};
+use clap::{AppSettings, Parser};
 
 /// This doc string acts as a help message when the user runs '--help'
 /// as do all doc strings on fields
-#[derive(Clap)]
+#[derive(Parser)]
 #[clap(version = "1.0", author = "Kevin K. <kbknapp@gmail.com>")]
 #[clap(setting = AppSettings::ColoredHelp)]
 struct Opts {
@@ -157,14 +157,14 @@ struct Opts {
     subcmd: SubCommand,
 }
 
-#[derive(Clap)]
+#[derive(Parser)]
 enum SubCommand {
     #[clap(version = "1.3", author = "Someone E. <someone_else@other.com>")]
     Test(Test),
 }
 
 /// A subcommand for controlling testing
-#[derive(Clap)]
+#[derive(Parser)]
 struct Test {
     /// Print debug info
     #[clap(short)]
@@ -466,7 +466,7 @@ Then run `cargo build` or `cargo update && cargo build` for your project.
 
 #### Features enabled by default
 
-* **derive**: Enables the custom derive (i.e. `#[derive(Clap)]`). Without this you must use one of the other methods of creating a `clap` CLI listed above.
+* **derive**: Enables the custom derive (i.e. `#[derive(Parser)]`). Without this you must use one of the other methods of creating a `clap` CLI listed above.
 * **cargo**: Turns on macros that read values from `CARGO_*` environment variables.
 * **suggestions**: Turns on the `Did you mean '--myoption'?` feature for when users make typos. (builds dependency `strsim`)
 * **color**: Turns on colored error messages. You still have to turn on colored help by setting `AppSettings::ColoredHelp`. (builds dependency `termcolor`)

--- a/clap_derive/README.md
+++ b/clap_derive/README.md
@@ -19,10 +19,10 @@ clap = "3"
 And then, in your rust file:
 ```rust
 use std::path::PathBuf;
-use clap::Clap;
+use clap::Parser;
 
 /// A basic example
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     // A flag, true if used in the command line. Note doc comment will

--- a/clap_derive/examples/after_help.rs
+++ b/clap_derive/examples/after_help.rs
@@ -1,11 +1,11 @@
 //! How to append a postscript to the help message generated.
 
-use clap::Clap;
+use clap::Parser;
 
 /// I am a program and I do things.
 ///
 /// Sometimes they even work.
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(after_help = "Beware `-d`, dragons be here")]
 struct Opt {
     /// Release the dragon.

--- a/clap_derive/examples/arg_enum.rs
+++ b/clap_derive/examples/arg_enum.rs
@@ -2,9 +2,9 @@
 //!
 //! All the variants of the enum and the enum itself support `rename_all`
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 enum ArgChoice {
     Foo,
     Bar,
@@ -13,7 +13,7 @@ enum ArgChoice {
     Baz,
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Opt {
     #[clap(arg_enum)]
     arg: ArgChoice,

--- a/clap_derive/examples/at_least_two.rs
+++ b/clap_derive/examples/at_least_two.rs
@@ -1,9 +1,9 @@
 //! How to require presence of at least N values,
 //! like `val1 val2 ... valN ... valM`.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt {
     #[clap(required = true, min_values = 2)]
     foos: Vec<String>,

--- a/clap_derive/examples/basic.rs
+++ b/clap_derive/examples/basic.rs
@@ -1,10 +1,10 @@
 //! A somewhat comprehensive example of a typical `clap_derive` usage.
 
-use clap::{Clap, ValueHint};
+use clap::{Parser, ValueHint};
 use std::path::PathBuf;
 
 /// A basic example
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     // A flag, true if used in the command line. Note doc comment will

--- a/clap_derive/examples/deny_missing_docs.rs
+++ b/clap_derive/examples/deny_missing_docs.rs
@@ -16,10 +16,10 @@
 
 #![deny(missing_docs)]
 
-use clap::Clap;
+use clap::Parser;
 
 /// The options
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 pub struct Opt {
     #[clap(short)]
     verbose: bool,
@@ -28,7 +28,7 @@ pub struct Opt {
 }
 
 /// Some subcommands
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 pub enum Cmd {
     /// command A
     A,
@@ -43,7 +43,7 @@ pub enum Cmd {
 }
 
 /// The options for C
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 pub struct COpt {
     #[clap(short)]
     bob: bool,

--- a/clap_derive/examples/doc_comments.rs
+++ b/clap_derive/examples/doc_comments.rs
@@ -1,10 +1,10 @@
 //! How to use doc comments in place of `help/long_help`.
 
-use clap::Clap;
+use clap::Parser;
 
 /// A basic example for the usage of doc comments as replacement
 /// of the arguments `help`, `long_help`, `about` and `long_about`.
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     /// Just use doc comments to replace `help`, `long_help`,
@@ -52,7 +52,7 @@ code) in the description:
     sub_command: SubCommand,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap()]
 enum SubCommand {
     /// The same rules described previously for flags. Are

--- a/clap_derive/examples/enum_tuple.rs
+++ b/clap_derive/examples/enum_tuple.rs
@@ -1,19 +1,19 @@
 //! How to extract subcommands' args into external structs.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, Parser)]
 pub struct Foo {
     pub bar: Option<String>,
 }
 
-#[derive(Debug, Clap)]
+#[derive(Debug, Parser)]
 pub enum Command {
     #[clap(name = "foo")]
     Foo(Foo),
 }
 
-#[derive(Debug, Clap)]
+#[derive(Debug, Parser)]
 #[clap(name = "classify")]
 pub struct ApplicationArguments {
     #[clap(subcommand)]

--- a/clap_derive/examples/env.rs
+++ b/clap_derive/examples/env.rs
@@ -1,10 +1,10 @@
 //! How to use environment variable fallback an how it
 //! interacts with `default_value`.
 
-use clap::{ArgSettings, Clap};
+use clap::{ArgSettings, Parser};
 
 /// Example for allowing to specify options via environment variables.
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "env")]
 struct Opt {
     // Use `env` to enable specifying the option with an environment

--- a/clap_derive/examples/example.rs
+++ b/clap_derive/examples/example.rs
@@ -1,8 +1,8 @@
-//! Somewhat complex example of usage of #[derive(Clap)].
+//! Somewhat complex example of usage of #[derive(Parser)].
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "example")]
 /// An example of clap_derive usage.
 struct Opt {

--- a/clap_derive/examples/flatten.rs
+++ b/clap_derive/examples/flatten.rs
@@ -1,8 +1,8 @@
 //! How to use flattening.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Cmdline {
     /// switch verbosity on
     #[clap(short)]
@@ -12,7 +12,7 @@ struct Cmdline {
     daemon_opts: DaemonOpts,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct DaemonOpts {
     /// daemon user
     #[clap(short)]

--- a/clap_derive/examples/from_crate.rs
+++ b/clap_derive/examples/from_crate.rs
@@ -1,8 +1,8 @@
 //! How to derive the author, description, and version from Cargo.toml
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(author, about, version)]
 //     ^^^^^^                   <- derive author from Cargo.toml
 //             ^^^^^            <- derive description from Cargo.toml

--- a/clap_derive/examples/git.rs
+++ b/clap_derive/examples/git.rs
@@ -3,9 +3,9 @@
 //! Documentation can be added either through doc comments or
 //! `help`/`about` attributes.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "git")]
 /// the stupid content tracker
 enum Opt {

--- a/clap_derive/examples/group.rs
+++ b/clap_derive/examples/group.rs
@@ -1,8 +1,8 @@
 //! How to use `clap::Arg::group`
 
-use clap::{ArgGroup, Clap};
+use clap::{ArgGroup, Parser};
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(group = ArgGroup::new("verb").required(true))]
 struct Opt {
     /// Set a custom HTTP verb

--- a/clap_derive/examples/keyvalue.rs
+++ b/clap_derive/examples/keyvalue.rs
@@ -1,6 +1,6 @@
-//! How to parse "key=value" pairs with #[derive(Clap)].
+//! How to parse "key=value" pairs with #[derive(Parser)].
 
-use clap::Clap;
+use clap::Parser;
 use std::error::Error;
 
 /// Parse a single key-value pair
@@ -17,7 +17,7 @@ where
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt {
     // number_of_values = 1 forces the user to repeat the -D option for each key-value pair:
     // my_program -D a=1 -D b=2

--- a/clap_derive/examples/negative_flag.rs
+++ b/clap_derive/examples/negative_flag.rs
@@ -1,9 +1,9 @@
 //! How to add `no-thing` flag which is `true` by default and
 //! `false` if passed.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Debug, Clap)]
+#[derive(Debug, Parser)]
 struct Opt {
     #[clap(long = "no-verbose", parse(from_flag = std::ops::Not::not))]
     verbose: bool,

--- a/clap_derive/examples/rename_all.rs
+++ b/clap_derive/examples/rename_all.rs
@@ -18,9 +18,9 @@
 //!                   with underscores.
 //! - **Verbatim**: Use the original attribute name defined in the code.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "rename_all", rename_all = "screaming_snake_case")]
 enum Opt {
     // This subcommand will be named `FIRST_COMMAND`. As the command doesn't
@@ -55,13 +55,13 @@ enum Opt {
     },
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Subcommands {
     // This one will be available as `first-subcommand`.
     FirstSubcommand,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct BonusOptions {
     // And this one will be available as `baz-option`.
     #[clap(long)]

--- a/clap_derive/examples/skip.rs
+++ b/clap_derive/examples/skip.rs
@@ -1,8 +1,8 @@
 //! How to use `#[clap(skip)]`
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 pub struct Opt {
     #[clap(long, short)]
     number: u32,

--- a/clap_derive/examples/subcommand_aliases.rs
+++ b/clap_derive/examples/subcommand_aliases.rs
@@ -1,8 +1,8 @@
 //! How to assign some aliases to subcommands
 
-use clap::{AppSettings, Clap};
+use clap::{AppSettings, Parser};
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 // https://docs.rs/clap/2/clap/enum.AppSettings.html#variant.InferSubcommands
 #[clap(setting = AppSettings::InferSubcommands)]
 enum Opt {

--- a/clap_derive/examples/true_or_false.rs
+++ b/clap_derive/examples/true_or_false.rs
@@ -1,6 +1,6 @@
 //! How to parse `--foo=true --bar=false` and turn them into bool.
 
-use clap::Clap;
+use clap::Parser;
 
 fn true_or_false(s: &str) -> Result<bool, &'static str> {
     match s {
@@ -10,7 +10,7 @@ fn true_or_false(s: &str) -> Result<bool, &'static str> {
     }
 }
 
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 struct Opt {
     // Default parser for `try_from_str` is FromStr::from_str.
     // `impl FromStr for bool` parses `true` or `false` so this

--- a/clap_derive/examples/value_hints_derive.rs
+++ b/clap_derive/examples/value_hints_derive.rs
@@ -12,14 +12,14 @@
 //! . ./value_hints_derive.fish
 //! ./target/debug/examples/value_hints_derive --<TAB>
 //! ```
-use clap::{App, AppSettings, Clap, IntoApp, ValueHint};
+use clap::{App, AppSettings, IntoApp, Parser, ValueHint};
 use clap_generate::generators::{Bash, Elvish, Fish, PowerShell, Zsh};
 use clap_generate::{generate, Generator};
 use std::ffi::OsString;
 use std::io;
 use std::path::PathBuf;
 
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 enum GeneratorChoice {
     Bash,
     Elvish,
@@ -29,7 +29,7 @@ enum GeneratorChoice {
     Zsh,
 }
 
-#[derive(Clap, Debug, PartialEq)]
+#[derive(Parser, Debug, PartialEq)]
 #[clap(
     name = "value_hints_derive",
     // AppSettings::TrailingVarArg is required to use ValueHint::CommandWithArguments

--- a/clap_derive/src/derives/mod.rs
+++ b/clap_derive/src/derives/mod.rs
@@ -12,12 +12,12 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 mod arg_enum;
-mod clap;
 mod from_arg_matches;
 mod into_app;
+mod parser;
 mod subcommand;
 
-pub use self::clap::derive_clap;
+pub use self::parser::derive_parser;
 pub use arg_enum::derive_arg_enum;
 // pub use from_arg_matches::derive_from_arg_matches;
 pub use into_app::derive_into_app;

--- a/clap_derive/src/derives/parser.rs
+++ b/clap_derive/src/derives/parser.rs
@@ -25,7 +25,7 @@ use syn::{
     Field, Fields, Ident,
 };
 
-pub fn derive_clap(input: &DeriveInput) -> TokenStream {
+pub fn derive_parser(input: &DeriveInput) -> TokenStream {
     let ident = &input.ident;
 
     match input.data {
@@ -33,21 +33,21 @@ pub fn derive_clap(input: &DeriveInput) -> TokenStream {
             fields: Fields::Named(ref fields),
             ..
         }) => {
-            dummies::clap_struct(ident);
+            dummies::parser_struct(ident);
             gen_for_struct(ident, &fields.named, &input.attrs)
         }
         Data::Struct(DataStruct {
             fields: Fields::Unit,
             ..
         }) => {
-            dummies::clap_struct(ident);
+            dummies::parser_struct(ident);
             gen_for_struct(ident, &Punctuated::<Field, Comma>::new(), &input.attrs)
         }
         Data::Enum(ref e) => {
-            dummies::clap_enum(ident);
+            dummies::parser_enum(ident);
             gen_for_enum(ident, &input.attrs, e)
         }
-        _ => abort_call_site!("`#[derive(Clap)]` only supports non-tuple structs and enums"),
+        _ => abort_call_site!("`#[derive(Parser)]` only supports non-tuple structs and enums"),
     }
 }
 
@@ -60,7 +60,7 @@ fn gen_for_struct(
     let from_arg_matches = from_arg_matches::gen_for_struct(name, fields, &attrs);
 
     quote! {
-        impl clap::Clap for #name {}
+        impl clap::Parser for #name {}
 
         #into_app
         #from_arg_matches
@@ -74,7 +74,7 @@ fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStream 
     let arg_enum = arg_enum::gen_for_enum(name, attrs, e);
 
     quote! {
-        impl clap::Clap for #name {}
+        impl clap::Parser for #name {}
 
         #into_app
         #from_arg_matches

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -115,7 +115,7 @@ fn gen_augment(
                             let ty = &unnamed[0];
                             quote_spanned! { ty.span()=>
                                 {
-                                    <#ty as clap::IntoApp>::augment_clap(#app_var)
+                                    <#ty as clap::IntoApp>::augment_parser(#app_var)
                                 }
                             }
                         }

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -4,18 +4,18 @@ use proc_macro2::Ident;
 use proc_macro_error::append_dummy;
 use quote::quote;
 
-pub fn clap_struct(name: &Ident) {
+pub fn parser_struct(name: &Ident) {
     into_app(name);
     from_arg_matches(name);
-    append_dummy(quote!( impl clap::Clap for #name {} ));
+    append_dummy(quote!( impl clap::Parser for #name {} ));
 }
 
-pub fn clap_enum(name: &Ident) {
+pub fn parser_enum(name: &Ident) {
     into_app(name);
     from_arg_matches(name);
     subcommand(name);
     arg_enum(name);
-    append_dummy(quote!( impl clap::Clap for #name {} ));
+    append_dummy(quote!( impl clap::Parser for #name {} ));
 }
 
 pub fn into_app(name: &Ident) {
@@ -24,13 +24,13 @@ pub fn into_app(name: &Ident) {
             fn into_app<'b>() -> clap::App<'b> {
                 unimplemented!()
             }
-            fn augment_clap<'b>(_app: clap::App<'b>) -> clap::App<'b> {
+            fn augment_parser<'b>(_app: clap::App<'b>) -> clap::App<'b> {
                 unimplemented!()
             }
             fn into_app_for_update<'b>() -> clap::App<'b> {
                 unimplemented!()
             }
-            fn augment_clap_for_update<'b>(_app: clap::App<'b>) -> clap::App<'b> {
+            fn augment_parser_for_update<'b>(_app: clap::App<'b>) -> clap::App<'b> {
                 unimplemented!()
             }
         }

--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -17,7 +17,7 @@
 
 //! This crate is custom derive for clap. It should not be used
 //! directly. See [clap documentation](clap)
-//! for the usage of `#[derive(Clap)]`.
+//! for the usage of `#[derive(Parser)]`.
 
 #![forbid(unsafe_code)]
 
@@ -41,17 +41,17 @@ pub fn arg_enum(input: TokenStream) -> TokenStream {
     derives::derive_arg_enum(&input).into()
 }
 
-/// Generates the `Clap` implementation.
+/// Generates the `Parser` implementation.
 ///
 /// This is far less verbose than defining the [`App`] struct manually,
 /// receiving an instance of [`ArgMatches`] from conducting parsing, and then
 /// implementing a conversion code to instantiate an instance of the user
 /// context struct.
-#[proc_macro_derive(Clap, attributes(clap))]
+#[proc_macro_derive(Parser, attributes(clap))]
 #[proc_macro_error]
-pub fn clap(input: TokenStream) -> TokenStream {
+pub fn parser(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
-    derives::derive_clap(&input).into()
+    derives::derive_parser(&input).into()
 }
 
 // /// Generates the `FromArgMatches` impl.

--- a/clap_derive/src/utils/doc_comments.rs
+++ b/clap_derive/src/utils/doc_comments.rs
@@ -1,6 +1,6 @@
 //! The preprocessing we apply to doc comments.
 //!
-//! #[derive(Clap)] works in terms of "paragraphs". Paragraph is a sequence of
+//! #[derive(Parser)] works in terms of "paragraphs". Paragraph is a sequence of
 //! non-empty adjacent lines, delimited by sequences of blank (whitespace only) lines.
 
 use crate::attrs::Method;

--- a/clap_derive/tests/app_name.rs
+++ b/clap_derive/tests/app_name.rs
@@ -1,8 +1,8 @@
-use clap::Clap;
 use clap::IntoApp;
+use clap::Parser;
 #[test]
 fn app_name_in_short_help_from_struct() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     struct MyApp {}
 
@@ -15,7 +15,7 @@ fn app_name_in_short_help_from_struct() {
 
 #[test]
 fn app_name_in_long_help_from_struct() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     struct MyApp {}
 
@@ -28,7 +28,7 @@ fn app_name_in_long_help_from_struct() {
 
 #[test]
 fn app_name_in_short_help_from_enum() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     enum MyApp {}
 
@@ -41,7 +41,7 @@ fn app_name_in_short_help_from_enum() {
 
 #[test]
 fn app_name_in_long_help_from_enum() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     enum MyApp {}
 
@@ -54,7 +54,7 @@ fn app_name_in_long_help_from_enum() {
 
 #[test]
 fn app_name_in_short_version_from_struct() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     struct MyApp {}
 
@@ -65,7 +65,7 @@ fn app_name_in_short_version_from_struct() {
 
 #[test]
 fn app_name_in_long_version_from_struct() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     struct MyApp {}
 
@@ -76,7 +76,7 @@ fn app_name_in_long_version_from_struct() {
 
 #[test]
 fn app_name_in_short_version_from_enum() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     enum MyApp {}
 
@@ -87,7 +87,7 @@ fn app_name_in_short_version_from_enum() {
 
 #[test]
 fn app_name_in_long_version_from_enum() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(name = "my-app")]
     enum MyApp {}
 

--- a/clap_derive/tests/arg_enum.rs
+++ b/clap_derive/tests/arg_enum.rs
@@ -7,17 +7,17 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use clap::{ArgEnum, Clap};
+use clap::{ArgEnum, Parser};
 
 #[test]
 fn basic() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         Foo,
         Bar,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum)]
         arg: ArgChoice,
@@ -40,14 +40,14 @@ fn basic() {
 
 #[test]
 fn multi_word_is_renamed_kebab() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[allow(non_camel_case_types)]
     enum ArgChoice {
         FooBar,
         BAR_BAZ,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum)]
         arg: ArgChoice,
@@ -70,13 +70,13 @@ fn multi_word_is_renamed_kebab() {
 
 #[test]
 fn variant_with_defined_casing() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         #[clap(rename_all = "screaming_snake")]
         FooBar,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum)]
         arg: ArgChoice,
@@ -93,13 +93,13 @@ fn variant_with_defined_casing() {
 
 #[test]
 fn casing_is_propogated_from_parent() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[clap(rename_all = "screaming_snake")]
     enum ArgChoice {
         FooBar,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum)]
         arg: ArgChoice,
@@ -116,14 +116,14 @@ fn casing_is_propogated_from_parent() {
 
 #[test]
 fn casing_propogation_is_overridden() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[clap(rename_all = "screaming_snake")]
     enum ArgChoice {
         #[clap(rename_all = "camel")]
         FooBar,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum)]
         arg: ArgChoice,
@@ -141,12 +141,12 @@ fn casing_propogation_is_overridden() {
 
 #[test]
 fn case_insensitive() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         Foo,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum, case_insensitive(true))]
         arg: ArgChoice,
@@ -168,12 +168,12 @@ fn case_insensitive() {
 
 #[test]
 fn case_insensitive_set_to_false() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         Foo,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum, case_insensitive(false))]
         arg: ArgChoice,
@@ -190,13 +190,13 @@ fn case_insensitive_set_to_false() {
 
 #[test]
 fn alias() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         #[clap(alias = "TOTP")]
         TOTP,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum, case_insensitive(false))]
         arg: ArgChoice,
@@ -218,13 +218,13 @@ fn alias() {
 
 #[test]
 fn multiple_alias() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         #[clap(alias = "TOTP", alias = "t")]
         TOTP,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum, case_insensitive(false))]
         arg: ArgChoice,
@@ -252,13 +252,13 @@ fn multiple_alias() {
 
 #[test]
 fn option() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         Foo,
         Bar,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum)]
         arg: Option<ArgChoice>,
@@ -282,13 +282,13 @@ fn option() {
 
 #[test]
 fn vector() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         Foo,
         Bar,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum, short, long)]
         arg: Vec<ArgChoice>,
@@ -312,7 +312,7 @@ fn vector() {
 
 #[test]
 fn from_str_invalid() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum ArgChoice {
         Foo,
     }

--- a/clap_derive/tests/argument_naming.rs
+++ b/clap_derive/tests/argument_naming.rs
@@ -1,8 +1,8 @@
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn test_single_word_enum_variant_is_default_renamed_into_kebab_case() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     enum Opt {
         Command { foo: u32 },
     }
@@ -15,7 +15,7 @@ fn test_single_word_enum_variant_is_default_renamed_into_kebab_case() {
 
 #[test]
 fn test_multi_word_enum_variant_is_renamed() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     enum Opt {
         FirstCommand { foo: u32 },
     }
@@ -28,7 +28,7 @@ fn test_multi_word_enum_variant_is_renamed() {
 
 #[test]
 fn test_standalone_long_generates_kebab_case() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
         #[clap(long)]
@@ -43,7 +43,7 @@ fn test_standalone_long_generates_kebab_case() {
 
 #[test]
 fn test_custom_long_overwrites_default_name() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(long = "foo")]
         foo_option: bool,
@@ -57,7 +57,7 @@ fn test_custom_long_overwrites_default_name() {
 
 #[test]
 fn test_standalone_long_uses_previous_defined_custom_name() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(name = "foo", long)]
         foo_option: bool,
@@ -71,7 +71,7 @@ fn test_standalone_long_uses_previous_defined_custom_name() {
 
 #[test]
 fn test_standalone_long_ignores_afterwards_defined_custom_name() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(long, name = "foo")]
         foo_option: bool,
@@ -85,7 +85,7 @@ fn test_standalone_long_ignores_afterwards_defined_custom_name() {
 
 #[test]
 fn test_standalone_short_generates_kebab_case() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
         #[clap(short)]
@@ -97,7 +97,7 @@ fn test_standalone_short_generates_kebab_case() {
 
 #[test]
 fn test_custom_short_overwrites_default_name() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(short = 'o')]
         foo_option: bool,
@@ -108,7 +108,7 @@ fn test_custom_short_overwrites_default_name() {
 
 #[test]
 fn test_standalone_short_uses_previous_defined_custom_name() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(name = "option", short)]
         foo_option: bool,
@@ -119,7 +119,7 @@ fn test_standalone_short_uses_previous_defined_custom_name() {
 
 #[test]
 fn test_standalone_short_ignores_afterwards_defined_custom_name() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(short, name = "option")]
         foo_option: bool,
@@ -130,7 +130,7 @@ fn test_standalone_short_ignores_afterwards_defined_custom_name() {
 
 #[test]
 fn test_standalone_long_uses_previous_defined_casing() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(rename_all = "screaming_snake", long)]
         foo_option: bool,
@@ -144,7 +144,7 @@ fn test_standalone_long_uses_previous_defined_casing() {
 
 #[test]
 fn test_standalone_short_uses_previous_defined_casing() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(rename_all = "screaming_snake", short)]
         foo_option: bool,
@@ -155,7 +155,7 @@ fn test_standalone_short_uses_previous_defined_casing() {
 
 #[test]
 fn test_standalone_long_works_with_verbatim_casing() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
         #[clap(rename_all = "verbatim", long)]
@@ -170,7 +170,7 @@ fn test_standalone_long_works_with_verbatim_casing() {
 
 #[test]
 fn test_standalone_short_works_with_verbatim_casing() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(rename_all = "verbatim", short)]
         _foo: bool,
@@ -181,7 +181,7 @@ fn test_standalone_short_works_with_verbatim_casing() {
 
 #[test]
 fn test_rename_all_is_propagated_from_struct_to_fields() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[clap(rename_all = "screaming_snake")]
     struct Opt {
         #[clap(long)]
@@ -193,14 +193,14 @@ fn test_rename_all_is_propagated_from_struct_to_fields() {
 
 #[test]
 fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[clap(rename_all = "screaming_snake")]
     struct Opt {
         #[clap(flatten)]
         foo: Foo,
     }
 
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Foo {
         #[clap(long)]
         foo: bool,
@@ -216,14 +216,14 @@ fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
 
 #[test]
 fn test_rename_all_is_not_propagated_from_struct_into_subcommand() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[clap(rename_all = "screaming_snake")]
     struct Opt {
         #[clap(subcommand)]
         foo: Foo,
     }
 
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     enum Foo {
         Command {
             #[clap(long)]
@@ -241,7 +241,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_subcommand() {
 
 #[test]
 fn test_rename_all_is_propagated_from_enum_to_variants_and_their_fields() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[clap(rename_all = "screaming_snake")]
     enum Opt {
         FirstVariant,
@@ -264,7 +264,7 @@ fn test_rename_all_is_propagated_from_enum_to_variants_and_their_fields() {
 
 #[test]
 fn test_rename_all_is_propagation_can_be_overridden() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[clap(rename_all = "screaming_snake")]
     enum Opt {
         #[clap(rename_all = "kebab_case")]

--- a/clap_derive/tests/arguments.rs
+++ b/clap_derive/tests/arguments.rs
@@ -12,11 +12,11 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn required_argument() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         arg: i32,
     }
@@ -27,7 +27,7 @@ fn required_argument() {
 
 #[test]
 fn optional_argument() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         arg: Option<i32>,
     }
@@ -38,7 +38,7 @@ fn optional_argument() {
 
 #[test]
 fn argument_with_default() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(default_value = "42")]
         arg: i32,
@@ -50,7 +50,7 @@ fn argument_with_default() {
 
 #[test]
 fn arguments() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         arg: Vec<i32>,
     }
@@ -64,7 +64,7 @@ fn arguments() {
 
 #[test]
 fn arguments_safe() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         arg: Vec<i32>,
     }

--- a/clap_derive/tests/author_version_about.rs
+++ b/clap_derive/tests/author_version_about.rs
@@ -14,12 +14,12 @@
 
 mod utils;
 
-use clap::Clap;
+use clap::Parser;
 use utils::*;
 
 #[test]
 fn no_author_version_about() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[clap(name = "foo")]
     struct Opt {}
 
@@ -29,7 +29,7 @@ fn no_author_version_about() {
 
 #[test]
 fn use_env() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[clap(author, about, version)]
     struct Opt {}
 
@@ -43,7 +43,7 @@ fn use_env() {
 fn explicit_version_not_str_lit() {
     const VERSION: &str = "custom version";
 
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(version = VERSION)]
     pub struct Opt {}
 

--- a/clap_derive/tests/basic.rs
+++ b/clap_derive/tests/basic.rs
@@ -12,11 +12,11 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn basic() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short = 'a', long = "arg")]
         arg: Vec<i32>,
@@ -31,7 +31,7 @@ fn basic() {
 
 #[test]
 fn update_basic() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short = 'a', long = "arg")]
         single_value: i32,
@@ -46,7 +46,7 @@ fn update_basic() {
 
 #[test]
 fn unit_struct() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt;
 
     assert_eq!(Opt {}, Opt::parse_from(&["test"]));

--- a/clap_derive/tests/boxed.rs
+++ b/clap_derive/tests/boxed.rs
@@ -1,12 +1,12 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Opt {
     #[clap(subcommand)]
     sub: Box<Sub>,
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Sub {
     Flame {
         #[clap(flatten)]
@@ -14,7 +14,7 @@ enum Sub {
     },
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Ext {
     arg: u32,
 }

--- a/clap_derive/tests/custom-string-parsers.rs
+++ b/clap_derive/tests/custom-string-parsers.rs
@@ -12,13 +12,13 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Clap;
+use clap::Parser;
 
 use std::ffi::{CString, OsStr};
 use std::num::ParseIntError;
 use std::path::PathBuf;
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct PathOpt {
     #[clap(short, long, parse(from_os_str))]
     path: PathBuf,
@@ -61,7 +61,7 @@ fn parse_hex(input: &str) -> Result<u64, ParseIntError> {
     u64::from_str_radix(input, 16)
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct HexOpt {
     #[clap(short, parse(try_from_str = parse_hex))]
     number: u64,
@@ -109,7 +109,7 @@ fn custom_parser_4(_: &OsStr) -> Result<&'static str, String> {
     Ok("D")
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct NoOpOpt {
     #[clap(short, parse(from_str = custom_parser_1))]
     a: &'static str,
@@ -160,7 +160,7 @@ fn update_every_custom_parser() {
 // conversion function from `&str` to `u8`.
 type Bytes = Vec<u8>;
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct DefaultedOpt {
     #[clap(short, parse(from_str))]
     bytes: Bytes,
@@ -199,7 +199,7 @@ fn foo(value: u64) -> Foo {
     Foo(value as u8)
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Occurrences {
     #[clap(short, long, parse(from_occurrences))]
     signed: i32,
@@ -242,7 +242,7 @@ fn test_custom_bool() {
             _ => Err(format!("invalid bool {}", s)),
         }
     }
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, parse(try_from_str = parse_bool))]
         debug: bool,
@@ -328,7 +328,7 @@ fn test_custom_bool() {
 
 #[test]
 fn test_cstring() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     struct Opt {
         #[clap(parse(try_from_str = CString::new))]
         c_string: CString,

--- a/clap_derive/tests/default_value.rs
+++ b/clap_derive/tests/default_value.rs
@@ -1,4 +1,4 @@
-use clap::Clap;
+use clap::Parser;
 
 mod utils;
 
@@ -6,7 +6,7 @@ use utils::*;
 
 #[test]
 fn auto_default_value() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(default_value)]
         arg: i32,

--- a/clap_derive/tests/deny-warnings.rs
+++ b/clap_derive/tests/deny-warnings.rs
@@ -14,7 +14,7 @@
 
 #![deny(warnings)]
 
-use clap::Clap;
+use clap::Parser;
 
 fn try_str(s: &str) -> Result<String, std::convert::Infallible> {
     Ok(s.into())
@@ -22,7 +22,7 @@ fn try_str(s: &str) -> Result<String, std::convert::Infallible> {
 
 #[test]
 fn warning_never_struct() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(parse(try_from_str = try_str))]
         s: String,
@@ -37,7 +37,7 @@ fn warning_never_struct() {
 
 #[test]
 fn warning_never_enum() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     enum Opt {
         Foo {
             #[clap(parse(try_from_str = try_str))]

--- a/clap_derive/tests/doc-comments-help.rs
+++ b/clap_derive/tests/doc-comments-help.rs
@@ -14,13 +14,13 @@
 
 mod utils;
 
-use clap::Clap;
+use clap::Parser;
 use utils::*;
 
 #[test]
 fn doc_comments() {
     /// Lorem ipsum
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct LoremIpsum {
         /// Fooify a bar
         /// and a baz
@@ -36,7 +36,7 @@ fn doc_comments() {
 #[test]
 fn help_is_better_than_comments() {
     /// Lorem ipsum
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
         /// Fooify a bar
@@ -55,7 +55,7 @@ fn empty_line_in_doc_comment_is_double_linefeed() {
     /// Foo.
     ///
     /// Bar
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[clap(name = "lorem-ipsum")]
     struct LoremIpsum {}
 
@@ -66,7 +66,7 @@ fn empty_line_in_doc_comment_is_double_linefeed() {
 #[test]
 fn field_long_doc_comment_both_help_long_help() {
     /// Lorem ipsumclap
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
         /// Dot is removed from multiline comments.
@@ -94,14 +94,14 @@ fn field_long_doc_comment_both_help_long_help() {
 #[test]
 fn top_long_doc_comment_both_help_long_help() {
     /// Lorem ipsumclap
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
         #[clap(subcommand)]
         foo: SubCommand,
     }
 
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     pub enum SubCommand {
         /// DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES
         ///
@@ -139,7 +139,7 @@ fn verbatim_doc_comment() {
     ///        \\    ||
     ///      ( ()    ||
     ///       (      () ) )
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     #[clap(verbatim_doc_comment)]
     struct SeeFigure1 {
         #[clap(long)]
@@ -169,7 +169,7 @@ fn verbatim_doc_comment() {
 
 #[test]
 fn verbatim_doc_comment_field() {
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     struct App {
         /// This help ends in a period.
         #[clap(long, verbatim_doc_comment)]

--- a/clap_derive/tests/explicit_name_no_renaming.rs
+++ b/clap_derive/tests/explicit_name_no_renaming.rs
@@ -1,11 +1,11 @@
 mod utils;
 
-use clap::Clap;
+use clap::Parser;
 use utils::*;
 
 #[test]
 fn explicit_short_long_no_rename() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short = '.', long = ".foo", multiple_occurrences(true))]
         foo: Vec<String>,
@@ -21,7 +21,7 @@ fn explicit_short_long_no_rename() {
 
 #[test]
 fn explicit_name_no_rename() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(name = ".options")]
         foo: Vec<String>,

--- a/clap_derive/tests/flags.rs
+++ b/clap_derive/tests/flags.rs
@@ -12,11 +12,11 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn unique_flag() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, long)]
         alice: bool,
@@ -33,7 +33,7 @@ fn unique_flag() {
 
 #[test]
 fn multiple_flag() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, long, parse(from_occurrences))]
         alice: u64,
@@ -65,7 +65,7 @@ fn parse_from_flag(b: bool) -> std::sync::atomic::AtomicBool {
 
 #[test]
 fn non_bool_flags() {
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     struct Opt {
         #[clap(short, long, parse(from_flag = parse_from_flag))]
         alice: std::sync::atomic::AtomicBool,
@@ -92,7 +92,7 @@ fn non_bool_flags() {
 
 #[test]
 fn combined_flags() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, long)]
         alice: bool,

--- a/clap_derive/tests/flatten.rs
+++ b/clap_derive/tests/flatten.rs
@@ -12,16 +12,16 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn flatten() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Common {
         arg: i32,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(flatten)]
         common: Common,
@@ -40,12 +40,12 @@ fn flatten() {
 #[test]
 #[should_panic]
 fn flatten_twice() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Common {
         arg: i32,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(flatten)]
         c1: Common,
@@ -58,12 +58,12 @@ fn flatten_twice() {
 
 #[test]
 fn flatten_in_subcommand() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Common {
         arg: i32,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Add {
         #[clap(short)]
         interactive: bool,
@@ -71,7 +71,7 @@ fn flatten_in_subcommand() {
         common: Common,
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     enum Opt {
         Fetch {
             #[clap(short)]
@@ -99,22 +99,22 @@ fn flatten_in_subcommand() {
     );
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum BaseCli {
     Command1(Command1),
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Command1 {
     arg1: i32,
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Command2 {
     arg2: i32,
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Opt {
     #[clap(flatten)]
     BaseCli(BaseCli),
@@ -135,7 +135,7 @@ fn merge_subcommands_with_flatten() {
 
 #[test]
 fn flatten_with_doc_comment() {
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     struct DaemonOpts {
         #[clap(short)]
         user: String,
@@ -143,7 +143,7 @@ fn flatten_with_doc_comment() {
         group: String,
     }
 
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     #[clap(name = "basic")]
     struct Opt {
         /// A very important doc comment I just can't leave out!

--- a/clap_derive/tests/issues.rs
+++ b/clap_derive/tests/issues.rs
@@ -3,11 +3,11 @@
 mod utils;
 use utils::*;
 
-use clap::{AppSettings, ArgGroup, Clap};
+use clap::{AppSettings, ArgGroup, Parser};
 
 #[test]
 fn issue_151() {
-    #[derive(Clap, Debug)]
+    #[derive(Parser, Debug)]
     #[clap(group = ArgGroup::new("verb").required(true).multiple(true))]
     struct Opt {
         #[clap(long, group = "verb")]
@@ -16,7 +16,7 @@ fn issue_151() {
         bar: bool,
     }
 
-    #[derive(Debug, Clap)]
+    #[derive(Debug, Parser)]
     struct Cli {
         #[clap(flatten)]
         a: Opt,
@@ -31,7 +31,7 @@ fn issue_151() {
 
 #[test]
 fn issue_289() {
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(setting = AppSettings::InferSubcommands)]
     enum Args {
         SomeCommand(SubSubCommand),
@@ -40,7 +40,7 @@ fn issue_289() {
 
     // FIXME (@CreepySkeleton): current implementation requires us to
     // derive IntoApp here while we don't really need it
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(setting = AppSettings::InferSubcommands)]
     enum SubSubCommand {
         TestCommand,
@@ -58,14 +58,14 @@ fn issue_324() {
         "MY_VERSION"
     }
 
-    #[derive(Clap)]
+    #[derive(Parser)]
     #[clap(version = my_version())]
     struct Opt {
         #[clap(subcommand)]
         _cmd: Option<SubCommand>,
     }
 
-    #[derive(Clap)]
+    #[derive(Parser)]
     enum SubCommand {
         Start,
     }

--- a/clap_derive/tests/nested-subcommands.rs
+++ b/clap_derive/tests/nested-subcommands.rs
@@ -12,9 +12,9 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Opt {
     #[clap(short, long)]
     force: bool,
@@ -24,13 +24,13 @@ struct Opt {
     cmd: Sub,
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Sub {
     Fetch {},
     Add {},
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Opt2 {
     #[clap(short, long)]
     force: bool,
@@ -107,7 +107,7 @@ fn test_badinput() {
     assert!(result.is_err());
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Opt3 {
     #[clap(short, long)]
     all: bool,
@@ -115,7 +115,7 @@ struct Opt3 {
     cmd: Sub2,
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Sub2 {
     Foo {
         file: String,
@@ -125,7 +125,7 @@ enum Sub2 {
     Bar {},
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Sub3 {
     Baz {},
     Quux {},
@@ -145,7 +145,7 @@ fn test_subsubcommand() {
     );
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum SubSubCmdWithOption {
     Remote {
         #[clap(subcommand)]
@@ -156,13 +156,13 @@ enum SubSubCmdWithOption {
         cmd: Stash,
     },
 }
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Remote {
     Add { name: String, url: String },
     Remove { name: String },
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Stash {
     Save,
     Pop,

--- a/clap_derive/tests/nested.rs
+++ b/clap_derive/tests/nested.rs
@@ -12,7 +12,7 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Clap;
+use clap::Parser;
 
 // Tests that clap_derive properly detects an `Option` field
 // that results from a macro expansion
@@ -20,7 +20,7 @@ use clap::Clap;
 fn use_option() {
     macro_rules! expand_ty {
         ($name:ident: $ty:ty) => {
-            #[derive(Clap)]
+            #[derive(Parser)]
             struct Outer {
                 #[clap(short, long)]
                 #[allow(dead_code)]

--- a/clap_derive/tests/non_literal_attributes.rs
+++ b/clap_derive/tests/non_literal_attributes.rs
@@ -12,13 +12,13 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::{AppSettings, Clap, ErrorKind};
+use clap::{AppSettings, ErrorKind, Parser};
 use std::num::ParseIntError;
 
 pub const DISPLAY_ORDER: usize = 2;
 
 // Check if the global settings compile
-#[derive(Clap, Debug, PartialEq, Eq)]
+#[derive(Parser, Debug, PartialEq, Eq)]
 #[clap(global_setting = AppSettings::ColoredHelp)]
 struct Opt {
     #[clap(
@@ -128,7 +128,7 @@ fn parse_hex(input: &str) -> Result<u64, ParseIntError> {
     u64::from_str_radix(input, 16)
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct HexOpt {
     #[clap(short, parse(try_from_str = parse_hex))]
     number: u64,

--- a/clap_derive/tests/options.rs
+++ b/clap_derive/tests/options.rs
@@ -14,11 +14,11 @@
 
 #![allow(clippy::option_option)]
 
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn required_option() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, long)]
         arg: i32,
@@ -32,7 +32,7 @@ fn required_option() {
 
 #[test]
 fn optional_option() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short)]
         arg: Option<i32>,
@@ -44,7 +44,7 @@ fn optional_option() {
 
 #[test]
 fn option_with_default() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, default_value = "42")]
         arg: i32,
@@ -56,7 +56,7 @@ fn option_with_default() {
 
 #[test]
 fn option_with_raw_default() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, default_value = "42")]
         arg: i32,
@@ -68,7 +68,7 @@ fn option_with_raw_default() {
 
 #[test]
 fn options() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, long, multiple_occurrences(true))]
         arg: Vec<i32>,
@@ -83,7 +83,7 @@ fn options() {
 
 #[test]
 fn default_value() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, default_value = "test")]
         arg: String,
@@ -106,7 +106,7 @@ fn option_from_str() {
         }
     }
 
-    #[derive(Debug, Clap, PartialEq)]
+    #[derive(Debug, Parser, PartialEq)]
     struct Opt {
         #[clap(parse(from_str))]
         a: Option<A>,
@@ -118,7 +118,7 @@ fn option_from_str() {
 
 #[test]
 fn optional_argument_for_optional_option() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, multiple_occurrences(true))]
         #[allow(clippy::option_option)]
@@ -137,7 +137,7 @@ fn optional_argument_for_optional_option() {
 
 #[test]
 fn two_option_options() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short)]
         arg: Option<Option<i32>>,
@@ -191,7 +191,7 @@ fn two_option_options() {
 
 #[test]
 fn optional_vec() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, multiple_occurrences(true))]
         arg: Option<Vec<i32>>,
@@ -248,7 +248,7 @@ fn optional_vec() {
 
 #[test]
 fn two_optional_vecs() {
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, multiple_occurrences(true))]
         arg: Option<Vec<i32>>,

--- a/clap_derive/tests/privacy.rs
+++ b/clap_derive/tests/privacy.rs
@@ -13,9 +13,9 @@
 // MIT/Apache 2.0 license.
 
 mod options {
-    use clap::Clap;
+    use clap::Parser;
 
-    #[derive(Debug, Clap)]
+    #[derive(Debug, Parser)]
     pub struct Options {
         #[clap(subcommand)]
         pub subcommand: super::subcommands::SubCommand,
@@ -23,9 +23,9 @@ mod options {
 }
 
 mod subcommands {
-    use clap::Clap;
+    use clap::Parser;
 
-    #[derive(Debug, Clap)]
+    #[derive(Debug, Parser)]
     pub enum SubCommand {
         /// foo
         Foo {

--- a/clap_derive/tests/raw_bool_literal.rs
+++ b/clap_derive/tests/raw_bool_literal.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn raw_bool_literal() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     #[clap(name = "raw_bool")]
     struct Opt {
         #[clap(raw(false))]

--- a/clap_derive/tests/raw_idents.rs
+++ b/clap_derive/tests/raw_idents.rs
@@ -1,8 +1,8 @@
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn raw_idents() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(short, long, multiple_occurrences(true))]
         r#type: Vec<String>,

--- a/clap_derive/tests/rename_all_env.rs
+++ b/clap_derive/tests/rename_all_env.rs
@@ -1,11 +1,11 @@
 mod utils;
 
-use clap::Clap;
+use clap::Parser;
 use utils::*;
 
 #[test]
 fn it_works() {
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     #[clap(rename_all_env = "kebab")]
     struct BehaviorModel {
         #[clap(env)]
@@ -18,7 +18,7 @@ fn it_works() {
 
 #[test]
 fn default_is_screaming() {
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     struct BehaviorModel {
         #[clap(env)]
         be_nice: String,
@@ -30,7 +30,7 @@ fn default_is_screaming() {
 
 #[test]
 fn overridable() {
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     #[clap(rename_all_env = "kebab")]
     struct BehaviorModel {
         #[clap(env)]

--- a/clap_derive/tests/skip.rs
+++ b/clap_derive/tests/skip.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
 #[test]
 fn skip_1() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(short)]
         x: u32,
@@ -37,7 +37,7 @@ fn skip_1() {
 
 #[test]
 fn skip_2() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     struct Opt {
         #[clap(short)]
         x: u32,
@@ -79,7 +79,7 @@ fn skip_enum() {
         }
     }
 
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     pub struct Opt {
         #[clap(long, short)]
         number: u32,
@@ -101,7 +101,7 @@ fn skip_enum() {
 
 #[test]
 fn skip_help_doc_comments() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     pub struct Opt {
         #[clap(skip, about = "internal_stuff")]
         a: u32,
@@ -132,7 +132,7 @@ fn skip_help_doc_comments() {
 
 #[test]
 fn skip_val() {
-    #[derive(Clap, Debug, PartialEq)]
+    #[derive(Parser, Debug, PartialEq)]
     pub struct Opt {
         #[clap(long, short)]
         number: u32,

--- a/clap_derive/tests/special_types.rs
+++ b/clap_derive/tests/special_types.rs
@@ -1,6 +1,6 @@
 //! Checks that types like `::std::option::Option` are not special
 
-use clap::Clap;
+use clap::Parser;
 
 #[rustversion::all(since(1.37), stable)]
 #[test]
@@ -19,7 +19,7 @@ fn special_types_bool() {
         }
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         arg: inner::bool,
     }
@@ -38,7 +38,7 @@ fn special_types_option() {
         Some(s.to_string())
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(parse(from_str = parser))]
         arg: ::std::option::Option<String>,
@@ -58,7 +58,7 @@ fn special_types_vec() {
         vec![s.to_string()]
     }
 
-    #[derive(Clap, PartialEq, Debug)]
+    #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(parse(from_str = parser))]
         arg: ::std::vec::Vec<String>,

--- a/clap_derive/tests/subcommands.rs
+++ b/clap_derive/tests/subcommands.rs
@@ -14,10 +14,10 @@
 
 mod utils;
 
-use clap::Clap;
+use clap::Parser;
 use utils::*;
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Opt {
     /// Fetch stuff from GitHub
     Fetch {
@@ -87,7 +87,7 @@ fn test_no_parse() {
     assert!(result.is_err());
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Opt2 {
     DoSomething { arg: String },
 }
@@ -104,7 +104,7 @@ fn test_hyphenated_subcommands() {
     );
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Opt3 {
     Add,
     Init,
@@ -118,17 +118,17 @@ fn test_null_commands() {
     assert_eq!(Opt3::Fetch, Opt3::parse_from(&["test", "fetch"]));
 }
 
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 #[clap(about = "Not shown")]
 struct Add {
     file: String,
 }
 /// Not shown
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 struct Fetch {
     remote: String,
 }
-#[derive(Clap, PartialEq, Debug)]
+#[derive(Parser, PartialEq, Debug)]
 enum Opt4 {
     // Not shown
     /// Add a file
@@ -163,7 +163,7 @@ fn test_tuple_commands() {
 
 #[test]
 fn global_passed_down() {
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     struct Opt {
         #[clap(global = true, long)]
         other: bool,
@@ -171,13 +171,13 @@ fn global_passed_down() {
         sub: Subcommands,
     }
 
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     enum Subcommands {
         Add,
         Global(GlobalCmd),
     }
 
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     struct GlobalCmd {
         #[clap(from_global)]
         other: bool,
@@ -202,13 +202,13 @@ fn global_passed_down() {
 
 #[test]
 fn external_subcommand() {
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     struct Opt {
         #[clap(subcommand)]
         sub: Subcommands,
     }
 
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     enum Subcommands {
         Add,
         Remove,
@@ -244,13 +244,13 @@ fn external_subcommand() {
 fn external_subcommand_os_string() {
     use std::ffi::OsString;
 
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     struct Opt {
         #[clap(subcommand)]
         sub: Subcommands,
     }
 
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     enum Subcommands {
         #[clap(external_subcommand)]
         Other(Vec<OsString>),
@@ -268,13 +268,13 @@ fn external_subcommand_os_string() {
 
 #[test]
 fn external_subcommand_optional() {
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     struct Opt {
         #[clap(subcommand)]
         sub: Option<Subcommands>,
     }
 
-    #[derive(Debug, PartialEq, Clap)]
+    #[derive(Debug, PartialEq, Parser)]
     enum Subcommands {
         #[clap(external_subcommand)]
         Other(Vec<String>),
@@ -293,12 +293,12 @@ fn external_subcommand_optional() {
 // #[test]
 // #[ignore] // FIXME (@CreepySkeleton)
 // fn enum_in_enum_subsubcommand() {
-//     #[derive(Clap, Debug, PartialEq)]
+//     #[derive(Parser, Debug, PartialEq)]
 //     pub enum Opt {
 //         Daemon(DaemonCommand),
 //     }
 
-//     #[derive(Clap, Debug, PartialEq)]
+//     #[derive(Parser, Debug, PartialEq)]
 //     pub enum DaemonCommand {
 //         Start,
 //         Stop,
@@ -320,12 +320,12 @@ fn external_subcommand_optional() {
 // #[test]
 // #[ignore]
 // fn flatten_enum() {
-//     #[derive(Clap, Debug, PartialEq)]
+//     #[derive(Parser, Debug, PartialEq)]
 //     struct Opt {
 //         #[clap(flatten)]
 //         sub_cmd: SubCmd,
 //     }
-//     #[derive(Clap, Debug, PartialEq)]
+//     #[derive(Parser, Debug, PartialEq)]
 //     enum SubCmd {
 //         Foo,
 //         Bar,

--- a/clap_derive/tests/ui/bool_arg_enum.rs
+++ b/clap_derive/tests/ui/bool_arg_enum.rs
@@ -1,6 +1,6 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(short, arg_enum)]

--- a/clap_derive/tests/ui/bool_default_value.rs
+++ b/clap_derive/tests/ui/bool_default_value.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(short, default_value = true)]

--- a/clap_derive/tests/ui/bool_required.rs
+++ b/clap_derive/tests/ui/bool_required.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(short, required = true)]

--- a/clap_derive/tests/ui/clap_empty_attr.rs
+++ b/clap_derive/tests/ui/clap_empty_attr.rs
@@ -1,10 +1,10 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap]
 struct Opt {}
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt1 {
     #[clap = "short"]
     foo: u32,

--- a/clap_derive/tests/ui/enum_flatten.rs
+++ b/clap_derive/tests/ui/enum_flatten.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 enum Opt {
     #[clap(flatten)]

--- a/clap_derive/tests/ui/external_subcommand_misuse.rs
+++ b/clap_derive/tests/ui/external_subcommand_misuse.rs
@@ -1,6 +1,6 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt {
     #[clap(external_subcommand)]
     field: String,

--- a/clap_derive/tests/ui/external_subcommand_wrong_type.rs
+++ b/clap_derive/tests/ui/external_subcommand_wrong_type.rs
@@ -1,19 +1,19 @@
-use clap::Clap;
+use clap::Parser;
 use std::ffi::CString;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Opt {
     #[clap(external_subcommand)]
     Other(Vec<CString>),
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Opt2 {
     #[clap(external_subcommand)]
     Other(String),
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Opt3 {
     #[clap(external_subcommand)]
     Other { a: String },

--- a/clap_derive/tests/ui/flatten_and_methods.rs
+++ b/clap_derive/tests/ui/flatten_and_methods.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct DaemonOpts {
     #[clap(short)]
     user: String,
@@ -16,7 +16,7 @@ struct DaemonOpts {
     group: String,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(short, flatten)]

--- a/clap_derive/tests/ui/flatten_and_parse.rs
+++ b/clap_derive/tests/ui/flatten_and_parse.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct DaemonOpts {
     #[clap(short)]
     user: String,
@@ -16,7 +16,7 @@ struct DaemonOpts {
     group: String,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(flatten, parse(from_occurrences))]

--- a/clap_derive/tests/ui/multiple_external_subcommand.rs
+++ b/clap_derive/tests/ui/multiple_external_subcommand.rs
@@ -1,12 +1,12 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt {
     #[clap(subcommand)]
     cmd: Command,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     #[clap(external_subcommand)]
     Run(Vec<String>),

--- a/clap_derive/tests/ui/non_existent_attr.rs
+++ b/clap_derive/tests/ui/non_existent_attr.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(short, non_existing_attribute = 1)]

--- a/clap_derive/tests/ui/opt_opt_nonpositional.rs
+++ b/clap_derive/tests/ui/opt_opt_nonpositional.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     n: Option<Option<u32>>,

--- a/clap_derive/tests/ui/opt_vec_nonpositional.rs
+++ b/clap_derive/tests/ui/opt_vec_nonpositional.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     n: Option<Vec<u32>>,

--- a/clap_derive/tests/ui/option_default_value.rs
+++ b/clap_derive/tests/ui/option_default_value.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(short, default_value = 1)]

--- a/clap_derive/tests/ui/option_required.rs
+++ b/clap_derive/tests/ui/option_required.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(short, required = true)]

--- a/clap_derive/tests/ui/parse_empty_try_from_os.rs
+++ b/clap_derive/tests/ui/parse_empty_try_from_os.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(parse(try_from_os_str))]

--- a/clap_derive/tests/ui/parse_function_is_not_path.rs
+++ b/clap_derive/tests/ui/parse_function_is_not_path.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(parse(from_str = "2"))]

--- a/clap_derive/tests/ui/parse_literal_spec.rs
+++ b/clap_derive/tests/ui/parse_literal_spec.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(parse("from_str"))]

--- a/clap_derive/tests/ui/parse_not_zero_args.rs
+++ b/clap_derive/tests/ui/parse_not_zero_args.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
     #[clap(parse(from_str, from_str))]

--- a/clap_derive/tests/ui/positional_bool.rs
+++ b/clap_derive/tests/ui/positional_bool.rs
@@ -1,6 +1,6 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt {
     verbose: bool,
 }

--- a/clap_derive/tests/ui/raw.rs
+++ b/clap_derive/tests/ui/raw.rs
@@ -6,15 +6,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt {
     #[clap(raw(case_insensitive = "true"))]
     s: String,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct Opt2 {
     #[clap(raw(requires_if = r#""one", "two""#))]
     s: String,

--- a/clap_derive/tests/ui/rename_all_wrong_casing.rs
+++ b/clap_derive/tests/ui/rename_all_wrong_casing.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic", rename_all = "fail")]
 struct Opt {
     #[clap(short)]

--- a/clap_derive/tests/ui/skip_flatten.rs
+++ b/clap_derive/tests/ui/skip_flatten.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "make-cookie")]
 struct MakeCookie {
     #[clap(short)]
@@ -18,7 +18,7 @@ struct MakeCookie {
     cmd: Command,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     #[clap(name = "pound")]
     /// Pound acorns into flour for cookie dough.

--- a/clap_derive/tests/ui/skip_subcommand.rs
+++ b/clap_derive/tests/ui/skip_subcommand.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "make-cookie")]
 struct MakeCookie {
     #[clap(short)]
@@ -18,7 +18,7 @@ struct MakeCookie {
     cmd: Command,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     #[clap(name = "pound")]
     /// Pound acorns into flour for cookie dough.

--- a/clap_derive/tests/ui/skip_with_other_options.rs
+++ b/clap_derive/tests/ui/skip_with_other_options.rs
@@ -1,6 +1,6 @@
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "test")]
 pub struct Opt {
     #[clap(long)]

--- a/clap_derive/tests/ui/skip_without_default.rs
+++ b/clap_derive/tests/ui/skip_without_default.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
 #[derive(Debug)]
 enum Kind {
@@ -14,7 +14,7 @@ enum Kind {
     B,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "test")]
 pub struct Opt {
     #[clap(short)]

--- a/clap_derive/tests/ui/struct_parse.rs
+++ b/clap_derive/tests/ui/struct_parse.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic", parse(from_str))]
 struct Opt {
     #[clap(short)]

--- a/clap_derive/tests/ui/struct_subcommand.rs
+++ b/clap_derive/tests/ui/struct_subcommand.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic", subcommand)]
 struct Opt {
     #[clap(short)]

--- a/clap_derive/tests/ui/subcommand_and_flatten.rs
+++ b/clap_derive/tests/ui/subcommand_and_flatten.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct MakeCookie {
     #[clap(short)]
     s: String,
@@ -17,7 +17,7 @@ struct MakeCookie {
     cmd: Command,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
     Pound { acorns: u32 },

--- a/clap_derive/tests/ui/subcommand_and_methods.rs
+++ b/clap_derive/tests/ui/subcommand_and_methods.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct MakeCookie {
     #[clap(short)]
     s: String,
@@ -17,7 +17,7 @@ struct MakeCookie {
     cmd: Command,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
     Pound { acorns: u32 },

--- a/clap_derive/tests/ui/subcommand_and_parse.rs
+++ b/clap_derive/tests/ui/subcommand_and_parse.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct MakeCookie {
     #[clap(short)]
     s: String,
@@ -17,7 +17,7 @@ struct MakeCookie {
     cmd: Command,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
     Pound { acorns: u32 },

--- a/clap_derive/tests/ui/subcommand_opt_opt.rs
+++ b/clap_derive/tests/ui/subcommand_opt_opt.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct MakeCookie {
     #[clap(short)]
     s: String,
@@ -17,7 +17,7 @@ struct MakeCookie {
     cmd: Option<Option<Command>>,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
     Pound { acorns: u32 },

--- a/clap_derive/tests/ui/subcommand_opt_vec.rs
+++ b/clap_derive/tests/ui/subcommand_opt_vec.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 struct MakeCookie {
     #[clap(short)]
     s: String,
@@ -17,7 +17,7 @@ struct MakeCookie {
     cmd: Option<Vec<Command>>,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
     Pound { acorns: u32 },

--- a/clap_derive/tests/ui/tuple_struct.rs
+++ b/clap_derive/tests/ui/tuple_struct.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use clap::Clap;
+use clap::Parser;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt(u32);
 

--- a/clap_derive/tests/ui/tuple_struct.stderr
+++ b/clap_derive/tests/ui/tuple_struct.stderr
@@ -1,7 +1,7 @@
-error: `#[derive(Clap)]` only supports non-tuple structs and enums
+error: `#[derive(Parser)]` only supports non-tuple structs and enums
   --> $DIR/tuple_struct.rs:11:10
    |
-11 | #[derive(Clap, Debug)]
+11 | #[derive(Parser, Debug)]
    |          ^^^^
    |
    = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -17,4 +17,4 @@ error[E0599]: no function or associated item named `parse` found for struct `Opt
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following trait defines an item `parse`, perhaps you need to implement it:
-           candidate #1: `clap::Clap`
+           candidate #1: `clap::Parser`

--- a/clap_up/Cargo.toml
+++ b/clap_up/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 	"Pavan Kumar Sunkara <pavan.sss1991@gmail.com>",
 	"Clap Maintainers",
 ]
-description = "Automatic code upgrader for Clap"
+description = "Automatic code upgrader for Parser"
 repository = "https://github.com/clap-rs/clap/tree/master/clap_up"
 homepage = "https://clap.rs/"
 keywords = [

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -2,15 +2,15 @@
 title = "Fast & Modern CLI Framework for Rust"
 +++
 
-**Clap** is a simple-to-use, efficient, and full-featured library for parsing command line arguments and subcommands when writing console/terminal applications.
+**Parser** is a simple-to-use, efficient, and full-featured library for parsing command line arguments and subcommands when writing console/terminal applications.
 
 Here is an example of a simple program:
 
 ```rust
-use clap::Clap;
+use clap::Parser;
 
 /// Simple program to greet a person
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
 #[clap(name = "hello")]
 struct Hello {
     /// Name of the person to greet

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "derive")]
-pub use crate::derive::{ArgEnum, Clap, FromArgMatches, IntoApp, Subcommand};
+pub use crate::derive::{ArgEnum, FromArgMatches, IntoApp, Parser, Subcommand};
 
 #[cfg(feature = "yaml")]
 #[doc(hidden)]


### PR DESCRIPTION
With #2005, we are looking at having 3 primary derive traits, `Clap`,
`Subcommand`, and `Args`.  `Clap` isn't very descriptive, so changing it
to `Parser` since that is the primary role of that trait, with all of
its `*parse*` functions.