### PR TITLE
Fix disabling the default help and version subcommands/flags

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -463,7 +463,10 @@ impl<'help, 'app> Parser<'help, 'app> {
                     let sc_name = self.possible_subcommand(&arg_os, valid_arg_found);
                     debug!("Parser::get_matches_with: sc={:?}", sc_name);
                     if let Some(sc_name) = sc_name {
-                        if sc_name == "help" && !self.is_set(AS::NoAutoHelp) {
+                        if sc_name == "help"
+                            && !self.is_set(AS::NoAutoHelp)
+                            && !self.is_set(AS::DisableHelpSubcommand)
+                        {
                             self.parse_help_subcommand(remaining_args)?;
                         }
                         subcmd_name = Some(sc_name.to_owned());
@@ -1102,7 +1105,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         if let Some(help) = self.app.find(&Id::help_hash()) {
             if let Some(h) = help.long {
-                if arg == h && !self.is_set(AS::NoAutoHelp) {
+                if arg == h && !self.is_set(AS::NoAutoHelp) && !self.is_set(AS::DisableHelpFlag) {
                     debug!("Help");
                     return Some(ParseResult::HelpFlag);
                 }
@@ -1111,7 +1114,10 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         if let Some(version) = self.app.find(&Id::version_hash()) {
             if let Some(v) = version.long {
-                if arg == v && !self.is_set(AS::NoAutoVersion) {
+                if arg == v
+                    && !self.is_set(AS::NoAutoVersion)
+                    && !self.is_set(AS::DisableVersionFlag)
+                {
                     debug!("Version");
                     return Some(ParseResult::VersionFlag);
                 }
@@ -1131,7 +1137,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         if let Some(help) = self.app.find(&Id::help_hash()) {
             if let Some(h) = help.short {
-                if arg == h && !self.is_set(AS::NoAutoHelp) {
+                if arg == h && !self.is_set(AS::NoAutoHelp) && !self.is_set(AS::DisableHelpFlag) {
                     debug!("Help");
                     return Some(ParseResult::HelpFlag);
                 }
@@ -1140,7 +1146,10 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         if let Some(version) = self.app.find(&Id::version_hash()) {
             if let Some(v) = version.short {
-                if arg == v && !self.is_set(AS::NoAutoVersion) {
+                if arg == v
+                    && !self.is_set(AS::NoAutoVersion)
+                    && !self.is_set(AS::DisableVersionFlag)
+                {
                     debug!("Version");
                     return Some(ParseResult::VersionFlag);
                 }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -2638,3 +2638,34 @@ USAGE:
         true
     ));
 }
+
+#[test]
+fn override_help_subcommand() {
+    let app = App::new("bar")
+        .subcommand(App::new("help").arg(Arg::new("arg").takes_value(true)))
+        .subcommand(App::new("not_help").arg(Arg::new("arg").takes_value(true)))
+        .setting(AppSettings::DisableHelpSubcommand);
+    let matches = app.get_matches_from(&["bar", "help", "foo"]);
+    assert_eq!(
+        matches.subcommand_matches("help").unwrap().value_of("arg"),
+        Some("foo")
+    );
+}
+
+#[test]
+fn override_help_flag_using_long() {
+    let app = App::new("foo")
+        .subcommand(App::new("help").long_flag("help"))
+        .setting(AppSettings::DisableHelpFlag);
+    let matches = app.get_matches_from(&["foo", "--help"]);
+    assert!(matches.subcommand_matches("help").is_some());
+}
+
+#[test]
+fn override_help_flag_using_short() {
+    let app = App::new("foo")
+        .setting(AppSettings::DisableHelpFlag)
+        .subcommand(App::new("help").short_flag('h'));
+    let matches = app.get_matches_from(&["foo", "-h"]);
+    assert!(matches.subcommand_matches("help").is_some());
+}

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -277,39 +277,21 @@ fn version_about_multi_subcmd_override() {
 #[test]
 fn disabled_version_long() {
     let app = App::new("foo").setting(AppSettings::DisableVersionFlag);
-    assert!(utils::compare_output(
-        app,
-        "foo --version",
-        "error: Found argument '--version' which wasn't expected, or isn't valid in this context
-
-\tIf you tried to supply `--version` as a value rather than a flag, use `-- --version`
-
-USAGE:
-    foo
-
-For more information try --help
-",
-        true
-    ));
+    let res = app.try_get_matches_from(&["foo", "--version"]);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert_eq!(err.kind, clap::ErrorKind::UnknownArgument);
+    assert_eq!(err.info, ["--version"]);
 }
 
 #[test]
 fn disabled_version_short() {
     let app = App::new("foo").setting(AppSettings::DisableVersionFlag);
-    assert!(utils::compare_output(
-        app,
-        "foo -V",
-        "error: Found argument '-V' which wasn't expected, or isn't valid in this context
-
-\tIf you tried to supply `-V` as a value rather than a flag, use `-- -V`
-
-USAGE:
-    foo
-
-For more information try --help
-",
-        true
-    ));
+    let res = app.try_get_matches_from(&["foo", "-V"]);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert_eq!(err.kind, clap::ErrorKind::UnknownArgument);
+    assert_eq!(err.info, ["-V"]);
 }
 
 #[test]

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -324,8 +324,8 @@ fn override_version_using_long() {
 #[test]
 fn override_version_using_short() {
     let app = App::new("foo")
-        .arg(Arg::new("version").short('V').default_missing_value("baz"))
+        .arg(Arg::new("version").short('V'))
         .setting(AppSettings::DisableVersionFlag);
     let matches = app.get_matches_from(&["foo", "-V"]);
-    assert_eq!(matches.value_of("version"), Some("baz"));
+    assert!(matches.is_present("version"));
 }

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use std::str;
 
-use clap::{App, Arg, ErrorKind};
+use clap::{App, AppSettings, Arg, ErrorKind};
 
 static VERSION: &str = "clap-test v1.4.8\n";
 
@@ -272,4 +272,60 @@ fn version_about_multi_subcmd_override() {
         VERSION_ABOUT_MULTI_SC_OVERRIDE,
         false
     ));
+}
+
+#[test]
+fn disabled_version_long() {
+    let app = App::new("foo").setting(AppSettings::DisableVersionFlag);
+    assert!(utils::compare_output(
+        app,
+        "foo --version",
+        "error: Found argument '--version' which wasn't expected, or isn't valid in this context
+
+\tIf you tried to supply `--version` as a value rather than a flag, use `-- --version`
+
+USAGE:
+    foo
+
+For more information try --help
+",
+        true
+    ));
+}
+
+#[test]
+fn disabled_version_short() {
+    let app = App::new("foo").setting(AppSettings::DisableVersionFlag);
+    assert!(utils::compare_output(
+        app,
+        "foo -V",
+        "error: Found argument '-V' which wasn't expected, or isn't valid in this context
+
+\tIf you tried to supply `-V` as a value rather than a flag, use `-- -V`
+
+USAGE:
+    foo
+
+For more information try --help
+",
+        true
+    ));
+}
+
+#[test]
+fn override_version_using_long() {
+    let app = App::new("foo")
+        .setting(AppSettings::DisableVersionFlag)
+        .arg(Arg::new("version").long("version"));
+    let matches = app.get_matches_from(&["foo", "--version"]);
+    assert!(matches.is_present("version"));
+}
+
+#[test]
+fn override_version_using_short() {
+    let app = App::new("foo")
+        .arg(Arg::new("version").short('V').default_missing_value("baz"))
+        .setting(AppSettings::DisableVersionFlag);
+    let matches = app.get_matches_from(&["foo", "-V"]);
+    assert_eq!(matches.value_of("version"), Some("baz"));
 }


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
Closes #2789

This removes the `NoAutoHelp` and `NoAutoVersion` settings. These settings were added in 471376fdc7cacd64389614787307851f809c3f03, but I believe they can now just be replaced with `DisableHelpSubcommand`, `DisableHelpFlag`, and `DisableVersionFlag`.

I've also added some tests to cover the cases not accounted for by the test `disabled_help_flag_and_subcommand` added in #2749.