### PR TITLE
Make colorizer respect `AppSettings::ColorAlways` / `ColorChoice::Always`

### DIFF
--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -65,10 +65,10 @@ impl Colorizer {
     pub(crate) fn print(&self) -> io::Result<()> {
         use termcolor::{BufferWriter, ColorSpec, WriteColor};
 
-        let color_when = if is_a_tty(self.use_stderr) {
-            self.color_when
-        } else {
-            ColorChoice::Never
+        let color_when = match self.color_when {
+            always @ ColorChoice::Always => always,
+            choice if is_a_tty(self.use_stderr) => choice,
+            _ => ColorChoice::Never,
         };
 
         let writer = if self.use_stderr {


### PR DESCRIPTION
`AppSettings::ColorAlways` currently appears to have no effect.
This was an issue in the past (see #1400), but was fixed in pr #1402; however, it seems to have been broken again.

I have tested the altered colorizer in a local project, and it seems to have the correct behavior.
No lints are triggered. All tests have passed.

This should fix issue #1400 ... again.