### PR TITLE
fix ArgEnum multiline doc comment

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -794,11 +794,22 @@ impl Attrs {
     }
 
     /// generate methods on top of a field
-    pub fn field_methods(&self) -> proc_macro2::TokenStream {
+    pub fn field_methods(&self, supports_long_about: bool) -> proc_macro2::TokenStream {
         let methods = &self.methods;
-        let doc_comment = &self.doc_comment;
         let help_heading = self.help_heading.as_ref().into_iter();
-        quote!( #(#doc_comment)* #(#help_heading)* #(#methods)* )
+        match supports_long_about {
+            true => {
+                let doc_comment = &self.doc_comment;
+                quote!( #(#doc_comment)* #(#help_heading)* #(#methods)* )
+            }
+            false => {
+                let doc_comment = self
+                    .doc_comment
+                    .iter()
+                    .filter(|mth| mth.name != "long_about");
+                quote!( #(#doc_comment)* #(#help_heading)* #(#methods)* )
+            }
+        }
     }
 
     pub fn cased_name(&self) -> TokenStream {

--- a/clap_derive/src/derives/arg_enum.rs
+++ b/clap_derive/src/derives/arg_enum.rs
@@ -85,7 +85,7 @@ fn lits(
             if let Kind::Skip(_) = &*attrs.kind() {
                 None
             } else {
-                let fields = attrs.field_methods();
+                let fields = attrs.field_methods(false);
                 let name = attrs.cased_name();
                 Some((
                     quote! {

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -347,7 +347,7 @@ pub fn gen_augment(
                 };
 
                 let name = attrs.cased_name();
-                let methods = attrs.field_methods();
+                let methods = attrs.field_methods(true);
 
                 Some(quote_spanned! { field.span()=>
                     let #app_var = #app_var.arg(

--- a/clap_derive/tests/doc-comments-help.rs
+++ b/clap_derive/tests/doc-comments-help.rs
@@ -14,7 +14,7 @@
 
 mod utils;
 
-use clap::Parser;
+use clap::{ArgEnum, Parser};
 use utils::*;
 
 #[test]
@@ -203,4 +203,15 @@ fn multiline_separates_default() {
     // The short help should still have the default on the same line
     let help = get_help::<App>();
     assert!(help.contains("Multiline [default"));
+}
+
+#[test]
+fn argenum_multiline_doc_comment() {
+    #[derive(ArgEnum, Clone)]
+    enum LoremIpsum {
+        /// Multiline
+        ///
+        /// Doc comment
+        Bar,
+    }
 }


### PR DESCRIPTION
I used something like this in my code, which failed
```rust
    #[derive(ArgEnum, Clone)]
    enum LoremIpsum {
        /// Multiline
        ///
        /// Doc comment
        Bar,
    }
```

because it expanded to this
```rust
    impl clap::ArgEnum for LoremIpsum {
        fn value_variants<'a>() -> &'a [Self] {
            &[Self::Bar]
        }
        fn to_arg_value<'a>(&self) -> Option<clap::ArgValue<'a>> {
            match self {
                Self::Bar => Some(
                    clap::ArgValue::new("bar")
                        .about("Multiline")
                        .long_about("Multiline\n\nDoc comment"),
                ),
                _ => None,
            }
        }
    }
 ```
 ArgValue does not seem to support long_about, so my fix was to just omit that method call. Maybe the true fix is to add long_about support to ArgValue?
 