### PR TITLE
Produce an error for "compact" arguments where takes_value is false

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2485,8 +2485,7 @@ impl<'help> App<'help> {
         {
             debug!("App::_check_help_and_version: Building help subcommand");
             self.subcommands.push(
-                App::new("help")
-                    .about("Print this message or the help of the given subcommand(s)"),
+                App::new("help").about("Print this message or the help of the given subcommand(s)"),
             );
         }
     }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -2,6 +2,7 @@
 use std::{
     cell::Cell,
     ffi::{OsStr, OsString},
+    slice,
 };
 
 // Internal
@@ -1076,6 +1077,13 @@ impl<'help, 'app> Parser<'help, 'app> {
             self.seen.push(opt.id.clone());
             if opt.is_set(ArgSettings::TakesValue) {
                 return self.parse_opt(&val, opt, matcher);
+            } else if let Some(val) = val {
+                return Err(ClapError::unknown_argument(
+                    val.to_string_lossy().to_string(),
+                    None,
+                    Usage::new(self).create_usage_with_title(slice::from_ref(&opt.id)),
+                    self.app.color(),
+                ));
             } else {
                 self.check_for_help_and_version_str(&arg)?;
                 return Ok(self.parse_flag(opt, matcher));

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -167,3 +167,24 @@ For more information try --help";
         true
     ));
 }
+
+#[test]
+fn issue_1543_compact_unexpected_value() {
+    static UNEXPECTED_ARGUMENT_FALSE: &str =
+        "error: Found argument '=false' which wasn't expected, or isn't valid in this context
+
+USAGE:
+    test --flag
+
+For more information try --help
+";
+
+    let app = App::new("test").arg(Arg::new("flag").long("flag").takes_value(false));
+
+    assert!(utils::compare_output(
+        app,
+        "test --flag=false",
+        UNEXPECTED_ARGUMENT_FALSE,
+        true
+    ));
+}


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Resolves #1543 

The error message produced is: "error: Found argument '=false' which wasn't expected, or isn't valid in this context". This uses `ClapError::unknown_argument`.

It might be better to remove the "=". If this would be better, I think it would also make sense to not produce the error when "--flag=" is used.
