### PR TITLE
fix: Apply app help heading in App::args()

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1139,7 +1139,7 @@ impl<'help> App<'help> {
         // @TODO @perf @p4 @v3-beta: maybe extend_from_slice would be possible and perform better?
         // But that may also not let us do `&["-a 'some'", "-b 'other']` because of not Into<Arg>
         for arg in args.into_iter() {
-            self.args.push(arg.into());
+            self = self.arg(arg);
         }
         self
     }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -564,6 +564,7 @@ OPTIONS:
 
 NETWORKING:
     -n, --no-proxy    Do not use system proxy settings
+        --port        
 ";
 
 static ISSUE_1487: &str = "test 
@@ -1763,7 +1764,8 @@ fn custom_headers_headers() {
                 .short('n')
                 .long("no-proxy")
                 .about("Do not use system proxy settings"),
-        );
+        )
+        .args(&[Arg::new("port").long("port")]);
 
     assert!(utils::compare_output(
         app,


### PR DESCRIPTION
We aren't setting it when bulk-adding arguments.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
