### PR TITLE
chore: CI improvements

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Default features
         run: cargo check --all-targets
       - name: All features + Debug
-        run: cargo check --all-targets  --features "wrap_help yaml regex debug"
+        run: cargo check --all-targets --features "wrap_help yaml regex unstable-replace debug"
       - name: No features
         run: cargo check --all-targets --no-default-features --features "std cargo"
       - name: UI Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master, staging, trying]
+    branches: [staging, trying]
 jobs:
   ci:
     name: CI
@@ -109,7 +109,7 @@ jobs:
         if: matrix.features == 'release'
         with:
           command: test
-          args: --target ${{ matrix.target }} --features "wrap_help yaml regex" --release
+          args: --target ${{ matrix.target }} --features "wrap_help yaml regex unstable-replace" --release
   nightly:
     name: Nightly Tests
     strategy:
@@ -151,7 +151,7 @@ jobs:
         if: matrix.features == 'release'
         with:
           command: test
-          args: --features "wrap_help yaml regex" --release
+          args: --features "wrap_help yaml regex unstable-replace" --release
   wasm:
     name: Wasm Check
     runs-on: ubuntu-latest
@@ -172,4 +172,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --target ${{ matrix.target }} --features "yaml regex"
+          args: --target ${{ matrix.target }} --features "yaml regex unstable-replace"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: [master, staging, trying]
+    branches: [master]
 concurrency:
   group: coverage-${{ github.ref }}
   cancel-in-progress: true
@@ -31,7 +31,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: llvm-cov
-          args: --features "wrap_help yaml regex" --lcov --output-path lcov.info
+          args: --features "wrap_help yaml regex unstable-replace" --lcov --output-path lcov.info
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [master]
   push:
-    branches: [master, staging, trying]
+    branches: [staging, trying]
 concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
@@ -32,7 +32,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --features "wrap_help yaml regex" -- -D warnings
+          args: --features "wrap_help yaml regex unstable-replace" -- -D warnings
       - name: Format check
         uses: actions-rs/cargo@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Another really great way to help is if you find an interesting, or helpful way i
 To test with all features both enabled and disabled, you can run these commands:
 
 ```sh
-$ cargo test --features "wrap_help yaml regex"
+$ cargo test --features "wrap_help yaml regex unstable-replace"
 ```
 
 Alternatively, if you have [`just`](https://github.com/casey/just) installed you can run the prebuilt recipes. *Not* using `just` is perfectly fine as well, it simply bundles commands automatically.
@@ -39,7 +39,7 @@ During the CI process `clap` runs against many different lints using [`clippy`](
 In order to check the code for lints and to format it run either:
 
 ```sh
-$ cargo clippy --features "wrap_help yaml regex" -- -D warnings
+$ cargo clippy --features "wrap_help yaml regex unstable-replace" -- -D warnings
 $ cargo fmt -- --check
 
 # Or
@@ -64,8 +64,8 @@ $ just debug <test_name>
 ### Tests and Documentation
 
 1. Create tests for your changes
-2. **Ensure the tests are passing.** Run the tests (`cargo test --features "wrap_help yaml regex"`), alternatively `just run-tests` if you have `just` installed.
-3. **Optional** Run the lints (`cargo build --features lints`) (requires a nightly compiler), alternatively `just lint`
+2. **Ensure the tests are passing.** Run the tests as specified above.
+3. **Ensure linting is passing** Run the lints as specified above.
 4. Ensure your changes contain documentation if adding new APIs or features.
 
 ### Preparing the PR

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/d/clap?style=flat-square)](https://crates.io/crates/clap)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/clap-rs/clap/blob/master/LICENSE-MIT)
-[![Build Status](https://img.shields.io/github/workflow/status/clap-rs/clap/CI/master?style=flat-square)](https://github.com/clap-rs/clap/actions/workflows/ci.yml?query=branch%3Amaster)
+[![Build Status](https://img.shields.io/github/workflow/status/clap-rs/clap/CI/staging?style=flat-square)](https://github.com/clap-rs/clap/actions/workflows/ci.yml?query=branch%3Astaging)
 [![Coverage Status](https://img.shields.io/coveralls/github/clap-rs/clap/master?style=flat-square)](https://coveralls.io/github/clap-rs/clap?branch=master)
 [![Contributors](https://img.shields.io/github/contributors/clap-rs/clap?style=flat-square)](https://github.com/clap-rs/clap/graphs/contributors)
 
@@ -37,6 +37,7 @@ We are currently hard at work trying to release `3.0`. We have a `3.0.0-beta.4` 
    1. [Optional Dependencies / Features](#optional-dependencies--features)
       1. [Features enabled by default](#features-enabled-by-default)
       2. [Opt-in features](#opt-in-features)
+      3. [Experimental features](#experimental-features)
    2. [More Information](#more-information)
 7. [Sponsors](#sponsors)
 8. [Contributing](#contributing)
@@ -504,6 +505,8 @@ features = ["std", "suggestions", "color"]
 * **yaml**: Enables building CLIs from YAML documents. (builds dependency `yaml-rust`)
 
 #### Experimental features
+
+These features are opt-in. But be wary that they can contain breaking changes between minor releases.
 
 * **unstable-replace**: Enable [`App::replace`](https://github.com/clap-rs/clap/issues/2836)
 

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@ debug TESTG TEST="":
 	cargo test --test {{TESTG}} --features debug -- {{TEST}}
 
 run-tests:
-	cargo test --features "wrap_help yaml regex"
+	cargo test --features "wrap_help yaml regex unstable-replace"
 
 @bench:
 	cargo bench
@@ -13,7 +13,7 @@ run-tests:
 @lint:
 	rustup component add clippy
 	rustup component add rustfmt
-	cargo clippy --features "wrap_help yaml regex" -- -D warnings
+	cargo clippy --features "wrap_help yaml regex unstable-replace" -- -D warnings
 	cargo fmt -- --check
 
 clean:


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->

As you can see from the commits on master, the `CI` workflow gets run for both `staging` and `master` even though the master commit is just a fast-forward. IIRC bors recommends disabling CI on `master` (which is what we used to follow before too).

I have moved `Coverage` to only run on `master` though.
