### PR TITLE
fix: Don't expose specialzied functions

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -224,18 +224,18 @@ impl<'help> App<'help> {
     }
 
     /// Iterate through the *positionals* that don't have custom heading.
-    pub fn get_positionals_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
+    pub(crate) fn get_positionals_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
         self.get_positionals()
             .filter(|a| a.get_help_heading().is_none())
     }
 
     /// Iterate through the *flags* that don't have custom heading.
-    pub fn get_flags_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
+    pub(crate) fn get_flags_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
         self.get_flags().filter(|a| a.get_help_heading().is_none())
     }
 
     /// Iterate through the *options* that don't have custom heading.
-    pub fn get_opts_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
+    pub(crate) fn get_opts_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
         self.get_opts().filter(|a| a.get_help_heading().is_none())
     }
 


### PR DESCRIPTION
We addedd these functions in clap3.  They seemed fairly specialized to
expose publicly, so moving these to be prviate.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
