### PR TITLE
fix(derive): Use variants help_heading

### DIFF
--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -224,7 +224,7 @@ fn gen_augment(
                     };
 
                     let name = attrs.cased_name();
-                    let initial_app_methods = parent_attribute.initial_top_level_methods();
+                    let initial_app_methods = attrs.initial_top_level_methods();
                     let final_from_attrs = attrs.final_top_level_methods();
                     let subcommand = quote! {
                         let #app_var = #app_var.subcommand({
@@ -267,7 +267,7 @@ fn gen_augment(
                     };
 
                     let name = attrs.cased_name();
-                    let initial_app_methods = parent_attribute.initial_top_level_methods();
+                    let initial_app_methods = attrs.initial_top_level_methods();
                     let final_from_attrs = attrs.final_top_level_methods();
                     let subcommand = quote! {
                         let #app_var = #app_var.subcommand({

--- a/clap_derive/tests/help.rs
+++ b/clap_derive/tests/help.rs
@@ -90,27 +90,27 @@ fn app_help_heading_flattened() {
     }
 
     #[derive(Debug, Clone, Subcommand)]
-    #[clap(help_heading = "SUB A")]
     enum SubA {
         #[clap(flatten)]
         SubB(SubB),
         #[clap(subcommand)]
         SubC(SubC),
         SubAOne,
+        #[clap(help_heading = "SUB A")]
         SubATwo {
             should_be_in_sub_a: Option<u32>,
         },
     }
 
     #[derive(Debug, Clone, Subcommand)]
-    #[clap(help_heading = "SUB B")]
     enum SubB {
+        #[clap(help_heading = "SUB B")]
         SubBOne { should_be_in_sub_b: Option<u32> },
     }
 
     #[derive(Debug, Clone, Subcommand)]
-    #[clap(help_heading = "SUB C")]
     enum SubC {
+        #[clap(help_heading = "SUB C")]
         SubCOne { should_be_in_sub_c: Option<u32> },
     }
 


### PR DESCRIPTION
Due to a copy/paste bug, we were reading the `help_heading` for
Subcommands from the enum's attribute and not the variant's attribute.

It doesn't make sense for the outer command's help_heading to control
the subcommands help_heading.

This does raise an interesting question on inheriting / propagating help_heading,
which I originally wrote the tests for.  We'd first need to answer
whether it should be built-in to the builder or derive-specific.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
