### PR TITLE
Change some wording to be more inclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ fn main() {
         0 => println!("No verbose info"),
         1 => println!("Some verbose info"),
         2 => println!("Tons of verbose info"),
-        _ => println!("Don't be crazy"),
+        _ => println!("Don't be ridiculous"),
     }
 
     // You can handle information about subcommands by requesting their matches by name


### PR DESCRIPTION
The word "crazy" is often used in a derogatory manner to people with mental disabilities:

https://www.selfdefined.app/definitions/crazy/

This PR changes the usage to the word "ridiculous" since it's just as clear and is more inclusive.