### PR TITLE
Implement BitOr for settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,9 +499,9 @@ features = ["std", "suggestions", "color"]
 
 #### Opt-in features
 
-* **"regex"**: Enables regex validators. (builds dependency `regex`)
-* **"wrap_help"**: Turns on the help text wrapping feature, based on the terminal size. (builds dependency `term-size`)
-* **"yaml"**: Enables building CLIs from YAML documents. (builds dependency `yaml-rust`)
+* **regex**: Enables regex validators. (builds dependency `regex`)
+* **wrap_help**: Turns on the help text wrapping feature, based on the terminal size. (builds dependency `term-size`)
+* **yaml**: Enables building CLIs from YAML documents. (builds dependency `yaml-rust`)
 
 ### More Information
 

--- a/benches/03_complex.rs
+++ b/benches/03_complex.rs
@@ -22,9 +22,9 @@ macro_rules! create_app {
                     .requires("positional2"),
                 Arg::from("[positional2] 'tests positionals with exclusions'"),
                 Arg::from("-O --Option [option3] 'tests options with specific value sets'")
-                    .possible_values(&OPT3_VALS),
+                    .possible_values(OPT3_VALS),
                 Arg::from("[positional3]... 'tests positionals with specific values'")
-                    .possible_values(&POS3_VALS),
+                    .possible_values(POS3_VALS),
                 Arg::from("--multvals [one] [two] 'Tests multiple values, not mult occs'"),
                 Arg::from("--multvalsmo... [one] [two] 'Tests multiple values, not mult occs'"),
                 Arg::from("--minvals2 [minvals]... 'Tests 2 min vals'").min_values(2),
@@ -96,7 +96,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .long("Option")
                         .setting(ArgSettings::TakesValue)
                         .about("tests options with specific value sets")
-                        .possible_values(&OPT3_VALS),
+                        .possible_values(OPT3_VALS),
                 )
                 .arg(
                     Arg::new("positional3")
@@ -105,7 +105,7 @@ pub fn build_from_builder(c: &mut Criterion) {
                         .setting(ArgSettings::MultipleOccurrences)
                         .about("tests positionals with specific values")
                         .index(4)
-                        .possible_values(&POS3_VALS),
+                        .possible_values(POS3_VALS),
                 )
                 .arg(
                     Arg::new("multvals")

--- a/benches/05_ripgrep.rs
+++ b/benches/05_ripgrep.rs
@@ -353,7 +353,7 @@ where
                 .value_name("WHEN")
                 .setting(ArgSettings::TakesValue)
                 .setting(ArgSettings::HidePossibleValues)
-                .possible_values(&["never", "auto", "always", "ansi"]),
+                .possible_values(["never", "auto", "always", "ansi"]),
         )
         .arg(
             flag("colors")

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -53,15 +53,9 @@ bitflags! {
     }
 }
 
+#[doc(hidden)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) struct AppFlags(Flags);
-
-impl BitOr for AppFlags {
-    type Output = Self;
-    fn bitor(self, rhs: Self) -> Self {
-        AppFlags(self.0 | rhs.0)
-    }
-}
+pub struct AppFlags(Flags);
 
 impl Default for AppFlags {
     fn default() -> Self {

--- a/src/build/arg/arg_value.rs
+++ b/src/build/arg/arg_value.rs
@@ -77,7 +77,7 @@ impl<'help> ArgValue<'help> {
     /// ArgValue::new("fast")
     /// # ;
     /// ```
-    /// [hidden]: ArgValue::hide
+    /// [hidden]: ArgValue::hidden
     /// [possible value]: crate::Arg::possible_values
     /// [`Arg::hide_possible_values(true)`]: crate::Arg::hide_possible_values()
     pub fn new(name: &'help str) -> Self {

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -1,5 +1,5 @@
 // Std
-use std::str::FromStr;
+use std::{ops::BitOr, str::FromStr};
 
 // Third party
 use bitflags::bitflags;
@@ -34,8 +34,15 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ArgFlags(Flags);
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArgFlags(Flags);
+
+impl Default for ArgFlags {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
 
 // @TODO @p6 @internal: Reorder alphabetically
 impl_settings! { ArgSettings, ArgFlags,
@@ -62,12 +69,6 @@ impl_settings! { ArgSettings, ArgFlags,
     HiddenShortHelp("hiddenshorthelp") => Flags::HIDDEN_SHORT_H,
     HiddenLongHelp("hiddenlonghelp") => Flags::HIDDEN_LONG_H,
     AllowInvalidUtf8("allowinvalidutf8") => Flags::UTF8_NONE
-}
-
-impl Default for ArgFlags {
-    fn default() -> Self {
-        ArgFlags(Flags::empty())
-    }
 }
 
 /// Various settings that apply to arguments and may be set, unset, and checked via getter/setter

--- a/src/build/macros.rs
+++ b/src/build/macros.rs
@@ -213,11 +213,11 @@ macro_rules! yaml_to_usize {
 
 #[cfg(feature = "yaml")]
 macro_rules! yaml_to_setting {
-    ($a:ident, $v:ident, $c:ident, $t:literal, $n:expr) => {{
+    ($a:ident, $v:ident, $c:ident, $s:ident, $t:literal, $n:expr) => {{
         if let Some(v) = $v.as_vec() {
             for ys in v {
                 if let Some(s) = ys.as_str() {
-                    $a = $a.$c(s.parse().unwrap_or_else(|_| {
+                    $a = $a.$c(s.parse::<$s>().unwrap_or_else(|_| {
                         panic!("Unknown {} '{}' found in YAML file for {}", $t, s, $n)
                     }));
                 } else {
@@ -229,7 +229,7 @@ macro_rules! yaml_to_setting {
             }
         } else if let Some(v) = $v.as_str() {
             $a = $a.$c(v
-                .parse()
+                .parse::<$s>()
                 .unwrap_or_else(|_| panic!("Unknown {} '{}' found in YAML file for {}", $t, v, $n)))
         } else {
             panic!("Failed to convert YAML {:?} value to a string", $v);

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -8,7 +8,7 @@ mod arg_group;
 mod usage_parser;
 
 pub use self::{
-    app::{App, AppSettings},
-    arg::{Arg, ArgSettings, ArgValue, ValueHint},
+    app::{App, AppFlags, AppSettings},
+    arg::{Arg, ArgFlags, ArgSettings, ArgValue, ValueHint},
     arg_group::ArgGroup,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,9 @@
 compile_error!("`std` feature is currently required to build `clap`");
 
 pub use crate::{
-    build::{App, AppSettings, Arg, ArgGroup, ArgSettings, ArgValue, ValueHint},
+    build::{
+        App, AppFlags, AppSettings, Arg, ArgFlags, ArgGroup, ArgSettings, ArgValue, ValueHint,
+    },
     parse::errors::{Error, ErrorKind, Result},
     parse::{ArgMatches, Indices, OsValues, Values},
 };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -532,6 +532,18 @@ macro_rules! impl_settings {
         ),+
     ) => {
         impl $flags {
+            pub(crate) fn empty() -> Self {
+                $flags(Flags::empty())
+            }
+
+            pub(crate) fn insert(&mut self, rhs: Self) {
+                self.0.insert(rhs.0);
+            }
+
+            pub(crate) fn remove(&mut self, rhs: Self) {
+                self.0.remove(rhs.0);
+            }
+
             pub(crate) fn set(&mut self, s: $settings) {
                 match s {
                     $(
@@ -557,6 +569,43 @@ macro_rules! impl_settings {
                         $settings::$setting => self.0.contains($flag),
                     )*
                 }
+            }
+        }
+
+        impl BitOr for $flags {
+            type Output = Self;
+
+            fn bitor(mut self, rhs: Self) -> Self::Output {
+                self.0.insert(rhs.0);
+                self
+            }
+        }
+
+        impl From<$settings> for $flags {
+            fn from(setting: $settings) -> Self {
+                let mut flags = $flags::empty();
+                flags.set(setting);
+                flags
+            }
+        }
+
+        impl BitOr<$settings> for $flags {
+            type Output = Self;
+
+            fn bitor(mut self, rhs: $settings) -> Self::Output {
+                self.set(rhs);
+                self
+            }
+        }
+
+        impl BitOr for $settings {
+            type Output = $flags;
+
+            fn bitor(self, rhs: Self) -> Self::Output {
+                let mut flags = $flags::empty();
+                flags.set(self);
+                flags.set(rhs);
+                flags
             }
         }
 

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -149,6 +149,75 @@ SUBCOMMANDS:
     test";
 
 #[test]
+fn setting() {
+    let m = App::new("setting").setting(AppSettings::AllArgsOverrideSelf);
+    assert!(m.is_set(AppSettings::AllArgsOverrideSelf));
+}
+
+#[test]
+fn global_setting() {
+    let m = App::new("global_setting").global_setting(AppSettings::AllArgsOverrideSelf);
+    assert!(m.is_set(AppSettings::AllArgsOverrideSelf));
+}
+
+#[test]
+fn unset_setting() {
+    let m = App::new("unset_setting").setting(AppSettings::AllArgsOverrideSelf);
+    assert!(m.is_set(AppSettings::AllArgsOverrideSelf));
+
+    let m = m.unset_setting(AppSettings::AllArgsOverrideSelf);
+    assert!(!m.is_set(AppSettings::AllArgsOverrideSelf), "{:#?}", m);
+}
+
+#[test]
+fn unset_global_setting() {
+    let m = App::new("unset_global_setting").global_setting(AppSettings::AllArgsOverrideSelf);
+    assert!(m.is_set(AppSettings::AllArgsOverrideSelf));
+
+    let m = m.unset_global_setting(AppSettings::AllArgsOverrideSelf);
+    assert!(!m.is_set(AppSettings::AllArgsOverrideSelf), "{:#?}", m);
+}
+
+#[test]
+fn unset_on_global_setting() {
+    let m = App::new("unset_on_global_setting").global_setting(AppSettings::AllArgsOverrideSelf);
+    assert!(m.is_set(AppSettings::AllArgsOverrideSelf));
+
+    let m = m.unset_setting(AppSettings::AllArgsOverrideSelf);
+    assert!(m.is_set(AppSettings::AllArgsOverrideSelf), "{:#?}", m);
+}
+
+#[test]
+fn setting_bitor() {
+    let m = App::new("setting_bitor").setting(
+        AppSettings::InferSubcommands | AppSettings::Hidden | AppSettings::DisableHelpSubcommand,
+    );
+
+    assert!(m.is_set(AppSettings::InferSubcommands));
+    assert!(m.is_set(AppSettings::Hidden));
+    assert!(m.is_set(AppSettings::DisableHelpSubcommand));
+}
+
+#[test]
+fn unset_setting_bitor() {
+    let m = App::new("unset_setting_bitor")
+        .setting(AppSettings::InferSubcommands)
+        .setting(AppSettings::Hidden)
+        .setting(AppSettings::DisableHelpSubcommand);
+
+    assert!(m.is_set(AppSettings::InferSubcommands));
+    assert!(m.is_set(AppSettings::Hidden));
+    assert!(m.is_set(AppSettings::DisableHelpSubcommand));
+
+    let m = m.unset_setting(
+        AppSettings::InferSubcommands | AppSettings::Hidden | AppSettings::DisableHelpSubcommand,
+    );
+    assert!(!m.is_set(AppSettings::InferSubcommands), "{:#?}", m);
+    assert!(!m.is_set(AppSettings::Hidden), "{:#?}", m);
+    assert!(!m.is_set(AppSettings::DisableHelpSubcommand), "{:#?}", m);
+}
+
+#[test]
 fn sub_command_negate_required() {
     App::new("sub_command_negate")
         .setting(AppSettings::SubcommandsNegateReqs)
@@ -581,24 +650,6 @@ fn leading_double_hyphen_trailingvararg() {
         m.values_of("opt").unwrap().collect::<Vec<_>>(),
         &["--foo", "-Wl", "bar"]
     );
-}
-
-#[test]
-fn unset_setting() {
-    let m = App::new("unset_setting").setting(AppSettings::AllArgsOverrideSelf);
-    assert!(m.is_set(AppSettings::AllArgsOverrideSelf));
-
-    let m = m.unset_setting(AppSettings::AllArgsOverrideSelf);
-    assert!(!m.is_set(AppSettings::AllArgsOverrideSelf));
-}
-
-#[test]
-fn unset_settings() {
-    let m = App::new("unset_settings");
-    assert!(&m.is_set(AppSettings::ColorAuto));
-
-    let m = m.unset_global_setting(AppSettings::ColorAuto);
-    assert!(!m.is_set(AppSettings::ColorAuto), "{:#?}", m);
 }
 
 #[test]

--- a/tests/arg_settings.rs
+++ b/tests/arg_settings.rs
@@ -1,0 +1,45 @@
+mod utils;
+
+use clap::{Arg, ArgSettings};
+
+#[test]
+fn setting() {
+    let m = Arg::new("setting").setting(ArgSettings::Required);
+    assert!(m.is_set(ArgSettings::Required));
+}
+
+#[test]
+fn unset_setting() {
+    let m = Arg::new("unset_setting").setting(ArgSettings::Required);
+    assert!(m.is_set(ArgSettings::Required));
+
+    let m = m.unset_setting(ArgSettings::Required);
+    assert!(!m.is_set(ArgSettings::Required), "{:#?}", m);
+}
+
+#[test]
+fn setting_bitor() {
+    let m = Arg::new("setting_bitor")
+        .setting(ArgSettings::Required | ArgSettings::Hidden | ArgSettings::Last);
+
+    assert!(m.is_set(ArgSettings::Required));
+    assert!(m.is_set(ArgSettings::Hidden));
+    assert!(m.is_set(ArgSettings::Last));
+}
+
+#[test]
+fn unset_setting_bitor() {
+    let m = Arg::new("unset_setting_bitor")
+        .setting(ArgSettings::Required)
+        .setting(ArgSettings::Hidden)
+        .setting(ArgSettings::Last);
+
+    assert!(m.is_set(ArgSettings::Required));
+    assert!(m.is_set(ArgSettings::Hidden));
+    assert!(m.is_set(ArgSettings::Last));
+
+    let m = m.unset_setting(ArgSettings::Required | ArgSettings::Hidden | ArgSettings::Last);
+    assert!(!m.is_set(ArgSettings::Required), "{:#?}", m);
+    assert!(!m.is_set(ArgSettings::Hidden), "{:#?}", m);
+    assert!(!m.is_set(ArgSettings::Last), "{:#?}", m);
+}


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->

This was one of the earliest goals for 3.0 but never got to be implemented. When I took over, I assumed this was and thus all the confusion.

The main reason IIUC behind doing this originally and removing all the `*_settings()` functions is to reduce the number of methods and complexity of the builders which are already pretty big.
