### PR TITLE
Add test for very large display_order values and a possible fix

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -12,7 +12,6 @@ use crate::{
     build::{arg::display_arg_val, App, AppSettings, Arg, ArgSettings},
     output::{fmt::Colorizer, Usage},
     parse::Parser,
-    util::VecMap,
 };
 
 // Third party
@@ -202,7 +201,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
         debug!("Help::write_args");
         // The shortest an arg can legally be is 2 (i.e. '-x')
         let mut longest = 2;
-        let mut ord_m = VecMap::new();
+        let mut ord_m = BTreeMap::new();
 
         // Determine the longest
         for arg in args.iter().filter(|arg| {
@@ -868,7 +867,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
         debug!("Help::write_subcommands");
         // The shortest an arg can legally be is 2 (i.e. '-x')
         let mut longest = 2;
-        let mut ord_m = VecMap::new();
+        let mut ord_m = BTreeMap::new();
         for subcommand in app
             .subcommands
             .iter()

--- a/tests/display_order.rs
+++ b/tests/display_order.rs
@@ -1,0 +1,26 @@
+mod utils;
+
+use clap::App;
+
+#[test]
+fn very_large_display_order() {
+    let app = App::new("test").subcommand(App::new("sub").display_order(usize::MAX));
+
+    assert!(utils::compare_output(
+        app,
+        "test --help",
+        "test 
+
+USAGE:
+    test [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    help    Print this message or the help of the given subcommand(s)
+    sub",
+        false
+    ));
+}


### PR DESCRIPTION
Closes #2772 

I'm aware that `VecMap` was added for performance reasons, so I'm not sure if switching back to `BTreeMap` is the correct solution.