### PR TITLE
Replace "Prints" with "Print" for default help and version commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,15 +415,15 @@ USAGE:
     MyApp [FLAGS] [OPTIONS] <INPUT> [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -v               Sets the level of verbosity
-    -V, --version    Prints version information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --config <FILE>    Sets a custom config file
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test    Controls testing features
 ```
 

--- a/benches/05_ripgrep.rs
+++ b/benches/05_ripgrep.rs
@@ -513,7 +513,7 @@ lazy_static! {
             "Show verbose help output.",
             "When given, more details about flags are provided."
         );
-        doc!(h, "version", "Prints version information.");
+        doc!(h, "version", "Print version information.");
 
         doc!(
             h,

--- a/clap_derive/README.md
+++ b/clap_derive/README.md
@@ -89,8 +89,8 @@ ARGS:
 
 FLAGS:
     -d, --debug      Activate debug mode
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
     -v, --verbose    Verbose mode (-v, -vv, -vvv, etc.)
 
 OPTIONS:

--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -75,7 +75,7 @@ _{name} \"$@\"",
 //      'show:Show the active and installed toolchains'
 //      'update:Update Rust toolchains'
 //      # ... snip for brevity
-//      'help:Prints this message or the help of the given subcommand(s)'
+//      'help:Print this message or the help of the given subcommand(s)'
 //     )
 //     _describe -t commands 'rustup commands' commands "$@"
 //
@@ -296,7 +296,7 @@ fn parser_of<'help, 'app>(parent: &'app App<'help>, bin_name: &str) -> Option<&'
 //
 // _arguments -C -s -S \
 //         '(-h --help --verbose)-v[Enable verbose output]' \
-//         '(-V -v --version --verbose --help)-h[Prints help information]' \
+//         '(-V -v --version --verbose --help)-h[Print help information]' \
 //      # ... snip for brevity
 //         ':: :_rustup_commands' \    # <-- displays subcommands
 //         '*::: :->rustup' \          # <-- displays subcommand args and child subcommands

--- a/clap_generate/tests/completions/elvish.rs
+++ b/clap_generate/tests/completions/elvish.rs
@@ -48,25 +48,25 @@ edit:completion:arg-completer[my_app] = [@words]{
     }
     completions = [
         &'my_app'= {
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
             cand test 'tests things'
-            cand help 'Prints this message or the help of the given subcommand(s)'
+            cand help 'Print this message or the help of the given subcommand(s)'
         }
         &'my_app;test'= {
             cand --case 'the case to test'
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
         }
         &'my_app;help'= {
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
         }
     ]
     $completions[$command]
@@ -112,40 +112,40 @@ edit:completion:arg-completer[my_app] = [@words]{
     }
     completions = [
         &'my_app'= {
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
             cand test 'tests things'
             cand some_cmd 'tests other things'
             cand some-cmd-with-hypens 'some-cmd-with-hypens'
-            cand help 'Prints this message or the help of the given subcommand(s)'
+            cand help 'Print this message or the help of the given subcommand(s)'
         }
         &'my_app;test'= {
             cand --case 'the case to test'
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
         }
         &'my_app;some_cmd'= {
             cand --config 'the other case to test'
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
         }
         &'my_app;some-cmd-with-hypens'= {
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
         }
         &'my_app;help'= {
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
         }
     ]
     $completions[$command]
@@ -205,10 +205,10 @@ edit:completion:arg-completer[cmd] = [@words]{
             cand -O 'cmd option'
             cand --option 'cmd option'
             cand --opt 'cmd option'
-            cand -h 'Prints help information'
-            cand --help 'Prints help information'
-            cand -V 'Prints version information'
-            cand --version 'Prints version information'
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
             cand -f 'cmd flag'
             cand -F 'cmd flag'
             cand --flag 'cmd flag'

--- a/clap_generate/tests/completions/fish.rs
+++ b/clap_generate/tests/completions/fish.rs
@@ -28,15 +28,15 @@ fn fish() {
     common::<Fish>(&mut app, "myapp", FISH);
 }
 
-static FISH: &str = r#"complete -c myapp -n "__fish_use_subcommand" -s h -l help -d 'Prints help information'
-complete -c myapp -n "__fish_use_subcommand" -s V -l version -d 'Prints version information'
+static FISH: &str = r#"complete -c myapp -n "__fish_use_subcommand" -s h -l help -d 'Print help information'
+complete -c myapp -n "__fish_use_subcommand" -s V -l version -d 'Print version information'
 complete -c myapp -n "__fish_use_subcommand" -f -a "test" -d 'tests things'
-complete -c myapp -n "__fish_use_subcommand" -f -a "help" -d 'Prints this message or the help of the given subcommand(s)'
+complete -c myapp -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c myapp -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
-complete -c myapp -n "__fish_seen_subcommand_from test" -s h -l help -d 'Prints help information'
-complete -c myapp -n "__fish_seen_subcommand_from test" -s V -l version -d 'Prints version information'
-complete -c myapp -n "__fish_seen_subcommand_from help" -s h -l help -d 'Prints help information'
-complete -c myapp -n "__fish_seen_subcommand_from help" -s V -l version -d 'Prints version information'
+complete -c myapp -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help information'
+complete -c myapp -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version information'
+complete -c myapp -n "__fish_seen_subcommand_from help" -s h -l help -d 'Print help information'
+complete -c myapp -n "__fish_seen_subcommand_from help" -s V -l version -d 'Print version information'
 "#;
 
 #[test]
@@ -58,22 +58,22 @@ fn build_app_special_commands() -> App<'static> {
         .subcommand(App::new("some-cmd-with-hypens").alias("hyphen"))
 }
 
-static FISH_SPECIAL_CMDS: &str = r#"complete -c my_app -n "__fish_use_subcommand" -s h -l help -d 'Prints help information'
-complete -c my_app -n "__fish_use_subcommand" -s V -l version -d 'Prints version information'
+static FISH_SPECIAL_CMDS: &str = r#"complete -c my_app -n "__fish_use_subcommand" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_use_subcommand" -s V -l version -d 'Print version information'
 complete -c my_app -n "__fish_use_subcommand" -f -a "test" -d 'tests things'
 complete -c my_app -n "__fish_use_subcommand" -f -a "some_cmd" -d 'tests other things'
 complete -c my_app -n "__fish_use_subcommand" -f -a "some-cmd-with-hypens"
-complete -c my_app -n "__fish_use_subcommand" -f -a "help" -d 'Prints this message or the help of the given subcommand(s)'
+complete -c my_app -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c my_app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
-complete -c my_app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Prints help information'
-complete -c my_app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Prints version information'
+complete -c my_app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version information'
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -l config -d 'the other case to test' -r
-complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Prints help information'
-complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Prints version information'
-complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hypens" -s h -l help -d 'Prints help information'
-complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hypens" -s V -l version -d 'Prints version information'
-complete -c my_app -n "__fish_seen_subcommand_from help" -s h -l help -d 'Prints help information'
-complete -c my_app -n "__fish_seen_subcommand_from help" -s V -l version -d 'Prints version information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Print version information'
+complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hypens" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hypens" -s V -l version -d 'Print version information'
+complete -c my_app -n "__fish_seen_subcommand_from help" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from help" -s V -l version -d 'Print version information'
 "#;
 
 #[test]
@@ -112,8 +112,8 @@ fn build_app_special_help() -> App<'static> {
         )
 }
 
-static FISH_SPECIAL_HELP: &str = r#"complete -c my_app -s h -l help -d 'Prints help information'
-complete -c my_app -s V -l version -d 'Prints version information'
+static FISH_SPECIAL_HELP: &str = r#"complete -c my_app -s h -l help -d 'Print help information'
+complete -c my_app -s V -l version -d 'Print version information'
 complete -c my_app -l single-quotes -d 'Can be \'always\', \'auto\', or \'never\''
 complete -c my_app -l double-quotes -d 'Can be "always", "auto", or "never"'
 complete -c my_app -l backticks -d 'For more information see `echo test`'
@@ -152,7 +152,7 @@ fn build_app_with_aliases() -> App<'static> {
 }
 
 static FISH_ALIASES: &str = r#"complete -c cmd -s o -s O -l option -l opt -d 'cmd option' -r
-complete -c cmd -s h -l help -d 'Prints help information'
-complete -c cmd -s V -l version -d 'Prints version information'
+complete -c cmd -s h -l help -d 'Print help information'
+complete -c cmd -s V -l version -d 'Print version information'
 complete -c cmd -s f -s F -l flag -l flg -d 'cmd flag'
 "#;

--- a/clap_generate/tests/completions/powershell.rs
+++ b/clap_generate/tests/completions/powershell.rs
@@ -58,31 +58,31 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
 
     $completions = @(switch ($command) {
         'my_app' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('-C', 'C', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('--conf', 'conf', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('test', 'test', [CompletionResultType]::ParameterValue, 'tests things')
-            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Prints this message or the help of the given subcommand(s)')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
         'my_app;test' {
             [CompletionResult]::new('--case', 'case', [CompletionResultType]::ParameterName, 'the case to test')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break
         }
         'my_app;help' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break
         }
     })
@@ -133,10 +133,10 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
 
     $completions = @(switch ($command) {
         'my_app' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-c', 'c', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('-C', 'C', [CompletionResultType]::ParameterName, 'some config file')
             [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'some config file')
@@ -144,37 +144,37 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             [CompletionResult]::new('test', 'test', [CompletionResultType]::ParameterValue, 'tests things')
             [CompletionResult]::new('some_cmd', 'some_cmd', [CompletionResultType]::ParameterValue, 'tests other things')
             [CompletionResult]::new('some-cmd-with-hypens', 'some-cmd-with-hypens', [CompletionResultType]::ParameterValue, 'some-cmd-with-hypens')
-            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Prints this message or the help of the given subcommand(s)')
+            [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
         'my_app;test' {
             [CompletionResult]::new('--case', 'case', [CompletionResultType]::ParameterName, 'the case to test')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break
         }
         'my_app;some_cmd' {
             [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'the other case to test')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break
         }
         'my_app;some-cmd-with-hypens' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break
         }
         'my_app;help' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break
         }
     })
@@ -239,10 +239,10 @@ Register-ArgumentCompleter -Native -CommandName 'cmd' -ScriptBlock {
             [CompletionResult]::new('-O', 'O', [CompletionResultType]::ParameterName, 'cmd option')
             [CompletionResult]::new('--option', 'option', [CompletionResultType]::ParameterName, 'cmd option')
             [CompletionResult]::new('--opt', 'opt', [CompletionResultType]::ParameterName, 'cmd option')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Prints help information')
-            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Prints version information')
-            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Prints version information')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('-f', 'f', [CompletionResultType]::ParameterName, 'cmd flag')
             [CompletionResult]::new('-F', 'F', [CompletionResultType]::ParameterName, 'cmd flag')
             [CompletionResult]::new('--flag', 'flag', [CompletionResultType]::ParameterName, 'cmd flag')

--- a/clap_generate/tests/completions/zsh.rs
+++ b/clap_generate/tests/completions/zsh.rs
@@ -45,10 +45,10 @@ _myapp() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '::file -- some input file:_files' \
 ":: :_myapp_commands" \
 "*::: :->myapp" \
@@ -62,18 +62,18 @@ _myapp() {
             (test)
 _arguments "${_arguments_options[@]}" \
 '--case=[the case to test]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
         esac
@@ -85,7 +85,7 @@ esac
 _myapp_commands() {
     local commands; commands=(
 'test:tests things' \
-'help:Prints this message or the help of the given subcommand(s)' \
+'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'myapp commands' commands "$@"
 }
@@ -142,10 +142,10 @@ _my_app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '::file -- some input file:_files' \
 ":: :_my_app_commands" \
 "*::: :->my_app" \
@@ -159,43 +159,43 @@ _my_app() {
             (test)
 _arguments "${_arguments_options[@]}" \
 '--case=[the case to test]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (some_cmd)
 _arguments "${_arguments_options[@]}" \
 '--config=[the other case to test]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (some-cmd-with-hypens)
 _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (some_cmd_with_special_characters)
 _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
         esac
@@ -210,7 +210,7 @@ _my_app_commands() {
 'some_cmd:tests other things' \
 'some-cmd-with-hypens:' \
 'some_cmd_with_special_characters:This '\''is'\'' a "special" \[character\] string \\' \
-'help:Prints this message or the help of the given subcommand(s)' \
+'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'my_app commands' commands "$@"
 }
@@ -295,10 +295,10 @@ _my_app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '--single-quotes[Can be '\''always'\'', '\''auto'\'', or '\''never'\'']' \
 '--double-quotes[Can be "always", "auto", or "never"]' \
 '--backticks[For more information see `echo test`]' \
@@ -344,10 +344,10 @@ _my_app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 ":: :_my_app_commands" \
 "*::: :->first" \
 && ret=0
@@ -359,10 +359,10 @@ _my_app() {
         case $line[1] in
             (second)
 _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 ":: :_my_app__second_commands" \
 "*::: :->second" \
 && ret=0
@@ -374,8 +374,8 @@ case $state in
         case $line[1] in
             (third)
 _arguments "${_arguments_options[@]}" \
-'--help[Prints help information]' \
-'--version[Prints version information]' \
+'--help[Print help information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
         esac
@@ -384,10 +384,10 @@ esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
         esac
@@ -399,7 +399,7 @@ esac
 _my_app_commands() {
     local commands; commands=(
 'second:' \
-'help:Prints this message or the help of the given subcommand(s)' \
+'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'my_app commands' commands "$@"
 }
@@ -473,10 +473,10 @@ _cmd() {
 '-O+[cmd option]' \
 '--option=[cmd option]' \
 '--opt=[cmd option]' \
-'-h[Prints help information]' \
-'--help[Prints help information]' \
-'-V[Prints version information]' \
-'--version[Prints version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '-f[cmd flag]' \
 '-F[cmd flag]' \
 '--flag[cmd flag]' \

--- a/clap_generate/tests/value_hints.rs
+++ b/clap_generate/tests/value_hints.rs
@@ -117,7 +117,7 @@ _my_app() {
 '--host=[]: :_hosts' \
 '--url=[]: :_urls' \
 '--email=[]: :_email_addresses' \
-'--help[Prints help information]' \
+'--help[Print help information]' \
 '*::command_with_args:_cmdambivalent' \
 && ret=0
     
@@ -144,7 +144,7 @@ complete -c my_app -s u -l user -r -f -a "(__fish_complete_users)"
 complete -c my_app -s h -l host -r -f -a "(__fish_print_hostnames)"
 complete -c my_app -l url -r -f
 complete -c my_app -l email -r -f
-complete -c my_app -l help -d 'Prints help information'
+complete -c my_app -l help -d 'Print help information'
 "#;
 
 #[test]

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -51,8 +51,8 @@ USAGE:
     hello [OPTIONS] --name <name>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --count <count>    Number of times to greet [default: 1]

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -369,14 +369,14 @@ impl<'help> App<'help> {
         .arg(
             Arg::new("help")
                 .long("help")
-                .about("Prints help information")
+                .about("Print help information")
                 .global(true)
                 .generated(),
         )
         .arg(
             Arg::new("version")
                 .long("version")
-                .about("Prints version information")
+                .about("Print version information")
                 .global(true)
                 .generated(),
         )
@@ -822,7 +822,7 @@ impl<'help> App<'help> {
     ///            -v               Be verbose\n\n\
     ///
     ///            Commmands:\n\
-    ///            help             Prints this message\n\
+    ///            help             Print this message\n\
     ///            work             Do some work")
     /// # ;
     /// ```
@@ -1687,8 +1687,8 @@ impl<'help> App<'help> {
     ///     cust-ord [FLAGS] [OPTIONS]
     ///
     /// FLAGS:
-    ///     -h, --help       Prints help information
-    ///     -V, --version    Prints version information
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///
     /// SUBCOMMANDS:
     ///     beta    I should be first!
@@ -2151,11 +2151,11 @@ impl<'help> App<'help> {
     ///     myprog [SUBCOMMAND]
     ///
     /// FLAGS:
-    ///     -h, --help       Prints help information
-    ///     -V, --version    Prints version information
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///
     /// SUBCOMMANDS:
-    ///     help    Prints this message or the help of the given subcommand(s)
+    ///     help    Print this message or the help of the given subcommand(s)
     ///     sub1
     /// ```
     ///
@@ -2179,11 +2179,11 @@ impl<'help> App<'help> {
     ///     myprog [THING]
     ///
     /// FLAGS:
-    ///     -h, --help       Prints help information
-    ///     -V, --version    Prints version information
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///
     /// THINGS:
-    ///     help    Prints this message or the help of the given subcommand(s)
+    ///     help    Print this message or the help of the given subcommand(s)
     ///     sub1
     /// ```
     pub fn subcommand_placeholder<S, T>(mut self, placeholder: S, header: T) -> Self
@@ -2486,7 +2486,7 @@ impl<'help> App<'help> {
             debug!("App::_check_help_and_version: Building help subcommand");
             self.subcommands.push(
                 App::new("help")
-                    .about("Prints this message or the help of the given subcommand(s)"),
+                    .about("Print this message or the help of the given subcommand(s)"),
             );
         }
     }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -653,8 +653,8 @@ impl<'help> Arg<'help> {
     ///
     /// FLAGS:
     ///     --config     Some help text describing the --config arg
-    /// -h, --help       Prints help information
-    /// -V, --version    Prints version information
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
     /// ```
     /// [`Arg::long_about`]: Arg::long_about()
     #[inline]
@@ -723,10 +723,10 @@ impl<'help> Arg<'help> {
     ///             and on, so I'll stop now.
     ///
     ///     -h, --help
-    ///             Prints help information
+    ///             Print help information
     ///
     ///     -V, --version
-    ///             Prints version information
+    ///             Print version information
     /// ```
     /// [`Arg::about`]: Arg::about()
     #[inline]
@@ -2487,8 +2487,8 @@ impl<'help> Arg<'help> {
     ///    valnames [FLAGS] [OPTIONS]
     ///
     /// FLAGS:
-    ///     -h, --help       Prints help information
-    ///     -V, --version    Prints version information
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///
     /// OPTIONS:
     ///     --io-files <INFILE> <OUTFILE>    Some help text
@@ -2545,8 +2545,8 @@ impl<'help> Arg<'help> {
     ///    valnames [FLAGS] [OPTIONS]
     ///
     /// FLAGS:
-    ///     -h, --help       Prints help information
-    ///     -V, --version    Prints version information
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///
     /// OPTIONS:
     ///     --config <FILE>     Some help text
@@ -3199,8 +3199,8 @@ impl<'help> Arg<'help> {
     ///     cust-ord [FLAGS] [OPTIONS]
     ///
     /// FLAGS:
-    ///     -h, --help       Prints help information
-    ///     -V, --version    Prints version information
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///
     /// OPTIONS:
     ///     -O, --other-option <b>    I should be first!
@@ -3779,8 +3779,8 @@ impl<'help> Arg<'help> {
     ///    helptest [FLAGS]
     ///
     /// FLAGS:
-    /// -h, --help       Prints help information
-    /// -V, --version    Prints version information
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
     /// ```
     #[inline]
     pub fn hidden(self, h: bool) -> Self {
@@ -4022,8 +4022,8 @@ impl<'help> Arg<'help> {
     ///     nlh [FLAGS] [OPTIONS]
     ///
     /// FLAGS:
-    ///     -h, --help       Prints help information
-    ///     -V, --version    Prints version information
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///
     /// OPTIONS:
     ///     -o, --long-option-flag <value1> <value2>
@@ -4407,8 +4407,8 @@ impl<'help> Arg<'help> {
     ///    helptest [FLAGS]
     ///
     /// FLAGS:
-    /// -h, --help       Prints help information
-    /// -V, --version    Prints version information
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
     /// ```
     ///
     /// However, when --help is called
@@ -4435,8 +4435,8 @@ impl<'help> Arg<'help> {
     ///
     /// FLAGS:
     ///     --config     Some help text describing the --config arg
-    /// -h, --help       Prints help information
-    /// -V, --version    Prints version information
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
     /// ```
     #[inline]
     pub fn hidden_short_help(self, hide: bool) -> Self {
@@ -4485,8 +4485,8 @@ impl<'help> Arg<'help> {
     ///    helptest [FLAGS]
     ///
     /// FLAGS:
-    /// -h, --help       Prints help information
-    /// -V, --version    Prints version information
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
     /// ```
     ///
     /// However, when -h is called
@@ -4513,8 +4513,8 @@ impl<'help> Arg<'help> {
     ///
     /// FLAGS:
     ///     --config     Some help text describing the --config arg
-    /// -h, --help       Prints help information
-    /// -V, --version    Prints version information
+    /// -h, --help       Print help information
+    /// -V, --version    Print version information
     /// ```
     #[inline]
     pub fn hidden_long_help(self, hide: bool) -> Self {

--- a/tests/app_from_crate.rs
+++ b/tests/app_from_crate.rs
@@ -10,8 +10,8 @@ USAGE:
     clap
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 ";
 
 #[test]

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -8,8 +8,8 @@ USAGE:
     clap-test [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static DONT_COLLAPSE_ARGS: &str = "clap-test v1.4.8
 
@@ -22,8 +22,8 @@ ARGS:
     <arg3>    some
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static REQUIRE_EQUALS: &str = "clap-test v1.4.8
 
@@ -31,8 +31,8 @@ USAGE:
     clap-test --opt=<FILE>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt=<FILE>    some";
@@ -51,9 +51,9 @@ ARGS:
 
 OPTIONS:
     -f, --flag            some flag
-    -h, --help            Prints help information
+    -h, --help            Print help information
         --option <opt>    some option
-    -V, --version         Prints version information";
+    -V, --version         Print version information";
 
 static SKIP_POS_VALS: &str = "test 1.3
 
@@ -68,8 +68,8 @@ ARGS:
     <arg1>    some pos arg
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <opt>    some option";
@@ -80,9 +80,9 @@ USAGE:
     test [FLAGS]
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -i, --info       Provides more info
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 static SUBCOMMAND_REQUIRED_ELSE_HELP: &str = "test 1.0
 
@@ -90,11 +90,11 @@ USAGE:
     test <SUBCOMMAND>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     info";
 
 static LONG_FORMAT_FOR_HELP_SUBCOMMAND: &str = "myprog-test 
@@ -108,10 +108,10 @@ ARGS:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version information";
+            Print version information";
 
 static LONG_FORMAT_FOR_NESTED_HELP_SUBCOMMAND: &str = "myprog-test-nested 
 
@@ -122,10 +122,10 @@ USAGE:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version information";
+            Print version information";
 
 static LONG_FORMAT_SINGLE_ARG_HELP_SUBCOMMAND: &str = "myprog 
 
@@ -138,14 +138,14 @@ ARGS:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version information
+            Print version information
 
 SUBCOMMANDS:
     help
-            Prints this message or the help of the given subcommand(s)
+            Print this message or the help of the given subcommand(s)
     test";
 
 #[test]

--- a/tests/arg_aliases.rs
+++ b/tests/arg_aliases.rs
@@ -11,8 +11,8 @@ USAGE:
 
 FLAGS:
     -f, --flag       [aliases: v_flg, flag2, flg3]
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <opt>    [aliases: visible]";
@@ -26,8 +26,8 @@ USAGE:
 
 FLAGS:
     -f, --flag       
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <opt>    ";

--- a/tests/arg_aliases_short.rs
+++ b/tests/arg_aliases_short.rs
@@ -11,8 +11,8 @@ USAGE:
 
 FLAGS:
     -f, --flag       [aliases: flag1] [short aliases: a, b, 🦆]
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <opt>    [short aliases: v]";
@@ -26,8 +26,8 @@ USAGE:
 
 FLAGS:
     -f, --flag       
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <opt>    ";

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -8,8 +8,8 @@ USAGE:
     prog
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 ";
 
 static AUTHORS_ONLY: &str = "prog 1
@@ -20,8 +20,8 @@ USAGE:
     prog
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 ";
 
 #[test]

--- a/tests/derive_order.rs
+++ b/tests/derive_order.rs
@@ -12,8 +12,8 @@ USAGE:
 FLAGS:
         --flag_a     second flag
         --flag_b     first flag
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --option_a <option_a>    second option
@@ -25,8 +25,8 @@ USAGE:
     test [FLAGS] [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
         --flag_b     first flag
         --flag_a     second flag
 
@@ -42,10 +42,10 @@ USAGE:
 OPTIONS:
         --flag_a                 second flag
         --flag_b                 first flag
-    -h, --help                   Prints help information
+    -h, --help                   Print help information
         --option_a <option_a>    second option
         --option_b <option_b>    first option
-    -V, --version                Prints version information";
+    -V, --version                Print version information";
 
 static UNIFIED_HELP_AND_DERIVE: &str = "test 1.2
 
@@ -53,8 +53,8 @@ USAGE:
     test [OPTIONS]
 
 OPTIONS:
-    -h, --help                   Prints help information
-    -V, --version                Prints version information
+    -h, --help                   Print help information
+    -V, --version                Print version information
         --flag_b                 first flag
         --option_b <option_b>    first option
         --flag_a                 second flag
@@ -68,8 +68,8 @@ USAGE:
 FLAGS:
         --flag_b     first flag
         --flag_a     second flag
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --option_b <option_b>    first option
@@ -83,10 +83,10 @@ USAGE:
 OPTIONS:
         --flag_a                 second flag
         --flag_b                 first flag
-    -h, --help                   Prints help information
+    -h, --help                   Print help information
         --option_a <option_a>    second option
         --option_b <option_b>    first option
-    -V, --version                Prints version information";
+    -V, --version                Print version information";
 
 static UNIFIED_DERIVE_SC_PROP: &str = "test-sub 1.2
 
@@ -98,8 +98,8 @@ OPTIONS:
         --option_b <option_b>    first option
         --flag_a                 second flag
         --option_a <option_a>    second option
-    -h, --help                   Prints help information
-    -V, --version                Prints version information";
+    -h, --help                   Print help information
+    -V, --version                Print version information";
 
 static UNIFIED_DERIVE_SC_PROP_EXPLICIT_ORDER: &str = "test-sub 1.2
 
@@ -111,8 +111,8 @@ OPTIONS:
         --flag_b                 first flag
         --option_b <option_b>    first option
         --option_a <option_a>    second option
-    -h, --help                   Prints help information
-    -V, --version                Prints version information";
+    -h, --help                   Print help information
+    -V, --version                Print version information";
 
 static PREFER_USER_HELP_DERIVE_ORDER: &str = "test 1.2
 
@@ -120,8 +120,8 @@ USAGE:
     test [FLAGS]
 
 FLAGS:
-    -V, --version    Prints version information
-    -h, --help       Prints help message
+    -V, --version    Print version information
+    -h, --help       Print help message
         --flag_b     first flag
         --flag_a     second flag";
 
@@ -131,10 +131,10 @@ USAGE:
     test sub [FLAGS]
 
 FLAGS:
-    -h, --help       Prints help message
+    -h, --help       Print help message
         --flag_b     first flag
         --flag_a     second flag
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 #[test]
 fn no_derive_order() {
@@ -361,7 +361,7 @@ fn prefer_user_help_with_derive_order() {
             Arg::new("help")
                 .long("help")
                 .short('h')
-                .about("Prints help message"),
+                .about("Print help message"),
             Arg::new("flag_b").long("flag_b").about("first flag"),
             Arg::new("flag_a").long("flag_a").about("second flag"),
         ]);
@@ -383,7 +383,7 @@ fn prefer_user_help_in_subcommand_with_derive_order() {
                 Arg::new("help")
                     .long("help")
                     .short('h')
-                    .about("Prints help message"),
+                    .about("Print help message"),
                 Arg::new("flag_b").long("flag_b").about("first flag"),
                 Arg::new("flag_a").long("flag_a").about("second flag"),
             ]),

--- a/tests/flag_subcommands.rs
+++ b/tests/flag_subcommands.rs
@@ -431,8 +431,8 @@ USAGE:
     pacman {query, --query, -Q} [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -i, --info <info>...        view package information
@@ -488,8 +488,8 @@ USAGE:
     pacman {query, --query} [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -i, --info <info>...        view package information
@@ -544,8 +544,8 @@ USAGE:
     pacman {query, -Q} [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -i, --info <info>...        view package information

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -263,8 +263,8 @@ ARGS:
     <A>    
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
     let app = App::new("prog")
         .arg(Arg::new("a").value_name("A"))
         .group(ArgGroup::new("group").arg("a").required(true));

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -12,8 +12,8 @@ USAGE:
     test --fake <some>:<val>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -f, --fake <some>:<val>    some help";
@@ -35,8 +35,8 @@ ARGS:
 FLAGS:
     -f, --flag       tests flags
     -F               tests flags with exclusions
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --long-option-2 <option2>    tests long options with exclusions
@@ -48,7 +48,7 @@ OPTIONS:
     -O, --Option <option3>           specific vals [possible values: fast, slow]
 
 SUBCOMMANDS:
-    help      Prints this message or the help of the given subcommand(s)
+    help      Print this message or the help of the given subcommand(s)
     subcmd    tests subcommands";
 
 static SC_NEGATES_REQS: &str = "prog 1.0
@@ -61,14 +61,14 @@ ARGS:
     <PATH>    help
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <FILE>    tests options
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test";
 
 static ARGS_NEGATE_SC: &str = "prog 1.0
@@ -82,14 +82,14 @@ ARGS:
 
 FLAGS:
     -f, --flag       testing flags
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <FILE>    tests options
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test";
 
 static AFTER_HELP: &str = "some text that comes before the help
@@ -102,8 +102,8 @@ USAGE:
     clap-test
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 some text that comes after the help";
 
@@ -118,10 +118,10 @@ USAGE:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version information
+            Print version information
 
 some longer text that comes after the help";
 
@@ -132,8 +132,8 @@ USAGE:
 
 FLAGS:
     -f, --flag       testing flags
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <FILE>    tests options";
@@ -152,8 +152,8 @@ ARGS:
 
 FLAGS:
     -f, --flag       tests flags
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --option <scoption>...     tests options
@@ -169,8 +169,8 @@ ARGS:
 
 FLAGS:
     -f, --flag       testing flags
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --opt <FILE>    tests options";
@@ -182,8 +182,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --option <option>...    tests options
@@ -198,8 +198,8 @@ USAGE:
     rg [OPTIONS] --type-list
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
 
@@ -212,8 +212,8 @@ USAGE:
 
 FLAGS:
     -f, --flag       tests flags
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -o, --option <scoption>...    tests options";
@@ -224,8 +224,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café is an
@@ -243,8 +243,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>
@@ -262,8 +262,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
@@ -276,11 +276,11 @@ USAGE:
 
 FLAGS:
     -h, --help
-            Prints help
+            Print help
             information
 
     -V, --version
-            Prints
+            Print
             version
             information";
 
@@ -290,10 +290,10 @@ USAGE:
     ctest [FLAGS]
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -m               Some help with some wrapping
                      (Defaults to something)
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 static WRAPPING_NEWLINE_CHARS: &str = "ctest 0.1
 
@@ -309,8 +309,8 @@ ARGS:
               characters, contains symbols.
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static ISSUE_688: &str = "ctest 0.1
 
@@ -318,8 +318,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --filter <filter>    Sets the filter, or sampling method, to use for interpolation when resizing the particle
@@ -340,8 +340,8 @@ ARGS:
     <arg2>...    some option
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -l, --label <label>...    a label
@@ -362,10 +362,10 @@ USAGE:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version
+            Print version
             information";
 
 static ISSUE_1642: &str = "prog 
@@ -381,10 +381,10 @@ FLAGS:
             and on, so I'll stop now.
 
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version information";
+            Print version information";
 
 static HELP_CONFLICT: &str = "conflict 
 
@@ -393,8 +393,8 @@ USAGE:
 
 FLAGS:
     -h               
-        --help       Prints help information
-    -V, --version    Prints version information";
+        --help       Print help information
+    -V, --version    Print version information";
 
 static LAST_ARG: &str = "last 0.1
 
@@ -407,8 +407,8 @@ ARGS:
     <ARGS>...    some
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static LAST_ARG_SC: &str = "last 0.1
 
@@ -422,11 +422,11 @@ ARGS:
     <ARGS>...    some
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test    some";
 
 static LAST_ARG_REQ: &str = "last 0.1
@@ -440,8 +440,8 @@ ARGS:
     <ARGS>...    some
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static LAST_ARG_REQ_SC: &str = "last 0.1
 
@@ -455,11 +455,11 @@ ARGS:
     <ARGS>...    some
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test    some";
 
 static HIDE_DEFAULT_VAL: &str = "default 0.1
@@ -468,8 +468,8 @@ USAGE:
     default [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --arg <argument>    Pass an argument to the program. [default: default-argument]";
@@ -480,8 +480,8 @@ USAGE:
     default [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --arg <argument>    Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
@@ -497,9 +497,9 @@ ARGS:
     <ARGS>...    Any arguments you wish to pass to the being profiled.
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -v, --verbose    Prints out more stuff.
-    -V, --version    Prints version information
+    -V, --version    Print version information
 
 OPTIONS:
     -f, --frequency <HERTZ>    The sampling frequency.
@@ -515,8 +515,8 @@ ARGS:
     <SECOND>...    Second
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static DEFAULT_HELP: &str = "ctest 1.0
 
@@ -524,8 +524,8 @@ USAGE:
     ctest
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static LONG_ABOUT: &str = "myapp 1.0
 
@@ -544,10 +544,10 @@ ARGS:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version information";
+            Print version information";
 
 static HIDE_ENV: &str = "ctest 0.1
 
@@ -555,8 +555,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.";
@@ -567,8 +567,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]";
@@ -579,8 +579,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR]
@@ -592,8 +592,8 @@ USAGE:
     ctest [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
@@ -609,8 +609,8 @@ USAGE:
     test --fake <some>:<val>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -f, --fake <some>:<val>    some help
@@ -628,8 +628,8 @@ ARGS:
     <arg2>    
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static ISSUE_1364: &str = "demo 
 
@@ -641,8 +641,8 @@ ARGS:
 
 FLAGS:
     -f               
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 static OPTION_USAGE_ORDER: &str = "order 
 
@@ -653,11 +653,11 @@ FLAGS:
     -a                     
     -b                     
     -B                     
-    -h, --help             Prints help information
+    -h, --help             Print help information
     -s                     
         --select_file      
         --select_folder    
-    -V, --version          Prints version information
+    -V, --version          Print version information
     -x";
 
 static ABOUT_IN_SUBCOMMANDS_LIST: &str = "about-in-subcommands-list 
@@ -667,11 +667,11 @@ USAGE:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
 SUBCOMMANDS:
     help
-            Prints this message or the help of the given subcommand(s)
+            Print this message or the help of the given subcommand(s)
     sub
             short about sub
 ";
@@ -925,7 +925,7 @@ FLAGS:
             `=`
 
     -h, --help
-            Prints help information
+            Print help information
 
         --no-git-commit
             Do not commit version changes
@@ -934,7 +934,7 @@ FLAGS:
             Do not push generated commit and tags to git remote
 
     -V, --version
-            Prints version information";
+            Print version information";
     let app = App::new("test")
         .term_width(67)
         .arg(
@@ -979,11 +979,11 @@ FLAGS:
                            (will not be published)
         --exact            Specify inter dependency version numbers
                            exactly with `=`
-    -h, --help             Prints help information
+    -h, --help             Print help information
         --no-git-commit    Do not commit version changes
         --no-git-push      Do not push generated commit and tags to
                            git remote
-    -V, --version          Prints version information";
+    -V, --version          Print version information";
     let app = App::new("test")
         .term_width(68)
         .arg(
@@ -1423,8 +1423,8 @@ USAGE:
     test
 
 FLAGS:
-    -H, --help       Prints help information
-    -V, --version    Prints version information";
+    -H, --help       Print help information
+    -V, --version    Print version information";
 
 #[test]
 fn override_help_short() {
@@ -1452,8 +1452,8 @@ USAGE:
     test [FLAGS]
 
 FLAGS:
-    -h, --hell       Prints help information
-    -V, --version    Prints version information";
+    -h, --hell       Print help information
+    -V, --version    Print version information";
 
 #[test]
 fn override_help_long() {
@@ -1482,7 +1482,7 @@ USAGE:
 
 FLAGS:
     -h, --help       Print help information
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 #[test]
 fn override_help_about() {
@@ -1872,8 +1872,8 @@ USAGE:
     test [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -f, --fake <some>:<val>    some help
@@ -1953,10 +1953,10 @@ USAGE:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -V, --version
-            Prints version information";
+            Print version information";
 
 #[test]
 fn show_long_about_issue_897() {
@@ -1982,8 +1982,8 @@ USAGE:
     ctest foo
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information";
+    -h, --help       Print help information
+    -V, --version    Print version information";
 
 #[test]
 fn show_short_about_issue_897() {
@@ -2165,7 +2165,7 @@ USAGE:
 
 FLAGS:
     -h, --help       Print custom help about text
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 static HELP_ABOUT_MULTI_SC_OVERRIDE: &str = "myapp-subcmd-multi 1.0
 
@@ -2174,7 +2174,7 @@ USAGE:
 
 FLAGS:
     -h, --help       Print custom help about text from multi
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 #[test]
 fn help_about_multi_subcmd() {
@@ -2283,9 +2283,9 @@ ARGS:
     <pos2>    
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
         --option1    
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
     let app = clap::App::new("hello")
         .bin_name("deno")
@@ -2346,7 +2346,7 @@ USAGE:
     test
 
 FLAGS:
-    -h, --help    Prints help information
+    -h, --help    Print help information
 
 NETWORKING:
     -s, --speed <SPEED>    How fast";
@@ -2376,7 +2376,7 @@ ARGS:
     <gear>    Which gear
 
 FLAGS:
-    -h, --help    Prints help information
+    -h, --help    Print help information
 
 NETWORKING:
     <speed>    How fast";
@@ -2404,7 +2404,7 @@ USAGE:
     test [speed]
 
 FLAGS:
-    -h, --help    Prints help information
+    -h, --help    Print help information
 
 NETWORKING:
     <speed>    How fast";
@@ -2519,8 +2519,8 @@ USAGE:
     my_app [OPTIONS]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --some_arg <some_arg> <some_arg>    

--- a/tests/hidden_args.rs
+++ b/tests/hidden_args.rs
@@ -13,8 +13,8 @@ USAGE:
 
 FLAGS:
     -F, --flag2      some other flag
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
         --option <opt>    some option";
@@ -49,9 +49,9 @@ USAGE:
     test [FLAGS]
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -v, --visible    This text should be visible
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 static HIDDEN_SHORT_ARGS_LONG_HELP: &str = "test 2.31.2
 
@@ -67,13 +67,13 @@ FLAGS:
             Some help text describing the --config arg
 
     -h, --help
-            Prints help information
+            Print help information
 
     -v, --visible
             This text should be visible
 
     -V, --version
-            Prints version information";
+            Print version information";
 
 /// Ensure hidden with short option
 #[test]
@@ -140,13 +140,13 @@ USAGE:
 
 FLAGS:
     -h, --help
-            Prints help information
+            Print help information
 
     -v, --visible
             This text should be visible
 
     -V, --version
-            Prints version information";
+            Print version information";
 
 #[test]
 fn hidden_long_args() {
@@ -185,9 +185,9 @@ USAGE:
 
 FLAGS:
     -c, --config     Some help text describing the --config arg
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -v, --visible    This text should be visible
-    -V, --version    Prints version information";
+    -V, --version    Print version information";
 
 #[test]
 fn hidden_long_args_short_help() {
@@ -246,7 +246,7 @@ USAGE:
 
 FLAGS:
         --flag    some flag
-    -h, --help    Prints help information";
+    -h, --help    Print help information";
 
 #[test]
 fn hidden_opt_args() {
@@ -275,7 +275,7 @@ ARGS:
     <another>    another pos
 
 FLAGS:
-    -h, --help    Prints help information";
+    -h, --help    Print help information";
 
 #[test]
 fn hidden_pos_args() {
@@ -301,7 +301,7 @@ USAGE:
     test
 
 FLAGS:
-    -h, --help    Prints help information";
+    -h, --help    Print help information";
 
 #[test]
 fn hidden_subcmds() {

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -13,15 +13,15 @@ FLAGS:
     -4, --4          Sets priority to 4
     -5, --5          Sets priority to 5
     -6, --6          Sets priority to 6
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -t, --task-num <task-num>    Task number [possible values: all, 0, 1, 2]
 
 SUBCOMMANDS:
     0             Set everything to zero priority
-    help          Prints this message or the help of the given subcommand(s)
+    help          Print this message or the help of the given subcommand(s)
     view-tasks    View all tasks";
 
 #[test]

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -8,11 +8,11 @@ USAGE:
     clap-test [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test    Some help [aliases: dongle, done]";
 
 static INVISIBLE_ALIAS_HELP: &str = "clap-test 2.6
@@ -21,11 +21,11 @@ USAGE:
     clap-test [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test    Some help";
 
 static SUBCMD_ALPHA_ORDER: &str = "test 1
@@ -34,13 +34,13 @@ USAGE:
     test [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
     a1      blah a1
     b1      blah b1
-    help    Prints this message or the help of the given subcommand(s)";
+    help    Print this message or the help of the given subcommand(s)";
 
 static SUBCMD_DECL_ORDER: &str = "test 1
 
@@ -48,13 +48,13 @@ USAGE:
     test [SUBCOMMAND]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
     b1      blah b1
     a1      blah a1
-    help    Prints this message or the help of the given subcommand(s)";
+    help    Print this message or the help of the given subcommand(s)";
 
 #[cfg(feature = "suggestions")]
 static DYM_SUBCMD: &str = "error: The subcommand 'subcm' wasn't recognized

--- a/tests/template_help.rs
+++ b/tests/template_help.rs
@@ -36,14 +36,14 @@ USAGE:
 
 FLAGS:
     -d               Turn debugging information on
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 OPTIONS:
     -c, --config <FILE>    Sets a custom config file
 ARGS:
     <output>    Sets an optional output file
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test    does testing things";
 
 static SIMPLE_TEMPLATE: &str = "MyApp 1.0
@@ -58,14 +58,14 @@ ARGS:
 
 FLAGS:
     -d               Turn debugging information on
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 OPTIONS:
     -c, --config <FILE>    Sets a custom config file
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
+    help    Print this message or the help of the given subcommand(s)
     test    does testing things";
 
 #[test]

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -110,8 +110,8 @@ USAGE:
     test
 
 FLAGS:
-    -h, --help       Prints help information
-    -v, --version    Prints version information";
+    -h, --help       Print help information
+    -v, --version    Print version information";
 
 #[test]
 fn override_version_short() {
@@ -147,8 +147,8 @@ USAGE:
     test [FLAGS]
 
 FLAGS:
-    -h, --help    Prints help information
-    -V, --vers    Prints version information";
+    -h, --help    Print help information
+    -V, --vers    Print version information";
 
 #[test]
 fn override_version_long() {
@@ -184,7 +184,7 @@ USAGE:
     test
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -V, --version    version info";
 
 #[test]
@@ -213,7 +213,7 @@ USAGE:
     myapp subcmd multi
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -V, --version    Print custom version about text";
 
 #[test]
@@ -248,7 +248,7 @@ USAGE:
     myapp subcmd multi
 
 FLAGS:
-    -h, --help       Prints help information
+    -h, --help       Print help information
     -V, --version    Print custom version about text from multi";
 
 #[test]


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Closes #2500 

This changes all occurences of:

- "Prints help information" to "Print help information"
- "Prints version information" to "Print version information"
- "Prints this message or the help of the given subcommand(s)" to "Print this message or the help of the given subcommand(s)"

There are a few remaining usages of "Prints", but those do not apply to the default messages.
