### PR TITLE
fix(derive)!: Compile-error on nested subcommands

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -107,13 +107,6 @@ pub struct Attrs {
     kind: Sp<Kind>,
 }
 
-/// Output for the gen_xxx() methods were we need more than a simple stream of tokens.
-///
-/// The output of a generation method is not only the stream of new tokens but also the attribute
-/// information of the current element. These attribute information may contain valuable information
-/// for any kind of child arguments.
-pub type GenOutput = (TokenStream, Attrs);
-
 impl Method {
     pub fn new(name: Ident, args: TokenStream) -> Self {
         Method { name, args }

--- a/clap_derive/src/derives/clap.rs
+++ b/clap_derive/src/derives/clap.rs
@@ -56,27 +56,25 @@ fn gen_for_struct(
     fields: &Punctuated<Field, Comma>,
     attrs: &[Attribute],
 ) -> TokenStream {
-    let (into_app, attrs) = into_app::gen_for_struct(name, fields, attrs);
-    let from_arg_matches = args::gen_from_arg_matches_for_struct(name, fields, &attrs);
+    let into_app = into_app::gen_for_struct(name, attrs);
+    let args = args::gen_for_struct(name, fields, attrs);
 
     quote! {
         impl clap::Clap for #name {}
 
         #into_app
-        #from_arg_matches
+        #args
     }
 }
 
 fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStream {
     let into_app = into_app::gen_for_enum(name, attrs);
-    let from_arg_matches = subcommand::gen_from_arg_matches_for_enum(name);
     let subcommand = subcommand::gen_for_enum(name, attrs, e);
 
     quote! {
         impl clap::Clap for #name {}
 
         #into_app
-        #from_arg_matches
         #subcommand
     }
 }

--- a/clap_derive/src/derives/mod.rs
+++ b/clap_derive/src/derives/mod.rs
@@ -19,6 +19,6 @@ mod subcommand;
 
 pub use self::clap::derive_clap;
 pub use arg_enum::derive_arg_enum;
-// pub use from_arg_matches::derive_from_arg_matches;
+pub use args::derive_args;
 pub use into_app::derive_into_app;
 pub use subcommand::derive_subcommand;

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -1,3 +1,16 @@
+// Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>,
+// Kevin Knapp (@kbknapp) <kbknapp@gmail.com>, and
+// Andrew Hobden (@hoverbear) <andrew@hoverbear.org>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+//
+// This work was derived from Structopt (https://github.com/TeXitoi/structopt)
+// commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
+// MIT/Apache 2.0 license.
 use crate::{
     attrs::{Attrs, Kind, Name, DEFAULT_CASING, DEFAULT_ENV_CASING},
     derives::args,

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -6,13 +6,12 @@ use quote::quote;
 
 pub fn clap_struct(name: &Ident) {
     into_app(name);
-    from_arg_matches(name);
+    args(name);
     append_dummy(quote!( impl clap::Clap for #name {} ));
 }
 
 pub fn clap_enum(name: &Ident) {
     into_app(name);
-    from_arg_matches(name);
     subcommand(name);
     append_dummy(quote!( impl clap::Clap for #name {} ));
 }
@@ -23,13 +22,7 @@ pub fn into_app(name: &Ident) {
             fn into_app<'b>() -> clap::App<'b> {
                 unimplemented!()
             }
-            fn augment_clap<'b>(_app: clap::App<'b>) -> clap::App<'b> {
-                unimplemented!()
-            }
             fn into_app_for_update<'b>() -> clap::App<'b> {
-                unimplemented!()
-            }
-            fn augment_clap_for_update<'b>(_app: clap::App<'b>) -> clap::App<'b> {
                 unimplemented!()
             }
         }
@@ -39,7 +32,7 @@ pub fn into_app(name: &Ident) {
 pub fn from_arg_matches(name: &Ident) {
     append_dummy(quote! {
         impl clap::FromArgMatches for #name {
-            fn from_arg_matches(_m: &clap::ArgMatches) -> Self {
+            fn from_arg_matches(_m: &clap::ArgMatches) -> Option<Self> {
                 unimplemented!()
             }
             fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) {
@@ -50,18 +43,27 @@ pub fn from_arg_matches(name: &Ident) {
 }
 
 pub fn subcommand(name: &Ident) {
+    from_arg_matches(name);
     append_dummy(quote! {
         impl clap::Subcommand for #name {
-            fn from_subcommand(_sub: Option<(&str, &clap::ArgMatches)>) -> Option<Self> {
-                unimplemented!()
-            }
-            fn update_from_subcommand(&mut self, _sub: Option<(&str, &clap::ArgMatches)>) {
-                unimplemented!()
-            }
             fn augment_subcommands(_app: clap::App<'_>) -> clap::App<'_> {
                 unimplemented!()
             }
             fn augment_subcommands_for_update(_app: clap::App<'_>) -> clap::App<'_> {
+                unimplemented!()
+            }
+        }
+    });
+}
+
+pub fn args(name: &Ident) {
+    from_arg_matches(name);
+    append_dummy(quote! {
+        impl clap::Args for #name {
+            fn augment_args(_app: clap::App<'_>) -> clap::App<'_> {
+                unimplemented!()
+            }
+            fn augment_args_for_update(_app: clap::App<'_>) -> clap::App<'_> {
                 unimplemented!()
             }
         }

--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -54,14 +54,6 @@ pub fn clap(input: TokenStream) -> TokenStream {
     derives::derive_clap(&input).into()
 }
 
-// /// Generates the `FromArgMatches` impl.
-// #[proc_macro_derive(FromArgMatches, attributes(clap))]
-// #[proc_macro_error]
-// pub fn from_arg_matches(input: TokenStream) -> TokenStream {
-//     let input: DeriveInput = parse_macro_input!(input);
-//     derives::derive_from_arg_matches(&input).into()
-// }
-
 /// Generates the `IntoApp` impl.
 #[proc_macro_derive(IntoApp, attributes(clap))]
 #[proc_macro_error]
@@ -76,4 +68,12 @@ pub fn into_app(input: TokenStream) -> TokenStream {
 pub fn subcommand(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
     derives::derive_subcommand(&input).into()
+}
+
+/// Generates the `Args` impl.
+#[proc_macro_derive(Args, attributes(clap))]
+#[proc_macro_error]
+pub fn args(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input);
+    derives::derive_args(&input).into()
 }

--- a/clap_derive/tests/issues.rs
+++ b/clap_derive/tests/issues.rs
@@ -34,7 +34,10 @@ fn issue_289() {
     #[derive(Clap)]
     #[clap(setting = AppSettings::InferSubcommands)]
     enum Args {
-        SomeCommand(SubSubCommand),
+        SomeCommand {
+            #[clap(subcommand)]
+            sub: SubSubCommand,
+        },
         AnotherCommand,
     }
 

--- a/clap_derive/tests/ui/enum_variant_not_args.rs
+++ b/clap_derive/tests/ui/enum_variant_not_args.rs
@@ -1,0 +1,9 @@
+#[derive(clap::Clap)]
+enum Opt {
+    Sub(SubCmd),
+}
+
+#[derive(clap::Clap)]
+enum SubCmd {}
+
+fn main() {}

--- a/clap_derive/tests/ui/enum_variant_not_args.stderr
+++ b/clap_derive/tests/ui/enum_variant_not_args.stderr
@@ -1,0 +1,7 @@
+error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
+ --> $DIR/enum_variant_not_args.rs:3:9
+  |
+3 |     Sub(SubCmd),
+  |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+  |
+  = note: required by `augment_args`

--- a/clap_derive/tests/ui/flatten_on_subcommand.rs
+++ b/clap_derive/tests/ui/flatten_on_subcommand.rs
@@ -1,0 +1,10 @@
+#[derive(clap::Clap)]
+struct Opt {
+    #[clap(flatten)]
+    sub: SubCmd,
+}
+
+#[derive(clap::Clap)]
+enum SubCmd {}
+
+fn main() {}

--- a/clap_derive/tests/ui/flatten_on_subcommand.stderr
+++ b/clap_derive/tests/ui/flatten_on_subcommand.stderr
@@ -1,0 +1,7 @@
+error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
+ --> $DIR/flatten_on_subcommand.rs:3:12
+  |
+3 |     #[clap(flatten)]
+  |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+  |
+  = note: required by `augment_args`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "derive")]
-pub use crate::derive::{ArgEnum, Clap, FromArgMatches, IntoApp, Subcommand};
+pub use crate::derive::{ArgEnum, Args, Clap, FromArgMatches, IntoApp, Subcommand};
 
 #[cfg(feature = "yaml")]
 #[doc(hidden)]


### PR DESCRIPTION
Before, partial command lines would panic at runtime.  Now it'll be a
compile error

For example:
```
#[derive(Clap)]
pub enum Opt {
  Daemon(DaemonCommand),
}

#[derive(Clap)]
pub enum DaemonCommand {
  Start,
  Stop,
}
```

Gives:
```
error[E0277]: the trait bound `DaemonCommand: clap::Args` is not satisfied
   --> clap_derive/tests/subcommands.rs:297:16
    |
297 |         Daemon(DaemonCommand),
    |                ^^^^^^^^^^^^^ the trait `clap::Args` is not implemented for `DaemonCommand`
    |
    = note: required by `augment_args`
```

To nest this, you currently need `enum -> struct -> enum`.  A later
change will make it so you can use the `subcommand` attribute within
enums to cover this case.

This is done by splitting out an `Args` trait from `IntoApp`, like `Subcommand` previously did in #1681.

As a side benefit of this work, a user can now `derive(Args)` for a `struct` while before they could `derive(IntoApp)` but must manually implement `FromArgMatches` since no derive existed for it.

Unlike with #1681, I did not move `from`/`update` logic into the trait but moved all of that logic into the `FromArgMatches` trait and it a supertrait for `Args` and `Subcommand`, deriving them all together.  For the top-level, we need `FromArgMatches`, like `IntoApp` but unlike `IntoApp`, we don't need divergent APIs.  A `FromArgMatches` impl is also coupled to the augment impl.

To support `FromArgMatches` being used in all cases, I had to switch its return type from `Self` to `Option<Self>` for when you have `#[clap(subcommand)] cmd: Option<SubCmd>`.  The caller has control over whether it is required or not.

So parsing call graph looks like:
- Clap::parse
  - IntoApp::into_app
    - Either Subcommand::augment_subcommands or Args:augment_args
  - FromArgMatches::from_arg_matches

BREAKING CHANGES:
- You can no longer nest enums-in-enums to implicitly get a sub-sub-command
- The derived traits went through a lot of changes

Depends on #2595 
This is a part of #2005