### PR TITLE
fix(ci): Restore serialization of site deployment

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -3,15 +3,14 @@ on:
   push:
     branches: [master]
     paths: ["site/**"]
+concurrency:
+  group: site
+  cancel-in-progress: true
 jobs:
   site:
     name: Deploy site
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous builds
-        uses: styfle/cancel-workflow-action@0.9.0
-        with:
-          access_token: ${{ github.token }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build


### PR DESCRIPTION
When removing `concurrency`, I overlooked this case where we want to
serialize deployments.

Queuing deployments also doesn't give us much.  I switched from using an
action for this to using built-in support.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
