### PR TITLE
fix(help)!: Merge OPTIONS / FLAGS default groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,15 +385,13 @@ ARGS:
     INPUT    The input file to use
 
 USAGE:
-    MyApp [FLAGS] [OPTIONS] <INPUT> [SUBCOMMAND]
-
-FLAGS:
-    -h, --help       Print help information
-    -v               Sets the level of verbosity
-    -V, --version    Print version information
+    MyApp [OPTIONS] <INPUT> [SUBCOMMAND]
 
 OPTIONS:
     -c, --config <FILE>    Sets a custom config file
+    -h, --help             Print help information
+    -v                     Sets the level of verbosity
+    -V, --version          Print version information
 
 SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)

--- a/benches/04_new_help.rs
+++ b/benches/04_new_help.rs
@@ -196,7 +196,7 @@ pub fn example10(c: &mut Criterion) {
 }
 
 pub fn example4_template(c: &mut Criterion) {
-    let mut app = app_example4().help_template("{bin} {version}\n{author}\n{about}\n\nUSAGE:\n    {usage}\n\nFLAGS:\n{flags}\n\nARGS:\n{args}\n");
+    let mut app = app_example4().help_template("{bin} {version}\n{author}\n{about}\n\nUSAGE:\n    {usage}\n\nOPTIONS:\n{options}\n\nARGS:\n{args}\n");
     c.bench_function("example4_template", |b| b.iter(|| build_help(&mut app)));
 }
 

--- a/benches/05_ripgrep.rs
+++ b/benches/05_ripgrep.rs
@@ -3,7 +3,7 @@
 //
 // CLI used is adapted from ripgrep 48a8a3a691220f9e5b2b08f4051abe8655ea7e8a
 
-use clap::{App, AppSettings, Arg, ArgSettings};
+use clap::{App, Arg, ArgSettings};
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -267,7 +267,7 @@ ARGS:
 {positionals}
 
 OPTIONS:
-{unified}";
+{options}";
 
 /// Build a clap application with short help strings.
 fn app_short() -> App<'static> {
@@ -306,7 +306,6 @@ where
         .version("0.4.0") // Simulating
         .about(ABOUT)
         .max_term_width(100)
-        .setting(AppSettings::UnifiedHelpMessage)
         .override_usage(USAGE)
         .help_template(TEMPLATE)
         // Handle help/version manually to make their output formatting

--- a/clap_derive/README.md
+++ b/clap_derive/README.md
@@ -82,22 +82,20 @@ Guillaume Pinot <texitoi@texitoi.eu>, others
 A basic example
 
 USAGE:
-    basic [FLAGS] [OPTIONS] --output <output> [--] [file]...
+    basic [OPTIONS] --output <output> [--] [file]...
 
 ARGS:
     <FILE>...    Files to process
 
-FLAGS:
-    -d, --debug      Activate debug mode
-    -h, --help       Print help information
-    -V, --version    Print version information
-    -v, --verbose    Verbose mode (-v, -vv, -vvv, etc.)
-
 OPTIONS:
-    -l, --level <level>...     admin_level to consider
     -c, --nb-cars <nb-cars>    Number of cars
+    -d, --debug                Activate debug mode
+    -h, --help                 Print help information
+    -l, --level <level>...     admin_level to consider
     -o, --output <output>      Output file
     -s, --speed <speed>        Set speed [default: 42]
+    -V, --version              Print version information
+    -v, --verbose              Verbose mode (-v, -vv, -vvv, etc.)
 
 ARGS:
     <file>...    Files to process

--- a/clap_derive/tests/non_literal_attributes.rs
+++ b/clap_derive/tests/non_literal_attributes.rs
@@ -19,7 +19,7 @@ pub const DISPLAY_ORDER: usize = 2;
 
 // Check if the global settings compile
 #[derive(Parser, Debug, PartialEq, Eq)]
