### PR TITLE
Don't suggest `help` or `--help` when not applicable

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -13,6 +13,7 @@ use crate::{
     output::fmt::Colorizer,
     parse::features::suggestions,
     util::{safe_exit, termcolor::ColorChoice, SUCCESS_CODE, USAGE_CODE},
+    App, AppSettings,
 };
 
 /// Short hand for [`Result`] type
@@ -450,10 +451,16 @@ fn put_usage(c: &mut Colorizer, usage: impl Into<String>) {
     c.none(usage);
 }
 
-fn try_help(c: &mut Colorizer) {
-    c.none("\n\nFor more information try ");
-    c.good("--help");
-    c.none("\n");
+fn try_help(app: &App, c: &mut Colorizer) {
+    if !app.settings.is_set(AppSettings::DisableHelpFlag) {
+        c.none("\n\nFor more information try ");
+        c.good("--help");
+        c.none("\n");
+    } else if app.has_subcommands() && !app.settings.is_set(AppSettings::DisableHelpSubcommand) {
+        c.none("\n\nFor more information try ");
+        c.good("help");
+        c.none("\n");
+    }
 }
 
 impl Error {
@@ -513,12 +520,12 @@ impl Error {
     }
 
     pub(crate) fn argument_conflict(
+        app: &App,
         arg: &Arg,
         other: Option<String>,
         usage: String,
-        color: ColorChoice,
     ) -> Self {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
         let arg = arg.to_string();
 
         start_error(&mut c, "The argument '");
@@ -537,7 +544,7 @@ impl Error {
         };
 
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         let mut info = vec![arg];
         if let Some(other) = other {
@@ -552,15 +559,15 @@ impl Error {
         }
     }
 
-    pub(crate) fn empty_value(arg: &Arg, usage: String, color: ColorChoice) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn empty_value(app: &App, arg: &Arg, usage: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
         let arg = arg.to_string();
 
         start_error(&mut c, "The argument '");
         c.warning(arg.clone());
         c.none("' requires a value but none was supplied");
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -570,15 +577,15 @@ impl Error {
         }
     }
 
-    pub(crate) fn no_equals(arg: String, usage: String, color: ColorChoice) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn no_equals(app: &App, arg: String, usage: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(&mut c, "Equal sign is needed when assigning values to '");
         c.warning(&arg);
         c.none("'.");
 
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -589,16 +596,16 @@ impl Error {
     }
 
     pub(crate) fn invalid_value<G>(
+        app: &App,
         bad_val: String,
         good_vals: &[G],
         arg: &Arg,
         usage: String,
-        color: ColorChoice,
     ) -> Self
     where
         G: AsRef<str> + Display,
     {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
         let suffix = suggestions::did_you_mean(&bad_val, good_vals.iter()).pop();
 
         let mut sorted: Vec<String> = good_vals
@@ -638,7 +645,7 @@ impl Error {
         }
 
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         let mut info = vec![arg.to_string(), bad_val];
         info.extend(sorted);
@@ -652,13 +659,13 @@ impl Error {
     }
 
     pub(crate) fn invalid_subcommand(
+        app: &App,
         subcmd: String,
         did_you_mean: String,
         name: String,
         usage: String,
-        color: ColorChoice,
     ) -> Self {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(&mut c, "The subcommand '");
         c.warning(subcmd.clone());
@@ -672,7 +679,7 @@ impl Error {
         c.good("--");
         c.none(format!(" {}'", subcmd));
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -682,19 +689,15 @@ impl Error {
         }
     }
 
-    pub(crate) fn unrecognized_subcommand(
-        subcmd: String,
-        name: String,
-        color: ColorChoice,
-    ) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn unrecognized_subcommand(app: &App, subcmd: String, name: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(&mut c, " The subcommand '");
         c.warning(subcmd.clone());
         c.none("' wasn't recognized\n\n");
         c.warning("USAGE:");
-        c.none(format!("\n\t{} help <subcommands>...", name));
-        try_help(&mut c);
+        c.none(format!("\n\t{} <subcommands>...", name));
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -705,11 +708,11 @@ impl Error {
     }
 
     pub(crate) fn missing_required_argument(
+        app: &App,
         required: Vec<String>,
         usage: String,
-        color: ColorChoice,
     ) -> Self {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(
             &mut c,
@@ -724,7 +727,7 @@ impl Error {
         }
 
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -734,14 +737,14 @@ impl Error {
         }
     }
 
-    pub(crate) fn missing_subcommand(name: String, usage: String, color: ColorChoice) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn missing_subcommand(app: &App, name: String, usage: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(&mut c, "'");
         c.warning(name);
         c.none("' requires a subcommand, but one was not provided");
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -751,15 +754,15 @@ impl Error {
         }
     }
 
-    pub(crate) fn invalid_utf8(usage: String, color: ColorChoice) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn invalid_utf8(app: &App, usage: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(
             &mut c,
             "Invalid UTF-8 was detected in one or more arguments",
         );
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -770,13 +773,13 @@ impl Error {
     }
 
     pub(crate) fn too_many_occurrences(
+        app: &App,
         arg: &Arg,
         max_occurs: usize,
         curr_occurs: usize,
         usage: String,
-        color: ColorChoice,
     ) -> Self {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
         let verb = Error::singular_or_plural(curr_occurs);
 
         start_error(&mut c, "The argument '");
@@ -787,7 +790,7 @@ impl Error {
         c.warning(curr_occurs.to_string());
         c.none(format!(" {} provided", verb));
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -801,13 +804,8 @@ impl Error {
         }
     }
 
-    pub(crate) fn too_many_values(
-        val: String,
-        arg: String,
-        usage: String,
-        color: ColorChoice,
-    ) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn too_many_values(app: &App, val: String, arg: String, usage: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(&mut c, "The value '");
         c.warning(val.clone());
@@ -815,7 +813,7 @@ impl Error {
         c.warning(&arg);
         c.none("' but it wasn't expecting any more values");
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -826,13 +824,13 @@ impl Error {
     }
 
     pub(crate) fn too_few_values(
+        app: &App,
         arg: &Arg,
         min_vals: usize,
         curr_vals: usize,
         usage: String,
-        color: ColorChoice,
     ) -> Self {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
         let verb = Error::singular_or_plural(curr_vals);
 
         start_error(&mut c, "The argument '");
@@ -843,7 +841,7 @@ impl Error {
         c.warning(curr_vals.to_string());
         c.none(format!(" {} provided", verb));
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -854,6 +852,35 @@ impl Error {
     }
 
     pub(crate) fn value_validation(
+        app: &App,
+        arg: String,
+        val: String,
+        err: Box<dyn error::Error + Send + Sync>,
+    ) -> Self {
+        let Self {
+            mut message,
+            kind,
+            info,
+            source,
+        } = Self::value_validation_with_color(arg, val, err, app.color());
+        try_help(app, &mut message);
+        Self {
+            message,
+            kind,
+            info,
+            source,
+        }
+    }
+
+    pub(crate) fn value_validation_without_app(
+        arg: String,
+        val: String,
+        err: Box<dyn error::Error + Send + Sync>,
+    ) -> Self {
+        Self::value_validation_with_color(arg, val, err, ColorChoice::Auto)
+    }
+
+    fn value_validation_with_color(
         arg: String,
         val: String,
         err: Box<dyn error::Error + Send + Sync>,
@@ -868,7 +895,6 @@ impl Error {
         c.none("'");
 
         c.none(format!(": {}", err));
-        try_help(&mut c);
 
         Error {
             message: c,
@@ -879,13 +905,13 @@ impl Error {
     }
 
     pub(crate) fn wrong_number_of_values(
+        app: &App,
         arg: &Arg,
         num_vals: usize,
         curr_vals: usize,
         usage: String,
-        color: ColorChoice,
     ) -> Self {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
         let verb = Error::singular_or_plural(curr_vals);
 
         start_error(&mut c, "The argument '");
@@ -896,7 +922,7 @@ impl Error {
         c.warning(curr_vals.to_string());
         c.none(format!(" {} provided", verb));
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -906,15 +932,15 @@ impl Error {
         }
     }
 
-    pub(crate) fn unexpected_multiple_usage(arg: &Arg, usage: String, color: ColorChoice) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn unexpected_multiple_usage(app: &App, arg: &Arg, usage: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
         let arg = arg.to_string();
 
         start_error(&mut c, "The argument '");
         c.warning(arg.clone());
         c.none("' was provided more than once, but cannot be used multiple times");
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -925,12 +951,12 @@ impl Error {
     }
 
     pub(crate) fn unknown_argument(
+        app: &App,
         arg: String,
         did_you_mean: Option<(String, Option<String>)>,
         usage: String,
-        color: ColorChoice,
     ) -> Self {
-        let mut c = Colorizer::new(true, color);
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(&mut c, "Found argument '");
         c.warning(arg.clone());
@@ -963,7 +989,7 @@ impl Error {
         }
 
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -973,8 +999,8 @@ impl Error {
         }
     }
 
-    pub(crate) fn unnecessary_double_dash(arg: String, usage: String, color: ColorChoice) -> Self {
-        let mut c = Colorizer::new(true, color);
+    pub(crate) fn unnecessary_double_dash(app: &App, arg: String, usage: String) -> Self {
+        let mut c = Colorizer::new(true, app.color());
 
         start_error(&mut c, "Found argument '");
         c.warning(arg.clone());
@@ -985,7 +1011,7 @@ impl Error {
             arg
         ));
         put_usage(&mut c, usage);
-        try_help(&mut c);
+        try_help(app, &mut c);
 
         Error {
             message: c,
@@ -1001,7 +1027,6 @@ impl Error {
         start_error(&mut c, "The argument '");
         c.warning(arg.clone());
         c.none("' wasn't found");
-        try_help(&mut c);
 
         Error {
             message: c,

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -696,7 +696,7 @@ impl Error {
         c.warning(subcmd.clone());
         c.none("' wasn't recognized\n\n");
         c.warning("USAGE:");
-        c.none(format!("\n\t{} <subcommands>...", name));
+        c.none(format!("\n    {} <subcommands>", name));
         try_help(app, &mut c);
 
         Error {

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -14,7 +14,7 @@ use indexmap::IndexMap;
 // Internal
 use crate::{
     parse::MatchedArg,
-    util::{termcolor::ColorChoice, Id, Key},
+    util::{Id, Key},
     {Error, INVALID_UTF8},
 };
 
@@ -391,12 +391,7 @@ impl ArgMatches {
                     v, name, e
                 );
 
-                Error::value_validation(
-                    name.to_string(),
-                    v.to_string(),
-                    message.into(),
-                    ColorChoice::Auto,
-                )
+                Error::value_validation_without_app(name.to_string(), v.to_string(), message.into())
             })
         } else {
             Err(Error::argument_not_found_auto(name.to_string()))
@@ -481,11 +476,10 @@ impl ArgMatches {
                 v.parse::<R>().map_err(|e| {
                     let message = format!("The argument '{}' isn't a valid value: {}", v, e);
 
-                    Error::value_validation(
+                    Error::value_validation_without_app(
                         name.to_string(),
                         v.to_string(),
                         message.into(),
-                        ColorChoice::Auto,
                     )
                 })
             })

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -507,9 +507,9 @@ impl<'help, 'app> Parser<'help, 'app> {
                         }
                         ParseResult::EqualsNotProvided { arg } => {
                             return Err(ClapError::no_equals(
+                                self.app,
                                 arg,
                                 Usage::new(self).create_usage_with_title(&[]),
-                                self.app.color(),
                             ));
                         }
                         ParseResult::NoMatchingArg { arg } => {
@@ -521,10 +521,10 @@ impl<'help, 'app> Parser<'help, 'app> {
                         }
                         ParseResult::UnneededAttachedValue { rest, used, arg } => {
                             return Err(ClapError::too_many_values(
+                                self.app,
                                 rest,
                                 arg,
                                 Usage::new(self).create_usage_no_title(&used),
-                                self.app.color(),
                             ))
                         }
                         ParseResult::HelpFlag => {
@@ -596,17 +596,17 @@ impl<'help, 'app> Parser<'help, 'app> {
                         }
                         ParseResult::EqualsNotProvided { arg } => {
                             return Err(ClapError::no_equals(
+                                self.app,
                                 arg,
                                 Usage::new(self).create_usage_with_title(&[]),
-                                self.app.color(),
                             ))
                         }
                         ParseResult::NoMatchingArg { arg } => {
                             return Err(ClapError::unknown_argument(
+                                self.app,
                                 arg,
                                 None,
                                 Usage::new(self).create_usage_with_title(&[]),
-                                self.app.color(),
                             ));
                         }
                         ParseResult::HelpFlag => {
@@ -648,10 +648,10 @@ impl<'help, 'app> Parser<'help, 'app> {
             if let Some(p) = self.app.args.get(&pos_counter) {
                 if p.is_set(ArgSettings::Last) && !trailing_values {
                     return Err(ClapError::unknown_argument(
+                        self.app,
                         arg_os.to_str_lossy().into_owned(),
                         None,
                         Usage::new(self).create_usage_with_title(&[]),
-                        self.app.color(),
                     ));
                 }
 
@@ -692,8 +692,8 @@ impl<'help, 'app> Parser<'help, 'app> {
                     Some(s) => s.to_string(),
                     None => {
                         return Err(ClapError::invalid_utf8(
+                            self.app,
                             Usage::new(self).create_usage_with_title(&[]),
-                            self.app.color(),
                         ));
                     }
                 };
@@ -706,8 +706,8 @@ impl<'help, 'app> Parser<'help, 'app> {
                         && v.to_str().is_none()
                     {
                         return Err(ClapError::invalid_utf8(
+                            self.app,
                             Usage::new(self).create_usage_with_title(&[]),
-                            self.app.color(),
                         ));
                     }
                     sc_m.add_val_to(
@@ -749,9 +749,9 @@ impl<'help, 'app> Parser<'help, 'app> {
         } else if self.is_set(AS::SubcommandRequired) {
             let bn = self.app.bin_name.as_ref().unwrap_or(&self.app.name);
             return Err(ClapError::missing_subcommand(
+                self.app,
                 bn.to_string(),
                 Usage::new(self).create_usage_with_title(&[]),
-                self.app.color(),
             ));
         } else if self.is_set(AS::SubcommandRequiredElseHelp) {
             debug!("Parser::get_matches_with: SubcommandRequiredElseHelp=true");
@@ -780,9 +780,9 @@ impl<'help, 'app> Parser<'help, 'app> {
             // If the arg matches a subcommand name, or any of its aliases (if defined)
             if self.possible_subcommand(arg_os, valid_arg_found).is_some() {
                 return ClapError::unnecessary_double_dash(
+                    self.app,
                     arg_os.to_str_lossy().into_owned(),
                     Usage::new(self).create_usage_with_title(&[]),
-                    self.app.color(),
                 );
             }
         }
@@ -795,6 +795,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                 .map(|candidate| format!("'{}'", candidate))
                 .collect();
             return ClapError::invalid_subcommand(
+                self.app,
                 arg_os.to_str_lossy().into_owned(),
                 candidates.join(" or "),
                 self.app
@@ -803,26 +804,25 @@ impl<'help, 'app> Parser<'help, 'app> {
                     .unwrap_or(&self.app.name)
                     .to_string(),
                 Usage::new(self).create_usage_with_title(&[]),
-                self.app.color(),
             );
         }
         // If the argument must be a subcommand.
         if !self.app.has_args() || self.is_set(AS::InferSubcommands) && self.app.has_subcommands() {
             return ClapError::unrecognized_subcommand(
+                self.app,
                 arg_os.to_str_lossy().into_owned(),
                 self.app
                     .bin_name
                     .as_ref()
                     .unwrap_or(&self.app.name)
                     .to_string(),
-                self.app.color(),
             );
         }
         ClapError::unknown_argument(
+            self.app,
             arg_os.to_str_lossy().into_owned(),
             None,
             Usage::new(self).create_usage_with_title(&[]),
-            self.app.color(),
         )
     }
 
@@ -933,13 +933,13 @@ impl<'help, 'app> Parser<'help, 'app> {
                     }
                 } else {
                     return Err(ClapError::unrecognized_subcommand(
+                        self.app,
                         cmd.to_string_lossy().into_owned(),
                         self.app
                             .bin_name
                             .as_ref()
                             .unwrap_or(&self.app.name)
                             .to_string(),
-                        self.app.color(),
                     ));
                 }
 
@@ -1865,10 +1865,10 @@ impl<'help, 'app> Parser<'help, 'app> {
             .collect();
 
         ClapError::unknown_argument(
+            self.app,
             format!("--{}", arg),
             did_you_mean,
             Usage::new(self).create_usage_with_title(&*used),
-            self.app.color(),
         )
     }
 

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -51,9 +51,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             };
             if should_err {
                 return Err(Error::empty_value(
+                    self.p.app,
                     o,
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ));
             }
         }
@@ -94,8 +94,8 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                     val
                 );
                 return Err(Error::invalid_utf8(
+                    self.p.app,
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ));
             }
             if !arg.possible_vals.is_empty() {
@@ -122,11 +122,11 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         .cloned()
                         .collect();
                     return Err(Error::invalid_value(
+                        self.p.app,
                         val_str.into_owned(),
                         &arg.possible_vals,
                         arg,
                         Usage::new(self.p).create_usage_with_title(&used),
-                        self.p.app.color(),
                     ));
                 }
             }
@@ -136,9 +136,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             {
                 debug!("Validator::validate_arg_values: illegal empty val found");
                 return Err(Error::empty_value(
+                    self.p.app,
                     arg,
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ));
             }
 
@@ -148,10 +148,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 if let Err(e) = vtor(&*val.to_string_lossy()) {
                     debug!("error");
                     return Err(Error::value_validation(
+                        self.p.app,
                         arg.to_string(),
                         val.to_string_lossy().into_owned(),
                         e,
-                        self.p.app.color(),
                     ));
                 } else {
                     debug!("good");
@@ -163,10 +163,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 if let Err(e) = vtor(val) {
                     debug!("error");
                     return Err(Error::value_validation(
+                        self.p.app,
                         arg.to_string(),
                         val.to_string_lossy().into(),
                         e,
-                        self.p.app.color(),
                     ));
                 } else {
                     debug!("good");
@@ -226,10 +226,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                     };
                     let usg = self.build_conflict_err_usage(matcher, former_arg, latter);
                     Err(Error::argument_conflict(
+                        self.p.app,
                         latter_arg,
                         Some(former_arg.to_string()),
                         usg,
-                        self.p.app.color(),
                     ))
                 })
         } else if let Some(g) = self.p.app.groups.iter().find(|x| x.id == *name) {
@@ -245,10 +245,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 .map(|x| self.p.app[x].to_string());
             debug!("Validator::build_conflict_err: c_with={:?}:group", c_with);
             Err(Error::argument_conflict(
+                self.p.app,
                 &self.p.app[first],
                 c_with,
                 usg,
-                self.p.app.color(),
             ))
         } else {
             Ok(())
@@ -321,10 +321,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             // Throw an error for the first conflict found.
             .try_for_each(|arg| {
                 Err(Error::argument_conflict(
+                    self.p.app,
                     arg,
                     None,
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ))
             })
     }
@@ -450,9 +450,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         if ma.occurs > 1 && !a.is_set(ArgSettings::MultipleOccurrences) && !a.is_positional() {
             // Not the first time, and we don't allow multiples
             return Err(Error::unexpected_multiple_usage(
+                self.p.app,
                 a,
                 Usage::new(self.p).create_usage_with_title(&[]),
-                self.p.app.color(),
             ));
         }
         if let Some(max_occurs) = a.max_occurs {
@@ -463,11 +463,11 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             let occurs = ma.occurs as usize;
             if occurs > max_occurs {
                 return Err(Error::too_many_occurrences(
+                    self.p.app,
                     a,
                     max_occurs,
                     occurs,
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ));
             }
         }
@@ -488,6 +488,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             if should_err {
                 debug!("Validator::validate_arg_num_vals: Sending error WrongNumberOfValues");
                 return Err(Error::wrong_number_of_values(
+                    self.p.app,
                     a,
                     num,
                     if a.is_set(ArgSettings::MultipleOccurrences) {
@@ -496,7 +497,6 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         total_num
                     },
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ));
             }
         }
@@ -505,6 +505,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             if ma.num_vals() > num {
                 debug!("Validator::validate_arg_num_vals: Sending error TooManyValues");
                 return Err(Error::too_many_values(
+                    self.p.app,
                     ma.vals_flatten()
                         .last()
                         .expect(INTERNAL_ERROR_MSG)
@@ -513,7 +514,6 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                         .to_string(),
                     a.to_string(),
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ));
             }
         }
@@ -522,11 +522,11 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             if ma.num_vals() < num && num != 0 {
                 debug!("Validator::validate_arg_num_vals: Sending error TooFewValues");
                 return Err(Error::too_few_values(
+                    self.p.app,
                     a,
                     num,
                     ma.num_vals(),
                     Usage::new(self.p).create_usage_with_title(&[]),
-                    self.p.app.color(),
                 ));
             }
             num == 0
@@ -537,9 +537,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         // Issue 1105 (https://github.com/kbknapp/clap-rs/issues/1105)
         if a.is_set(ArgSettings::TakesValue) && !min_vals_zero && ma.is_vals_empty() {
             return Err(Error::empty_value(
+                self.p.app,
                 a,
                 Usage::new(self.p).create_usage_with_title(&[]),
-                self.p.app.color(),
             ));
         }
         Ok(())
@@ -698,9 +698,9 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             .collect();
 
         Err(Error::missing_required_argument(
+            self.p.app,
             req_args,
             usg.create_usage_with_title(&used),
-            self.p.app.color(),
         ))
     }
 }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -2514,3 +2514,40 @@ FLAGS:
         false
     ));
 }
+
+#[test]
+fn disabled_help_flag() {
+    let app = App::new("foo")
+        .subcommand(App::new("sub"))
+        .setting(AppSettings::DisableHelpFlag);
+    assert!(utils::compare_output(
+        app,
+        "foo a",
+        "error: Found argument 'a' which wasn't expected, or isn't valid in this context
+
+USAGE:
+    foo [SUBCOMMAND]
+
+For more information try help
+",
+        true
+    ));
+}
+
+#[test]
+fn disabled_help_flag_and_subcommand() {
+    let app = App::new("foo")
+        .subcommand(App::new("sub"))
+        .setting(AppSettings::DisableHelpFlag)
+        .setting(AppSettings::DisableHelpSubcommand);
+    assert!(utils::compare_output(
+        app,
+        "foo help",
+        "error: Found argument 'help' which wasn't expected, or isn't valid in this context
+
+USAGE:
+    foo [SUBCOMMAND]
+",
+        true
+    ));
+}

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -490,7 +490,7 @@ fn subcommand_not_recognized() {
         "error:  The subcommand 'help' wasn't recognized
 
 USAGE:
-\tfake <subcommands>...
+    fake <subcommands>
 
 For more information try --help
 ",

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use clap::{App, Arg, ErrorKind};
+use clap::{App, AppSettings, Arg, ErrorKind};
 
 static VISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 
@@ -476,4 +476,24 @@ fn issue_2494_subcommand_is_present() {
     let m = app.get_matches_from(&["opt", "global"]);
     assert_eq!(m.subcommand_name().unwrap(), "global");
     assert!(!m.is_present("global"));
+}
+
+#[test]
+fn subcommand_not_recognized() {
+    let app = App::new("fake")
+        .subcommand(App::new("sub"))
+        .setting(AppSettings::DisableHelpSubcommand)
+        .setting(AppSettings::InferSubcommands);
+    assert!(utils::compare_output(
+        app,
+        "fake help",
+        "error:  The subcommand 'help' wasn't recognized
+
+USAGE:
+\tfake <subcommands>...
+
+For more information try --help
+",
+        true
+    ));
 }


### PR DESCRIPTION
Closes #1463

I have changed some error constructing methods to take an `app: &App`. In many cases, this also allowed for the `color` as a parameter, as it was generally based off of `app.color()`. `try_help` now checks first for if the `--help` argument is enabled, and then if the `help` subcommand is enabled. In cases where there is no access to the original `App`, I have omitted the help suggestion entirely. I'm not sure if there is a better way to do this.

The main issue described in #1463 seemed to be caused by `src/parse/errors.rs` line 696. I believe there is no reason for the `help` to be there.
