### PR TITLE
fix: Swallow broken pipes

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -478,11 +478,13 @@ impl Error {
     /// or prints to `stdout` and exits with a status of `0`.
     pub fn exit(&self) -> ! {
         if self.use_stderr() {
-            self.message.print().expect("Error writing Error to stderr");
+            // Swallow broken pipe errors
+            let _ = self.message.print();
             safe_exit(USAGE_CODE);
         }
 
-        self.message.print().expect("Error writing Error to stdout");
+        // Swallow broken pipe errors
+        let _ = self.message.print();
         safe_exit(SUCCESS_CODE)
     }
 


### PR DESCRIPTION
Previously, we paniced.  This is one less reason people have to call
lower level `get_matches` to get the commonly expected behavior, making
it more likely for the Rust community to "do the right thing"

Fixes #2659

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
