### PR TITLE
fix(style): eliminate several `clippy` warnings

### DIFF
--- a/examples/01a_quick_example.rs
+++ b/examples/01a_quick_example.rs
@@ -64,7 +64,7 @@ fn main() {
 
     // You can check for the existence of subcommands, and if found use their
     // matches just as you would the top level app
-    if let Some(ref matches) = matches.subcommand_matches("test") {
+    if let Some(matches) = matches.subcommand_matches("test") {
         // "$ myapp test" was run
         if matches.is_present("list") {
             // "$ myapp test -l" was run

--- a/examples/01b_quick_example.rs
+++ b/examples/01b_quick_example.rs
@@ -83,7 +83,7 @@ fn main() {
 
     // You can check for the existence of subcommands, and if found use their
     // matches just as you would the top level app
-    if let Some(ref matches) = matches.subcommand_matches("test") {
+    if let Some(matches) = matches.subcommand_matches("test") {
         // "$ myapp test" was run
         if matches.is_present("list") {
             // "$ myapp test -l" was run

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -42,7 +42,7 @@ fn main() {
     }
 
     // You can get the independent subcommand matches (which function exactly like App matches)
-    if let Some(ref matches) = matches.subcommand_matches("add") {
+    if let Some(matches) = matches.subcommand_matches("add") {
         // Safe to use unwrap() because of the required() option
         println!("Adding file: {}", matches.value_of("input").unwrap());
     }

--- a/examples/18_builder_macro.rs
+++ b/examples/18_builder_macro.rs
@@ -69,7 +69,7 @@ fn main() {
 
     // You can check for the existence of subcommands, and if found use their
     // matches just as you would the top level app
-    if let Some(ref matches) = matches.subcommand_matches("test") {
+    if let Some(matches) = matches.subcommand_matches("test") {
         // "$ myapp test" was run
         if matches.is_present("list") {
             // "$ myapp test -l" was run

--- a/examples/21_aliases.rs
+++ b/examples/21_aliases.rs
@@ -24,7 +24,7 @@ fn main() {
     }
 
     // You can get the independent subcommand matches (which function exactly like App matches)
-    if let Some(ref matches) = matches.subcommand_matches("add") {
+    if let Some(matches) = matches.subcommand_matches("add") {
         // Safe to use unwrap() because of the required() option
         println!("Adding file: {}", matches.value_of("input").unwrap());
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -570,10 +570,12 @@ macro_rules! wlnerr {
 
 #[cfg(feature = "debug")]
 macro_rules! debug {
-    ($($arg:tt)*) => {
+    ($($arg:tt)*) => ({
+        // The `print!` line will make clippy complain about duplicates.
+        #[allow(clippy::branches_sharing_code)]
         print!("[{:>w$}] \t", module_path!(), w = 28);
-        println!($($arg)*)
-    }
+        println!($($arg)*);
+    })
 }
 
 #[cfg(not(feature = "debug"))]

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -376,10 +376,9 @@ mod tests {
         }
 
         {
-            let mut m = m.clone();
+            let mut m = m;
             m.remove_vals(9);
-            let vals1: Vec<&Vec<OsString>> = m.vals().collect();
-            assert!(vals1.is_empty());
+            assert_eq!(m.vals().next(), None);
         }
     }
 }

--- a/tests/default_missing_vals.rs
+++ b/tests/default_missing_vals.rs
@@ -110,6 +110,7 @@ fn opt_default_user_override() {
 }
 
 #[test]
+#[allow(clippy::bool_assert_comparison)]
 fn default_missing_value_flag_value() {
     let app = App::new("test").arg(
         Arg::new("flag")

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -2273,7 +2273,7 @@ fn about_in_subcommands_list() {
 
 #[test]
 fn issue_1794_usage() {
-    static USAGE_WITH_GROUP: &'static str = "hello 
+    static USAGE_WITH_GROUP: &str = "hello 
 
 USAGE:
     deno <pos1|--option1> [pos2]
@@ -2306,7 +2306,7 @@ FLAGS:
     ));
 }
 
-static ONLY_CUSTOM_HEADING_FLAGS: &'static str = "test 1.4
+static ONLY_CUSTOM_HEADING_FLAGS: &str = "test 1.4
 
 USAGE:
     test [OPTIONS]
@@ -2340,7 +2340,7 @@ fn only_custom_heading_flags() {
     ));
 }
 
-static ONLY_CUSTOM_HEADING_OPTS: &'static str = "test 1.4
+static ONLY_CUSTOM_HEADING_OPTS: &str = "test 1.4
 
 USAGE:
     test
@@ -2367,7 +2367,7 @@ fn only_custom_heading_opts() {
     ));
 }
 
-static CUSTOM_HEADING_POS: &'static str = "test 1.4
+static CUSTOM_HEADING_POS: &str = "test 1.4
 
 USAGE:
     test [ARGS]
@@ -2398,7 +2398,7 @@ fn custom_heading_pos() {
     ));
 }
 
-static ONLY_CUSTOM_HEADING_POS: &'static str = "test 1.4
+static ONLY_CUSTOM_HEADING_POS: &str = "test 1.4
 
 USAGE:
     test [speed]
@@ -2425,7 +2425,7 @@ fn only_custom_heading_pos() {
     ));
 }
 
-static ONLY_CUSTOM_HEADING_FLAGS_NO_ARGS: &'static str = "test 1.4
+static ONLY_CUSTOM_HEADING_FLAGS_NO_ARGS: &str = "test 1.4
 
 USAGE:
     test
@@ -2450,7 +2450,7 @@ fn only_custom_heading_flags_no_args() {
     ));
 }
 
-static ONLY_CUSTOM_HEADING_OPTS_NO_ARGS: &'static str = "test 1.4
+static ONLY_CUSTOM_HEADING_OPTS_NO_ARGS: &str = "test 1.4
 
 USAGE:
     test
@@ -2475,7 +2475,7 @@ fn only_custom_heading_opts_no_args() {
     ));
 }
 
-static ONLY_CUSTOM_HEADING_POS_NO_ARGS: &'static str = "test 1.4
+static ONLY_CUSTOM_HEADING_POS_NO_ARGS: &str = "test 1.4
 
 USAGE:
     test [speed]

--- a/tests/require.rs
+++ b/tests/require.rs
@@ -937,7 +937,7 @@ fn issue_1158_app() -> App<'static> {
 
 #[test]
 fn multiple_required_unless_usage_printing() {
-    static MULTIPLE_REQUIRED_UNLESS_USAGE: &'static str =
+    static MULTIPLE_REQUIRED_UNLESS_USAGE: &str =
         "error: The following required arguments were not provided:
     --a <a>
     --b <b>


### PR DESCRIPTION
The PR solves 2 minor issues:
- The `debug!` macro fills up the IDE with `branches_sharing_code` warnings.
  - Ideally this should not affect much since in release mode it's a no-op.
- Unnecessary usages of `.clone()`,`.collect()`, `ref` and `'static`, reported by `clippy`.
