### PR TITLE
fix(help): Show [OPTIONS] with help_heading

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -1023,10 +1023,10 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
                         self.write_args(&opts_flags)?;
                     }
                     "flags" => {
-                        self.write_args(&self.parser.app.get_flags_with_no_heading().collect::<Vec<_>>())?;
+                        self.write_args(&self.parser.app.get_flags().collect::<Vec<_>>())?;
                     }
                     "options" => {
-                        self.write_args(&self.parser.app.get_opts_with_no_heading().collect::<Vec<_>>())?;
+                        self.write_args(&self.parser.app.get_opts().collect::<Vec<_>>())?;
                     }
                     "positionals" => {
                         self.write_args(&self.parser.app.get_positionals().collect::<Vec<_>>())?;

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -72,7 +72,7 @@ impl<'help, 'app, 'parser> Usage<'help, 'app, 'parser> {
             && self
                 .p
                 .app
-                .get_opts_with_no_heading()
+                .get_opts()
                 .any(|o| !o.is_set(ArgSettings::Required) && !o.is_set(ArgSettings::Hidden))
         {
             usage.push_str(" [OPTIONS]");
@@ -93,7 +93,7 @@ impl<'help, 'app, 'parser> Usage<'help, 'app, 'parser> {
         if self
             .p
             .app
-            .get_opts_with_no_heading()
+            .get_opts()
             .any(|o| o.is_set(ArgSettings::MultipleValues))
             && self
                 .p
@@ -331,7 +331,7 @@ impl<'help, 'app, 'parser> Usage<'help, 'app, 'parser> {
     // Determines if we need the `[FLAGS]` tag in the usage string
     fn needs_flags_tag(&self) -> bool {
         debug!("Usage::needs_flags_tag");
-        'outer: for f in self.p.app.get_flags_with_no_heading() {
+        'outer: for f in self.p.app.get_flags() {
             debug!("Usage::needs_flags_tag:iter: f={}", f.name);
 
             // Don't print `[FLAGS]` just for help or version

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -585,7 +585,7 @@ Will M.
 does stuff
 
 USAGE:
-    test --fake <some>:<val>
+    test [FLAGS] --fake <some>:<val>
 
 FLAGS:
     -h, --help       Print help information
@@ -1804,7 +1804,7 @@ Will M.
 does stuff
 
 USAGE:
-    test [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
+    test [FLAGS] [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
 
 FLAGS:
     -h, --help       Print help information
@@ -1887,7 +1887,7 @@ Will M.
 does stuff
 
 USAGE:
-    test --song <song> --song-volume <volume>
+    test [FLAGS] --song <song> --song-volume <volume>
 
 FLAGS:
     -h, --help       Print help information
@@ -2307,7 +2307,7 @@ FLAGS:
 static ONLY_CUSTOM_HEADING_FLAGS: &str = "test 1.4
 
 USAGE:
-    test [OPTIONS]
+    test [FLAGS] [OPTIONS]
 
 OPTIONS:
         --speed <speed>    How fast
@@ -2342,7 +2342,7 @@ fn only_custom_heading_flags() {
 static ONLY_CUSTOM_HEADING_OPTS: &str = "test 1.4
 
 USAGE:
-    test
+    test [OPTIONS]
 
 FLAGS:
     -h, --help       Print help information
@@ -2430,7 +2430,7 @@ fn only_custom_heading_pos() {
 static ONLY_CUSTOM_HEADING_FLAGS_NO_ARGS: &str = "test 1.4
 
 USAGE:
-    test
+    test [FLAGS]
 
 NETWORKING:
         --flag    Some flag
@@ -2456,7 +2456,7 @@ fn only_custom_heading_flags_no_args() {
 static ONLY_CUSTOM_HEADING_OPTS_NO_ARGS: &str = "test 1.4
 
 USAGE:
-    test
+    test [OPTIONS]
 
 NETWORKING:
     -s, --speed <SPEED>    How fast


### PR DESCRIPTION
This was changed in #1989 without an explanation:
- In the help template, there isn't a way to expose with help_headings,
  so show all.
- In usage, we don't know whether the user wants to see `[FLAGS]` /
  `[OPTIONS]` or not, so let's default to showing them.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
