### PR TITLE
Partial Revert of "Change MissingArgumentOrSubcommand to DisplayHelpO…

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -491,9 +491,7 @@ impl Error {
     pub fn use_stderr(&self) -> bool {
         !matches!(
             self.kind,
-            ErrorKind::DisplayHelp
-                | ErrorKind::DisplayVersion
-                | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
         )
     }
 

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -260,6 +260,7 @@ fn arg_required_else_help() {
         .setting(AppSettings::ArgRequiredElseHelp)
         .arg(Arg::new("test").index(1))
         .try_get_matches_from(vec![""]);
+
     assert!(result.is_err());
     let err = result.err().unwrap();
     assert_eq!(
@@ -274,6 +275,7 @@ fn arg_required_else_help_over_reqs() {
         .setting(AppSettings::ArgRequiredElseHelp)
         .arg(Arg::new("test").index(1).required(true))
         .try_get_matches_from(vec![""]);
+
     assert!(result.is_err());
     let err = result.err().unwrap();
     assert_eq!(
@@ -297,7 +299,7 @@ fn arg_required_else_help_error_message() {
         app,
         "test",
         ARG_REQUIRED_ELSE_HELP,
-        false
+        true // Unlike normal displaying of help, we should provide a fatal exit code
     ));
 }
 
@@ -307,6 +309,7 @@ fn subcommand_required_else_help() {
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(App::new("info"))
         .try_get_matches_from(&[""]);
+
     assert!(result.is_err());
     let err = result.err().unwrap();
     assert_eq!(
@@ -325,7 +328,7 @@ fn subcommand_required_else_help_error_message() {
         app,
         "test",
         SUBCOMMAND_REQUIRED_ELSE_HELP,
-        false
+        true // Unlike normal displaying of help, we should provide a fatal exit code
     ));
 }
 


### PR DESCRIPTION
…nMissingArgumentOrSubcommand and don't use stderr"

This partially reverts commit 7f627fc.

This reverts the error code change but not the `ErrorKind` change.  I
was mixed on whether we should do that or not.  The benefit is it makes
it so people can check the Kind for cases like #2021.  On the other
hand, it doesn't seem that hard to re-implement the feature.

Fixes #2767

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
