### PR TITLE
fix(error): Never show unrequested color

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -870,7 +870,7 @@ impl Error {
         val: String,
         err: Box<dyn error::Error + Send + Sync>,
     ) -> Self {
-        Self::value_validation_with_color(arg, val, err, ColorChoice::Auto)
+        Self::value_validation_with_color(arg, val, err, ColorChoice::Never)
     }
 
     fn value_validation_with_color(
@@ -996,7 +996,7 @@ impl Error {
     }
 
     pub(crate) fn argument_not_found_auto(arg: String) -> Self {
-        let mut c = Colorizer::new(true, ColorChoice::Auto);
+        let mut c = Colorizer::new(true, ColorChoice::Never);
 
         start_error(&mut c, "The argument '");
         c.warning(arg.clone());


### PR DESCRIPTION
If the user prints a raw error, it may include color even if the user
turned it off at runtime.  Now we'll be more conservative and never show
color for raw errors.

This is a follow up to #2943; apparently I had missed some cases.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
