### PR TITLE
docs(example): clarify `stop_parsing_with_--`

### DIFF
--- a/examples/22_stop_parsing_with_--.rs
+++ b/examples/22_stop_parsing_with_--.rs
@@ -1,6 +1,5 @@
 use clap::{App, Arg};
 
-/// myprog -f -p=bob -- sloppy slop slop
 fn main() {
     let matches = App::new("myprog")
         .arg(Arg::new("eff").short('f'))
@@ -9,18 +8,19 @@ fn main() {
             Arg::new("slop")
                 .takes_value(true)
                 .multiple_values(true)
-                .last(true),
+                .last(true), // Indicates that `slop` is only accessible after `--`.
         )
         .get_matches();
 
-    println!("-f used: {:?}", matches.is_present("eff"));
-    println!("-p's value: {:?}", matches.value_of("pea"));
+    // This is what will happen with `myprog -f -p=bob -- sloppy slop slop`...
+    println!("-f used: {:?}", matches.is_present("eff")); // -f used: true
+    println!("-p's value: {:?}", matches.value_of("pea")); // -p's value: Some("bob")
     println!(
         "'slops' values: {:?}",
         matches
             .values_of("slop")
             .map(|vals| vals.collect::<Vec<_>>())
-    );
+    ); // 'slops' values: Some(["sloppy", "slop", "slop"])
 
     // Continued program logic goes here...
 }


### PR DESCRIPTION
Closes #2661.
