### PR TITLE
feat: Add backtraces to errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ termcolor = { version = "1.1", optional = true }
 terminal_size = { version = "0.1.12", optional = true }
 lazy_static = { version = "1", optional = true }
 regex = { version = "1.0", optional = true }
+backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]
 regex = "1.0"
@@ -89,7 +90,7 @@ default = [
 	"suggestions",
 	"unicode_help",
 ]
-debug = ["clap_derive/debug"] # Enables debug messages
+debug = ["clap_derive/debug", "backtrace"] # Enables debug messages
 
 # Used in default
 std = ["indexmap/std"] # support for no_std in a backwards-compatible way

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -759,12 +759,10 @@ impl<'help, 'app> Parser<'help, 'app> {
         } else if self.is_set(AS::SubcommandRequiredElseHelp) {
             debug!("Parser::get_matches_with: SubcommandRequiredElseHelp=true");
             let message = self.write_help_err()?;
-            return Err(ClapError {
+            return Err(ClapError::new(
                 message,
-                kind: ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
-                info: vec![],
-                source: None,
-            });
+                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+            ));
         }
 
         self.remove_overrides(matcher);
@@ -1903,12 +1901,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         match Help::new(HelpWriter::Buffer(&mut c), self, use_long).write_help() {
             Err(e) => e.into(),
-            _ => ClapError {
-                message: c,
-                kind: ErrorKind::DisplayHelp,
-                info: vec![],
-                source: None,
-            },
+            _ => ClapError::new(c, ErrorKind::DisplayHelp),
         }
     }
 
@@ -1918,12 +1911,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         let msg = self.app._render_version(use_long);
         let mut c = Colorizer::new(false, self.color_help());
         c.none(msg);
-        ClapError {
-            message: c,
-            kind: ErrorKind::DisplayVersion,
-            info: vec![],
-            source: None,
-        }
+        ClapError::new(c, ErrorKind::DisplayVersion)
     }
 }
 

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -63,12 +63,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             && self.p.is_set(AS::ArgRequiredElseHelp)
         {
             let message = self.p.write_help_err()?;
-            return Err(Error {
+            return Err(Error::new(
                 message,
-                kind: ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
-                info: vec![],
-                source: None,
-            });
+                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+            ));
         }
         self.validate_conflicts(matcher)?;
         if !(self.p.is_set(AS::SubcommandsNegateReqs) && is_subcmd || reqs_validated) {


### PR DESCRIPTION
This is gated behind the `debug` feature flag so only explicit debugging
cases pay the build time and runtime costs.

The builder API's stack traces are generally not too interesting.  Where
this really helps is with `clap_derive`.  We currently panic on
unexpected conditions which at least gives us a backtrace.  We'd like to
turn these into errors but to do so would lose those debuggin
backtraces, which is where this comes in.

This is a part of #2255

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
