### PR TITLE
feat(parser): accept boolean literal with env vars

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -3061,7 +3061,7 @@ impl<'help> Arg<'help> {
     /// # use clap::{App, Arg};
     ///
     /// env::set_var("TRUE_FLAG", "true");
-    /// env::set_var("FALSE_FLAG", "OFF");
+    /// env::set_var("FALSE_FLAG", "0");
     ///
     /// let m = App::new("prog")
     ///     .arg(Arg::new("true_flag")

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -3050,14 +3050,18 @@ impl<'help> Arg<'help> {
     /// assert_eq!(m.value_of("flag"), Some("env"));
     /// ```
     ///
-    /// In this example, we show the flag being raised but with no value because
-    /// of not setting [`Arg::takes_value(true)`]:
+    /// In this example, because [`Arg::takes_value(false)`] (by default),
+    /// `prog` is a flag that only accepts optional, case-insensitive boolean literals.
+    /// A `true` literal is `y`, `yes`, `t`, `true`, `on` or `1`;
+    /// a `false` literal is `n`, `no`, `f`, `false`, `off` or `0`.
+    /// An absent environment variable will be considered as `false`.
+    /// Anything else will cause a parsing error.
     ///
     /// ```rust
     /// # use std::env;
     /// # use clap::{App, Arg};
     ///
-    /// env::set_var("MY_FLAG", "env");
+    /// env::set_var("MY_FLAG", "true");
     ///
     /// let m = App::new("prog")
     ///     .arg(Arg::new("flag")

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -3051,28 +3051,36 @@ impl<'help> Arg<'help> {
     /// ```
     ///
     /// In this example, because [`Arg::takes_value(false)`] (by default),
-    /// `prog` is a flag that only accepts optional, case-insensitive boolean literals.
-    /// A `true` literal is `y`, `yes`, `t`, `true`, `on` or `1`;
-    /// a `false` literal is `n`, `no`, `f`, `false`, `off` or `0`.
-    /// An absent environment variable will be considered as `false`.
-    /// Anything else will cause a parsing error.
+    /// `prog` is a flag that accepts an optional, case-insensitive boolean literal.
+    /// A `false` literal is `n`, `no`, `f`, `false`, `off` or `0`.
+    /// An absent environment variable will also be considered as `false`.
+    /// Anything else will considered as `true`.
     ///
     /// ```rust
     /// # use std::env;
     /// # use clap::{App, Arg};
     ///
-    /// env::set_var("MY_FLAG", "true");
+    /// env::set_var("TRUE_FLAG", "true");
+    /// env::set_var("FALSE_FLAG", "OFF");
     ///
     /// let m = App::new("prog")
-    ///     .arg(Arg::new("flag")
-    ///         .long("flag")
-    ///         .env("MY_FLAG"))
+    ///     .arg(Arg::new("true_flag")
+    ///         .long("true_flag")
+    ///         .env("TRUE_FLAG"))
+    ///     .arg(Arg::new("false_flag")
+    ///         .long("false_flag")
+    ///         .env("FALSE_FLAG"))
+    ///     .arg(Arg::new("absent_flag")
+    ///         .long("absent_flag")
+    ///         .env("ABSENT_FLAG"))
     ///     .get_matches_from(vec![
     ///         "prog"
     ///     ]);
     ///
-    /// assert!(m.is_present("flag"));
-    /// assert_eq!(m.value_of("flag"), None);
+    /// assert!(m.is_present("true_flag"));
+    /// assert_eq!(m.value_of("true_flag"), None);
+    /// assert!(!m.is_present("false_flag"));
+    /// assert!(!m.is_present("absent_flag"));
     /// ```
     ///
     /// In this example, we show the variable coming from an option on the CLI:

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1772,40 +1772,91 @@ impl<'help, 'app> Parser<'help, 'app> {
         matcher: &mut ArgMatcher,
         trailing_values: bool,
     ) -> ClapResult<()> {
+        use crate::util::{str_to_bool, FALSE_LITERALS, TRUE_LITERALS};
+
         if self.app.is_set(AS::DisableEnv) {
+            debug!("Parser::add_env: Env vars disabled, quitting");
             return Ok(());
         }
 
-        for a in self.app.args.args() {
-            // Use env only if the arg was not present among command line args
-            if matcher.get(&a.id).map_or(true, |a| a.occurs == 0) {
-                if let Some((_, Some(ref val))) = a.env {
-                    let val = ArgStr::new(val);
-                    if a.is_set(ArgSettings::TakesValue) {
-                        self.add_val_to_arg(
-                            a,
-                            val,
-                            matcher,
-                            ValueType::EnvVariable,
-                            false,
-                            trailing_values,
-                        );
-                    } else {
-                        match self.check_for_help_and_version_str(&val) {
-                            Some(ParseResult::HelpFlag) => {
-                                return Err(self.help_err(true));
-                            }
-                            Some(ParseResult::VersionFlag) => {
-                                return Err(self.version_err(true));
-                            }
-                            _ => (),
+        self.app.args.args().try_for_each(|a| {
+            // Use env only if the arg was absent among command line args,
+            // early return if this is not the case.
+            if matcher.get(&a.id).map_or(false, |a| a.occurs != 0) {
+                debug!("Parser::add_env: Skipping existing arg `{}`", a);
+                return Ok(());
+            }
+
+            debug!("Parser::add_env: Checking arg `{}`", a);
+            if let Some((_, Some(ref val))) = a.env {
+                let val = ArgStr::new(val);
+
+                if a.is_set(ArgSettings::TakesValue) {
+                    debug!(
+                        "Parser::add_env: Found an opt with value={:?}, trailing={:?}",
+                        val, trailing_values
+                    );
+                    self.add_val_to_arg(
+                        a,
+                        val,
+                        matcher,
+                        ValueType::EnvVariable,
+                        false,
+                        trailing_values,
+                    );
+                    return Ok(());
+                }
+
+                debug!("Parser::add_env: Checking for help and version");
+                // Early return on `HelpFlag` or `VersionFlag`.
+                match self.check_for_help_and_version_str(&val) {
+                    Some(ParseResult::HelpFlag) => {
+                        return Err(self.help_err(true));
+                    }
+                    Some(ParseResult::VersionFlag) => {
+                        return Err(self.version_err(true));
+                    }
+                    _ => (),
+                }
+
+                debug!("Parser::add_env: Found a flag with value `{:?}`", val);
+                match str_to_bool(val.to_string_lossy()) {
+                    Ok(predicate) => {
+                        debug!("Parser::add_env: Found boolean literal `{}`", predicate);
+                        if predicate {
+                            matcher.add_index_to(&a.id, self.cur_idx.get(), ValueType::EnvVariable);
                         }
-                        matcher.add_index_to(&a.id, self.cur_idx.get(), ValueType::EnvVariable);
+                    }
+                    Err(rest) => {
+                        debug!("Parser::parse_long_arg: Got invalid literal `{}`", rest);
+                        let used: Vec<Id> = matcher
+                            .arg_names()
+                            .filter(|&n| {
+                                self.app.find(n).map_or(true, |a| {
+                                    !(a.is_set(ArgSettings::Hidden)
+                                        || self.required.contains(&a.id))
+                                })
+                            })
+                            .cloned()
+                            .collect();
+                        let good_vals: Vec<&str> = TRUE_LITERALS
+                            .iter()
+                            .chain(FALSE_LITERALS.iter())
+                            .copied()
+                            .collect();
+                        return Err(ClapError::invalid_value(
+                            rest.into(),
+                            &good_vals,
+                            a,
+                            Usage::new(self).create_usage_no_title(&used),
+                            self.app.color(),
+                        ));
                     }
                 }
             }
-        }
-        Ok(())
+
+            Ok(())
+        })
     }
 
     /// Increase occurrence of specific argument and the grouped arg it's in.

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -16,7 +16,7 @@ use crate::{
     parse::features::suggestions,
     parse::{ArgMatcher, SubCommand},
     parse::{Validator, ValueType},
-    util::{termcolor::ColorChoice, ArgStr, ChildGraph, Id},
+    util::{str_to_bool, termcolor::ColorChoice, ArgStr, ChildGraph, Id},
     INTERNAL_ERROR_MSG, INVALID_UTF8,
 };
 
@@ -1772,8 +1772,6 @@ impl<'help, 'app> Parser<'help, 'app> {
         matcher: &mut ArgMatcher,
         trailing_values: bool,
     ) -> ClapResult<()> {
-        use crate::util::str_to_bool;
-
         if self.app.is_set(AS::DisableEnv) {
             debug!("Parser::add_env: Env vars disabled, quitting");
             return Ok(());

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,10 +4,16 @@ mod argstr;
 mod fnv;
 mod graph;
 mod id;
+mod str_to_bool;
 
 pub use self::fnv::Key;
 
-pub(crate) use self::{argstr::ArgStr, graph::ChildGraph, id::Id};
+pub(crate) use self::{
+    argstr::ArgStr,
+    graph::ChildGraph,
+    id::Id,
+    str_to_bool::{str_to_bool, FALSE_LITERALS, TRUE_LITERALS},
+};
 pub(crate) use vec_map::VecMap;
 
 #[cfg(feature = "color")]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,12 +8,7 @@ mod str_to_bool;
 
 pub use self::fnv::Key;
 
-pub(crate) use self::{
-    argstr::ArgStr,
-    graph::ChildGraph,
-    id::Id,
-    str_to_bool::{str_to_bool, FALSE_LITERALS, TRUE_LITERALS},
-};
+pub(crate) use self::{argstr::ArgStr, graph::ChildGraph, id::Id, str_to_bool::str_to_bool};
 pub(crate) use vec_map::VecMap;
 
 #[cfg(feature = "color")]

--- a/src/util/str_to_bool.rs
+++ b/src/util/str_to_bool.rs
@@ -1,0 +1,24 @@
+/// True values are `y`, `yes`, `t`, `true`, `on`, and `1`.
+pub(crate) const TRUE_LITERALS: [&str; 6] = ["y", "yes", "t", "true", "on", "1"];
+
+/// False values are `n`, `no`, `f`, `false`, `off`, and `0`.
+pub(crate) const FALSE_LITERALS: [&str; 6] = ["n", "no", "f", "false", "off", "0"];
+
+/// Converts a string literal representation of truth to true or false.
+///
+/// Translated from the Python function [`strtobool`].
+///
+/// [`strtobool`]: https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool
+///
+/// # Errors
+/// Returns Err(val) if `val` is anything else.
+pub(crate) fn str_to_bool<S: AsRef<str>>(val: S) -> Result<bool, S> {
+    let pat: &str = &val.as_ref().to_lowercase();
+    if TRUE_LITERALS.contains(&pat) {
+        Ok(true)
+    } else if FALSE_LITERALS.contains(&pat) {
+        Ok(false)
+    } else {
+        Err(val)
+    }
+}

--- a/src/util/str_to_bool.rs
+++ b/src/util/str_to_bool.rs
@@ -1,24 +1,15 @@
 /// True values are `y`, `yes`, `t`, `true`, `on`, and `1`.
-pub(crate) const TRUE_LITERALS: [&str; 6] = ["y", "yes", "t", "true", "on", "1"];
+// pub(crate) const TRUE_LITERALS: [&str; 6] = ["y", "yes", "t", "true", "on", "1"];
 
 /// False values are `n`, `no`, `f`, `false`, `off`, and `0`.
-pub(crate) const FALSE_LITERALS: [&str; 6] = ["n", "no", "f", "false", "off", "0"];
+const FALSE_LITERALS: [&str; 6] = ["n", "no", "f", "false", "off", "0"];
 
 /// Converts a string literal representation of truth to true or false.
 ///
-/// Translated from the Python function [`strtobool`].
+/// `false` values are `n`, `no`, `f`, `false`, `off`, and `0` (case insensitive).
 ///
-/// [`strtobool`]: https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool
-///
-/// # Errors
-/// Returns Err(val) if `val` is anything else.
-pub(crate) fn str_to_bool<S: AsRef<str>>(val: S) -> Result<bool, S> {
+/// Any other value will be considered as `true`.
+pub(crate) fn str_to_bool(val: impl AsRef<str>) -> bool {
     let pat: &str = &val.as_ref().to_lowercase();
-    if TRUE_LITERALS.contains(&pat) {
-        Ok(true)
-    } else if FALSE_LITERALS.contains(&pat) {
-        Ok(false)
-    } else {
-        Err(val)
-    }
+    !FALSE_LITERALS.contains(&pat)
 }

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::ffi::OsStr;
 
-use clap::{App, AppSettings, Arg, Error as ClapError};
+use clap::{App, AppSettings, Arg};
 
 #[test]
 fn env() {
@@ -20,23 +20,6 @@ fn env() {
     assert!(m.is_present("arg"));
     assert_eq!(m.occurrences_of("arg"), 0);
     assert_eq!(m.value_of("arg").unwrap(), "env");
-}
-
-#[test]
-fn env_no_takes_value() {
-    env::set_var("CLP_TEST_ENV", "env");
-
-    let r = App::new("df")
-        .arg(Arg::from("[arg] 'some opt'").env("CLP_TEST_ENV"))
-        .try_get_matches_from(vec![""]);
-
-    assert!(matches!(
-        dbg!(r),
-        Err(ClapError {
-            kind: clap::ErrorKind::InvalidValue,
-            ..
-        })
-    ));
 }
 
 #[test]


### PR DESCRIPTION
Closes #2539.

This PR allows boolean literals following the Python [`strtobool`] convention (case-insensitive):

[`strtobool`]: https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool

> True values are y, yes, t, true, on and 1; false values are n, no, f, false, off and 0. Raises ValueError if val is anything else.

- A `false` literal or an absent env var will cause the flag to be considered absent.
- ~~If the env var gets a `true` literal, then the flag is considered present by the parser.~~
- ~~If the boolean literal is anything else, the parser returns an error.~~
- If the env var gets anything else, then the flag is considered present by the parser (suggested by @pksunkara).

## Questions

- [x] Should we adjust the APIs so that other conventions are also allowed?
  - The [`pseudo-flag`](https://github.com/clap-rs/clap/issues/1649#issuecomment-891176637) pattern should be used in this case.
- [ ] How will this adjustment interact with the rest of the APIs?
