### PR TITLE
Fix keyvalue example

### DIFF
--- a/clap_derive/examples/keyvalue.rs
+++ b/clap_derive/examples/keyvalue.rs
@@ -26,7 +26,7 @@ struct Opt {
     // but this makes adding an argument after the values impossible:
     // my_program -D a=1 -D b=2 my_input_file
     // becomes invalid.
-    #[clap(short = 'D', parse(try_from_str = parse_key_val), number_of_values = 1)]
+    #[clap(short = 'D', parse(try_from_str = parse_key_val), multiple_occurrences(true), number_of_values = 1)]
     defines: Vec<(String, i32)>,
 }
 


### PR DESCRIPTION
This was broken earlier due to 3f94d17c71d8dea26133dbe107289c7f0c187499 not
taking into account this example.

Closes #2746.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
