### PR TITLE
Add placeholders for Cookbook and Cheatsheet pages in the website

### DIFF
--- a/site/content/cheatsheet.md
+++ b/site/content/cheatsheet.md
@@ -1,0 +1,5 @@
++++
+title = "Cookbook"
++++
+
+Work in progress...

--- a/site/content/cheatsheet.md
+++ b/site/content/cheatsheet.md
@@ -1,5 +1,5 @@
 +++
-title = "Cookbook"
+title = "Cheatsheet"
 +++
 
 Work in progress...

--- a/site/content/cookbook.md
+++ b/site/content/cookbook.md
@@ -1,0 +1,5 @@
++++
+title = "Cookbook"
++++
+
+Work in progress...

--- a/site/templates/page.html
+++ b/site/templates/page.html
@@ -1,0 +1,15 @@
+{% extends "shared/base.html" %}
+
+{% block title %}{{ page.title }}{% endblock title %}
+
+{% block content %}
+{% include "shared/header.html" %}
+
+<main id="content" class="maxview">
+  <article>
+    <h1 class="post-title">{{ page.title }}</h1>
+
+    {{ page.content | safe }}
+  </article>
+</main>
+{% endblock content %}


### PR DESCRIPTION
Reading the website, I stumbled on 404 errors, according to #2601 this is expected.
However I think it would be better to be explicit about the fact this is expected ;-)
