### PR TITLE
fix(derive): Support 'update' with 'flatten'

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -198,9 +198,15 @@ pub fn gen_augment(
             | Kind::ExternalSubcommand => None,
             Kind::Flatten => {
                 let ty = &field.ty;
-                Some(quote_spanned! { kind.span()=>
-                    let #app_var = <#ty as clap::Args>::augment_args(#app_var);
-                })
+                if override_required {
+                    Some(quote_spanned! { kind.span()=>
+                        let #app_var = <#ty as clap::Args>::augment_args_for_update(#app_var);
+                    })
+                } else {
+                    Some(quote_spanned! { kind.span()=>
+                        let #app_var = <#ty as clap::Args>::augment_args(#app_var);
+                    })
+                }
             }
             Kind::Arg(ty) => {
                 let convert_type = match **ty {

--- a/clap_derive/tests/flatten.rs
+++ b/clap_derive/tests/flatten.rs
@@ -102,6 +102,32 @@ fn flatten_in_subcommand() {
     );
 }
 
+#[test]
+fn update_args_with_flatten() {
+    #[derive(Args, PartialEq, Debug)]
+    struct Common {
+        arg: i32,
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[clap(flatten)]
+        common: Common,
+    }
+
+    let mut opt = Opt {
+        common: Common { arg: 42 },
+    };
+    opt.try_update_from(&["test"]).unwrap();
+    assert_eq!(Opt::parse_from(&["test", "42"]), opt);
+
+    let mut opt = Opt {
+        common: Common { arg: 42 },
+    };
+    opt.try_update_from(&["test", "52"]).unwrap();
+    assert_eq!(Opt::parse_from(&["test", "52"]), opt);
+}
+
 #[derive(Subcommand, PartialEq, Debug)]
 enum BaseCli {
     Command1(Command1),

--- a/clap_derive/tests/ui/flatten_enum_in_struct.stderr
+++ b/clap_derive/tests/ui/flatten_enum_in_struct.stderr
@@ -5,3 +5,11 @@ error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
   |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
   |
   = note: required by `augment_args`
+
+error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
+ --> $DIR/flatten_enum_in_struct.rs:3:12
+  |
+3 |     #[clap(flatten)]
+  |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+  |
+  = note: required by `augment_args_for_update`


### PR DESCRIPTION
When working on #2803, I noticed a disprecancy in the augment
behavior between `Arg`s and `Subcommand`s that makes it so `Arg`s can't
be flattened with the update functionality.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
