### PR TITLE
[clap_generate] [zsh] sort out multiple occurrence vs multiple_value.

### DIFF
--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -431,19 +431,23 @@ fn write_opts_of(p: &App, p_global: Option<&App>) -> String {
         let help = o.get_about().map_or(String::new(), escape_help);
         let conflicts = arg_conflicts(p, o, p_global);
 
-        // @TODO @soundness should probably be either multiple occurrences or multiple values and
-        // not both
-        let multiple = if o.is_set(ArgSettings::MultipleOccurrences)
-            || o.is_set(ArgSettings::MultipleValues)
-        {
+        let multiple = if o.is_set(ArgSettings::MultipleOccurrences) {
             "*"
         } else {
             ""
         };
 
+        let vn = match o.get_value_names() {
+            None => " ".to_string(),
+            Some(val) => val[0].to_string(),
+        };
         let vc = match value_completion(o) {
-            Some(val) => format!(": :{}", val),
-            None => "".to_string(),
+            Some(val) => format!(":{}:{}", vn, val),
+            None => format!(":{}: ", vn),
+        };
+        let vc = match o.get_num_vals() {
+            Some(num_vals) => vc.repeat(num_vals),
+            None => vc,
         };
 
         if let Some(shorts) = o.get_short_and_visible_aliases() {

--- a/clap_generate/tests/value_hints.rs
+++ b/clap_generate/tests/value_hints.rs
@@ -97,7 +97,7 @@ _my_app() {
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
 '--choice=[]: :(bash fish zsh)' \
-'--unknown=[]' \
+'--unknown=[]: : ' \
 '--other=[]: :( )' \
 '-p+[]: :_files' \
 '--path=[]: :_files' \

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -239,6 +239,22 @@ impl<'help> Arg<'help> {
         }
     }
 
+    /// Get the names of values for this argument.
+    #[inline]
+    pub fn get_value_names(&self) -> Option<&[&str]> {
+        if self.val_names.is_empty() {
+            None
+        } else {
+            Some(&self.val_names)
+        }
+    }
+
+    /// Get the number of values for this argument.
+    #[inline]
+    pub fn get_num_vals(&self) -> Option<usize> {
+        self.num_vals
+    }
+
     /// Get the index of this argument, if any
     #[inline]
     pub fn get_index(&self) -> Option<usize> {


### PR DESCRIPTION
As indicated by the `@TODO`, MultipleOccurrences and MultipleValues were a bit mixed up here, I'll try to give some examples.

For testing I used
```
zsh -f
zstyle ':completion:*' file-patterns '%p:globbed-files *(-/):directories'
zstyle ':completion:*:descriptions' format $'%d:'
autoload -U is-at-least
autoload -U compinit
compinit
compdef _my_app my_app
```

and then I do `cargo run` with the below test programs, from the ouput i copy and past the parts from `_my_app()` to `ret=0 }` into the shell and test with `my_app TAB` to see what happens.

(the settings mean "start a new zsh but don't load my personal config", "don't complete just any files when there are not correct paths left" - this should in my example avoid opinionated matches. then "show the description of what is being completed above the matches", load the bare minimum for what the clap generated completions need, complete the my_app program with the _my_app function.)

## multiple occurrences

Intended usage `my_app --dir src --dir target --dir /etc`

```
fn build_app_with_files_and_dirs() -> App<'static> {
    App::new("my_app")
        .about("testing zsh completions")
        .arg(
            Arg::new("directory")
                .long("dir")
                .about("specify a directory")
                .value_name("DIR")
                .multiple_occurrences(true)
                .value_hint(ValueHint::DirPath),
        )
}

fn main() {
    let args = build_app_with_files_and_dirs().get_matches();
    if let Some(f) = args.values_of("directory") {
        for ff in f {
            println!("{}", ff);
        }
    }
    let mut app = build_app_with_files_and_dirs();
    app.set_bin_name("my_app");
    generate::<Zsh, _>(&mut app, "my_app", &mut io::stdout());
}
```

generates

```
_my_app() {
    typeset -A opt_args
    typeset -a _arguments_options
    local ret=1

    if is-at-least 5.2; then
        _arguments_options=(-s -S -C)
    else
        _arguments_options=(-s -C)
    fi

    local context curcontext="$curcontext" state line
    _arguments "${_arguments_options[@]}" \
'*--dir=[specify a directory]:DIR:_files -/' \
'-h[Print help information]' \
'--help[Print help information]' \
'-V[Print version information]' \
'--version[Print version information]' \
&& ret=0
    
}

```

tab completion then looks like (`kona%` is my shell prompt with `zsh -f`

```
kona% ./my_app --dir TAB
DIR:
src/     target/
```

and 

```
kona% ./my_app --dir src --TAB
option:
--dir      -- specify a directory
--help     -- Print help information
--version  -- Print version information
```

this is the intended behaviour
 * triggered by the `*` in `*--dir`. the flag `--dir` can be provided multiple times.
 * the argument name `DIR` (also visible in the `--help` as `--dir <DIR>    specify a directory`) gets shown above the completions, triggered by `:DIR:`

## multiple values

Intented usage `./my_app --dir /usr/bin /usr/sbin`

```
fn build_app_with_files_and_dirs() -> App<'static> {
    App::new("my_app")
        .about("testing zsh completions")
        .arg(
            Arg::new("directory")
                .long("dir")
                .about("specify a directory")
                .value_name("DIR")
                .number_of_values(2)
                .value_hint(ValueHint::DirPath),
        )
}
```

generates

```
_my_app() {
    typeset -A opt_args
    typeset -a _arguments_options
    local ret=1

    if is-at-least 5.2; then
        _arguments_options=(-s -S -C)
    else
        _arguments_options=(-s -C)
    fi

    local context curcontext="$curcontext" state line
    _arguments "${_arguments_options[@]}" \
'--dir=[specify a directory]:DIR:_files -/:DIR:_files -/' \
'-h[Print help information]' \
'--help[Print help information]' \
'-V[Print version information]' \
'--version[Print version information]' \
&& ret=0
    
}
```
which completes (unspectacular first value)
```
kona% ./my_app --dir target/TAB
DIR:
debug/
```

it also completes (change! second value)
```
kona% ./my_app --dir target/ target/debug/TAB
DIR:
build/        deps/         examples/     incremental/
```

it also completes (no more directories, we got two of them, back to the main options)
```
kona% ./my_app --dir target/ target/debug/ TAB
option:
--help     -h  -- Print help information                                                              
--version  -V  -- Print version information                                                           
```
This is intended
 * Before my change there'd` be a `*` at the start of the line and in the last completion we'd get `--dir` offered again, although `multiple_occurrence` is not set.
 * My change replicates the `:DIR:_files -/` patterns. each group of two colons introduces another word that should follow the flag. so for two `:DIR: ` the first and second completions that i copy and pasted here ask me to provide a `DIR` before the completion falls back to suggesting options

## don't suggest other options when a value is needed

```
fn build_app_with_files_and_dirs() -> App<'static> {
    App::new("my_app")
        .about("testing zsh completions")
        .arg(   
            Arg::new("directory")
                .long("dir")
                .about("specify a directory")
                .takes_value(true)
        )
        .arg(
            Arg::new("user")
                .value_name("USER")
                .value_hint(ValueHint::Username),
        )
}

```
generates
```
_my_app() {
    typeset -A opt_args
    typeset -a _arguments_options
    local ret=1

    if is-at-least 5.2; then
        _arguments_options=(-s -S -C)
    else
        _arguments_options=(-s -C)
    fi

    local context curcontext="$curcontext" state line
    _arguments "${_arguments_options[@]}" \
'--dir=[specify a directory]: : ' \
'-h[Print help information]' \
'--help[Print help information]' \
'-V[Print version information]' \
'--version[Print version information]' \
'::user:_users' \
&& ret=0
    
}
```
My change introduces the trailing `: : `.

This means that in the following nothing gets suggested

```
kona% ./my_app --dir TAB
                          <- nothing
```

```
kona% ./my_app --dir src TAB
user:
_apt               geoclue            man                rtkit              systemd-timesync
avahi              gnats              messagebus         saned              tss

```
 * this is intended. Without my change, the completion to `./my_app --dir TAB` would jump to complete user names already
 * once the first word got provided, the completion for the positional argument kicks in.
 * (not shown: no value_hint, no value_name, with number_of_values(2), my completion trails `: : : : ` and behaves as intended.

PS: I should say my change introduces `: : ` where a single `:` would have been enough - the second is only needed to provide value completion. Similary for multple values `: : :` does the same job as `: : : : `. istm the trailing `: ` doesn't harm and keeps the code generation understandable

## value_name but no value_hint

```
fn build_app_with_files_and_dirs() -> App<'static> {
    App::new("my_app")
        .about("testing zsh completions")
        .arg(
            Arg::new("words")
                .long("two-words")
                .number_of_values(2)
                .value_name("WORD")
        )
}
```

generates

```
_my_app() {
    typeset -A opt_args
    typeset -a _arguments_options
    local ret=1

    if is-at-least 5.2; then
        _arguments_options=(-s -S -C)
    else
        _arguments_options=(-s -C)
    fi

    local context curcontext="$curcontext" state line
    _arguments "${_arguments_options[@]}" \
'--two-words=[]:WORD: :WORD: ' \
'-h[Print help information]' \
'--help[Print help information]' \
'-V[Print version information]' \
'--version[Print version information]' \
&& ret=0
    
}
```
completes
```
kona% ./my_app --two-words TAB
WORD:
      <- nothing
```
```
kona% ./my_app --two-words hello TAB
WORD:
      <- nothing
```
```
kona% ./my_app --two-words hello world TAB
option:
--help     -h  -- Print help information                                                              
--version  -V  -- Print version information                                                           
```
 * works as intended, wanted to add the combination with value_name and without value_hint, where we don't have these `: : : : ` combinations, but descriptions alternating with non-existant value completions.

## missing in this PR

I didn't attack positional arguments or multiple value_names as in
```
fn build_app_with_files_and_dirs() -> App<'static> {
    App::new("my_app")
        .about("testing zsh completions")
        .arg(
            Arg::new("words")
                .long("two-words")
                .number_of_values(2)
                .value_names(&["WORD1", "WORD2"])
        )
}
```
the help shows the different names
```
OPTIONS:
        --two-words <WORD1> <WORD2>    
```
but the completion function turns out
```
'--two-words=[]:WORD1: :WORD1: ' \
```
and asks for `WORD1` twice instead of `WORD2`
```
kona% ./my_app --two-words hello worlTAB
WORD1:
```