### PR TITLE
fix(derive): Allow partial update of Subcommand arguments

### DIFF
--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -187,9 +187,17 @@ fn gen_augment(
                         Unit => quote!( #app_var ),
                         Unnamed(FieldsUnnamed { ref unnamed, .. }) if unnamed.len() == 1 => {
                             let ty = &unnamed[0];
-                            quote_spanned! { ty.span()=>
-                                {
-                                    <#ty as clap::Args>::augment_args(#app_var)
+                            if override_required {
+                                quote_spanned! { ty.span()=>
+                                    {
+                                        <#ty as clap::Args>::augment_args_for_update(#app_var)
+                                    }
+                                }
+                            } else {
+                                quote_spanned! { ty.span()=>
+                                    {
+                                        <#ty as clap::Args>::augment_args(#app_var)
+                                    }
                                 }
                             }
                         }

--- a/clap_derive/tests/subcommands.rs
+++ b/clap_derive/tests/subcommands.rs
@@ -313,3 +313,39 @@ fn enum_in_enum_subsubcommand() {
     let result = Opt::parse_from(&["test", "daemon", "start"]);
     assert_eq!(Opt::Daemon(DaemonCommand::Start), result);
 }
+
+#[test]
+fn update_subcommands() {
+    #[derive(Clap, PartialEq, Debug)]
+    enum Opt {
+        Command1(Command1),
+        Command2(Command2),
+    }
+
+    #[derive(Clap, PartialEq, Debug)]
+    struct Command1 {
+        arg1: i32,
+        arg2: i32,
+    }
+
+    #[derive(Clap, PartialEq, Debug)]
+    struct Command2 {
+        arg2: i32,
+    }
+
+    // Full subcommand update
+    let mut opt = Opt::Command1(Command1 { arg1: 12, arg2: 14 });
+    opt.try_update_from(&["test", "command1", "42", "44"])
+        .unwrap();
+    assert_eq!(Opt::parse_from(&["test", "command1", "42", "44"]), opt);
+
+    // Partial subcommand update
+    let mut opt = Opt::Command1(Command1 { arg1: 12, arg2: 14 });
+    opt.try_update_from(&["test", "command1", "42"]).unwrap();
+    assert_eq!(Opt::parse_from(&["test", "command1", "42", "14"]), opt);
+
+    // Change subcommand
+    let mut opt = Opt::Command1(Command1 { arg1: 12, arg2: 14 });
+    opt.try_update_from(&["test", "command2", "43"]).unwrap();
+    assert_eq!(Opt::parse_from(&["test", "command2", "43"]), opt);
+}


### PR DESCRIPTION
Before, when doing an `update` involving subcommands, we generated
parsing rules for the `from` case instead, requiring all arguments to be
present.

This switches us to descending into `update` code and adds tests to
verify it works.

This is a part of #2605

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
