### PR TITLE
Add new `App::mut_args` for mutating all arguments

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1805,6 +1805,45 @@ impl<'help> App<'help> {
         self
     }
 
+    /// Allows one to mutate all arguments after they've been added to an [`App`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{App, Arg};
+    ///
+    /// let mut app = App::new("foo")
+    ///     .arg(Arg::new("foo")
+    ///         .short('x'))
+    ///     .arg(Arg::new("bar")
+    ///         .short('y'))
+    ///     .mut_args(|a| (a.get_name() == "foo").then(|| a.short('f')));
+    ///
+    /// let res = app.try_get_matches_from_mut(vec!["foo", "-x"]);
+    ///
+    /// // Since we changed `bar`'s short to "f" this should err as there
+    /// // is no `-x` anymore, only `-f`
+    ///
+    /// assert!(res.is_err());
+    ///
+    /// let res = app.try_get_matches_from_mut(vec!["foo", "-f"]);
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn mut_args<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Arg<'help>) -> Option<Arg<'help>>,
+    {
+        for a in self.args.args_mut() {
+            if let Some(arg) = f(a.clone()) {
+                *a = arg;
+                if a.provider == ArgProvider::Generated {
+                    a.provider = ArgProvider::GeneratedMutated;
+                }
+            }
+        }
+        self
+    }
+
     /// Custom error message for post-parsing validation
     ///
     /// # Examples

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1821,7 +1821,7 @@ impl<'help> App<'help> {
     ///
     /// let res = app.try_get_matches_from_mut(vec!["foo", "-x"]);
     ///
-    /// // Since we changed `bar`'s short to "f" this should err as there
+    /// // Since we changed `foo`'s short to "f" this should err as there
     /// // is no `-x` anymore, only `-f`
     ///
     /// assert!(res.is_err());

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -138,7 +138,7 @@ USAGE:
 OPTIONS:
         --first      first about
     -h, --help       Print help information
-        --second     [env: ENV_REPLACED=]
+    -s, --second     
         --third      third arg
     -V, --version    Print version information
 ";
@@ -1257,11 +1257,11 @@ fn partial_mut_args() {
         .arg(
             Arg::new("first").long("first").about("first arg"), // this about will be replaced
         )
-        .arg(Arg::new("second").long("second").env("ENV_SECOND")) // this env will be replaced
+        .arg(Arg::new("second").long("second").short('r')) // this short will be replaced
         .arg(Arg::new("third").long("third").about("third arg")) // this will not be mutated
         .mut_args(|v| match v.get_name() {
             "first" => Some(v.about("first about")),
-            "second" => Some(v.env("ENV_REPLACED")),
+            "second" => Some(v.short('s')),
             _ => None,
         });
 

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -1216,3 +1216,23 @@ fn no_auto_version_mut_arg() {
     assert!(result.is_ok());
     assert!(result.unwrap().is_present("version"));
 }
+
+#[test]
+fn no_auto_version_mut_args() {
+    let app = App::new("myprog")
+        .version("3.0")
+        .mut_args(|v| Some(v.about("custom about")))
+        .setting(AppSettings::NoAutoVersion);
+
+    let result = app
+        .clone()
+        .try_get_matches_from("myprog --version".split(" "));
+
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_present("version"));
+
+    let result = app.clone().try_get_matches_from("myprog -V".split(" "));
+
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_present("version"));
+}

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -130,6 +130,19 @@ SUBCOMMANDS:
             
 ";
 
+static PARTIAL_MUT_ARGS: &str = "myprog 3.0
+
+USAGE:
+    myprog [OPTIONS]
+
+OPTIONS:
+        --first      first about
+    -h, --help       Print help information
+        --second     [env: ENV_REPLACED=]
+        --third      third arg
+    -V, --version    Print version information
+";
+
 #[test]
 fn setting() {
     let m = App::new("setting").setting(AppSettings::AllArgsOverrideSelf);
@@ -1235,4 +1248,27 @@ fn no_auto_version_mut_args() {
 
     assert!(result.is_ok());
     assert!(result.unwrap().is_present("version"));
+}
+
+#[test]
+fn partial_mut_args() {
+    let app = App::new("myprog")
+        .version("3.0")
+        .arg(
+            Arg::new("first").long("first").about("first arg"), // this about will be replaced
+        )
+        .arg(Arg::new("second").long("second").env("ENV_SECOND")) // this env will be replaced
+        .arg(Arg::new("third").long("third").about("third arg")) // this will not be mutated
+        .mut_args(|v| match v.get_name() {
+            "first" => Some(v.about("first about")),
+            "second" => Some(v.env("ENV_REPLACED")),
+            _ => None,
+        });
+
+    assert!(utils::compare_output(
+        app,
+        "myprog -h",
+        PARTIAL_MUT_ARGS,
+        false
+    ));
 }


### PR DESCRIPTION
This adds a `App::mut_args` function that can be used to programmatically mutate all or some arguments by iterating through them even without specifying or knowing the names of the arguments. 

It follows a similar pattern to the existing `App::mut_arg` but instead of specifying a single named argument it will iterate through all arguments in the app and call the closure on them where the user can create or mutate the argument or return `None` to skip affecting it.

Found it useful that the closure returns an `Option` for this so you have a choice in mutating or leaving the argument as is, because otherwise all arguments would be tagged as `ArgProvider::GeneratedMutated` including the auto-generated `version` which often led to `Used App::mut_arg("version", ..) without providing App::version, App::long_version or using AppSettings::NoAutoVersion'`. With returning an `Option` you have to make an explicit choice to mutate an argument or not while iterating through all of them.

One of our use cases that we had that drove the implementation of this was to be able to in our application tests to set an argument setting on all arguments programmatically just in the test context, and we had a lot of arguments so safest, cleanest, and easiest, to be able to set it with this new function.
Essentially: `app.mut_args(|arg| Some(arg.setting(ArgSettings::HideEnvValues)))`.
