### PR TITLE
fix(derive): Don't duplicate subcommand aliases

### DIFF
--- a/clap_derive/tests/issues.rs
+++ b/clap_derive/tests/issues.rs
@@ -76,6 +76,32 @@ fn issue_324() {
 }
 
 #[test]
+fn issue_418() {
+    #[derive(Debug, Parser)]
+    struct Opts {
+        #[clap(subcommand)]
+        /// The command to run
+        command: Command,
+    }
+
+    #[derive(Debug, Subcommand)]
+    enum Command {
+        /// Reticulate the splines
+        #[clap(visible_alias = "ret")]
+        Reticulate {
+            /// How many splines
+            num_splines: u8,
+        },
+        /// Frobnicate the rest
+        #[clap(visible_alias = "frob")]
+        Frobnicate,
+    }
+
+    let help = get_long_help::<Opts>();
+    assert!(help.contains("Reticulate the splines [aliases: ret]"));
+}
+
+#[test]
 fn issue_490() {
     use clap::Parser;
     use std::iter::FromIterator;


### PR DESCRIPTION
When an anonymous struct is inside of an enum, we end up applying the
App methods twice, once for the `augment_args` and once for variant.

This consolidates those calls.

Fixes #2898

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
