### PR TITLE
Inline macros in yaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ unicode_help = ["textwrap/unicode-width"]  # Enable if any unicode in help messa
 # Optional
 wrap_help = ["terminal_size", "textwrap/terminal_size"]
 yaml = ["yaml-rust"]
+yaml_inline_macros = ["yaml"]
 
 [profile.test]
 opt-level = 1

--- a/examples/24_yaml.yml
+++ b/examples/24_yaml.yml
@@ -1,0 +1,3 @@
+name: env!("TEST_NAME")
+version: crate_version!()
+about: Simple tests using .yaml and enviroment variables/macros

--- a/examples/24_yaml_env_variable.rs
+++ b/examples/24_yaml_env_variable.rs
@@ -1,0 +1,20 @@
+#[cfg(feature="yaml")]
+fn main() {
+    use clap::{load_yaml, App};
+    use std::env;
+
+    // The the env variable used in the yaml file
+    env::set_var("TEST_NAME", "This is an enviroment variable value");
+
+    // Load yaml file
+    let yaml = load_yaml!("24_yaml.yml");
+    let m = App::from(yaml).get_matches();
+    println!("Type --help and check that the version is the one in the env");
+}
+
+#[cfg(not(feature = "yaml"))]
+fn main() {
+    // As stated above, if clap is not compiled with the YAML feature, it is disabled.
+    println!("YAML feature is disabled.");
+    println!("Pass --features yaml to cargo when trying this example.");
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,5 @@
+// Because its evaluated before the tests compilation here I can set env
+// variables and the macros later will expand with them.
+pub fn setup() {
+    std::env::set_var("EXAMPLE_NAME", "AppName");
+}

--- a/tests/fixtures/inline-env.yml
+++ b/tests/fixtures/inline-env.yml
@@ -1,0 +1,2 @@
+name: env!("EXAMPLE_NAME")
+

--- a/tests/fixtures/inline-macros.yml
+++ b/tests/fixtures/inline-macros.yml
@@ -1,0 +1,4 @@
+name: crate_name!()
+version: crate_version!()
+about: crate_description!()
+author: crate_authors!(' ')

--- a/tests/yaml_inline_macros.rs
+++ b/tests/yaml_inline_macros.rs
@@ -1,0 +1,31 @@
+#![cfg(feature="yaml_inline_macros")]
+
+use clap::{load_yaml, App};
+
+mod common;
+
+#[test]
+fn replaces_env() {
+    common::setup();
+
+    let yaml = load_yaml!("fixtures/inline-env.yml");
+    let mut app = App::from(yaml);
+    assert_eq!(app.get_name(), "AppName");
+}
+
+#[test]
+fn replaces_macros() {
+    common::setup();
+
+    let yaml = load_yaml!("fixtures/inline-macros.yml");
+    let mut app = App::from(yaml);
+    assert_eq!(app.get_name(), "clap");
+    // Generate the full help message!
+    let _ = app.try_get_matches_from_mut(Vec::<String>::new());
+
+    let mut help_buffer = Vec::new();
+    app.write_help(&mut help_buffer).unwrap();
+    let help_string = String::from_utf8(help_buffer).unwrap();
+    assert!(help_string.contains("Kevin K. <kbknapp@gmail.com> Clap Maintainers"));
+    assert!(help_string.contains("A simple to use, efficient, and full-featured"));
+}


### PR DESCRIPTION
allows using `env!` and also clap macros inside the yaml file. This is something that I used to do with a python script, so I thought, why not making a PR for this feature?

Example of what it does:
```yml
name: crate_name!()
version: crate_version!()
about: crate_description!()
author: crate_authors!(' <=> ')
args:
    - help:
        short: h
        long: help
        about: env!("HELP_DESCR")
```

Will expand to:
```yml
name: clap
version: 3.0.0-beta.4
about: A simple to use, efficient, and full-featured Command Line Argument Parser
author: Kevin K. <kbknapp@gmail.com> <=> Clap Maintainers
args:
    - help:
        short: h
        long: help
        about: prints help
```