### PR TITLE
docs: Clarify corner caseses with default values

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -1045,6 +1045,8 @@ impl<'help> Arg<'help> {
     ///
     /// **NOTE** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
     ///
+    /// **NOTE:** An argument is considered present when there is a [`Arg::default_value`]
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1094,6 +1096,8 @@ impl<'help> Arg<'help> {
     /// followed by an array of strings will achieve the equivalent effect.
     ///
     /// **NOTE:** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
+    ///
+    /// **NOTE:** An argument is considered present when there is a [`Arg::default_value`]
     ///
     /// # Examples
     ///
@@ -1328,6 +1332,8 @@ impl<'help> Arg<'help> {
     ///
     /// **NOTE:** [Conflicting] rules and [override] rules take precedence over being required
     ///
+    /// **NOTE:** This argument is considered present when there is a [`Arg::default_value`]
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1388,6 +1394,8 @@ impl<'help> Arg<'help> {
     /// This method takes `value, another_arg` pair. At runtime, clap will check
     /// if this arg (`self`) is present and its value equals to `val`.
     /// If it does, `another_arg` will be marked as required.
+    ///
+    /// **NOTE:** This argument is considered present when there is a [`Arg::default_value`]
     ///
     /// # Examples
     ///
@@ -1509,6 +1517,8 @@ impl<'help> Arg<'help> {
 
     /// Allows specifying that this argument is [required] only if the specified
     /// `arg` is present at runtime and its value equals `val`.
+    ///
+    /// **NOTE:** This argument is considered present when there is a [`Arg::default_value`]
     ///
     /// # Examples
     ///
@@ -1785,6 +1795,8 @@ impl<'help> Arg<'help> {
     ///
     /// **NOTE:** [Conflicting] rules and [override] rules take precedence over being required
     /// by default.
+    ///
+    /// **NOTE:** This argument is considered present when there is a [`Arg::default_value`]
     ///
     /// # Examples
     ///

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -249,6 +249,8 @@ impl<'help> ArgGroup<'help> {
     /// Use of more than one arg is an error." Vice setting `ArgGroup::multiple(true)` which
     /// states, '*At least* one arg from this group must be used. Using multiple is OK."
     ///
+    /// **NOTE:** An argument is considered present when there is a [`Arg::default_value`]
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -284,6 +286,8 @@ impl<'help> ArgGroup<'help> {
     ///
     /// **NOTE:** The name provided may be an argument, or group name
     ///
+    /// **NOTE:** An argument is considered present when there is a [`Arg::default_value`]
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -318,6 +322,8 @@ impl<'help> ArgGroup<'help> {
     /// group is used.
     ///
     /// **NOTE:** The names provided may be an argument, or group name
+    ///
+    /// **NOTE:** An argument is considered present when there is a [`Arg::default_value`]
     ///
     /// # Examples
     ///
@@ -357,6 +363,8 @@ impl<'help> ArgGroup<'help> {
     ///
     /// **NOTE:** The name provided may be an argument, or group name
     ///
+    /// **NOTE:** An argument is considered present when there is a [`Arg::default_value`]
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -388,6 +396,8 @@ impl<'help> ArgGroup<'help> {
     /// present when one of the arguments from this group are used.
     ///
     /// **NOTE:** The names provided may be an argument, or group name
+    ///
+    /// **NOTE:** An argument is considered present when there is a [`Arg::default_value`]
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This is meant to lower the chance of confusion with cases like #2714 and #1586

This is not meant to be exhaustive, looked at the mentioned cases in
that issue and pattern matched on other ones mentioning "is present".

When working on this, I wanted to make sure we limit our `**NOTE:**`s to not lower their value, so I moved the YAML description down into the examples which seems more fitting and some cases already do this.