-#[clap(global_setting = AppSettings::UnifiedHelpMessage)]
+#[clap(global_setting = AppSettings::AllowLeadingHyphen)]
 struct Opt {
     #[clap(
         long = "x",

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -50,11 +50,9 @@ Simple program to greet a person
 USAGE:
     hello [OPTIONS] --name <name>
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -c, --count <count>    Number of times to greet [default: 1]
+    -h, --help             Print help information
     -n, --name <name>      Name of the person to greet
+    -V, --version          Print version information
 ```

--- a/src/build/app/debug_asserts.rs
+++ b/src/build/app/debug_asserts.rs
@@ -283,6 +283,19 @@ pub(crate) fn assert_app(app: &App) {
     detect_duplicate_flags(&long_flags, "long");
     detect_duplicate_flags(&short_flags, "short");
 
+    if let Some(help_template) = app.template {
+        assert!(
+            !help_template.contains("{flags}"),
+            "{}",
+            "`{flags}` template variable was removed in clap3, they are now included in `{options}`"
+        );
+        assert!(
+            !help_template.contains("{unified}"),
+            "{}",
+            "`{unified}` template variable was removed in clap3, use `{options}` instead"
+        );
+    }
+
     app._panic_on_missing_help(app.g_settings.is_set(AppSettings::HelpRequired));
     assert_app_flags(app);
 }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -206,7 +206,7 @@ impl<'help> App<'help> {
         self.args.args()
     }
 
-    /// Iterate through the *positionals*.
+    /// Iterate through the *positionals* arguments.
     #[inline]
     pub fn get_positionals(&self) -> impl Iterator<Item = &Arg<'help>> {
         self.get_arguments().filter(|a| a.is_positional())
@@ -222,22 +222,6 @@ impl<'help> App<'help> {
     pub fn get_opts(&self) -> impl Iterator<Item = &Arg<'help>> {
         self.get_arguments()
             .filter(|a| a.is_set(ArgSettings::TakesValue) && a.get_index().is_none())
-    }
-
-    /// Iterate through the *positionals* that don't have custom heading.
-    pub fn get_positionals_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
-        self.get_positionals()
-            .filter(|a| a.get_help_heading().is_none())
-    }
-
-    /// Iterate through the *flags* that don't have custom heading.
-    pub fn get_flags_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
-        self.get_flags().filter(|a| a.get_help_heading().is_none())
-    }
-
-    /// Iterate through the *options* that don't have custom heading.
-    pub fn get_opts_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
-        self.get_opts().filter(|a| a.get_help_heading().is_none())
     }
 
     // Get a list of subcommands which contain the provided Argument
@@ -863,10 +847,6 @@ impl<'help> App<'help> {
     ///   * `{usage}`               - Automatically generated or given usage string.
     ///   * `{all-args}`            - Help for all arguments (options, flags, positional
     ///                               arguments, and subcommands) including titles.
-    ///   * `{unified}`             - Unified help for options and flags. Note, you must *also*
-    ///                               set [`AppSettings::UnifiedHelpMessage`] to fully merge both
-    ///                               options and flags, otherwise the ordering is "best effort".
-    ///   * `{flags}`               - Help for flags.
     ///   * `{options}`             - Help for options.
     ///   * `{positionals}`         - Help for positional arguments.
     ///   * `{subcommands}`         - Help for subcommands.
@@ -986,7 +966,7 @@ impl<'help> App<'help> {
     /// ```no_run
     /// # use clap::{App, AppSettings};
     /// App::new("myprog")
-    ///     .unset_global_setting(AppSettings::UnifiedHelpMessage)
+    ///     .unset_global_setting(AppSettings::AllowNegativeNumbers)
     /// # ;
     /// ```
     /// [global]: App::global_setting()
@@ -1116,7 +1096,7 @@ impl<'help> App<'help> {
     /// header for the specified argument type) until a subsequent call to
     /// [`App::help_heading`] or [`App::stop_custom_headings`].
     ///
-    /// This is useful if the default `FLAGS`, `OPTIONS`, or `ARGS` headings are
+    /// This is useful if the default `OPTIONS` or `ARGS` headings are
     /// not specific enough for one's use case.
     ///
     /// [`App::arg`]: App::arg()
@@ -1732,9 +1712,9 @@ impl<'help> App<'help> {
     /// cust-ord
     ///
     /// USAGE:
-    ///     cust-ord [FLAGS] [OPTIONS]
+    ///     cust-ord [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     ///     -h, --help       Print help information
     ///     -V, --version    Print version information
     ///
@@ -2200,7 +2180,7 @@ impl<'help> App<'help> {
     /// USAGE:
     ///     myprog [SUBCOMMAND]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     ///     -h, --help       Print help information
     ///     -V, --version    Print version information
     ///
@@ -2228,7 +2208,7 @@ impl<'help> App<'help> {
     /// USAGE:
     ///     myprog [THING]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     ///     -h, --help       Print help information
     ///     -V, --version    Print version information
     ///
@@ -2674,6 +2654,23 @@ impl<'a, T> Captures<'a> for T {}
 
 // Internal Query Methods
 impl<'help> App<'help> {
+    /// Iterate through the *named* arguments.
+    pub(crate) fn get_non_positional(&self) -> impl Iterator<Item = &Arg<'help>> {
+        self.get_arguments().filter(|a| !a.is_positional())
+    }
+
+    /// Iterate through the *positionals* that don't have custom heading.
+    pub(crate) fn get_positionals_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
+        self.get_positionals()
+            .filter(|a| a.get_help_heading().is_none())
+    }
+
+    /// Iterate through the *named* that don't have custom heading.
+    pub(crate) fn get_non_positional_with_no_heading(&self) -> impl Iterator<Item = &Arg<'help>> {
+        self.get_non_positional()
+            .filter(|a| a.get_help_heading().is_none())
+    }
+
     pub(crate) fn find(&self, arg_id: &Id) -> Option<&Arg<'help>> {
         self.args.args().find(|a| a.id == *arg_id)
     }

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -11,7 +11,6 @@ bitflags! {
         const ARG_REQUIRED_ELSE_HELP         = 1 << 2;
         const PROPAGATE_VERSION              = 1 << 3;
         const DISABLE_VERSION_FOR_SC         = 1 << 4;
-        const UNIFIED_HELP                   = 1 << 5;
         const WAIT_ON_ERROR                  = 1 << 6;
         const SC_REQUIRED_ELSE_HELP          = 1 << 7;
         const NO_AUTO_HELP                   = 1 << 8;
@@ -112,8 +111,6 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::USE_LONG_FORMAT_FOR_HELP_SC,
     TrailingVarArg("trailingvararg")
         => Flags::TRAILING_VARARG,
-    UnifiedHelpMessage("unifiedhelpmessage")
-        => Flags::UNIFIED_HELP,
     NextLineHelp("nextlinehelp")
         => Flags::NEXT_LINE_HELP,
     IgnoreErrors("ignoreerrors")
@@ -892,25 +889,6 @@ pub enum AppSettings {
     /// [`Arg::multiple_values(true)`]: crate::Arg::multiple_values()
     TrailingVarArg,
 
-    /// Groups flags and options together, presenting a more unified help message
-    /// (a la `getopts` or `docopt` style).
-    ///
-    /// The default is that the auto-generated help message will group flags, and options
-    /// separately.
-    ///
-    /// **NOTE:** This setting is cosmetic only and does not affect any functionality.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .setting(AppSettings::UnifiedHelpMessage)
-    ///     .get_matches();
-    /// // running `myprog --help` will display a unified "docopt" or "getopts" style help message
-    /// ```
-    UnifiedHelpMessage,
-
     /// Will display a message "Press \[ENTER\]/\[RETURN\] to continue..." and wait for user before
     /// exiting
     ///
@@ -1085,10 +1063,6 @@ mod test {
         assert_eq!(
             "trailingvararg".parse::<AppSettings>().unwrap(),
             AppSettings::TrailingVarArg
-        );
-        assert_eq!(
-            "unifiedhelpmessage".parse::<AppSettings>().unwrap(),
-            AppSettings::UnifiedHelpMessage
         );
         assert_eq!(
             "waitonerror".parse::<AppSettings>().unwrap(),

--- a/src/build/app/tests.rs
+++ b/src/build/app/tests.rs
@@ -13,7 +13,7 @@ fn propagate_version() {
 #[test]
 fn global_setting() {
     let mut app = App::new("test")
-        .global_setting(AppSettings::UnifiedHelpMessage)
+        .global_setting(AppSettings::AllowLeadingHyphen)
         .subcommand(App::new("subcmd"));
     app._propagate();
     assert!(app
@@ -21,13 +21,13 @@ fn global_setting() {
         .iter()
         .find(|s| s.name == "subcmd")
         .unwrap()
-        .is_set(AppSettings::UnifiedHelpMessage));
+        .is_set(AppSettings::AllowLeadingHyphen));
 }
 
 #[test]
 fn global_settings() {
     let mut app = App::new("test")
-        .global_setting(AppSettings::UnifiedHelpMessage)
+        .global_setting(AppSettings::AllowLeadingHyphen)
         .global_setting(AppSettings::TrailingVarArg)
         .subcommand(App::new("subcmd"));
     app._propagate();
@@ -36,7 +36,7 @@ fn global_settings() {
         .iter()
         .find(|s| s.name == "subcmd")
         .unwrap()
-        .is_set(AppSettings::UnifiedHelpMessage));
+        .is_set(AppSettings::AllowLeadingHyphen));
     assert!(app
         .subcommands
         .iter()

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -659,9 +659,9 @@ impl<'help> Arg<'help> {
     /// helptest
     ///
     /// USAGE:
-    ///    helptest [FLAGS]
+    ///    helptest [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     ///     --config     Some help text describing the --config arg
     /// -h, --help       Print help information
     /// -V, --version    Print version information
@@ -723,9 +723,9 @@ impl<'help> Arg<'help> {
     /// prog
     ///
     /// USAGE:
-    ///     prog [FLAGS]
+    ///     prog [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     ///         --config
     ///             The config file used by the myprog must be in JSON format
     ///             with only valid keys and may not contain other nonsense
@@ -2575,14 +2575,12 @@ impl<'help> Arg<'help> {
     /// valnames
     ///
     /// USAGE:
-    ///    valnames [FLAGS] [OPTIONS]
-    ///
-    /// FLAGS:
-    ///     -h, --help       Print help information
-    ///     -V, --version    Print version information
+    ///    valnames [OPTIONS]
     ///
     /// OPTIONS:
+    ///     -h, --help                       Print help information
     ///     --io-files <INFILE> <OUTFILE>    Some help text
+    ///     -V, --version                    Print version information
     /// ```
     /// [`Arg::next_line_help(true)`]: Arg::next_line_help()
     /// [`Arg::number_of_values`]: Arg::number_of_values()
@@ -2628,14 +2626,12 @@ impl<'help> Arg<'help> {
     /// valnames
     ///
     /// USAGE:
-    ///    valnames [FLAGS] [OPTIONS]
-    ///
-    /// FLAGS:
-    ///     -h, --help       Print help information
-    ///     -V, --version    Print version information
+    ///    valnames [OPTIONS]
     ///
     /// OPTIONS:
     ///     --config <FILE>     Some help text
+    ///     -h, --help          Print help information
+    ///     -V, --version       Print version information
     /// ```
     /// [option]: Arg::takes_value()
     /// [positional]: Arg::index()
@@ -3293,13 +3289,11 @@ impl<'help> Arg<'help> {
     /// cust-ord
     ///
     /// USAGE:
-    ///     cust-ord [FLAGS] [OPTIONS]
-    ///
-    /// FLAGS:
-    ///     -h, --help       Print help information
-    ///     -V, --version    Print version information
+    ///     cust-ord [OPTIONS]
     ///
     /// OPTIONS:
+    ///     -h, --help                Print help information
+    ///     -V, --version             Print version information
     ///     -O, --other-option <b>    I should be first!
     ///     -o, --long-option <a>     Some help and text
     /// ```
@@ -3318,14 +3312,13 @@ impl<'help> Arg<'help> {
     /// allows one to access this arg early using the `--` syntax. Accessing an arg early, even with
     /// the `--` syntax is otherwise not possible.
     ///
-    /// **NOTE:** This will change the usage string to look like `$ prog [FLAGS] [-- <ARG>]` if
+    /// **NOTE:** This will change the usage string to look like `$ prog [OPTIONS] [-- <ARG>]` if
     /// `ARG` is marked as `.last(true)`.
     ///
     /// **NOTE:** This setting will imply [`crate::AppSettings::DontCollapseArgsInUsage`] because failing
     /// to set this can make the usage string very confusing.
     ///
-    /// **NOTE**: This setting only applies to positional arguments, and has no affect on FLAGS /
-    /// OPTIONS
+    /// **NOTE**: This setting only applies to positional arguments, and has no affect on OPTIONS
     ///
     /// **NOTE:** Setting this requires [`crate::ArgSettings::TakesValue`]
     ///
@@ -3873,9 +3866,9 @@ impl<'help> Arg<'help> {
     /// helptest
     ///
     /// USAGE:
-    ///    helptest [FLAGS]
+    ///    helptest [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     /// -h, --help       Print help information
     /// -V, --version    Print version information
     /// ```
@@ -4114,13 +4107,11 @@ impl<'help> Arg<'help> {
     /// nlh
     ///
     /// USAGE:
-    ///     nlh [FLAGS] [OPTIONS]
-    ///
-    /// FLAGS:
-    ///     -h, --help       Print help information
-    ///     -V, --version    Print version information
+    ///     nlh [OPTIONS]
     ///
     /// OPTIONS:
+    ///     -h, --help       Print help information
+    ///     -V, --version    Print version information
     ///     -o, --long-option-flag <value1> <value2>
     ///         Some really long help and complex
     ///         help that makes more sense to be
@@ -4499,9 +4490,9 @@ impl<'help> Arg<'help> {
     /// helptest
     ///
     /// USAGE:
-    ///    helptest [FLAGS]
+    ///    helptest [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     /// -h, --help       Print help information
     /// -V, --version    Print version information
     /// ```
@@ -4526,9 +4517,9 @@ impl<'help> Arg<'help> {
     /// helptest
     ///
     /// USAGE:
-    ///    helptest [FLAGS]
+    ///    helptest [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     ///     --config     Some help text describing the --config arg
     /// -h, --help       Print help information
     /// -V, --version    Print version information
@@ -4577,9 +4568,9 @@ impl<'help> Arg<'help> {
     /// helptest
     ///
     /// USAGE:
-    ///    helptest [FLAGS]
+    ///    helptest [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     /// -h, --help       Print help information
     /// -V, --version    Print version information
     /// ```
@@ -4604,9 +4595,9 @@ impl<'help> Arg<'help> {
     /// helptest
     ///
     /// USAGE:
-    ///    helptest [FLAGS]
+    ///    helptest [OPTIONS]
     ///
-    /// FLAGS:
+    /// OPTIONS:
     ///     --config     Some help text describing the --config arg
     /// -h, --help       Print help information
     /// -V, --version    Print version information

--- a/tests/app_from_crate.rs
+++ b/tests/app_from_crate.rs
@@ -9,7 +9,7 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 USAGE:
     clap
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -7,7 +7,7 @@ static ALLOW_EXT_SC: &str = "clap-test v1.4.8
 USAGE:
     clap-test [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -22,7 +22,7 @@ ARGS:
     <arg2>    some
     <arg3>    some
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -32,31 +32,10 @@ static REQUIRE_EQUALS: &str = "clap-test v1.4.8
 USAGE:
     clap-test --opt=<FILE>
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -h, --help          Print help information
     -o, --opt=<FILE>    some
-";
-
-static UNIFIED_HELP: &str = "test 1.3
-
-Kevin K.
-
-tests stuff
-
-USAGE:
-    test [OPTIONS] [arg1]
-
-ARGS:
-    <arg1>    some pos arg
-
-OPTIONS:
-    -f, --flag            some flag
-    -h, --help            Print help information
-        --option <opt>    some option
-    -V, --version         Print version information
+    -V, --version       Print version information
 ";
 
 static SKIP_POS_VALS: &str = "test 1.3
@@ -71,20 +50,18 @@ USAGE:
 ARGS:
     <arg1>    some pos arg
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -h, --help         Print help information
     -o, --opt <opt>    some option
+    -V, --version      Print version information
 ";
 
 static ARG_REQUIRED_ELSE_HELP: &str = "test 1.0
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -i, --info       Provides more info
     -V, --version    Print version information
@@ -95,7 +72,7 @@ static SUBCOMMAND_REQUIRED_ELSE_HELP: &str = "test 1.0
 USAGE:
     test <SUBCOMMAND>
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -113,7 +90,7 @@ ARGS:
     <foo>
             long form about message
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 ";
@@ -125,7 +102,7 @@ long form about message
 USAGE:
     myprog test nested
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 ";
@@ -139,7 +116,7 @@ ARGS:
     <foo>
             long form about message
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 
@@ -443,26 +420,6 @@ fn no_bin_name() {
     assert!(result.is_ok());
     let matches = result.unwrap();
     assert_eq!(matches.value_of("test").unwrap(), "testing");
-}
-
-#[test]
-fn unified_help() {
-    let app = App::new("myTest")
-        .name("test")
-        .author("Kevin K.")
-        .about("tests stuff")
-        .version("1.3")
-        .setting(AppSettings::UnifiedHelpMessage)
-        .arg("-f, --flag 'some flag'")
-        .arg("[arg1] 'some pos arg'")
-        .arg("--option [opt] 'some option'");
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        UNIFIED_HELP,
-        false
-    ));
 }
 
 #[test]

--- a/tests/arg_aliases.rs
+++ b/tests/arg_aliases.rs
@@ -7,15 +7,13 @@ static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
 USAGE:
-    ct test [FLAGS] [OPTIONS]
-
-FLAGS:
-    -f, --flag       [aliases: v_flg, flag2, flg3]
-    -h, --help       Print help information
-    -V, --version    Print version information
+    ct test [OPTIONS]
 
 OPTIONS:
+    -f, --flag         [aliases: v_flg, flag2, flg3]
+    -h, --help         Print help information
     -o, --opt <opt>    [aliases: visible]
+    -V, --version      Print version information
 ";
 
 static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
@@ -23,15 +21,13 @@ static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
 USAGE:
-    ct test [FLAGS] [OPTIONS]
-
-FLAGS:
-    -f, --flag       
-    -h, --help       Print help information
-    -V, --version    Print version information
+    ct test [OPTIONS]
 
 OPTIONS:
+    -f, --flag         
+    -h, --help         Print help information
     -o, --opt <opt>    
+    -V, --version      Print version information
 ";
 
 #[test]

--- a/tests/arg_aliases_short.rs
+++ b/tests/arg_aliases_short.rs
@@ -7,15 +7,13 @@ static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
 USAGE:
-    ct test [FLAGS] [OPTIONS]
-
-FLAGS:
-    -f, --flag       [aliases: flag1] [short aliases: a, b, 🦆]
-    -h, --help       Print help information
-    -V, --version    Print version information
+    ct test [OPTIONS]
 
 OPTIONS:
+    -f, --flag         [aliases: flag1] [short aliases: a, b, 🦆]
+    -h, --help         Print help information
     -o, --opt <opt>    [short aliases: v]
+    -V, --version      Print version information
 ";
 
 static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
@@ -23,15 +21,13 @@ static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
 USAGE:
-    ct test [FLAGS] [OPTIONS]
-
-FLAGS:
-    -f, --flag       
-    -h, --help       Print help information
-    -V, --version    Print version information
+    ct test [OPTIONS]
 
 OPTIONS:
+    -f, --flag         
+    -h, --help         Print help information
     -o, --opt <opt>    
+    -V, --version      Print version information
 ";
 
 #[test]

--- a/tests/cargo.rs
+++ b/tests/cargo.rs
@@ -7,7 +7,7 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 USAGE:
     prog
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -19,7 +19,7 @@ Kevin K. <kbknapp@gmail.com>:Clap Maintainers
 USAGE:
     prog
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";

--- a/tests/derive_order.rs
+++ b/tests/derive_order.rs
@@ -7,38 +7,6 @@ use clap::{App, AppSettings, Arg};
 static NO_DERIVE_ORDER: &str = "test 1.2
 
 USAGE:
-    test [FLAGS] [OPTIONS]
-
-FLAGS:
-        --flag_a     second flag
-        --flag_b     first flag
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-OPTIONS:
-        --option_a <option_a>    second option
-        --option_b <option_b>    first option
-";
-
-static DERIVE_ORDER: &str = "test 1.2
-
-USAGE:
-    test [FLAGS] [OPTIONS]
-
-FLAGS:
-        --flag_b     first flag
-        --flag_a     second flag
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-OPTIONS:
-        --option_b <option_b>    first option
-        --option_a <option_a>    second option
-";
-
-static UNIFIED_HELP: &str = "test 1.2
-
-USAGE:
     test [OPTIONS]
 
 OPTIONS:
@@ -61,36 +29,6 @@ OPTIONS:
         --flag_a                 second flag
         --option_a <option_a>    second option
     -h, --help                   Print help information
-    -V, --version                Print version information
-";
-
-static DERIVE_ORDER_SC_PROP: &str = "test-sub 1.2
-
-USAGE:
-    test sub [FLAGS] [OPTIONS]
-
-FLAGS:
-        --flag_b     first flag
-        --flag_a     second flag
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-OPTIONS:
-        --option_b <option_b>    first option
-        --option_a <option_a>    second option
-";
-
-static UNIFIED_SC_PROP: &str = "test-sub 1.2
-
-USAGE:
-    test sub [OPTIONS]
-
-OPTIONS:
-        --flag_a                 second flag
-        --flag_b                 first flag
-    -h, --help                   Print help information
-        --option_a <option_a>    second option
-        --option_b <option_b>    first option
     -V, --version                Print version information
 ";
 
@@ -125,9 +63,9 @@ OPTIONS:
 static PREFER_USER_HELP_DERIVE_ORDER: &str = "test 1.2
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help message
         --flag_b     first flag
         --flag_a     second flag
@@ -137,9 +75,9 @@ FLAGS:
 static PREFER_USER_HELP_SUBCMD_DERIVE_ORDER: &str = "test-sub 1.2
 
 USAGE:
-    test sub [FLAGS]
+    test sub [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help message
         --flag_b     first flag
         --flag_a     second flag
@@ -190,59 +128,6 @@ fn derive_order() {
     assert!(utils::compare_output(
         app,
         "test --help",
-        DERIVE_ORDER,
-        false
-    ));
-}
-
-#[test]
-fn unified_help() {
-    let app = App::new("test")
-        .setting(AppSettings::UnifiedHelpMessage)
-        .version("1.2")
-        .args(&[
-            Arg::new("flag_b").long("flag_b").about("first flag"),
-            Arg::new("option_b")
-                .long("option_b")
-                .takes_value(true)
-                .about("first option"),
-            Arg::new("flag_a").long("flag_a").about("second flag"),
-            Arg::new("option_a")
-                .long("option_a")
-                .takes_value(true)
-                .about("second option"),
-        ]);
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        UNIFIED_HELP,
-        false
-    ));
-}
-
-#[test]
-fn unified_help_and_derive_order() {
-    let app = App::new("test")
-        .setting(AppSettings::DeriveDisplayOrder)
-        .setting(AppSettings::UnifiedHelpMessage)
-        .version("1.2")
-        .args(&[
-            Arg::new("flag_b").long("flag_b").about("first flag"),
-            Arg::new("option_b")
-                .long("option_b")
-                .takes_value(true)
-                .about("first option"),
-            Arg::new("flag_a").long("flag_a").about("second flag"),
-            Arg::new("option_a")
-                .long("option_a")
-                .takes_value(true)
-                .about("second option"),
-        ]);
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
         UNIFIED_HELP_AND_DERIVE,
         false
     ));
@@ -252,62 +137,6 @@ fn unified_help_and_derive_order() {
 fn derive_order_subcommand_propagate() {
     let app = App::new("test")
         .global_setting(AppSettings::DeriveDisplayOrder)
-        .version("1.2")
-        .subcommand(
-            App::new("sub").version("1.2").args(&[
-                Arg::new("flag_b").long("flag_b").about("first flag"),
-                Arg::new("option_b")
-                    .long("option_b")
-                    .takes_value(true)
-                    .about("first option"),
-                Arg::new("flag_a").long("flag_a").about("second flag"),
-                Arg::new("option_a")
-                    .long("option_a")
-                    .takes_value(true)
-                    .about("second option"),
-            ]),
-        );
-
-    assert!(utils::compare_output(
-        app,
-        "test sub --help",
-        DERIVE_ORDER_SC_PROP,
-        false
-    ));
-}
-
-#[test]
-fn unified_help_subcommand_propagate() {
-    let app = App::new("test")
-        .global_setting(AppSettings::UnifiedHelpMessage)
-        .subcommand(
-            App::new("sub").version("1.2").args(&[
-                Arg::new("flag_b").long("flag_b").about("first flag"),
-                Arg::new("option_b")
-                    .long("option_b")
-                    .takes_value(true)
-                    .about("first option"),
-                Arg::new("flag_a").long("flag_a").about("second flag"),
-                Arg::new("option_a")
-                    .long("option_a")
-                    .takes_value(true)
-                    .about("second option"),
-            ]),
-        );
-
-    assert!(utils::compare_output(
-        app,
-        "test sub --help",
-        UNIFIED_SC_PROP,
-        false
-    ));
-}
-
-#[test]
-fn unified_help_and_derive_order_subcommand_propagate() {
-    let app = App::new("test")
-        .global_setting(AppSettings::DeriveDisplayOrder)
-        .global_setting(AppSettings::UnifiedHelpMessage)
         .subcommand(
             App::new("sub").version("1.2").args(&[
                 Arg::new("flag_b").long("flag_b").about("first flag"),
@@ -332,10 +161,9 @@ fn unified_help_and_derive_order_subcommand_propagate() {
 }
 
 #[test]
-fn unified_help_and_derive_order_subcommand_propagate_with_explicit_display_order() {
+fn derive_order_subcommand_propagate_with_explicit_display_order() {
     let app = App::new("test")
         .global_setting(AppSettings::DeriveDisplayOrder)
-        .global_setting(AppSettings::UnifiedHelpMessage)
         .subcommand(
             App::new("sub").version("1.2").args(&[
                 Arg::new("flag_b").long("flag_b").about("first flag"),

--- a/tests/display_order.rs
+++ b/tests/display_order.rs
@@ -14,7 +14,7 @@ fn very_large_display_order() {
 USAGE:
     test [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -h, --help    Print help information
 
 SUBCOMMANDS:

--- a/tests/double_require.rs
+++ b/tests/double_require.rs
@@ -3,9 +3,9 @@ use clap::{App, Arg, ErrorKind};
 static HELP: &str = "prog 
 
 USAGE:
-    prog [FLAGS]
+    prog [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -a            
     -b            
     -c            
@@ -16,7 +16,7 @@ static ONLY_B_ERROR: &str = "error: The following required arguments were not pr
     -c
 
 USAGE:
-    prog [FLAGS] -c -b
+    prog [OPTIONS] -c -b
 
 For more information try --help
 ";
@@ -25,7 +25,7 @@ static ONLY_C_ERROR: &str = "error: The following required arguments were not pr
     -b
 
 USAGE:
-    prog [FLAGS] -b -c
+    prog [OPTIONS] -b -c
 
 For more information try --help
 ";

--- a/tests/flag_subcommands.rs
+++ b/tests/flag_subcommands.rs
@@ -430,10 +430,8 @@ Query the package database.
 USAGE:
     pacman {query, --query, -Q} [OPTIONS]
 
-FLAGS:
-    -h, --help    Print help information
-
 OPTIONS:
+    -h, --help                  Print help information
     -i, --info <info>...        view package information
     -s, --search <search>...    search locally installed packages for matching strings
 ";
@@ -487,10 +485,8 @@ Query the package database.
 USAGE:
     pacman {query, --query} [OPTIONS]
 
-FLAGS:
-    -h, --help    Print help information
-
 OPTIONS:
+    -h, --help                  Print help information
     -i, --info <info>...        view package information
     -s, --search <search>...    search locally installed packages for matching strings
 ";
@@ -543,10 +539,8 @@ Query the package database.
 USAGE:
     pacman {query, -Q} [OPTIONS]
 
-FLAGS:
-    -h, --help    Print help information
-
 OPTIONS:
+    -h, --help                  Print help information
     -i, --info <info>...        view package information
     -s, --search <search>...    search locally installed packages for matching strings
 ";

--- a/tests/flags.rs
+++ b/tests/flags.rs
@@ -7,7 +7,7 @@ const USE_FLAG_AS_ARGUMENT: &str =
 \tIf you tried to supply `--another-flag` as a value rather than a flag, use `-- --another-flag`
 
 USAGE:
-    mycat [FLAGS] [filename]
+    mycat [OPTIONS] [filename]
 
 For more information try --help
 ";

--- a/tests/groups.rs
+++ b/tests/groups.rs
@@ -265,7 +265,7 @@ USAGE:
 ARGS:
     <A>    
 
-FLAGS:
+OPTIONS:
     -h, --help    Print help information
 ";
     let app = App::new("prog")

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -11,12 +11,10 @@ tests stuff
 USAGE:
     test --fake <some>:<val>
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -f, --fake <some>:<val>    some help
+    -h, --help                 Print help information
+    -V, --version              Print version information
 ";
 
 static HELP: &str = "clap-test v1.4.8
@@ -26,20 +24,17 @@ Kevin K. <kbknapp@gmail.com>
 tests clap library
 
 USAGE:
-    clap-test [FLAGS] [OPTIONS] [ARGS] [SUBCOMMAND]
+    clap-test [OPTIONS] [ARGS] [SUBCOMMAND]
 
 ARGS:
     <positional>        tests positionals
     <positional2>       tests positionals with exclusions
     <positional3>...    tests specific values [possible values: vi, emacs]
 
-FLAGS:
-    -f, --flag       tests flags
-    -F               tests flags with exclusions
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -f, --flag                       tests flags
+    -F                               tests flags with exclusions
+    -h, --help                       Print help information
         --long-option-2 <option2>    tests long options with exclusions
         --maxvals3 <maxvals>...      Tests 3 max vals
         --minvals2 <minvals>...      Tests 2 min vals
@@ -47,6 +42,7 @@ OPTIONS:
         --multvalsmo <one> <two>     Tests multiple values, and mult occs
     -o, --option <opt>...            tests options
     -O, --Option <option3>           specific vals [possible values: fast, slow]
+    -V, --version                    Print version information
 
 SUBCOMMANDS:
     help      Print this message or the help of the given subcommand(s)
@@ -62,12 +58,10 @@ USAGE:
 ARGS:
     <PATH>    help
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -h, --help          Print help information
     -o, --opt <FILE>    tests options
+    -V, --version       Print version information
 
 SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)
@@ -77,19 +71,17 @@ SUBCOMMANDS:
 static ARGS_NEGATE_SC: &str = "prog 1.0
 
 USAGE:
-    prog [FLAGS] [OPTIONS] [PATH]
+    prog [OPTIONS] [PATH]
     prog <SUBCOMMAND>
 
 ARGS:
     <PATH>    help
 
-FLAGS:
-    -f, --flag       testing flags
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -f, --flag          testing flags
+    -h, --help          Print help information
     -o, --opt <FILE>    tests options
+    -V, --version       Print version information
 
 SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)
@@ -105,7 +97,7 @@ tests clap library
 USAGE:
     clap-test
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -121,7 +113,7 @@ tests clap library
 USAGE:
     clap-test
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 
@@ -134,15 +126,13 @@ some longer text that comes after the help
 static HIDDEN_ARGS: &str = "prog 1.0
 
 USAGE:
-    prog [FLAGS] [OPTIONS]
-
-FLAGS:
-    -f, --flag       testing flags
-    -h, --help       Print help information
-    -V, --version    Print version information
+    prog [OPTIONS]
 
 OPTIONS:
+    -f, --flag          testing flags
+    -h, --help          Print help information
     -o, --opt <FILE>    tests options
+    -V, --version       Print version information
 ";
 
 static SC_HELP: &str = "clap-test-subcmd 0.1
@@ -152,36 +142,32 @@ Kevin K. <kbknapp@gmail.com>
 tests subcommands
 
 USAGE:
-    clap-test subcmd [FLAGS] [OPTIONS] [--] [scpositional]
+    clap-test subcmd [OPTIONS] [--] [scpositional]
 
 ARGS:
     <scpositional>    tests positionals
 
-FLAGS:
-    -f, --flag       tests flags
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -f, --flag                     tests flags
+    -h, --help                     Print help information
     -o, --option <scoption>...     tests options
     -s, --subcmdarg <subcmdarg>    tests other args
+    -V, --version                  Print version information
 ";
 
 static ISSUE_1046_HIDDEN_SCS: &str = "prog 1.0
 
 USAGE:
-    prog [FLAGS] [OPTIONS] [PATH]
+    prog [OPTIONS] [PATH]
 
 ARGS:
     <PATH>    some
 
-FLAGS:
-    -f, --flag       testing flags
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -f, --flag          testing flags
+    -h, --help          Print help information
     -o, --opt <FILE>    tests options
+    -V, --version       Print version information
 ";
 
 // Using number_of_values(1) with multiple_values(true) misaligns help message
@@ -190,13 +176,11 @@ static ISSUE_760: &str = "ctest 0.1
 USAGE:
     ctest [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -h, --help               Print help information
     -o, --option <option>    tests options
     -O, --opt <opt>          tests options
+    -V, --version            Print version information
 ";
 
 static RIPGREP_USAGE: &str = "ripgrep 0.5
@@ -207,7 +191,7 @@ USAGE:
     rg [OPTIONS] --files [<path> ...]
     rg [OPTIONS] --type-list
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -219,25 +203,19 @@ Kevin K. <kbknapp@gmail.com>
 tests subcommands
 
 USAGE:
-    ctest subcmd multi [FLAGS] [OPTIONS]
-
-FLAGS:
-    -f, --flag       tests flags
-    -h, --help       Print help information
-    -V, --version    Print version information
+    ctest subcmd multi [OPTIONS]
 
 OPTIONS:
+    -f, --flag                    tests flags
+    -h, --help                    Print help information
     -o, --option <scoption>...    tests options
+    -V, --version                 Print version information
 ";
 
 static ISSUE_626_CUTOFF: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
-
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café is an
@@ -248,16 +226,14 @@ OPTIONS:
                          cold beverages such as iced coffee and iced
                          tea. Many cafés also serve some type of food,
                          such as light snacks, muffins, or pastries.
+    -h, --help           Print help information
+    -V, --version        Print version information
 ";
 
 static ISSUE_626_PANIC: &str = "ctest 0.1
 
 USAGE:
     ctest [OPTIONS]
-
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
 
 OPTIONS:
     -c, --cafe <FILE>
@@ -268,6 +244,12 @@ OPTIONS:
             les marchés d\'exportation. Le café est
             souvent une contribution majeure aux
             exportations des régions productrices.
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
 ";
 
 static HIDE_POS_VALS: &str = "ctest 0.1
@@ -275,13 +257,11 @@ static HIDE_POS_VALS: &str = "ctest 0.1
 USAGE:
     ctest [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
+    -h, --help           Print help information
     -p, --pos <VAL>      Some vals [possible values: fast, slow]
+    -V, --version        Print version information
 ";
 
 static FINAL_WORD_WRAPPING: &str = "ctest 0.1
@@ -289,7 +269,7 @@ static FINAL_WORD_WRAPPING: &str = "ctest 0.1
 USAGE:
     ctest
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help
             information
@@ -303,9 +283,9 @@ FLAGS:
 static OLD_NEWLINE_CHARS: &str = "ctest 0.1
 
 USAGE:
-    ctest [FLAGS]
+    ctest [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -m               Some help with some wrapping
                      (Defaults to something)
@@ -325,7 +305,7 @@ ARGS:
               m, med, medium    Copy-friendly, 8
               characters, contains symbols.
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -335,14 +315,12 @@ static ISSUE_688: &str = "ctest 0.1
 USAGE:
     ctest [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
         --filter <filter>    Sets the filter, or sampling method, to use for interpolation when resizing the particle
                              images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic,
                              Gaussian, Lanczos3]
+    -h, --help               Print help information
+    -V, --version            Print version information
 ";
 
 static ISSUE_702: &str = "myapp 1.0
@@ -358,14 +336,12 @@ ARGS:
     <arg1>       some option
     <arg2>...    some option
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
+    -h, --help                Print help information
     -l, --label <label>...    a label
     -o, --other <other>       some other option
     -s, --some <some>         some option
+    -V, --version             Print version information
 ";
 
 static ISSUE_777: &str = "A app with a crazy very long long
@@ -380,7 +356,7 @@ wrapped
 USAGE:
     ctest
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 
@@ -392,9 +368,9 @@ FLAGS:
 static ISSUE_1642: &str = "prog 
 
 USAGE:
-    prog [FLAGS]
+    prog [OPTIONS]
 
-FLAGS:
+OPTIONS:
         --config
             The config file used by the myprog must be in JSON format
             with only valid keys and may not contain other nonsense
@@ -408,9 +384,9 @@ FLAGS:
 static HELP_CONFLICT: &str = "conflict 
 
 USAGE:
-    conflict [FLAGS]
+    conflict [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h            
         --help    Print help information
 ";
@@ -425,7 +401,7 @@ ARGS:
     <CORPUS>     some
     <ARGS>...    some
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -441,7 +417,7 @@ ARGS:
     <CORPUS>     some
     <ARGS>...    some
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -460,7 +436,7 @@ ARGS:
     <CORPUS>     some
     <ARGS>...    some
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -476,7 +452,7 @@ ARGS:
     <CORPUS>     some
     <ARGS>...    some
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -490,12 +466,10 @@ static HIDE_DEFAULT_VAL: &str = "default 0.1
 USAGE:
     default [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
         --arg <argument>    Pass an argument to the program. [default: default-argument]
+    -h, --help              Print help information
+    -V, --version           Print version information
 ";
 
 static ESCAPED_DEFAULT_VAL: &str = "default 0.1
@@ -503,32 +477,28 @@ static ESCAPED_DEFAULT_VAL: &str = "default 0.1
 USAGE:
     default [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
         --arg <argument>    Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
                             other]
+    -h, --help              Print help information
+    -V, --version           Print version information
 ";
 
 static LAST_ARG_USAGE: &str = "flamegraph 0.1
 
 USAGE:
-    flamegraph [FLAGS] [OPTIONS] [BINFILE] [-- <ARGS>...]
+    flamegraph [OPTIONS] [BINFILE] [-- <ARGS>...]
 
 ARGS:
     <BINFILE>    The path of the binary to be profiled. for a binary.
     <ARGS>...    Any arguments you wish to pass to the being profiled.
 
-FLAGS:
-    -h, --help       Print help information
-    -v, --verbose    Prints out more stuff.
-    -V, --version    Print version information
-
 OPTIONS:
     -f, --frequency <HERTZ>    The sampling frequency.
+    -h, --help                 Print help information
     -t, --timeout <SECONDS>    Timeout in seconds.
+    -v, --verbose              Prints out more stuff.
+    -V, --version              Print version information
 ";
 
 static LAST_ARG_REQ_MULT: &str = "example 1.0
@@ -540,7 +510,7 @@ ARGS:
     <FIRST>...     First
     <SECOND>...    Second
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -550,7 +520,7 @@ static DEFAULT_HELP: &str = "ctest 1.0
 USAGE:
     ctest
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -570,7 +540,7 @@ ARGS:
     <arg1>
             some option
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 
@@ -585,14 +555,12 @@ Will M.
 does stuff
 
 USAGE:
-    test [FLAGS] --fake <some>:<val>
-
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+    test [OPTIONS] --fake <some>:<val>
 
 OPTIONS:
     -f, --fake <some>:<val>    some help
+    -h, --help                 Print help information
+    -V, --version              Print version information
 
 NETWORKING:
     -n, --no-proxy    Do not use system proxy settings
@@ -607,19 +575,19 @@ ARGS:
     <arg1>    
     <arg2>    
 
-FLAGS:
+OPTIONS:
     -h, --help    Print help information
 ";
 
 static ISSUE_1364: &str = "demo 
 
 USAGE:
-    demo [FLAGS] [OPTIONS] [FILES]...
+    demo [OPTIONS] [FILES]...
 
 ARGS:
     <FILES>...    
 
-FLAGS:
+OPTIONS:
     -f            
     -h, --help    Print help information
 ";
@@ -627,9 +595,9 @@ FLAGS:
 static OPTION_USAGE_ORDER: &str = "order 
 
 USAGE:
-    order [FLAGS]
+    order [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -a                     
     -b                     
     -B                     
@@ -645,7 +613,7 @@ static ABOUT_IN_SUBCOMMANDS_LIST: &str = "about-in-subcommands-list
 USAGE:
     about-in-subcommands-list [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 
@@ -903,9 +871,9 @@ fn wrapped_help() {
     static WRAPPED_HELP: &str = "test 
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -a, --all
             Also do versioning for private crates (will not be
             published)
@@ -960,9 +928,9 @@ fn unwrapped_help() {
     static UNWRAPPED_HELP: &str = "test 
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -a, --all              Also do versioning for private crates
                            (will not be published)
         --exact            Specify inter dependency version numbers
@@ -1333,10 +1301,8 @@ fn issue_1571() {
 USAGE:
     hello [OPTIONS]
 
-FLAGS:
-    -h, --help    Print help information
-
 OPTIONS:
+    -h, --help              Print help information
     -p, --package <name>    
 ",
         false
@@ -1377,8 +1343,8 @@ fn ripgrep_usage_using_templates() {
 
 USAGE:{usage}
 
-FLAGS:
-{flags}",
+OPTIONS:
+{options}",
         );
 
     assert!(utils::compare_output(
@@ -1468,7 +1434,7 @@ static OVERRIDE_HELP_SHORT: &str = "test 0.1
 USAGE:
     test
 
-FLAGS:
+OPTIONS:
     -H, --help       Print help information
     -V, --version    Print version information
 ";
@@ -1496,9 +1462,9 @@ fn override_help_short() {
 static OVERRIDE_HELP_LONG: &str = "test 0.1
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h, --hell       Print help information
     -V, --version    Print version information
 ";
@@ -1528,7 +1494,7 @@ static OVERRIDE_HELP_ABOUT: &str = "test 0.1
 USAGE:
     test
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -1814,15 +1780,13 @@ Will M.
 does stuff
 
 USAGE:
-    test [FLAGS] [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
-
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+    test [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
 
 OPTIONS:
     -f, --fake <some>:<val>    some help
+    -h, --help                 Print help information
     -s, --speed <SPEED>        How fast? [possible values: fast, slow]
+    -V, --version              Print version information
 
 NETWORKING:
     -a, --server-addr    Set server address
@@ -1897,9 +1861,9 @@ Will M.
 does stuff
 
 USAGE:
-    test [FLAGS] --song <song> --song-volume <volume>
+    test [OPTIONS] --song <song> --song-volume <volume>
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -1956,7 +1920,7 @@ Long about foo
 USAGE:
     ctest foo
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 
@@ -1987,7 +1951,7 @@ About foo
 USAGE:
     ctest foo
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -2170,7 +2134,7 @@ static HELP_ABOUT_MULTI_SC: &str = "myapp-subcmd-multi 1.0
 USAGE:
     myapp subcmd multi
 
-FLAGS:
+OPTIONS:
     -h, --help       Print custom help about text
     -V, --version    Print version information
 ";
@@ -2180,7 +2144,7 @@ static HELP_ABOUT_MULTI_SC_OVERRIDE: &str = "myapp-subcmd-multi 1.0
 USAGE:
     myapp subcmd multi
 
-FLAGS:
+OPTIONS:
     -h, --help       Print custom help about text from multi
     -V, --version    Print version information
 ";
@@ -2288,7 +2252,7 @@ ARGS:
     <pos1>    
     <pos2>    
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
         --option1    
 ";
@@ -2312,69 +2276,6 @@ FLAGS:
     ));
 }
 
-static ONLY_CUSTOM_HEADING_FLAGS: &str = "test 1.4
-
-USAGE:
-    test [FLAGS] [OPTIONS]
-
-OPTIONS:
-        --speed <speed>    How fast
-
-NETWORKING:
-        --flag    Some flag
-";
-
-#[test]
-fn only_custom_heading_flags() {
-    let app = App::new("test")
-        .version("1.4")
-        .setting(AppSettings::DisableVersionFlag)
-        .mut_arg("help", |a| a.hidden(true))
-        .arg(
-            Arg::new("speed")
-                .long("speed")
-                .takes_value(true)
-                .about("How fast"),
-        )
-        .help_heading("NETWORKING")
-        .arg(Arg::new("flag").long("flag").about("Some flag"));
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        ONLY_CUSTOM_HEADING_FLAGS,
-        false
-    ));
-}
-
-static ONLY_CUSTOM_HEADING_OPTS: &str = "test 1.4
-
-USAGE:
-    test [OPTIONS]
-
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-NETWORKING:
-    -s, --speed <SPEED>    How fast
-";
-
-#[test]
-fn only_custom_heading_opts() {
-    let app = App::new("test")
-        .version("1.4")
-        .help_heading("NETWORKING")
-        .arg(Arg::from("-s, --speed [SPEED] 'How fast'"));
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        ONLY_CUSTOM_HEADING_OPTS,
-        false
-    ));
-}
-
 static CUSTOM_HEADING_POS: &str = "test 1.4
 
 USAGE:
@@ -2383,7 +2284,7 @@ USAGE:
 ARGS:
     <gear>    Which gear
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -2403,60 +2304,6 @@ fn custom_heading_pos() {
         app,
         "test --help",
         CUSTOM_HEADING_POS,
-        false
-    ));
-}
-
-static ONLY_CUSTOM_HEADING_POS: &str = "test 1.4
-
-USAGE:
-    test [speed]
-
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-NETWORKING:
-    <speed>    How fast
-";
-
-#[test]
-fn only_custom_heading_pos() {
-    let app = App::new("test")
-        .version("1.4")
-        .help_heading("NETWORKING")
-        .arg(Arg::new("speed").about("How fast"));
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        ONLY_CUSTOM_HEADING_POS,
-        false
-    ));
-}
-
-static ONLY_CUSTOM_HEADING_FLAGS_NO_ARGS: &str = "test 1.4
-
-USAGE:
-    test [FLAGS]
-
-NETWORKING:
-        --flag    Some flag
-";
-
-#[test]
-fn only_custom_heading_flags_no_args() {
-    let app = App::new("test")
-        .version("1.4")
-        .setting(AppSettings::DisableVersionFlag)
-        .mut_arg("help", |a| a.hidden(true))
-        .help_heading("NETWORKING")
-        .arg(Arg::new("flag").long("flag").about("Some flag"));
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        ONLY_CUSTOM_HEADING_FLAGS_NO_ARGS,
         false
     ));
 }
@@ -2531,10 +2378,8 @@ fn issue_2508_number_of_values_with_single_value_name() {
 USAGE:
     my_app [OPTIONS]
 
-FLAGS:
-    -h, --help    Print help information
-
 OPTIONS:
+    -h, --help                              Print help information
         --some_arg <some_arg> <some_arg>    
         --some_arg_issue <ARG> <ARG>        
 ",
@@ -2560,7 +2405,7 @@ ARGS:
     <arg1>    
     <arg2>    
 
-FLAGS:
+OPTIONS:
     -h, --help    Print help information
 ",
         false
@@ -2587,7 +2432,7 @@ ARGS:
     <bar>       
     <baz>...    
 
-FLAGS:
+OPTIONS:
     -h, --help    Print help information
 ",
         false

--- a/tests/help_env.rs
+++ b/tests/help_env.rs
@@ -11,12 +11,10 @@ static HIDE_ENV: &str = "ctest 0.1
 USAGE:
     ctest [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
+    -h, --help           Print help information
+    -V, --version        Print version information
 ";
 
 static SHOW_ENV: &str = "ctest 0.1
@@ -24,12 +22,10 @@ static SHOW_ENV: &str = "ctest 0.1
 USAGE:
     ctest [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
+    -h, --help           Print help information
+    -V, --version        Print version information
 ";
 
 static HIDE_ENV_VALS: &str = "ctest 0.1
@@ -37,12 +33,10 @@ static HIDE_ENV_VALS: &str = "ctest 0.1
 USAGE:
     ctest [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR]
+    -h, --help           Print help information
+    -V, --version        Print version information
 ";
 
 static SHOW_ENV_VALS: &str = "ctest 0.1
@@ -50,20 +44,18 @@ static SHOW_ENV_VALS: &str = "ctest 0.1
 USAGE:
     ctest [OPTIONS]
 
-FLAGS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
+    -h, --help           Print help information
+    -V, --version        Print version information
 ";
 
 static HIDE_ENV_FLAG: &str = "ctest 0.1
 
 USAGE:
-    ctest [FLAGS]
+    ctest [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -c, --cafe       A coffeehouse, coffee shop, or café.
     -h, --help       Print help information
     -V, --version    Print version information
@@ -72,9 +64,9 @@ FLAGS:
 static SHOW_ENV_FLAG: &str = "ctest 0.1
 
 USAGE:
-    ctest [FLAGS]
+    ctest [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -h, --help       Print help information
     -V, --version    Print version information
@@ -83,9 +75,9 @@ FLAGS:
 static HIDE_ENV_VALS_FLAG: &str = "ctest 0.1
 
 USAGE:
-    ctest [FLAGS]
+    ctest [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR]
     -h, --help       Print help information
     -V, --version    Print version information
@@ -94,9 +86,9 @@ FLAGS:
 static SHOW_ENV_VALS_FLAG: &str = "ctest 0.1
 
 USAGE:
-    ctest [FLAGS]
+    ctest [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -h, --help       Print help information
     -V, --version    Print version information

--- a/tests/hidden_args.rs
+++ b/tests/hidden_args.rs
@@ -9,15 +9,13 @@ Kevin K.
 tests stuff
 
 USAGE:
-    test [FLAGS] [OPTIONS]
-
-FLAGS:
-    -F, --flag2      some other flag
-    -h, --help       Print help information
-    -V, --version    Print version information
+    test [OPTIONS]
 
 OPTIONS:
+    -F, --flag2           some other flag
+    -h, --help            Print help information
         --option <opt>    some option
+    -V, --version         Print version information
 ";
 
 #[test]
@@ -47,9 +45,9 @@ Steve P.
 hides short args
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -v, --visible    This text should be visible
     -V, --version    Print version information
@@ -62,9 +60,9 @@ Steve P.
 hides short args
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -c, --config
             Some help text describing the --config arg
 
@@ -139,9 +137,9 @@ Steve P.
 hides long args
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -h, --help
             Print help information
 
@@ -185,9 +183,9 @@ Steve P.
 hides long args
 
 USAGE:
-    test [FLAGS]
+    test [OPTIONS]
 
-FLAGS:
+OPTIONS:
     -c, --config     Some help text describing the --config arg
     -h, --help       Print help information
     -v, --visible    This text should be visible
@@ -220,57 +218,6 @@ fn hidden_long_args_short_help() {
     ));
 }
 
-static HIDDEN_FLAG_ARGS: &str = "test 1.4
-
-USAGE:
-    test [OPTIONS]
-
-OPTIONS:
-        --option <opt>    some option
-";
-
-#[test]
-fn hidden_flag_args() {
-    let app = App::new("test")
-        .version("1.4")
-        .mut_arg("help", |a| a.hidden(true))
-        .mut_arg("version", |a| a.hidden(true))
-        .args(&[Arg::from("--option [opt] 'some option'")]);
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        HIDDEN_FLAG_ARGS,
-        false
-    ));
-}
-
-static HIDDEN_OPT_ARGS: &str = "test 1.4
-
-USAGE:
-    test [FLAGS]
-
-FLAGS:
-        --flag       some flag
-    -h, --help       Print help information
-    -V, --version    Print version information
-";
-
-#[test]
-fn hidden_opt_args() {
-    let app = App::new("test").version("1.4").args(&[
-        Arg::from("--flag 'some flag'"),
-        Arg::from("--option [opt] 'some option'").hidden(true),
-    ]);
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        HIDDEN_OPT_ARGS,
-        false
-    ));
-}
-
 static HIDDEN_POS_ARGS: &str = "test 1.4
 
 USAGE:
@@ -279,7 +226,7 @@ USAGE:
 ARGS:
     <another>    another pos
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -304,7 +251,7 @@ static HIDDEN_SUBCMDS: &str = "test 1.4
 USAGE:
     test
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -319,30 +266,6 @@ fn hidden_subcmds() {
         app,
         "test --help",
         HIDDEN_SUBCMDS,
-        false
-    ));
-}
-
-static HIDDEN_FLAG_ARGS_ONLY: &str = "test 1.4
-
-USAGE:
-    test
-
-After help
-";
-
-#[test]
-fn hidden_flag_args_only() {
-    let app = App::new("test")
-        .version("1.4")
-        .after_help("After help")
-        .mut_arg("help", |a| a.hidden(true))
-        .mut_arg("version", |a| a.hidden(true));
-
-    assert!(utils::compare_output(
-        app,
-        "test --help",
-        HIDDEN_FLAG_ARGS_ONLY,
         false
     ));
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -7,17 +7,15 @@ use clap::ErrorKind;
 static LITERALS: &str = "clap-tests 0.1
 
 USAGE:
-    clap-tests [FLAGS] [OPTIONS] [SUBCOMMAND]
-
-FLAGS:
-    -4, --4          Sets priority to 4
-    -5, --5          Sets priority to 5
-    -6, --6          Sets priority to 6
-    -h, --help       Print help information
-    -V, --version    Print version information
+    clap-tests [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
+    -4, --4                      Sets priority to 4
+    -5, --5                      Sets priority to 5
+    -6, --6                      Sets priority to 6
+    -h, --help                   Print help information
     -t, --task-num <task-num>    Task number [possible values: all, 0, 1, 2]
+    -V, --version                Print version information
 
 SUBCOMMANDS:
     0             Set everything to zero priority
@@ -32,7 +30,7 @@ fn basic() {
         (version: "0.1")
         (about: "tests clap library")
         (author: "Kevin K. <kbknapp@gmail.com>")
-        (@global_setting UnifiedHelpMessage)
+        (@global_setting AllowNegativeNumbers)
         (@arg opt: -o --option +takes_value ... "tests options")
         (@arg positional: index(1) "tests positionals")
         (@arg flag: -f --flag ... +global "tests flags")

--- a/tests/subcommands.rs
+++ b/tests/subcommands.rs
@@ -7,7 +7,7 @@ static VISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 USAGE:
     clap-test [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -21,7 +21,7 @@ static INVISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 USAGE:
     clap-test [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -35,7 +35,7 @@ static SUBCMD_ALPHA_ORDER: &str = "test 1
 USAGE:
     test [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -50,7 +50,7 @@ static SUBCMD_DECL_ORDER: &str = "test 1
 USAGE:
     test [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/tests/template_help.rs
+++ b/tests/template_help.rs
@@ -18,8 +18,6 @@ static EXAMPLE1_TMPS_F: &str = "{bin} {version}
 USAGE:
     {usage}
 
-FLAGS:
-{flags}
 OPTIONS:
 {options}
 ARGS:
@@ -32,14 +30,13 @@ Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
 USAGE:
-    MyApp [FLAGS] [OPTIONS] <output> [SUBCOMMAND]
+    MyApp [OPTIONS] <output> [SUBCOMMAND]
 
-FLAGS:
-    -d               Turn debugging information on
-    -h, --help       Print help information
-    -V, --version    Print version information
 OPTIONS:
     -c, --config <FILE>    Sets a custom config file
+    -d                     Turn debugging information on
+    -h, --help             Print help information
+    -V, --version          Print version information
 ARGS:
     <output>    Sets an optional output file
 SUBCOMMANDS:
@@ -52,18 +49,16 @@ Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
 USAGE:
-    MyApp [FLAGS] [OPTIONS] <output> [SUBCOMMAND]
+    MyApp [OPTIONS] <output> [SUBCOMMAND]
 
 ARGS:
     <output>    Sets an optional output file
 
-FLAGS:
-    -d               Turn debugging information on
-    -h, --help       Print help information
-    -V, --version    Print version information
-
 OPTIONS:
     -c, --config <FILE>    Sets a custom config file
+    -d                     Turn debugging information on
+    -h, --help             Print help information
+    -V, --version          Print version information
 
 SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -16,13 +16,15 @@ where
     // Strip out any mismatching \r character on windows that might sneak in on either side
     let ls = l.as_ref().replace("\r", "");
     let rs = r.as_ref().replace("\r", "");
-    let left = re.replace_all(&*ls, "");
+    let left_ = re.replace_all(&*ls, "");
     let right = re.replace_all(&*rs, "");
-    let b = left == right;
+    let b = left_ == right;
     if !b {
+        dbg!(&left_);
+        dbg!(&right);
         println!();
         println!("--> left");
-        println!("{}", left);
+        println!("{}", left_);
         println!("--> right");
         println!("{}", right);
         println!("--")

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -151,7 +151,7 @@ static VERSION_ABOUT_MULTI_SC: &str = "foo-bar-baz 3.0
 USAGE:
     foo bar baz
 
-FLAGS:
+OPTIONS:
     -h, --help       Print help information
     -V, --version    Print custom version about text
 ";

--- a/tests/yaml.rs
+++ b/tests/yaml.rs
@@ -25,8 +25,9 @@ fn help_message() {
     let mut help_buffer = Vec::new();
     app.write_help(&mut help_buffer).unwrap();
     let help_string = String::from_utf8(help_buffer).unwrap();
+    println!("{}", help_string);
     assert!(help_string
-        .contains("-h, --help                   prints help with a nonstandard description\n"));
+        .contains("-h, --help\n            prints help with a nonstandard description\n"));
 }
 
 #[test]


### PR DESCRIPTION
For those that want the original behavior, you can usxe
`arg.help_heading(Some("FLAGS"))` on your flags.  Limitations:
- This will not give you a special sort order
- This will not get a `[FLAGS]` added to usage
- This will not allow `{flags}` template variable

For templates, we removed `{unified}` and `{flags}`.  To help people
catch these, a debug_assert was added.

I'm unsure but I think there might be a change in behavior in calcuating
when to show `[OPTION]` in usage.  The old code only looked at
`required` while flags looked only at arg groups.  We now look at both.

Ideally we'd default help headings in `_build` and remove special casing for
no-groups except in the sort order of groups.  I feel like thats best
left for later.

This also reduced the scope of `App`s public API.
`get_*_with_no_heading` seemed a bit specialized to be in the public
API.  #2853 looks at splitting it out into its own PR.

The most interesting changes are in
- src/output/help.rs
- src/output/usage.rs
- src/build/app/debug_asserts.rs

Followed by
- src/build/app/mod.rs
- src/build/app/settings.rs

BREAKING CHANGE: Multiple
- `UnifiedHelpMessage` removed
- `{flags}` and `{unified}` are removed and will assert when present.
- `get_*_with_no_heading` removed

Fixes #2807

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
