### PR TITLE
doc(generate) fix link in `generate_to`

### DIFF
--- a/clap_generate/src/lib.rs
+++ b/clap_generate/src/lib.rs
@@ -42,7 +42,7 @@ pub use shell::Shell;
 /// Generate a completions file for a specified shell at compile-time.
 ///
 /// **NOTE:** to generate the file at compile time you must use a `build.rs` "Build Script" or a
-/// [`cargo-xtask`]](https://github.com/matklad/cargo-xtask)
+/// [`cargo-xtask`](https://github.com/matklad/cargo-xtask)
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Maybe we should add `cargo doc` to our CI, it would have cought this:
```
warning: this URL is not a hyperlink
  --> clap_generate/src/lib.rs:45:22
   |
45 | /// [`cargo-xtask`]](https://github.com/matklad/cargo-xtask)
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/matklad/cargo-xtask>`
   |
   = note: `#[warn(rustdoc::bare_urls)]` on by default
   = note: bare URLs are not automatically turned into clickable links

warning: 1 warning emitted
```
