### PR TITLE
fix(exit): Be consistent in exit code

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     mkeymap::MKeyMap,
     output::{fmt::Colorizer, Help, HelpWriter, Usage},
     parse::{ArgMatcher, ArgMatches, Input, Parser},
-    util::{safe_exit, termcolor::ColorChoice, ArgStr, Id, Key},
+    util::{safe_exit, termcolor::ColorChoice, ArgStr, Id, Key, USAGE_CODE},
     Result as ClapResult, INTERNAL_ERROR_MSG,
 };
 
@@ -1956,7 +1956,7 @@ impl<'help> App<'help> {
                     }
 
                     drop(e);
-                    safe_exit(2);
+                    safe_exit(USAGE_CODE);
                 }
 
                 e.exit()

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -12,7 +12,7 @@ use crate::{
     build::Arg,
     output::fmt::Colorizer,
     parse::features::suggestions,
-    util::{safe_exit, termcolor::ColorChoice},
+    util::{safe_exit, termcolor::ColorChoice, SUCCESS_CODE, USAGE_CODE},
 };
 
 /// Short hand for [`Result`] type
@@ -479,11 +479,11 @@ impl Error {
     pub fn exit(&self) -> ! {
         if self.use_stderr() {
             self.message.print().expect("Error writing Error to stderr");
-            safe_exit(1);
+            safe_exit(USAGE_CODE);
         }
 
         self.message.print().expect("Error writing Error to stdout");
-        safe_exit(0)
+        safe_exit(SUCCESS_CODE)
     }
 
     /// Prints formatted and colored error to `stdout` or `stderr` according to its error kind

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,14 @@ pub(crate) use termcolor;
 #[cfg(not(feature = "color"))]
 pub(crate) mod termcolor;
 
+pub(crate) const SUCCESS_CODE: i32 = 0;
+// While sysexists.h defines EX_USAGE as 64, this doesn't seem to be used much in practice but
+// instead 2 seems to be frequently used.
+// Examples
+// - GNU `ls` returns 2
+// - Python's `argparse` returns 2
+pub(crate) const USAGE_CODE: i32 = 2;
+
 pub(crate) fn safe_exit(code: i32) -> ! {
     use std::io::Write;
 


### PR DESCRIPTION
PR #1637 switched clap to report `64` on errors and then #1653 switch it
to `2`, but both missed a case.  This also documents the reason why inline
since I had to go and dig through the history to re-discover the
motivation.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
