### PR TITLE
fix(derive): Fix the problem where the build fails due to the ambigous type of `map`

### DIFF
--- a/clap_derive/tests/issues.rs
+++ b/clap_derive/tests/issues.rs
@@ -76,3 +76,32 @@ fn issue_324() {
     let help = get_long_help::<Opt>();
     assert!(help.contains("MY_VERSION"));
 }
+
+#[test]
+fn issue_490() {
+    use clap::Clap;
+    use std::iter::FromIterator;
+    use std::str::FromStr;
+
+    struct U16ish;
+    impl FromStr for U16ish {
+        type Err = ();
+        fn from_str(_: &str) -> Result<Self, Self::Err> {
+            unimplemented!()
+        }
+    }
+    impl<'a> FromIterator<&'a U16ish> for Vec<u16> {
+        fn from_iter<T: IntoIterator<Item = &'a U16ish>>(_: T) -> Self {
+            unimplemented!()
+        }
+    }
+
+    #[derive(Clap, Debug)]
+    struct Opt {
+        opt_vec: Vec<u16>,
+        #[clap(long)]
+        opt_opt_vec: Option<Vec<u16>>,
+    }
+
+    // Assert that it compiles
+}


### PR DESCRIPTION
> This PR closes [TeXitoi/structopt/#490](https://github.com/TeXitoi/structopt/issues/490). Please refer to [#490](https://github.com/TeXitoi/structopt/issues/490) for the detail of the problem. Let me know if you want to make `convert_type` a function.

This is a port of https://github.com/TeXitoi/structopt/pull/491

This is part of #2809

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
