### PR TITLE
Fix Elvish completions generation

### DIFF
--- a/clap_generate/src/generators/shells/elvish.rs
+++ b/clap_generate/src/generators/shells/elvish.rs
@@ -25,21 +25,21 @@ impl Generator for Elvish {
 use builtin;
 use str;
 
-edit:completion:arg-completer[{bin_name}] = [@words]{{
+set edit:completion:arg-completer[{bin_name}] = [@words]{{
     fn spaces [n]{{
         builtin:repeat $n ' ' | str:join ''
     }}
     fn cand [text desc]{{
-        edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }}
-    command = '{bin_name}'
+    var command = '{bin_name}'
     for word $words[1..-1] {{
         if (str:has-prefix $word '-') {{
             break
         }}
-        command = $command';'$word
+        set command = $command';'$word
     }}
-    completions = [{subcommands_cases}
+    var completions = [{subcommands_cases}
     ]
     $completions[$command]
 }}

--- a/clap_generate/tests/completions/elvish.rs
+++ b/clap_generate/tests/completions/elvish.rs
@@ -32,21 +32,21 @@ static ELVISH: &str = r#"
 use builtin;
 use str;
 
-edit:completion:arg-completer[my_app] = [@words]{
+set edit:completion:arg-completer[my_app] = [@words]{
     fn spaces [n]{
         builtin:repeat $n ' ' | str:join ''
     }
     fn cand [text desc]{
-        edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }
-    command = 'my_app'
+    var command = 'my_app'
     for word $words[1..-1] {
         if (str:has-prefix $word '-') {
             break
         }
-        command = $command';'$word
+        set command = $command';'$word
     }
-    completions = [
+    var completions = [
         &'my_app'= {
             cand -h 'Print help information'
             cand --help 'Print help information'
@@ -96,21 +96,21 @@ static ELVISH_SPECIAL_CMDS: &str = r#"
 use builtin;
 use str;
 
-edit:completion:arg-completer[my_app] = [@words]{
+set edit:completion:arg-completer[my_app] = [@words]{
     fn spaces [n]{
         builtin:repeat $n ' ' | str:join ''
     }
     fn cand [text desc]{
-        edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }
-    command = 'my_app'
+    var command = 'my_app'
     for word $words[1..-1] {
         if (str:has-prefix $word '-') {
             break
         }
-        command = $command';'$word
+        set command = $command';'$word
     }
-    completions = [
+    var completions = [
         &'my_app'= {
             cand -h 'Print help information'
             cand --help 'Print help information'
@@ -185,21 +185,21 @@ static ELVISH_ALIASES: &str = r#"
 use builtin;
 use str;
 
-edit:completion:arg-completer[cmd] = [@words]{
+set edit:completion:arg-completer[cmd] = [@words]{
     fn spaces [n]{
         builtin:repeat $n ' ' | str:join ''
     }
     fn cand [text desc]{
-        edit:complex-candidate $text &display-suffix=' '(spaces (- 14 (wcswidth $text)))$desc
+        edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }
-    command = 'cmd'
+    var command = 'cmd'
     for word $words[1..-1] {
         if (str:has-prefix $word '-') {
             break
         }
-        command = $command';'$word
+        set command = $command';'$word
     }
-    completions = [
+    var completions = [
         &'cmd'= {
             cand -o 'cmd option'
             cand -O 'cmd option'


### PR DESCRIPTION
The `display-suffix` option for `edit:complex-candidate` was [deprecated in Elvish v0.14.0][1] and removed in v0.15.0 (latest version is v0.16.3), so this PR changes the Elvish completions generation to use the `display` option instead.

Additionally, this PR changes assignments to use the `var` and `set` keywords as using `name = value` without these keywords ('legacy assignment form') [will be deprecated][2].

[1]: https://elv.sh/blog/0.14.0-release-notes.html
[2]: https://elv.sh/ref/language.html#legacy-assignment-form