### PR TITLE
Fix order of arguments in help message with AllowMissingPositional

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2485,8 +2485,7 @@ impl<'help> App<'help> {
         {
             debug!("App::_check_help_and_version: Building help subcommand");
             self.subcommands.push(
-                App::new("help")
-                    .about("Print this message or the help of the given subcommand(s)"),
+                App::new("help").about("Print this message or the help of the given subcommand(s)"),
             );
         }
     }

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -76,7 +76,10 @@ impl<'help, 'app, 'parser> Usage<'help, 'app, 'parser> {
             usage.push_str(" [OPTIONS]");
         }
 
-        usage.push_str(&req_string[..]);
+        let allow_mising_positional = self.p.app.is_set(AS::AllowMissingPositional);
+        if !allow_mising_positional {
+            usage.push_str(&req_string);
+        }
 
         let has_last = self
             .p
@@ -140,6 +143,10 @@ impl<'help, 'app, 'parser> Usage<'help, 'app, 'parser> {
                     usage.push(']');
                 }
             }
+        }
+
+        if allow_mising_positional {
+            usage.push_str(&req_string);
         }
 
         // incl_reqs is only false when this function is called recursively

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -2528,3 +2528,57 @@ OPTIONS:
         false
     ));
 }
+
+#[test]
+fn missing_positional_final_required() {
+    let app = App::new("test")
+        .setting(AppSettings::AllowMissingPositional)
+        .arg(Arg::new("arg1"))
+        .arg(Arg::new("arg2").required(true));
+    assert!(utils::compare_output(
+        app,
+        "test --help",
+        "test 
+
+USAGE:
+    test [arg1] <arg2>
+
+ARGS:
+    <arg1>    
+    <arg2>    
+
+FLAGS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+",
+        false
+    ));
+}
+
+#[test]
+fn missing_positional_final_multiple() {
+    let app = App::new("test")
+        .setting(AppSettings::AllowMissingPositional)
+        .arg(Arg::new("foo"))
+        .arg(Arg::new("bar"))
+        .arg(Arg::new("baz").takes_value(true).multiple_values(true));
+    assert!(utils::compare_output(
+        app,
+        "test --help",
+        "test 
+
+USAGE:
+    test [ARGS]
+
+ARGS:
+    <foo>       
+    <bar>       
+    <baz>...    
+
+FLAGS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+",
+        false
+    ));
+}


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Closes #1737

If `AppSettings::AllowMissingPositional` is enabled, then `req_string` is added after other arguments.