### PR TITLE
Performance "Improvements"

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1159,8 +1159,10 @@ impl<'help> App<'help> {
         I: IntoIterator<Item = T>,
         T: Into<Arg<'help>>,
     {
-        // @TODO @perf @p4 @v3-beta: maybe extend_from_slice would be possible and perform better?
-        // But that may also not let us do `&["-a 'some'", "-b 'other']` because of not Into<Arg>
+        let args = args.into_iter();
+        let (lower, _) = args.size_hint();
+        self.args.reserve(lower);
+
         for arg in args.into_iter() {
             self = self.arg(arg);
         }

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -78,6 +78,11 @@ impl<'help> MKeyMap<'help> {
         self.keys.iter().any(|x| x.key == key)
     }
 
+    /// Reserves capacity for at least additional more elements to be inserted
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.args.reserve(additional);
+    }
+
     /// Push an argument in the map.
     pub(crate) fn push(&mut self, new_arg: Arg<'help>) {
         self.args.push(new_arg);


### PR DESCRIPTION
When benchmarking, the performance for `build_rg_with_short_help` was a wash.  I figured I'd still put it in
- To resolve the TODO
- Because someone else will see these opportunities and spend time on it
- And it feels good to get rid of allocations :)

I also played with reserving MKeyMap's keys (`self.keys.reserve(2 * self.args.len())`, most args had both short and long but no aiases).   I decided to drop it just out of caution of having a bad reserve size.