### PR TITLE
Fix packaging of LICENSE-* files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 include = [
 	"src/**/*",
 	"Cargo.toml",
+	"LICENSE-*",
 	"README.md"
 ]
 description = "A simple to use, efficient, and full-featured Command Line Argument Parser"

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 include = [
 	"src/**/*",
 	"Cargo.toml",
+	"LICENSE-*",
 	"README.md"
 ]
 description = "Parse command line argument by defining a struct, derive crate."

--- a/clap_generate/Cargo.toml
+++ b/clap_generate/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 include = [
 	"src/**/*",
 	"Cargo.toml",
+	"LICENSE-*",
 	"README.md"
 ]
 description = "A generator library used with clap for shell completion scripts, manpage, etc."

--- a/clap_generate_fig/Cargo.toml
+++ b/clap_generate_fig/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
 include = [
 	"src/**/*",
 	"Cargo.toml",
+	"LICENSE-*",
 	"README.md"
 ]
 description = "A generator library used with clap for Fig completion scripts"


### PR DESCRIPTION
Neither `LICENSE-MIT` nor `LICENSE-APACHE` were present in the packaged crates in this repo as they were not part of the inclusion list, which this PR addresses.