### PR TITLE
fix(derive): Follow value_name convention

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -791,6 +791,10 @@ impl Attrs {
         self.name.clone().translate(*self.casing)
     }
 
+    pub fn value_name(&self) -> TokenStream {
+        self.name.clone().translate(CasingStyle::ScreamingSnake)
+    }
+
     pub fn parser(&self) -> &Sp<Parser> {
         &self.parser
     }

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -231,6 +231,8 @@ pub fn gen_augment(
                     _ => quote!(),
                 };
 
+                let value_name = attrs.value_name();
+
                 let modifier = match **ty {
                     Ty::Bool => quote!(),
 
@@ -245,6 +247,7 @@ pub fn gen_augment(
 
                         quote_spanned! { ty.span()=>
                             .takes_value(true)
+                            .value_name(#value_name)
                             #possible_values
                             #validator
                         }
@@ -252,6 +255,7 @@ pub fn gen_augment(
 
                     Ty::OptionOption => quote_spanned! { ty.span()=>
                         .takes_value(true)
+                        .value_name(#value_name)
                         .multiple_values(false)
                         .min_values(0)
                         .max_values(1)
@@ -260,6 +264,7 @@ pub fn gen_augment(
 
                     Ty::OptionVec => quote_spanned! { ty.span()=>
                         .takes_value(true)
+                        .value_name(#value_name)
                         .multiple_values(true)
                         .min_values(0)
                         #validator
@@ -276,6 +281,7 @@ pub fn gen_augment(
 
                         quote_spanned! { ty.span()=>
                             .takes_value(true)
+                            .value_name(#value_name)
                             .multiple_values(true)
                             #possible_values
                             #validator
@@ -301,6 +307,7 @@ pub fn gen_augment(
 
                         quote_spanned! { ty.span()=>
                             .takes_value(true)
+                            .value_name(#value_name)
                             .required(#required)
                             #possible_values
                             #validator

--- a/clap_derive/tests/arguments.rs
+++ b/clap_derive/tests/arguments.rs
@@ -13,6 +13,7 @@
 // MIT/Apache 2.0 license.
 
 use clap::Clap;
+use clap::IntoApp;
 
 #[test]
 fn required_argument() {
@@ -82,4 +83,18 @@ fn arguments_safe() {
         clap::ErrorKind::ValueValidation,
         Opt::try_parse_from(&["test", "NOPE"]).err().unwrap().kind
     );
+}
+
+#[test]
+fn value_name() {
+    #[derive(Clap, PartialEq, Debug)]
+    struct Opt {
+        my_special_arg: i32,
+    }
+
+    let mut help = Vec::new();
+    Opt::into_app().write_help(&mut help).unwrap();
+    let help = String::from_utf8(help).unwrap();
+
+    assert!(help.contains("MY_SPECIAL_ARG"));
 }


### PR DESCRIPTION
I debated putting this fix inside of the Builder API but I figure this
makes it so you "pay for what you use", with the derive API giving it to
you "for free".

A potential next step is to improve the default value name.  I tend to
use value_name to hint at how to use an argument, which correlates with
types.  We could add a
`ValueName::value_name(fallback: &str) -> &str` with impls for common
types, so we get more of a usage-based result.

Fixes #2608

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
