### PR TITLE
fix(generate): Hide option/argument description for argenum

### DIFF
--- a/clap_generate/src/generators/shells/fish.rs
+++ b/clap_generate/src/generators/shells/fish.rs
@@ -133,7 +133,7 @@ fn value_completion(option: &Arg) -> String {
     }
 
     if let Some(data) = option.get_possible_values() {
-        // We return the possible values with their own empty description e.g. {a\t,b\t} 
+        // We return the possible values with their own empty description e.g. {a\t,b\t}
         // this makes sure that a and b don't get the description of the option or argument
         format!(
             " -r -f -a \"{{{}}}\"",

--- a/clap_generate/src/generators/shells/fish.rs
+++ b/clap_generate/src/generators/shells/fish.rs
@@ -133,7 +133,15 @@ fn value_completion(option: &Arg) -> String {
     }
 
     if let Some(data) = option.get_possible_values() {
-        format!(" -r -f -a \"{}\"", data.join(" "))
+        // We return the possible values with their own empty description e.g. {a\t,b\t} 
+        // this makes sure that a and b don't get the description of the option or argument
+        format!(
+            " -r -f -a \"{{{}}}\"",
+            data.iter()
+                .map(|value| format!("{}\t", value))
+                .collect::<Vec<_>>()
+                .join(",")
+        )
     } else {
         // NB! If you change this, please also update the table in `ValueHint` documentation.
         match option.get_value_hint() {

--- a/clap_generate/tests/value_hints.rs
+++ b/clap_generate/tests/value_hints.rs
@@ -131,7 +131,7 @@ _my_app_commands() {
 
 _my_app "$@""#;
 
-static FISH_VALUE_HINTS: &str = r#"complete -c my_app -l choice -r -f -a "bash fish zsh"
+static FISH_VALUE_HINTS: &str = r#"complete -c my_app -l choice -r -f -a "{bash	,fish	,zsh	}"
 complete -c my_app -l unknown -r
 complete -c my_app -l other -r -f
 complete -c my_app -s p -l path -r -F


### PR DESCRIPTION
This returns `"{a\t,b\t}"` instead of `"a b"` for possible_values
completion. Therefore fish displays and therefor hides the empty
description after the `\t`.

Fixes #2727

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
