### PR TITLE
feat(generate): reduce dependencies of clap_generate (42 to 13)

### DIFF
--- a/clap_generate/Cargo.toml
+++ b/clap_generate/Cargo.toml
@@ -30,7 +30,7 @@ readme = "README.md"
 bench = false
 
 [dependencies]
-clap = { path = "../", version = "=3.0.0-beta.4" }
+clap = { path = "../", version = "=3.0.0-beta.4", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 pretty_assertions = "0.7"


### PR DESCRIPTION
Currently `clap_generate` depends on `clap` with all default features enabled. But `clap_generate` actually only relies on `std` feature.

Since I'm using clap with smaller features than default, adding `clap_generate` as dependency increases dependencies. They include proc macro lib `clap_derive` which increases compile time.

This PR makes `clap_generate` depend on minimal required features of `clap`. It reduces number of dependencies from 42 to 13 and makes compilation time 1.4x faster.

Before:

```
cargo build --release  48.52s user 2.64s system 505% cpu 10.121 total
```

After:

```
cargo build --release  33.88s user 1.31s system 667% cpu 5.269 total
```
