### PR TITLE
fix(derive): Support arg_enum everywhere

### DIFF
--- a/clap_derive/src/utils/mod.rs
+++ b/clap_derive/src/utils/mod.rs
@@ -5,5 +5,5 @@ mod ty;
 pub use self::{
     doc_comments::process_doc_comment,
     spanned::Sp,
-    ty::{is_simple_ty, sub_type, subty_if_name, Ty},
+    ty::{inner_type, is_simple_ty, sub_type, subty_if_name, Ty},
 };

--- a/clap_derive/src/utils/ty.rs
+++ b/clap_derive/src/utils/ty.rs
@@ -40,6 +40,16 @@ impl Ty {
     }
 }
 
+pub fn inner_type(ty: Ty, field_ty: &syn::Type) -> &syn::Type {
+    match ty {
+        Ty::Vec | Ty::Option => sub_type(field_ty).unwrap_or(field_ty),
+        Ty::OptionOption | Ty::OptionVec => {
+            sub_type(field_ty).and_then(sub_type).unwrap_or(field_ty)
+        }
+        _ => field_ty,
+    }
+}
+
 pub fn sub_type(ty: &syn::Type) -> Option<&syn::Type> {
     subty_if(ty, |_| true)
 }

--- a/clap_derive/tests/arg_enum.rs
+++ b/clap_derive/tests/arg_enum.rs
@@ -327,6 +327,37 @@ fn option() {
 }
 
 #[test]
+fn option_option() {
+    #[derive(ArgEnum, PartialEq, Debug, Clone)]
+    enum ArgChoice {
+        Foo,
+        Bar,
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[clap(arg_enum, long)]
+        arg: Option<Option<ArgChoice>>,
+    }
+
+    assert_eq!(Opt { arg: None }, Opt::parse_from(&[""]));
+    assert_eq!(Opt { arg: Some(None) }, Opt::parse_from(&["", "--arg"]));
+    assert_eq!(
+        Opt {
+            arg: Some(Some(ArgChoice::Foo))
+        },
+        Opt::parse_from(&["", "--arg", "foo"])
+    );
+    assert_eq!(
+        Opt {
+            arg: Some(Some(ArgChoice::Bar))
+        },
+        Opt::parse_from(&["", "--arg", "bar"])
+    );
+    assert!(Opt::try_parse_from(&["", "--arg", "fOo"]).is_err());
+}
+
+#[test]
 fn vector() {
     #[derive(ArgEnum, PartialEq, Debug, Clone)]
     enum ArgChoice {
@@ -350,6 +381,37 @@ fn vector() {
     assert_eq!(
         Opt {
             arg: vec![ArgChoice::Foo, ArgChoice::Bar]
+        },
+        Opt::parse_from(&["", "-a", "foo", "bar"])
+    );
+    assert!(Opt::try_parse_from(&["", "-a", "fOo"]).is_err());
+}
+
+#[test]
+fn option_vector() {
+    #[derive(ArgEnum, PartialEq, Debug, Clone)]
+    enum ArgChoice {
+        Foo,
+        Bar,
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[clap(arg_enum, short, long)]
+        arg: Option<Vec<ArgChoice>>,
+    }
+
+    assert_eq!(Opt { arg: None }, Opt::parse_from(&[""]));
+    assert_eq!(Opt { arg: Some(vec![]) }, Opt::parse_from(&["", "-a"]));
+    assert_eq!(
+        Opt {
+            arg: Some(vec![ArgChoice::Foo])
+        },
+        Opt::parse_from(&["", "-a", "foo"])
+    );
+    assert_eq!(
+        Opt {
+            arg: Some(vec![ArgChoice::Foo, ArgChoice::Bar])
         },
         Opt::parse_from(&["", "-a", "foo", "bar"])
     );


### PR DESCRIPTION
In working on converting unwraps to errors, I noticed that we did not
support `arg_enum` for  `Option<Option<_>>` and `Option<Vec<_>>`, so this
addresses that.

My main motivation was to consolidate and make the logic more
consistent, the bug fix just fell out of that work.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
