### PR TITLE
fix(derive): Don't produce warnings

### DIFF
--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -93,7 +93,7 @@ fn gen_from_arg_matches_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum
     let update_from_arg_matches = gen_update_from_arg_matches(name, &e.variants, &attrs);
 
     quote! {
-        #[allow(dead_code, unreachable_code, unused_variables)]
+        #[allow(dead_code, unreachable_code, unused_variables, unused_braces)]
         #[allow(
             clippy::style,
             clippy::complexity,


### PR DESCRIPTION
I did some digging to root cause this but gave up and suppressed it,
like others.  Warnings like this also come with a cost of code-gen
complexity.

Fixes #2712

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
