### PR TITLE
Rename `ArgEnum::arg_value` to `to_arg_value`

### DIFF
--- a/clap_derive/src/derives/arg_enum.rs
+++ b/clap_derive/src/derives/arg_enum.rs
@@ -48,7 +48,7 @@ pub fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStr
 
     let lits = lits(&e.variants, &attrs);
     let arg_values = gen_arg_values(&lits);
-    let arg_value = gen_arg_value(&lits);
+    let to_arg_value = gen_to_arg_value(&lits);
 
     quote! {
         #[allow(dead_code, unreachable_code, unused_variables)]
@@ -65,7 +65,7 @@ pub fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStr
         #[deny(clippy::correctness)]
         impl clap::ArgEnum for #name {
             #arg_values
-            #arg_value
+            #to_arg_value
         }
     }
 }
@@ -109,11 +109,11 @@ fn gen_arg_values(lits: &[(TokenStream, Ident)]) -> TokenStream {
     }
 }
 
-fn gen_arg_value(lits: &[(TokenStream, Ident)]) -> TokenStream {
+fn gen_to_arg_value(lits: &[(TokenStream, Ident)]) -> TokenStream {
     let (lit, variant): (Vec<TokenStream>, Vec<Ident>) = lits.iter().cloned().unzip();
 
     quote! {
-        fn arg_value<'a>(&self) -> Option<clap::ArgValue<'a>> {
+        fn to_arg_value<'a>(&self) -> Option<clap::ArgValue<'a>> {
             match self {
                 #(Self::#variant => Some(#lit),)*
                 _ => None

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -361,7 +361,7 @@ pub fn gen_augment(
 
 fn gen_arg_enum_possible_values(ty: &Type) -> TokenStream {
     quote_spanned! { ty.span()=>
-        .possible_values(<#ty as clap::ArgEnum>::value_variants().iter().filter_map(clap::ArgEnum::arg_value))
+        .possible_values(<#ty as clap::ArgEnum>::value_variants().iter().filter_map(clap::ArgEnum::to_arg_value))
     }
 }
 

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -82,7 +82,7 @@ pub fn arg_enum(name: &Ident) {
             fn from_str(_input: &str, _case_insensitive: bool) -> Result<Self, String> {
                 unimplemented!()
             }
-            fn arg_value<'a>(&self) -> Option<clap::ArgValue<'a>>{
+            fn to_arg_value<'a>(&self) -> Option<clap::ArgValue<'a>>{
                 unimplemented!()
             }
         }

--- a/clap_derive/tests/arg_enum.rs
+++ b/clap_derive/tests/arg_enum.rs
@@ -54,7 +54,7 @@ fn default_value() {
 
     impl std::fmt::Display for ArgChoice {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-            std::fmt::Display::fmt(self.arg_value().unwrap().get_name(), f)
+            std::fmt::Display::fmt(self.to_arg_value().unwrap().get_name(), f)
         }
     }
 
@@ -370,7 +370,7 @@ fn skip_variant() {
     assert_eq!(
         ArgChoice::value_variants()
             .iter()
-            .map(ArgEnum::arg_value)
+            .map(ArgEnum::to_arg_value)
             .map(Option::unwrap)
             .collect::<Vec<_>>(),
         vec![ArgValue::new("foo"), ArgValue::new("bar")]

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -289,7 +289,11 @@ pub trait ArgEnum: Sized + Clone {
     fn from_str(input: &str, case_insensitive: bool) -> Result<Self, String> {
         Self::value_variants()
             .iter()
-            .find(|v| v.arg_value().unwrap().matches(input, case_insensitive))
+            .find(|v| {
+                v.to_arg_value()
+                    .expect("ArgEnum::value_variants contains only values with a corresponding ArgEnum::to_arg_value")
+                    .matches(input, case_insensitive)
+            })
             .cloned()
             .ok_or_else(|| format!("Invalid variant: {}", input))
     }
@@ -297,7 +301,7 @@ pub trait ArgEnum: Sized + Clone {
     /// The canonical argument value.
     ///
     /// The value is `None` for skipped variants.
-    fn arg_value<'a>(&self) -> Option<ArgValue<'a>>;
+    fn to_arg_value<'a>(&self) -> Option<ArgValue<'a>>;
 }
 
 impl<T: Clap> Clap for Box<T> {


### PR DESCRIPTION
This is a follow up to #2762, adding a clarifying `to_` prefix to the function.