### PR TITLE
fix(derive): Subcommands not working within macro_rules

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use proc_macro2::{Ident, Span, TokenStream};
 use proc_macro_error::{abort, abort_call_site};
-use quote::{quote, quote_spanned};
+use quote::{format_ident, quote, quote_spanned};
 use syn::{
     punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Data, DataStruct,
     DeriveInput, Field, Fields, Type,
@@ -372,7 +372,7 @@ pub fn gen_constructor(fields: &Punctuated<Field, Comma>, parent_attribute: &Att
         );
         let field_name = field.ident.as_ref().unwrap();
         let kind = attrs.kind();
-        let arg_matches = quote! { arg_matches };
+        let arg_matches = format_ident!("arg_matches");
         match &*kind {
             Kind::ExternalSubcommand => {
                 abort! { kind.span(),
@@ -438,7 +438,7 @@ pub fn gen_updater(
         } else {
             quote!()
         };
-        let arg_matches = quote! { arg_matches };
+        let arg_matches = format_ident!("arg_matches");
 
         match &*kind {
             Kind::ExternalSubcommand => {
@@ -547,10 +547,10 @@ fn gen_parsers(
         }
         _ => &field.ty,
     };
-    // Use `quote!` to give this identifier the same hygiene
+    // Give this identifier the same hygiene
     // as the `arg_matches` parameter definition. This
     // allows us to refer to `arg_matches` within a `quote_spanned` block
-    let arg_matches = quote! { arg_matches };
+    let arg_matches = format_ident!("arg_matches");
 
     let field_value = match **ty {
         Ty::Bool => {

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -96,6 +96,7 @@ pub fn gen_for_enum(enum_name: &Ident, attrs: &[Attribute]) -> TokenStream {
         Sp::call_site(DEFAULT_ENV_CASING),
     );
     let name = attrs.cased_name();
+    let app_var = Ident::new("app", Span::call_site());
 
     quote! {
         #[allow(dead_code, unreachable_code, unused_variables)]
@@ -112,14 +113,14 @@ pub fn gen_for_enum(enum_name: &Ident, attrs: &[Attribute]) -> TokenStream {
         #[deny(clippy::correctness)]
         impl clap::IntoApp for #enum_name {
             fn into_app<'b>() -> clap::App<'b> {
-                let app = clap::App::new(#name)
+                let #app_var = clap::App::new(#name)
                     .setting(clap::AppSettings::SubcommandRequiredElseHelp);
-                <#enum_name as clap::Subcommand>::augment_subcommands(app)
+                <#enum_name as clap::Subcommand>::augment_subcommands(#app_var)
             }
 
             fn into_app_for_update<'b>() -> clap::App<'b> {
-                let app = clap::App::new(#name);
-                <#enum_name as clap::Subcommand>::augment_subcommands_for_update(app)
+                let #app_var = clap::App::new(#name);
+                <#enum_name as clap::Subcommand>::augment_subcommands_for_update(#app_var)
             }
         }
     }

--- a/clap_derive/tests/nested.rs
+++ b/clap_derive/tests/nested.rs
@@ -31,3 +31,23 @@ fn use_option() {
 
     expand_ty!(my_field: Option<String>);
 }
+
+#[test]
+fn issue_447() {
+    macro_rules! Command {
+        ( $name:ident, [
+        #[$meta:meta] $var:ident($inner:ty)
+      ] ) => {
+            #[derive(Debug, PartialEq, clap::Clap)]
+            enum $name {
+                #[$meta]
+                $var($inner),
+            }
+        };
+    }
+
+    Command! {GitCmd, [
+      #[clap(external_subcommand)]
+      Ext(Vec<String>)
+    ]}
+}


### PR DESCRIPTION
This carries over a test case from
https://github.com/TeXitoi/structopt/pull/448, and re-fixes it according
to the changes we've made since we forked.  I also tried to  identify
other cases and quote them to avoid playing whack-a-mole with this.

This is a part of #2809

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
