### PR TITLE
Minor cosmetic: Place default/env/… on separate lines for multiline help output

### DIFF
--- a/clap_derive/tests/doc-comments-help.rs
+++ b/clap_derive/tests/doc-comments-help.rs
@@ -184,3 +184,23 @@ fn verbatim_doc_comment_field() {
     assert!(help.contains("This help ends in a period."));
     assert!(help.contains("This help does not end in a period"));
 }
+
+#[test]
+fn multiline_separates_default() {
+    #[derive(Parser, Debug)]
+    struct App {
+        /// Multiline
+        ///
+        /// Doc comment
+        #[clap(long, default_value = "x")]
+        x: String,
+    }
+
+    let help = get_long_help::<App>();
+    assert!(!help.contains("Doc comment [default"));
+    assert!(help.lines().any(|s| s.trim().starts_with("[default")));
+
+    // The short help should still have the default on the same line
+    let help = get_help::<App>();
+    assert!(help.contains("Multiline [default"));
+}

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -604,12 +604,17 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
 
             spec_vals.push(format!("[possible values: {}]", pvs));
         }
+        let connector = if self.use_long { "\n" } else { " " };
         let prefix = if !spec_vals.is_empty() && !a.get_about().unwrap_or("").is_empty() {
-            " "
+            if self.use_long {
+                "\n\n"
+            } else {
+                " "
+            }
         } else {
             ""
         };
-        prefix.to_string() + &spec_vals.join(" ")
+        prefix.to_string() + &spec_vals.join(connector)
     }
 
     fn write_about(&mut self, before_new_line: bool, after_new_line: bool) -> io::Result<()> {


### PR DESCRIPTION
I'd like to have the following help output
```
-f, --foo-bar <FOO_BAR>
        Foo Bar!

        Very advanced, has a long long long long long long long long multiline explanation

        [env: BAR_FOO=]
        [default: hoge]
```
but without this change, I get
```
-f, --foo-bar <FOO_BAR>
        Foo Bar!

        Very advanced, has a long long long long long long long long multiline explanation [env:
        BAR_FOO=] [default: hoge]
```
Backing code:
```rust
#[derive(Parser)]
pub struct Opts {
    /// Foo Bar!
    ///
    /// Very advanced, has a long long long long long long long long multiline explanation
    #[clap(short, long, default_value = "hoge", env = "BAR_FOO")]
    foo_bar: String,
}
```

I've tried around whether I can't achieve this some other way, and the closest I've got is by putting an empty line and then a line with a zero width space at the end of the doc comment. Maybe a less invasive method to achieve similar output would be to stop cutting trailing newlines, but that seems [deliberate](
https://github.com/clap-rs/clap/blob/1c2b09e57b1debf9a51eba07ec42e6e635d3a892/clap_derive/src/utils/doc_comments.rs#L15).