### PR TITLE
feat(derive): Add skip attribute support for enum variants

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -552,9 +552,7 @@ impl Attrs {
 
                 res.kind = Sp::new(Kind::Subcommand(ty), res.kind.span());
             }
-            Kind::Skip(_) => {
-                abort!(res.kind.span(), "skip is not supported on variants");
-            }
+            Kind::Skip(_) => (),
             Kind::FromGlobal(_) => {
                 abort!(res.kind.span(), "from_global is not supported on variants");
             }

--- a/clap_derive/tests/subcommands.rs
+++ b/clap_derive/tests/subcommands.rs
@@ -474,3 +474,49 @@ fn subcommand_name_not_literal() {
 
     assert!(Opt::try_parse_from(&["test", "renamed"]).is_ok());
 }
+
+#[test]
+fn skip_subcommand() {
+    #[derive(Debug, PartialEq, Clap)]
+    struct Opt {
+        #[clap(subcommand)]
+        sub: Subcommands,
+    }
+
+    #[derive(Debug, PartialEq, Clap)]
+    enum Subcommands {
+        Add,
+        Remove,
+
+        #[allow(dead_code)]
+        #[clap(skip)]
+        Skip,
+    }
+
+    assert_eq!(
+        Opt::parse_from(&["test", "add"]),
+        Opt {
+            sub: Subcommands::Add
+        }
+    );
+
+    assert_eq!(
+        Opt::parse_from(&["test", "remove"]),
+        Opt {
+            sub: Subcommands::Remove
+        }
+    );
+
+    let res = Opt::try_parse_from(&["test", "skip"]);
+    assert!(
+        matches!(
+            res,
+            Err(clap::Error {
+                kind: clap::ErrorKind::UnknownArgument,
+                ..
+            })
+        ),
+        "Unexpected result: {:?}",
+        res
+    );
+}


### PR DESCRIPTION
> Resolves [TeXitoi/structopt/#493](https://github.com/TeXitoi/structopt/issue/493)

This is a port of https://github.com/TeXitoi/structopt/pull/494

This is part of #2809

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
