### PR TITLE
fix(generate): Better subcommand completion in fish

### DIFF
--- a/clap_generate/src/generators/shells/fish.rs
+++ b/clap_generate/src/generators/shells/fish.rs
@@ -57,6 +57,10 @@ fn gen_fish_inner(root_command: &str, parent_commands: &[&str], app: &App, buffe
                 parent_commands
                     .iter()
                     .map(|command| format!("__fish_seen_subcommand_from {}", command))
+                    .chain(
+                        app.get_subcommands()
+                            .map(|command| format!("not __fish_seen_subcommand_from {}", command))
+                    )
                     .collect::<Vec<_>>()
                     .join("; and ")
             )
@@ -114,24 +118,8 @@ fn gen_fish_inner(root_command: &str, parent_commands: &[&str], app: &App, buffe
         buffer.push('\n');
     }
 
-    let mut subcommand_template = basic_template;
-    // We only need to do this for subcommands of subcommands
-    if !parent_commands.is_empty() {
-        // Removes the `"` at the end of the basic_template
-        subcommand_template.remove(subcommand_template.len() - 1);
-        subcommand_template.push_str(
-            format!(
-                "{}\"",
-                app.get_subcommands()
-                    .map(|command| format!("; and not __fish_seen_subcommand_from {}", command))
-                    .collect::<String>()
-            )
-            .as_str(),
-        );
-    }
-
     for subcommand in app.get_subcommands() {
-        let mut template = subcommand_template.clone();
+        let mut template = basic_template.clone();
 
         template.push_str(" -f");
         template.push_str(format!(" -a \"{}\"", &subcommand.get_name()).as_str());

--- a/clap_generate/tests/completions/fish.rs
+++ b/clap_generate/tests/completions/fish.rs
@@ -156,3 +156,42 @@ complete -c cmd -s h -l help -d 'Print help information'
 complete -c cmd -s V -l version -d 'Print version information'
 complete -c cmd -s f -s F -l flag -l flg -d 'cmd flag'
 "#;
+
+#[test]
+fn fish_with_sub_subcommands() {
+    let mut app = build_app_sub_subcommands();
+    common::<Fish>(&mut app, "my_app", FISH_SUB_SUBCMDS);
+}
+
+fn build_app_sub_subcommands() -> App<'static> {
+    build_app_with_name("my_app").subcommand(
+        App::new("some_cmd")
+            .about("top level subcommand")
+            .subcommand(
+                App::new("sub_cmd").about("sub-subcommand").arg(
+                    Arg::new("config")
+                        .long("--config")
+                        .takes_value(true)
+                        .about("the other case to test"),
+                ),
+            ),
+    )
+}
+
+static FISH_SUB_SUBCMDS: &str = r#"complete -c my_app -n "__fish_use_subcommand" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_use_subcommand" -s V -l version -d 'Print version information'
+complete -c my_app -n "__fish_use_subcommand" -f -a "test" -d 'tests things'
+complete -c my_app -n "__fish_use_subcommand" -f -a "some_cmd" -d 'top level subcommand'
+complete -c my_app -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my_app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
+complete -c my_app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Print version information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd" -f -a "sub_cmd" -d 'sub-subcommand'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l version -d 'Print version information'
+complete -c my_app -n "__fish_seen_subcommand_from help" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from help" -s V -l version -d 'Print version information'
+"#;

--- a/clap_generate/tests/completions/fish.rs
+++ b/clap_generate/tests/completions/fish.rs
@@ -186,8 +186,8 @@ complete -c my_app -n "__fish_use_subcommand" -f -a "help" -d 'Print this messag
 complete -c my_app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
 complete -c my_app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help information'
 complete -c my_app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version information'
-complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Print help information'
-complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Print version information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help information'
+complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version information'
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd" -f -a "sub_cmd" -d 'sub-subcommand'
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l help -d 'Print help information'


### PR DESCRIPTION
* Prevent completing subcommands that were already completed
* Make sure all parent subcommands actually existent

Partially does a bit of #2715 (the "simple case")

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
 