### PR TITLE
Add DisableColoredHelp setting to improve flexibility

### DIFF
--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -25,6 +25,7 @@ bitflags! {
         const NO_POS_VALUES                  = 1 << 17;
         const NEXT_LINE_HELP                 = 1 << 18;
         const DERIVE_DISP_ORDER              = 1 << 19;
+        const DISABLE_COLORED_HELP           = 1 << 20;
         const COLOR_ALWAYS                   = 1 << 21;
         const COLOR_AUTO                     = 1 << 22;
         const COLOR_NEVER                    = 1 << 23;
@@ -97,6 +98,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::DONT_COLLAPSE_ARGS,
     DeriveDisplayOrder("derivedisplayorder")
         => Flags::DERIVE_DISP_ORDER,
+    DisableColoredHelp("disablecoloredhelp")
+        => Flags::DISABLE_COLORED_HELP,
     DisableHelpSubcommand("disablehelpsubcommand")
         => Flags::DISABLE_HELP_SC,
     DisableHelpFlag("disablehelpflag")
@@ -557,6 +560,18 @@ pub enum AppSettings {
     ///
     /// [`Arg::use_delimiter(false)`]: crate::Arg::use_delimiter()
     DontDelimitTrailingValues,
+
+    /// Disables colorized help messages.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::{App, AppSettings};
+    /// App::new("myprog")
+    ///     .setting(AppSettings::DisableColoredHelp)
+    ///     .get_matches();
+    /// ```
+    DisableColoredHelp,
 
     /// Disables `-h` and `--help` flag.
     ///
@@ -1172,6 +1187,10 @@ mod test {
         assert_eq!(
             "derivedisplayorder".parse::<AppSettings>().unwrap(),
             AppSettings::DeriveDisplayOrder
+        );
+        assert_eq!(
+            "disablecoloredhelp".parse::<AppSettings>().unwrap(),
+            AppSettings::DisableColoredHelp
         );
         assert_eq!(
             "propagateversion".parse::<AppSettings>().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,14 @@
 #[cfg(not(feature = "std"))]
 compile_error!("`std` feature is currently required to build `clap`");
 
+#[cfg(feature = "color")]
+pub use crate::util::color::ColorChoice;
 pub use crate::{
     build::{
         App, AppFlags, AppSettings, Arg, ArgFlags, ArgGroup, ArgSettings, PossibleValue, ValueHint,
     },
     parse::errors::{Error, ErrorKind, Result},
     parse::{ArgMatches, Indices, OsValues, Values},
-    util::color::ColorChoice,
 };
 
 pub use crate::derive::{ArgEnum, Args, FromArgMatches, IntoApp, Parser, Subcommand};

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -19,7 +19,7 @@ use crate::{
     parse::features::suggestions,
     parse::{ArgMatcher, SubCommand},
     parse::{Validator, ValueType},
-    util::{ChildGraph, Id},
+    util::{color::ColorChoice, ChildGraph, Id},
     INTERNAL_ERROR_MSG, INVALID_UTF8,
 };
 
@@ -331,6 +331,16 @@ impl<'help, 'app> Parser<'help, 'app> {
                 }
             }
         }
+    }
+
+    // Should we color the help?
+    pub(crate) fn color_help(&self) -> ColorChoice {
+        #[cfg(feature = "color")]
+        if self.is_set(AS::DisableColoredHelp) {
+            return ColorChoice::Never;
+        }
+
+        self.app.get_color()
     }
 }
 
@@ -1866,7 +1876,7 @@ impl<'help, 'app> Parser<'help, 'app> {
     }
 
     pub(crate) fn write_help_err(&self) -> ClapResult<Colorizer> {
-        let mut c = Colorizer::new(true, self.app.get_color());
+        let mut c = Colorizer::new(true, self.color_help());
         Help::new(HelpWriter::Buffer(&mut c), self, false).write_help()?;
         Ok(c)
     }
@@ -1878,7 +1888,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         );
 
         use_long = use_long && self.use_long_help();
-        let mut c = Colorizer::new(false, self.app.get_color());
+        let mut c = Colorizer::new(false, self.color_help());
 
         match Help::new(HelpWriter::Buffer(&mut c), self, use_long).write_help() {
             Err(e) => e.into(),
@@ -1894,7 +1904,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         debug!("Parser::version_err");
 
         let msg = self.app._render_version(use_long);
-        let mut c = Colorizer::new(false, self.app.get_color());
+        let mut c = Colorizer::new(false, self.color_help());
         c.none(msg);
         ClapError::new(
             c,


### PR DESCRIPTION
Until we have a modular help generator that can be configured and/or authored by the users themselves as part of #2914, we will provide the flexibility of turning off colored help messages but still wanting colored error messages.

This flexibility was available before #2845 and @dbrgn immediately noticed it and requested it back to which I agree. This was also suggested by Josh in [here](https://github.com/clap-rs/clap/issues/2806#issuecomment-933877438)
