### PR TITLE
fix(derive): Support WaitOnError for derive-genned errors

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -12,7 +12,7 @@ use std::{
     env,
     ffi::OsString,
     fmt,
-    io::{self, BufRead, Write},
+    io::{self, Write},
     ops::Index,
     path::Path,
 };
@@ -28,7 +28,7 @@ use crate::{
     mkeymap::MKeyMap,
     output::{fmt::Colorizer, Help, HelpWriter, Usage},
     parse::{ArgMatcher, ArgMatches, Input, Parser, ValueType},
-    util::{color::ColorChoice, safe_exit, Id, Key, USAGE_CODE},
+    util::{color::ColorChoice, Id, Key},
     Error, ErrorKind, Result as ClapResult, INTERNAL_ERROR_MSG,
 };
 
@@ -2029,24 +2029,7 @@ impl<'help> App<'help> {
     /// [`App::get_matches`]: App::get_matches()
     pub fn get_matches_mut(&mut self) -> ArgMatches {
         self.try_get_matches_from_mut(&mut env::args_os())
-            .unwrap_or_else(|e| {
-                // Otherwise, write to stderr and exit
-                if e.use_stderr() {
-                    e.print().expect("Error writing Error to stderr");
-
-                    if self.settings.is_set(AppSettings::WaitOnError) {
-                        wlnerr!("\nPress [ENTER] / [RETURN] to continue...");
-                        let mut s = String::new();
-                        let i = io::stdin();
-                        i.lock().read_line(&mut s).unwrap();
-                    }
-
-                    drop(e);
-                    safe_exit(USAGE_CODE);
-                }
-
-                e.exit()
-            })
+            .unwrap_or_else(|e| e.exit())
     }
 
     /// Starts the parsing process. This method will return a [`clap::Result`] type instead of exiting
@@ -2112,22 +2095,6 @@ impl<'help> App<'help> {
         T: Into<OsString> + Clone,
     {
         self.try_get_matches_from_mut(itr).unwrap_or_else(|e| {
-            // Otherwise, write to stderr and exit
-            if e.use_stderr() {
-                e.print().expect("Error writing Error to stderr");
-
-                if self.settings.is_set(AppSettings::WaitOnError) {
-                    wlnerr!("\nPress [ENTER] / [RETURN] to continue...");
-                    let mut s = String::new();
-                    let i = io::stdin();
-                    i.lock().read_line(&mut s).unwrap();
-                }
-
-                drop(self);
-                drop(e);
-                safe_exit(USAGE_CODE);
-            }
-
             drop(self);
             e.exit()
         })

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -763,6 +763,7 @@ impl<'help, 'app> Parser<'help, 'app> {
             return Err(ClapError::new(
                 message,
                 ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+                self.app.settings.is_set(AS::WaitOnError),
             ));
         }
 
@@ -1881,7 +1882,11 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         match Help::new(HelpWriter::Buffer(&mut c), self, use_long).write_help() {
             Err(e) => e.into(),
-            _ => ClapError::new(c, ErrorKind::DisplayHelp),
+            _ => ClapError::new(
+                c,
+                ErrorKind::DisplayHelp,
+                self.app.settings.is_set(AS::WaitOnError),
+            ),
         }
     }
 
@@ -1891,7 +1896,11 @@ impl<'help, 'app> Parser<'help, 'app> {
         let msg = self.app._render_version(use_long);
         let mut c = Colorizer::new(false, self.app.get_color());
         c.none(msg);
-        ClapError::new(c, ErrorKind::DisplayVersion)
+        ClapError::new(
+            c,
+            ErrorKind::DisplayVersion,
+            self.app.settings.is_set(AS::WaitOnError),
+        )
     }
 }
 

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -66,6 +66,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             return Err(Error::new(
                 message,
                 ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+                self.p.is_set(AS::WaitOnError),
             ));
         }
         self.validate_conflicts(matcher)?;


### PR DESCRIPTION
Before, `Error::exit` didn't provide `WaitOnError`, requiring each call
site to duplicate half of `Error::exit`s behavior to get it.  This
hadn't been done for errors raised by derive-generated code.  Ideally,
these errors never happen but all the same, having this consistent would
be good.

This moves knowledge of `WaitOnError` to `Error` (including through
`Error::format`) so `Error::exit` can wait.  Now all of the callers to
`.exit` get a consistent experience without duplication.

While #2938 made a lot of `Error` fields optional for less churn-heavy
modifications, I made this new field required to minimize the risk of a
raise site forgetting to set it.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
