### PR TITLE
chore: Silence bad clippy lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 #![forbid(unsafe_code)]
 // TODO: https://github.com/rust-lang/rust-clippy/issues/7290
 #![allow(clippy::single_component_path_imports)]
+#![allow(clippy::branches_sharing_code)]
 
 #[cfg(not(feature = "std"))]
 compile_error!("`std` feature is currently required to build `clap`");


### PR DESCRIPTION
While in some cases "branches-sharing-code" might catch bugs, it overall encourages a form
of DRY that leads to bad code.  In this specific case, it is relying on
the implementation detail of the formatting of each branch being the
same.  If the `'` wasn't part of it, I could see it being about a shared
`?` to go with the shared start of the question.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
