### PR TITLE
Fix invalid_value returning an Error with no info

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -640,7 +640,7 @@ impl Error {
         Error {
             message: c,
             kind: ErrorKind::InvalidValue,
-            info: vec![],
+            info,
             source: None,
         }
     }


### PR DESCRIPTION
When constructing the Error for an invalid value, an info `Vec` is constructed, populated with the argument, the invalid value, and possible valid values… and then discarded and an empty `Vec` is used instead.

I can only assume this is unintentional, so this PR fixes that.