### PR TITLE
Pin `clap_derive` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ name = "06_rustup"
 path = "benches/06_rustup.rs"
 
 [dependencies]
-clap_derive = { path = "./clap_derive", version = "3.0.0-beta.4", optional = true }
+clap_derive = { path = "./clap_derive", version = "=3.0.0-beta.4", optional = true }
 bitflags = "1.2"
 textwrap = { version = "0.14.0", default-features = false, features = [] }
 indexmap = "1.0"

--- a/clap_generate/Cargo.toml
+++ b/clap_generate/Cargo.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 bench = false
 
 [dependencies]
-clap = { path = "../", version = "3.0.0-beta.4" }
+clap = { path = "../", version = "=3.0.0-beta.4" }
 
 [dev-dependencies]
 pretty_assertions = "0.7"


### PR DESCRIPTION
Pin since `clap_derive` is unstable. Fixes #2705 