### PR TITLE
chore(ci): Hopefully speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+      - name: Cache Builds
+        uses: Swatinem/rust-cache@v1
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install linker
@@ -126,6 +128,8 @@ jobs:
         with:
           toolchain: nightly
           override: true
+      - name: Cache Builds
+        uses: Swatinem/rust-cache@v1
       - name: Checkout
         uses: actions/checkout@v2
       - name: Test almost no features
@@ -166,6 +170,8 @@ jobs:
           toolchain: 1.54.0
           target: ${{ matrix.target }}
           override: true
+      - name: Cache Builds
+        uses: Swatinem/rust-cache@v1
       - name: Checkout
         uses: actions/checkout@v2
       - name: Check

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,8 @@ jobs:
           toolchain: nightly
           components: llvm-tools-preview
           override: true
+      - name: Cache Builds
+        uses: Swatinem/rust-cache@v1
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install llvm-cov


### PR DESCRIPTION
Just doing a release build takes ~20m (a release job takes 30-50m!).
I'm hoping this cache will help speed up bors.  We are using this today
with CI-PR pipelines but I'm seeing a lot of cache misses for some
reason, so unsure of the full benefit.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
