### PR TITLE
Allow subcmd name to be something else than a literal in clap derive

### DIFF
--- a/clap_derive/tests/subcommands.rs
+++ b/clap_derive/tests/subcommands.rs
@@ -454,3 +454,23 @@ fn update_ext_subcommand() {
     opt.try_update_from(&["test", "ext", "42", "44"]).unwrap();
     assert_eq!(Opt::parse_from(&["test", "ext", "42", "44"]), opt);
 }
+#[test]
+fn subcommand_name_not_literal() {
+    fn get_name() -> &'static str {
+        "renamed"
+    }
+
+    #[derive(Clap, PartialEq, Debug)]
+    struct Opt {
+        #[clap(subcommand)]
+        subcmd: SubCmd,
+    }
+
+    #[derive(Clap, PartialEq, Debug)]
+    enum SubCmd {
+        #[clap(name = get_name())]
+        SubCmd1,
+    }
+
+    assert!(Opt::try_parse_from(&["test", "renamed"]).is_ok());
+}


### PR DESCRIPTION
Modify clap_derive to allow to compute sub command name dynamically (via a function for example):

```rust
    fn get_name() -> String {
        if runtime_check() {
          "some-name".to_string()
        } else {
          "some-other-name".to_string()
        }
    }

    #[derive(Clap, PartialEq, Debug)]
    struct Opt {
        #[clap(subcommand)]
        subcmd: SubCmd,
    }

    #[derive(Clap, PartialEq, Debug)]
    enum SubCmd {
        #[clap(name = get_name())]
        SubCmd1,
    }
```

It was expected to be a literal and was used in `match`, I replaced it with `if` statements.