### PR TITLE
fix: Ease clap2->3 transition for Settings

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -90,7 +90,6 @@ pub struct App<'help> {
     pub(crate) template: Option<&'help str>,
     pub(crate) settings: AppFlags,
     pub(crate) g_settings: AppFlags,
-    pub(crate) color: ColorChoice,
     pub(crate) args: MKeyMap<'help>,
     pub(crate) subcommands: Vec<App<'help>>,
     pub(crate) replacers: HashMap<&'help str, &'help [&'help str]>,
@@ -1021,9 +1020,13 @@ impl<'help> App<'help> {
     /// [`ColorChoice::Auto`]: crate::ColorChoice::Auto
     #[cfg(feature = "color")]
     #[inline]
-    pub fn color(mut self, color: ColorChoice) -> Self {
-        self.color = color;
-        self
+    pub fn color(self, color: ColorChoice) -> Self {
+        #[allow(deprecated)]
+        match color {
+            ColorChoice::Auto => self.setting(AppSettings::ColorAuto),
+            ColorChoice::Always => self.setting(AppSettings::ColorAlways),
+            ColorChoice::Never => self.setting(AppSettings::ColorNever),
+        }
     }
 
     /// Sets the terminal width at which to wrap help messages. Defaults to
@@ -2818,8 +2821,21 @@ impl<'help> App<'help> {
     }
 
     #[inline]
+    // Should we color the output?
     pub(crate) fn get_color(&self) -> ColorChoice {
-        self.color
+        debug!("App::color: Color setting...");
+
+        #[allow(deprecated)]
+        if self.is_set(AppSettings::ColorNever) {
+            debug!("Never");
+            ColorChoice::Never
+        } else if self.is_set(AppSettings::ColorAlways) {
+            debug!("Always");
+            ColorChoice::Always
+        } else {
+            debug!("Auto");
+            ColorChoice::Auto
+        }
     }
 
     #[inline]

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -50,6 +50,7 @@ bitflags! {
         const IGNORE_ERRORS                  = 1 << 44;
         #[cfg(feature = "unstable-multicall")]
         const MULTICALL                      = 1 << 45;
+        const NO_OP                          = 0;
     }
 }
 
@@ -72,6 +73,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::ARGS_NEGATE_SCS,
     AllowExternalSubcommands("allowexternalsubcommands")
         => Flags::ALLOW_UNK_SC,
+    StrictUtf8("strictutf8")
+        => Flags::NO_OP,
     AllowInvalidUtf8ForExternalSubcommands("allowinvalidutf8forexternalsubcommands")
         => Flags::SC_UTF8_NONE,
     AllowLeadingHyphen("allowleadinghyphen")
@@ -80,6 +83,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::ALLOW_NEG_NUMS,
     AllowMissingPositional("allowmissingpositional")
         => Flags::ALLOW_MISSING_POS,
+    ColoredHelp("coloredhelp")
+        => Flags::NO_OP,
     ColorAlways("coloralways")
         => Flags::COLOR_ALWAYS,
     ColorAuto("colorauto")
@@ -131,6 +136,7 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::USE_LONG_FORMAT_FOR_HELP_SC,
     TrailingVarArg("trailingvararg")
         => Flags::TRAILING_VARARG,
+    UnifiedHelp("unifiedhelp") => Flags::NO_OP,
     NextLineHelp("nextlinehelp")
         => Flags::NEXT_LINE_HELP,
     IgnoreErrors("ignoreerrors")
@@ -157,6 +163,13 @@ impl_settings! { AppSettings, AppFlags,
 /// [`App`]: crate::App
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum AppSettings {
+    /// Deprecated, this is now the default, see [`AppSettings::AllowInvalidUtf8ForExternalSubcommands`] and [`ArgSettings::AllowInvalidUtf8ForExternalSubcommands`] for the opposite.
+    #[deprecated(
+        since = "3.0.0",
+        note = "This is now the default see [`AppSettings::AllowInvalidUtf8ForExternalSubcommands`] and [`ArgSettings::AllowInvalidUtf8ForExternalSubcommands`] for the opposite."
+    )]
+    StrictUtf8,
+
     /// Specifies that external subcommands that are invalid UTF-8 should *not* be treated as an error.
     ///
     /// **NOTE:** Using external subcommand argument values with invalid UTF-8 requires using
@@ -497,6 +510,10 @@ pub enum AppSettings {
     /// assert!(matches.subcommand_matches("sub").is_some());
     /// ```
     SubcommandPrecedenceOverArg,
+
+    /// Deprecated, this is now the default
+    #[deprecated(since = "3.0.0", note = "This is now the default")]
+    ColoredHelp,
 
     /// Deprecated, see [`App::color`]
     #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
@@ -1022,6 +1039,10 @@ pub enum AppSettings {
     /// ```
     /// [`Arg::multiple_values(true)`]: crate::Arg::multiple_values()
     TrailingVarArg,
+
+    /// Deprecated, this is now the default
+    #[deprecated(since = "3.0.0", note = "This is now the default")]
+    UnifiedHelp,
 
     /// Will display a message "Press \[ENTER\]/\[RETURN\] to continue..." and wait for user before
     /// exiting

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -87,9 +87,15 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::DISABLE_HELP_SC,
     DisableHelpFlag("disablehelpflag")
         => Flags::DISABLE_HELP_FLAG,
+    DisableHelpFlags("disablehelpflag")
+        => Flags::DISABLE_HELP_FLAG,
     DisableVersionFlag("disableversionflag")
         => Flags::DISABLE_VERSION_FLAG,
+    DisableVersion("disableversionflag")
+        => Flags::DISABLE_VERSION_FLAG,
     PropagateVersion("propagateversion")
+        => Flags::PROPAGATE_VERSION,
+    GlobalVersion("propagateversion")
         => Flags::PROPAGATE_VERSION,
     HidePossibleValuesInHelp("hidepossiblevaluesinhelp")
         => Flags::NO_POS_VALUES,
@@ -530,6 +536,10 @@ pub enum AppSettings {
     /// ```
     DisableHelpFlag,
 
+    /// Deprecated, see [`AppSettings::DisableHelpFlag`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `AppSettings::DisableHelpFlag`")]
+    DisableHelpFlags,
+
     /// Disables the `help` [`subcommand`].
     ///
     /// # Examples
@@ -566,6 +576,13 @@ pub enum AppSettings {
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
     /// ```
     DisableVersionFlag,
+
+    /// Deprecated, see [`AppSettings::DisableVersionFlag`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `AppSettings::DisableVersionFlag`"
+    )]
+    DisableVersion,
 
     /// Displays the arguments and [`subcommands`] in the help message in the order that they were
     /// declared in, and not alphabetically which is the default.
@@ -687,6 +704,13 @@ pub enum AppSettings {
     ///
     /// [`subcommands`]: crate::App::subcommand()
     PropagateVersion,
+
+    /// Deprecated, see [`AppSettings::PropagateVersion`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Replaced with `AppSettings::PropagateVersion`"
+    )]
+    GlobalVersion,
 
     /// Specifies that this [`subcommand`] should be hidden from help messages
     ///

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -25,6 +25,9 @@ bitflags! {
         const NO_POS_VALUES                  = 1 << 17;
         const NEXT_LINE_HELP                 = 1 << 18;
         const DERIVE_DISP_ORDER              = 1 << 19;
+        const COLOR_ALWAYS                   = 1 << 21;
+        const COLOR_AUTO                     = 1 << 22;
+        const COLOR_NEVER                    = 1 << 23;
         const DONT_DELIM_TRAIL               = 1 << 24;
         const ALLOW_NEG_NUMS                 = 1 << 25;
         const DISABLE_HELP_SC                = 1 << 27;
@@ -56,7 +59,7 @@ pub struct AppFlags(Flags);
 
 impl Default for AppFlags {
     fn default() -> Self {
-        Self::empty()
+        AppFlags(Flags::COLOR_AUTO)
     }
 }
 
@@ -77,6 +80,12 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::ALLOW_NEG_NUMS,
     AllowMissingPositional("allowmissingpositional")
         => Flags::ALLOW_MISSING_POS,
+    ColorAlways("coloralways")
+        => Flags::COLOR_ALWAYS,
+    ColorAuto("colorauto")
+        => Flags::COLOR_AUTO,
+    ColorNever("colornever")
+        => Flags::COLOR_NEVER,
     DontDelimitTrailingValues("dontdelimittrailingvalues")
         => Flags::DONT_DELIM_TRAIL,
     DontCollapseArgsInUsage("dontcollapseargsinusage")
@@ -488,6 +497,18 @@ pub enum AppSettings {
     /// assert!(matches.subcommand_matches("sub").is_some());
     /// ```
     SubcommandPrecedenceOverArg,
+
+    /// Deprecated, see [`App::color`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
+    ColorAuto,
+
+    /// Deprecated, see [`App::color`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
+    ColorAlways,
+
+    /// Deprecated, see [`App::color`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `App::color`")]
+    ColorNever,
 
     /// Disables the automatic collapsing of positional args into `[ARGS]` inside the usage string
     ///

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -27,6 +27,7 @@ bitflags! {
         const HIDDEN_SHORT_H   = 1 << 18;
         const HIDDEN_LONG_H    = 1 << 19;
         const MULTIPLE_VALS    = 1 << 20;
+        const MULTIPLE         = Self::MULTIPLE_OCC.bits | Self::MULTIPLE_VALS.bits;
         #[cfg(feature = "env")]
         const HIDE_ENV         = 1 << 21;
         const UTF8_NONE        = 1 << 22;
@@ -48,6 +49,7 @@ impl_settings! { ArgSettings, ArgFlags,
     Required("required") => Flags::REQUIRED,
     MultipleOccurrences("multipleoccurrences") => Flags::MULTIPLE_OCC,
     MultipleValues("multiplevalues") => Flags::MULTIPLE_VALS,
+    Multiple("multiple") => Flags::MULTIPLE,
     ForbidEmptyValues("forbidemptyvalues") => Flags::NO_EMPTY_VALS,
     Hidden("hidden") => Flags::HIDDEN,
     TakesValue("takesvalue") => Flags::TAKES_VAL,
@@ -59,6 +61,7 @@ impl_settings! { ArgSettings, ArgFlags,
     RequireEquals("requireequals") => Flags::REQUIRE_EQUALS,
     Last("last") => Flags::LAST,
     IgnoreCase("ignorecase") => Flags::CASE_INSENSITIVE,
+    CaseInsensitive("ignorecase") => Flags::CASE_INSENSITIVE,
     #[cfg(feature = "env")]
     HideEnv("hideenv") => Flags::HIDE_ENV,
     #[cfg(feature = "env")]
@@ -85,6 +88,13 @@ pub enum ArgSettings {
     MultipleValues,
     /// Allows an arg to appear multiple times
     MultipleOccurrences,
+    /// Deprecated, see [`ArgSettings::MultipleOccurrences`] (most likely what you want) and
+    /// [`ArgSettings::MultipleValues`]
+    #[deprecated(
+        since = "3.0.0",
+        note = "Split into `ArgSettings::MultipleOccurrences` (most likely what you want)  and `ArgSettings::MultipleValues`"
+    )]
+    Multiple,
     /// Forbids an arg from accepting empty values such as `""`
     ForbidEmptyValues,
     /// Hides an arg from the help message
@@ -111,6 +121,9 @@ pub enum ArgSettings {
     HideDefaultValue,
     /// Possible values become case insensitive
     IgnoreCase,
+    /// Deprecated, see [`ArgSettings::IgnoreCase`]
+    #[deprecated(since = "3.0.0", note = "Replaced with `ArgSettings::IgnoreCase`")]
+    CaseInsensitive,
     /// Hides environment variable arguments from the help message
     #[cfg(feature = "env")]
     HideEnv,

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -31,6 +31,7 @@ bitflags! {
         #[cfg(feature = "env")]
         const HIDE_ENV         = 1 << 21;
         const UTF8_NONE        = 1 << 22;
+        const NO_OP            = 0;
     }
 }
 
@@ -51,6 +52,7 @@ impl_settings! { ArgSettings, ArgFlags,
     MultipleValues("multiplevalues") => Flags::MULTIPLE_VALS,
     Multiple("multiple") => Flags::MULTIPLE,
     ForbidEmptyValues("forbidemptyvalues") => Flags::NO_EMPTY_VALS,
+    EmptyValues("emptyvalues") => Flags::NO_OP,
     Hidden("hidden") => Flags::HIDDEN,
     TakesValue("takesvalue") => Flags::TAKES_VAL,
     UseValueDelimiter("usevaluedelimiter") => Flags::USE_DELIM,
@@ -97,6 +99,13 @@ pub enum ArgSettings {
     Multiple,
     /// Forbids an arg from accepting empty values such as `""`
     ForbidEmptyValues,
+    /// Deprecated, this is now the default, see [`ArgSettings::ForbidEmptyValues`] for the
+    /// opposite.
+    #[deprecated(
+        since = "3.0.0",
+        note = "This is now the default see [`ArgSettings::ForbidEmptyValues`] for the opposite."
+    )]
+    EmptyValues,
     /// Hides an arg from the help message
     Hidden,
     /// Allows an argument to take a value (such as `--option value`)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -553,6 +553,7 @@ macro_rules! impl_settings {
 
             #[allow(dead_code)]
             pub(crate) fn set(&mut self, s: $settings) {
+                #[allow(deprecated)]  // some Settings might be deprecated
                 match s {
                     $(
                         $(#[$inner $($args)*])*
@@ -563,6 +564,7 @@ macro_rules! impl_settings {
 
             #[allow(dead_code)]
             pub(crate) fn unset(&mut self, s: $settings) {
+                #[allow(deprecated)]  // some Settings might be deprecated
                 match s {
                     $(
                         $(#[$inner $($args)*])*
@@ -573,6 +575,7 @@ macro_rules! impl_settings {
 
             #[allow(dead_code)]
             pub(crate) fn is_set(&self, s: $settings) -> bool {
+                #[allow(deprecated)]  // some Settings might be deprecated
                 match s {
                     $(
                         $(#[$inner $($args)*])*
@@ -622,6 +625,8 @@ macro_rules! impl_settings {
         impl FromStr for $settings {
             type Err = String;
             fn from_str(s: &str) -> Result<Self, <Self as FromStr>::Err> {
+                #[allow(deprecated)]  // some Settings might be deprecated
+                #[allow(unreachable_patterns)] // some Settings might be deprecated
                 match &*s.to_ascii_lowercase() {
                     $(
                         $(#[$inner $($args)*])*


### PR DESCRIPTION
This is handling non-behavior changes in Settings as part of #2617 