### PR TITLE
fix(help): Partial fix for 'help help'

### DIFF
--- a/tests/help.rs
+++ b/tests/help.rs
@@ -2137,6 +2137,62 @@ fn after_help_no_args() {
     assert_eq!(help, AFTER_HELP_NO_ARGS);
 }
 
+static HELP_SUBCMD_HELP: &str = "myapp-help 
+
+Print this message or the help of the given subcommand(s)
+
+USAGE:
+    myapp help [SUBCOMMAND]...
+
+ARGS:
+    <SUBCOMMAND>...    The subcommand whose help message to display
+
+OPTIONS:
+    -h, --help    Print custom help about text
+";
+
+#[test]
+fn help_subcmd_help() {
+    let app = App::new("myapp")
+        .mut_arg("help", |h| h.about("Print custom help about text"))
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app.clone(),
+        "myapp help help",
+        HELP_SUBCMD_HELP,
+        false
+    ));
+}
+
+static SUBCMD_HELP_SUBCMD_HELP: &str = "myapp-subcmd-help 
+
+Print this message or the help of the given subcommand(s)
+
+USAGE:
+    myapp subcmd help [SUBCOMMAND]...
+
+ARGS:
+    <SUBCOMMAND>...    The subcommand whose help message to display
+
+OPTIONS:
+    -h, --help    Print custom help about text
+";
+
+#[test]
+fn subcmd_help_subcmd_help() {
+    let app = App::new("myapp")
+        .mut_arg("help", |h| h.about("Print custom help about text"))
+        .subcommand(App::new("subcmd").subcommand(App::new("multi").version("1.0")));
+
+    assert!(utils::compare_output(
+        app.clone(),
+        "myapp subcmd help help",
+        SUBCMD_HELP_SUBCMD_HELP,
+        false
+    ));
+}
+
 static HELP_ABOUT_MULTI_SC: &str = "myapp-subcmd-multi 1.0
 
 USAGE:


### PR DESCRIPTION
Who knew people need to ask `help` for how to use `help`?

While auditing `MultpleValues`, I saw commented out code.   Looks
its commit (f230cfedc) was part of a large refactor and updating that
part fell through the cracks.  Just simply updating it didn't quite get
it to work.  The advantage of this approach is it gets us closer to how
clap works on its own.

In clap 2.33.3, `cmd help help` looks like
```
myapp-help
Prints this message or the help of the given subcommand(s)

USAGE:
    myapp help [subcommand]...

ARGS:
    <subcommand>...    The subcommand whose help message to display
```

But clap3 master looks like:
```
myapp

USAGE:
    myapp [SUBCOMMAND]

OPTIONS:
    -h, --help    Print custom help about text

SUBCOMMANDS:
    help      Print this message or the help of the given subcommand(s)
    subcmd
```

This change improves it to:
```
myapp-help

Print this message or the help of the given subcommand(s)

USAGE:
    myapp help [SUBCOMMAND]...

ARGS:
    <SUBCOMMAND>...    The subcommand whose help message to display

OPTIONS:
    -h, --help    Print custom help about text
```

We still have global arguments showing up (like `-h`) that will error but its
an improvement!  In general, I'd like to find a way to leverage clap's stanard
behavior for implementing this so we don't have to worry about any of these
corner cases in the future.

Note: compared to clap2, I changed `<subcommand>` to `<SUBCOMMAND>` because I
believe the standard convention is for value names to be all caps (e.g.
`clap_derive` has been updated to default to that).

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
