### PR TITLE
Make `multiple_values` `false` with derived `Option<Option<...>>`

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -264,9 +264,9 @@ pub fn gen_augment(
                     Ty::OptionOption => quote_spanned! { ty.span()=>
                         .takes_value(true)
                         #value_name
-                        .multiple_values(false)
                         .min_values(0)
                         .max_values(1)
+                        .multiple_values(false)
                         #validator
                     },
 

--- a/clap_derive/tests/options.rs
+++ b/clap_derive/tests/options.rs
@@ -14,7 +14,10 @@
 
 #![allow(clippy::option_option)]
 
+mod utils;
+
 use clap::Clap;
+use utils::*;
 
 #[test]
 fn required_option() {
@@ -133,6 +136,18 @@ fn optional_argument_for_optional_option() {
     assert_eq!(Opt { arg: Some(None) }, Opt::parse_from(&["test", "-a"]));
     assert_eq!(Opt { arg: None }, Opt::parse_from(&["test"]));
     assert!(Opt::try_parse_from(&["test", "-a42", "-a24"]).is_err());
+}
+
+#[test]
+fn option_option_help() {
+    #[derive(Clap, Debug)]
+    struct Opt {
+        #[clap(long, value_name = "val")]
+        arg: Option<Option<i32>>,
+    }
+    let help = get_help::<Opt>();
+    assert!(help.contains("--arg <val>"));
+    assert!(!help.contains("--arg <val>..."));
 }
 
 #[test]


### PR DESCRIPTION
Possibly closes #2448

When setting `min_value` and `max_value`, `multiple_values` is automatically to `true`. By moving `multiple_values(false)` to after those, it actually has an effect, and the ellipsis is not displayed.

This does not make the value appear as `[<val>]`. I was unsure of what circumstances it would apply to: only with `Option<Option<...>>`, with all values that are not required, or some other conditions.
