### PR TITLE
test(derive): Provide better error info

### DIFF
--- a/clap_derive/tests/arg_enum.rs
+++ b/clap_derive/tests/arg_enum.rs
@@ -27,13 +27,13 @@ fn basic() {
         Opt {
             arg: ArgChoice::Foo
         },
-        Opt::parse_from(&["", "foo"])
+        Opt::try_parse_from(&["", "foo"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::Bar
         },
-        Opt::parse_from(&["", "bar"])
+        Opt::try_parse_from(&["", "bar"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "fOo"]).is_err());
 }
@@ -68,19 +68,19 @@ fn default_value() {
         Opt {
             arg: ArgChoice::Foo
         },
-        Opt::parse_from(&["", "foo"])
+        Opt::try_parse_from(&["", "foo"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::Bar
         },
-        Opt::parse_from(&["", "bar"])
+        Opt::try_parse_from(&["", "bar"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::Bar
         },
-        Opt::parse_from(&[""])
+        Opt::try_parse_from(&[""]).unwrap()
     );
 }
 
@@ -103,13 +103,13 @@ fn multi_word_is_renamed_kebab() {
         Opt {
             arg: ArgChoice::FooBar
         },
-        Opt::parse_from(&["", "foo-bar"])
+        Opt::try_parse_from(&["", "foo-bar"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::BAR_BAZ
         },
-        Opt::parse_from(&["", "bar-baz"])
+        Opt::try_parse_from(&["", "bar-baz"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "FooBar"]).is_err());
 }
@@ -132,7 +132,7 @@ fn variant_with_defined_casing() {
         Opt {
             arg: ArgChoice::FooBar
         },
-        Opt::parse_from(&["", "FOO_BAR"])
+        Opt::try_parse_from(&["", "FOO_BAR"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "FooBar"]).is_err());
 }
@@ -155,7 +155,7 @@ fn casing_is_propagated_from_parent() {
         Opt {
             arg: ArgChoice::FooBar
         },
-        Opt::parse_from(&["", "FOO_BAR"])
+        Opt::try_parse_from(&["", "FOO_BAR"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "FooBar"]).is_err());
 }
@@ -179,7 +179,7 @@ fn casing_propagation_is_overridden() {
         Opt {
             arg: ArgChoice::FooBar
         },
-        Opt::parse_from(&["", "fooBar"])
+        Opt::try_parse_from(&["", "fooBar"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "FooBar"]).is_err());
     assert!(Opt::try_parse_from(&["", "FOO_BAR"]).is_err());
@@ -202,13 +202,13 @@ fn case_insensitive() {
         Opt {
             arg: ArgChoice::Foo
         },
-        Opt::parse_from(&["", "foo"])
+        Opt::try_parse_from(&["", "foo"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::Foo
         },
-        Opt::parse_from(&["", "fOo"])
+        Opt::try_parse_from(&["", "fOo"]).unwrap()
     );
 }
 
@@ -229,7 +229,7 @@ fn case_insensitive_set_to_false() {
         Opt {
             arg: ArgChoice::Foo
         },
-        Opt::parse_from(&["", "foo"])
+        Opt::try_parse_from(&["", "foo"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "fOo"]).is_err());
 }
@@ -252,13 +252,13 @@ fn alias() {
         Opt {
             arg: ArgChoice::TOTP
         },
-        Opt::parse_from(&["", "totp"])
+        Opt::try_parse_from(&["", "totp"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::TOTP
         },
-        Opt::parse_from(&["", "TOTP"])
+        Opt::try_parse_from(&["", "TOTP"]).unwrap()
     );
 }
 
@@ -280,19 +280,19 @@ fn multiple_alias() {
         Opt {
             arg: ArgChoice::TOTP
         },
-        Opt::parse_from(&["", "totp"])
+        Opt::try_parse_from(&["", "totp"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::TOTP
         },
-        Opt::parse_from(&["", "TOTP"])
+        Opt::try_parse_from(&["", "TOTP"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: ArgChoice::TOTP
         },
-        Opt::parse_from(&["", "t"])
+        Opt::try_parse_from(&["", "t"]).unwrap()
     );
 }
 
@@ -310,18 +310,18 @@ fn option() {
         arg: Option<ArgChoice>,
     }
 
-    assert_eq!(Opt { arg: None }, Opt::parse_from(&[""]));
+    assert_eq!(Opt { arg: None }, Opt::try_parse_from(&[""]).unwrap());
     assert_eq!(
         Opt {
             arg: Some(ArgChoice::Foo)
         },
-        Opt::parse_from(&["", "foo"])
+        Opt::try_parse_from(&["", "foo"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: Some(ArgChoice::Bar)
         },
-        Opt::parse_from(&["", "bar"])
+        Opt::try_parse_from(&["", "bar"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "fOo"]).is_err());
 }
@@ -340,19 +340,22 @@ fn option_option() {
         arg: Option<Option<ArgChoice>>,
     }
 
-    assert_eq!(Opt { arg: None }, Opt::parse_from(&[""]));
-    assert_eq!(Opt { arg: Some(None) }, Opt::parse_from(&["", "--arg"]));
+    assert_eq!(Opt { arg: None }, Opt::try_parse_from(&[""]).unwrap());
+    assert_eq!(
+        Opt { arg: Some(None) },
+        Opt::try_parse_from(&["", "--arg"]).unwrap()
+    );
     assert_eq!(
         Opt {
             arg: Some(Some(ArgChoice::Foo))
         },
-        Opt::parse_from(&["", "--arg", "foo"])
+        Opt::try_parse_from(&["", "--arg", "foo"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: Some(Some(ArgChoice::Bar))
         },
-        Opt::parse_from(&["", "--arg", "bar"])
+        Opt::try_parse_from(&["", "--arg", "bar"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "--arg", "fOo"]).is_err());
 }
@@ -371,18 +374,18 @@ fn vector() {
         arg: Vec<ArgChoice>,
     }
 
-    assert_eq!(Opt { arg: vec![] }, Opt::parse_from(&[""]));
+    assert_eq!(Opt { arg: vec![] }, Opt::try_parse_from(&[""]).unwrap());
     assert_eq!(
         Opt {
             arg: vec![ArgChoice::Foo]
         },
-        Opt::parse_from(&["", "-a", "foo"])
+        Opt::try_parse_from(&["", "-a", "foo"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: vec![ArgChoice::Foo, ArgChoice::Bar]
         },
-        Opt::parse_from(&["", "-a", "foo", "bar"])
+        Opt::try_parse_from(&["", "-a", "foo", "bar"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "-a", "fOo"]).is_err());
 }
@@ -401,19 +404,22 @@ fn option_vector() {
         arg: Option<Vec<ArgChoice>>,
     }
 
-    assert_eq!(Opt { arg: None }, Opt::parse_from(&[""]));
-    assert_eq!(Opt { arg: Some(vec![]) }, Opt::parse_from(&["", "-a"]));
+    assert_eq!(Opt { arg: None }, Opt::try_parse_from(&[""]).unwrap());
+    assert_eq!(
+        Opt { arg: Some(vec![]) },
+        Opt::try_parse_from(&["", "-a"]).unwrap()
+    );
     assert_eq!(
         Opt {
             arg: Some(vec![ArgChoice::Foo])
         },
-        Opt::parse_from(&["", "-a", "foo"])
+        Opt::try_parse_from(&["", "-a", "foo"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: Some(vec![ArgChoice::Foo, ArgChoice::Bar])
         },
-        Opt::parse_from(&["", "-a", "foo", "bar"])
+        Opt::try_parse_from(&["", "-a", "foo", "bar"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["", "-a", "fOo"]).is_err());
 }

--- a/clap_derive/tests/argument_naming.rs
+++ b/clap_derive/tests/argument_naming.rs
@@ -9,7 +9,7 @@ fn test_single_word_enum_variant_is_default_renamed_into_kebab_case() {
 
     assert_eq!(
         Opt::Command { foo: 0 },
-        Opt::parse_from(&["test", "command", "0"])
+        Opt::try_parse_from(&["test", "command", "0"]).unwrap()
     );
 }
 
@@ -22,7 +22,7 @@ fn test_multi_word_enum_variant_is_renamed() {
 
     assert_eq!(
         Opt::FirstCommand { foo: 0 },
-        Opt::parse_from(&["test", "first-command", "0"])
+        Opt::try_parse_from(&["test", "first-command", "0"]).unwrap()
     );
 }
 
@@ -37,7 +37,7 @@ fn test_standalone_long_generates_kebab_case() {
 
     assert_eq!(
         Opt { FOO_OPTION: true },
-        Opt::parse_from(&["test", "--foo-option"])
+        Opt::try_parse_from(&["test", "--foo-option"]).unwrap()
     );
 }
 
@@ -51,7 +51,7 @@ fn test_custom_long_overwrites_default_name() {
 
     assert_eq!(
         Opt { foo_option: true },
-        Opt::parse_from(&["test", "--foo"])
+        Opt::try_parse_from(&["test", "--foo"]).unwrap()
     );
 }
 
@@ -65,7 +65,7 @@ fn test_standalone_long_uses_previous_defined_custom_name() {
 
     assert_eq!(
         Opt { foo_option: true },
-        Opt::parse_from(&["test", "--foo"])
+        Opt::try_parse_from(&["test", "--foo"]).unwrap()
     );
 }
 
@@ -79,7 +79,7 @@ fn test_standalone_long_ignores_afterwards_defined_custom_name() {
 
     assert_eq!(
         Opt { foo_option: true },
-        Opt::parse_from(&["test", "--foo-option"])
+        Opt::try_parse_from(&["test", "--foo-option"]).unwrap()
     );
 }
 
@@ -92,7 +92,10 @@ fn test_standalone_short_generates_kebab_case() {
         FOO_OPTION: bool,
     }
 
-    assert_eq!(Opt { FOO_OPTION: true }, Opt::parse_from(&["test", "-f"]));
+    assert_eq!(
+        Opt { FOO_OPTION: true },
+        Opt::try_parse_from(&["test", "-f"]).unwrap()
+    );
 }
 
 #[test]
@@ -103,7 +106,10 @@ fn test_custom_short_overwrites_default_name() {
         foo_option: bool,
     }
 
-    assert_eq!(Opt { foo_option: true }, Opt::parse_from(&["test", "-o"]));
+    assert_eq!(
+        Opt { foo_option: true },
+        Opt::try_parse_from(&["test", "-o"]).unwrap()
+    );
 }
 
 #[test]
@@ -114,7 +120,10 @@ fn test_standalone_short_uses_previous_defined_custom_name() {
         foo_option: bool,
     }
 
-    assert_eq!(Opt { foo_option: true }, Opt::parse_from(&["test", "-o"]));
+    assert_eq!(
+        Opt { foo_option: true },
+        Opt::try_parse_from(&["test", "-o"]).unwrap()
+    );
 }
 
 #[test]
@@ -125,7 +134,10 @@ fn test_standalone_short_ignores_afterwards_defined_custom_name() {
         foo_option: bool,
     }
 
-    assert_eq!(Opt { foo_option: true }, Opt::parse_from(&["test", "-f"]));
+    assert_eq!(
+        Opt { foo_option: true },
+        Opt::try_parse_from(&["test", "-f"]).unwrap()
+    );
 }
 
 #[test]
@@ -138,7 +150,7 @@ fn test_standalone_long_uses_previous_defined_casing() {
 
     assert_eq!(
         Opt { foo_option: true },
-        Opt::parse_from(&["test", "--FOO_OPTION"])
+        Opt::try_parse_from(&["test", "--FOO_OPTION"]).unwrap()
     );
 }
 
@@ -150,7 +162,10 @@ fn test_standalone_short_uses_previous_defined_casing() {
         foo_option: bool,
     }
 
-    assert_eq!(Opt { foo_option: true }, Opt::parse_from(&["test", "-F"]));
+    assert_eq!(
+        Opt { foo_option: true },
+        Opt::try_parse_from(&["test", "-F"]).unwrap()
+    );
 }
 
 #[test]
@@ -164,7 +179,7 @@ fn test_standalone_long_works_with_verbatim_casing() {
 
     assert_eq!(
         Opt { _fOO_oPtiON: true },
-        Opt::parse_from(&["test", "--_fOO_oPtiON"])
+        Opt::try_parse_from(&["test", "--_fOO_oPtiON"]).unwrap()
     );
 }
 
@@ -176,7 +191,10 @@ fn test_standalone_short_works_with_verbatim_casing() {
         _foo: bool,
     }
 
-    assert_eq!(Opt { _foo: true }, Opt::parse_from(&["test", "-_"]));
+    assert_eq!(
+        Opt { _foo: true },
+        Opt::try_parse_from(&["test", "-_"]).unwrap()
+    );
 }
 
 #[test]
@@ -188,7 +206,10 @@ fn test_rename_all_is_propagated_from_struct_to_fields() {
         foo: bool,
     }
 
-    assert_eq!(Opt { foo: true }, Opt::parse_from(&["test", "--FOO"]));
+    assert_eq!(
+        Opt { foo: true },
+        Opt::try_parse_from(&["test", "--FOO"]).unwrap()
+    );
 }
 
 #[test]
@@ -210,7 +231,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
         Opt {
             foo: Foo { foo: true }
         },
-        Opt::parse_from(&["test", "--foo"])
+        Opt::try_parse_from(&["test", "--foo"]).unwrap()
     );
 }
 
@@ -235,7 +256,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_subcommand() {
         Opt {
             foo: Foo::Command { foo: true }
         },
-        Opt::parse_from(&["test", "command", "--foo"])
+        Opt::try_parse_from(&["test", "command", "--foo"]).unwrap()
     );
 }
 
@@ -253,12 +274,12 @@ fn test_rename_all_is_propagated_from_enum_to_variants_and_their_fields() {
 
     assert_eq!(
         Opt::FirstVariant,
-        Opt::parse_from(&["test", "FIRST_VARIANT"])
+        Opt::try_parse_from(&["test", "FIRST_VARIANT"]).unwrap()
     );
 
     assert_eq!(
         Opt::SecondVariant { foo: true },
-        Opt::parse_from(&["test", "SECOND_VARIANT", "--FOO"])
+        Opt::try_parse_from(&["test", "SECOND_VARIANT", "--FOO"]).unwrap()
     );
 }
 
@@ -280,12 +301,12 @@ fn test_rename_all_is_propagation_can_be_overridden() {
 
     assert_eq!(
         Opt::FirstVariant { foo_option: true },
-        Opt::parse_from(&["test", "first-variant", "--foo-option"])
+        Opt::try_parse_from(&["test", "first-variant", "--foo-option"]).unwrap()
     );
 
     assert_eq!(
         Opt::SecondVariant { foo_option: true },
-        Opt::parse_from(&["test", "SECOND_VARIANT", "--foo-option"])
+        Opt::try_parse_from(&["test", "SECOND_VARIANT", "--foo-option"]).unwrap()
     );
 }
 
@@ -299,7 +320,7 @@ fn test_lower_is_renamed() {
 
     assert_eq!(
         Opt { foo_option: true },
-        Opt::parse_from(&["test", "--foooption"])
+        Opt::try_parse_from(&["test", "--foooption"]).unwrap()
     );
 }
 
@@ -313,6 +334,6 @@ fn test_upper_is_renamed() {
 
     assert_eq!(
         Opt { foo_option: true },
-        Opt::parse_from(&["test", "--FOOOPTION"])
+        Opt::try_parse_from(&["test", "--FOOOPTION"]).unwrap()
     );
 }

--- a/clap_derive/tests/arguments.rs
+++ b/clap_derive/tests/arguments.rs
@@ -21,7 +21,10 @@ fn required_argument() {
     struct Opt {
         arg: i32,
     }
-    assert_eq!(Opt { arg: 42 }, Opt::parse_from(&["test", "42"]));
+    assert_eq!(
+        Opt { arg: 42 },
+        Opt::try_parse_from(&["test", "42"]).unwrap()
+    );
     assert!(Opt::try_parse_from(&["test"]).is_err());
     assert!(Opt::try_parse_from(&["test", "42", "24"]).is_err());
 }
@@ -32,8 +35,11 @@ fn optional_argument() {
     struct Opt {
         arg: Option<i32>,
     }
-    assert_eq!(Opt { arg: Some(42) }, Opt::parse_from(&["test", "42"]));
-    assert_eq!(Opt { arg: None }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: Some(42) },
+        Opt::try_parse_from(&["test", "42"]).unwrap()
+    );
+    assert_eq!(Opt { arg: None }, Opt::try_parse_from(&["test"]).unwrap());
     assert!(Opt::try_parse_from(&["test", "42", "24"]).is_err());
 }
 
@@ -44,8 +50,11 @@ fn argument_with_default() {
         #[clap(default_value = "42")]
         arg: i32,
     }
-    assert_eq!(Opt { arg: 24 }, Opt::parse_from(&["test", "24"]));
-    assert_eq!(Opt { arg: 42 }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: 24 },
+        Opt::try_parse_from(&["test", "24"]).unwrap()
+    );
+    assert_eq!(Opt { arg: 42 }, Opt::try_parse_from(&["test"]).unwrap());
     assert!(Opt::try_parse_from(&["test", "42", "24"]).is_err());
 }
 
@@ -55,11 +64,14 @@ fn arguments() {
     struct Opt {
         arg: Vec<i32>,
     }
-    assert_eq!(Opt { arg: vec![24] }, Opt::parse_from(&["test", "24"]));
-    assert_eq!(Opt { arg: vec![] }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: vec![24] },
+        Opt::try_parse_from(&["test", "24"]).unwrap()
+    );
+    assert_eq!(Opt { arg: vec![] }, Opt::try_parse_from(&["test"]).unwrap());
     assert_eq!(
         Opt { arg: vec![24, 42] },
-        Opt::parse_from(&["test", "24", "42"])
+        Opt::try_parse_from(&["test", "24", "42"]).unwrap()
     );
 }
 
@@ -98,7 +110,10 @@ fn auto_value_name() {
 
     assert!(help.contains("MY_SPECIAL_ARG"));
     // Ensure the implicit `num_vals` is just 1
-    assert_eq!(Opt { my_special_arg: 10 }, Opt::parse_from(&["test", "10"]));
+    assert_eq!(
+        Opt { my_special_arg: 10 },
+        Opt::try_parse_from(&["test", "10"]).unwrap()
+    );
 }
 
 #[test]
@@ -116,5 +131,8 @@ fn explicit_value_name() {
     assert!(help.contains("BROWNIE_POINTS"));
     assert!(!help.contains("MY_SPECIAL_ARG"));
     // Ensure the implicit `num_vals` is just 1
-    assert_eq!(Opt { my_special_arg: 10 }, Opt::parse_from(&["test", "10"]));
+    assert_eq!(
+        Opt { my_special_arg: 10 },
+        Opt::try_parse_from(&["test", "10"]).unwrap()
+    );
 }

--- a/clap_derive/tests/basic.rs
+++ b/clap_derive/tests/basic.rs
@@ -21,11 +21,14 @@ fn basic() {
         #[clap(short = 'a', long = "arg")]
         arg: Vec<i32>,
     }
-    assert_eq!(Opt { arg: vec![24] }, Opt::parse_from(&["test", "-a24"]));
-    assert_eq!(Opt { arg: vec![] }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: vec![24] },
+        Opt::try_parse_from(&["test", "-a24"]).unwrap()
+    );
+    assert_eq!(Opt { arg: vec![] }, Opt::try_parse_from(&["test"]).unwrap());
     assert_eq!(
         Opt { arg: vec![24, 42] },
-        Opt::parse_from(&["test", "--arg", "24", "42"])
+        Opt::try_parse_from(&["test", "--arg", "24", "42"]).unwrap()
     );
 }
 
@@ -37,7 +40,7 @@ fn update_basic() {
         single_value: i32,
     }
 
-    let mut opt = Opt::parse_from(&["test", "-a0"]);
+    let mut opt = Opt::try_parse_from(&["test", "-a0"]).unwrap();
 
     opt.update_from(&["test", "-a42"]);
 
@@ -49,5 +52,5 @@ fn unit_struct() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt;
 
-    assert_eq!(Opt {}, Opt::parse_from(&["test"]));
+    assert_eq!(Opt {}, Opt::try_parse_from(&["test"]).unwrap());
 }

--- a/clap_derive/tests/boxed.rs
+++ b/clap_derive/tests/boxed.rs
@@ -27,13 +27,13 @@ fn boxed_flatten_subcommand() {
                 arg: Box::new(Ext { arg: 1 })
             })
         },
-        Opt::parse_from(&["test", "flame", "1"])
+        Opt::try_parse_from(&["test", "flame", "1"]).unwrap()
     );
 }
 
 #[test]
 fn update_boxed_flatten_subcommand() {
-    let mut opt = Opt::parse_from(&["test", "flame", "1"]);
+    let mut opt = Opt::try_parse_from(&["test", "flame", "1"]).unwrap();
 
     opt.update_from(&["test", "flame", "42"]);
 

--- a/clap_derive/tests/custom-string-parsers.rs
+++ b/clap_derive/tests/custom-string-parsers.rs
@@ -50,10 +50,11 @@ fn test_path_opt_simple() {
             option_path_1: None,
             option_path_2: Some(PathBuf::from("j.zip")),
         },
-        PathOpt::parse_from(&[
+        PathOpt::try_parse_from(&[
             "test", "-p", "/usr/bin", "-v", "/a/b/c", "-v", "/d/e/f", "-v", "/g/h/i", "-q",
             "j.zip",
         ])
+        .unwrap()
     );
 }
 
@@ -71,13 +72,13 @@ struct HexOpt {
 fn test_parse_hex() {
     assert_eq!(
         HexOpt { number: 5 },
-        HexOpt::parse_from(&["test", "-n", "5"])
+        HexOpt::try_parse_from(&["test", "-n", "5"]).unwrap()
     );
     assert_eq!(
         HexOpt {
             number: 0x00ab_cdef
         },
-        HexOpt::parse_from(&["test", "-n", "abcdef"])
+        HexOpt::try_parse_from(&["test", "-n", "abcdef"]).unwrap()
     );
 
     let err = HexOpt::try_parse_from(&["test", "-n", "gg"]).unwrap_err();
@@ -130,7 +131,7 @@ fn test_every_custom_parser() {
             c: "C",
             d: "D"
         },
-        NoOpOpt::parse_from(&["test", "-a=?", "-b=?", "-c=?", "-d=?"])
+        NoOpOpt::try_parse_from(&["test", "-a=?", "-b=?", "-c=?", "-d=?"]).unwrap()
     );
 }
 
@@ -180,7 +181,7 @@ fn test_parser_with_default_value() {
             integer: 9000,
             path: PathBuf::from("src/lib.rs"),
         },
-        DefaultedOpt::parse_from(&[
+        DefaultedOpt::try_parse_from(&[
             "test",
             "-b",
             "E²=p²c²+m²c⁴",
@@ -189,6 +190,7 @@ fn test_parser_with_default_value() {
             "-p",
             "src/lib.rs",
         ])
+        .unwrap()
     );
 }
 
@@ -227,9 +229,10 @@ fn test_parser_occurrences() {
             little_unsigned: 4,
             custom: Foo(5),
         },
-        Occurrences::parse_from(&[
+        Occurrences::try_parse_from(&[
             "test", "-s", "--signed", "--signed", "-l", "-rrrr", "-cccc", "--custom",
         ])
+        .unwrap()
     );
 }
 
@@ -268,7 +271,7 @@ fn test_custom_bool() {
             tribool: None,
             bitset: vec![],
         },
-        Opt::parse_from(&["test", "-dfalse"])
+        Opt::try_parse_from(&["test", "-dfalse"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -277,7 +280,7 @@ fn test_custom_bool() {
             tribool: None,
             bitset: vec![],
         },
-        Opt::parse_from(&["test", "-dtrue"])
+        Opt::try_parse_from(&["test", "-dtrue"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -286,7 +289,7 @@ fn test_custom_bool() {
             tribool: None,
             bitset: vec![],
         },
-        Opt::parse_from(&["test", "-dtrue", "-vfalse"])
+        Opt::try_parse_from(&["test", "-dtrue", "-vfalse"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -295,7 +298,7 @@ fn test_custom_bool() {
             tribool: None,
             bitset: vec![],
         },
-        Opt::parse_from(&["test", "-dtrue", "-vtrue"])
+        Opt::try_parse_from(&["test", "-dtrue", "-vtrue"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -304,7 +307,7 @@ fn test_custom_bool() {
             tribool: Some(false),
             bitset: vec![],
         },
-        Opt::parse_from(&["test", "-dtrue", "-tfalse"])
+        Opt::try_parse_from(&["test", "-dtrue", "-tfalse"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -313,7 +316,7 @@ fn test_custom_bool() {
             tribool: Some(true),
             bitset: vec![],
         },
-        Opt::parse_from(&["test", "-dtrue", "-ttrue"])
+        Opt::try_parse_from(&["test", "-dtrue", "-ttrue"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -322,7 +325,8 @@ fn test_custom_bool() {
             tribool: None,
             bitset: vec![false, true, false, false],
         },
-        Opt::parse_from(&["test", "-dtrue", "-bfalse", "-btrue", "-bfalse", "-bfalse"])
+        Opt::try_parse_from(&["test", "-dtrue", "-bfalse", "-btrue", "-bfalse", "-bfalse"])
+            .unwrap()
     );
 }
 
@@ -336,7 +340,10 @@ fn test_cstring() {
 
     assert!(Opt::try_parse_from(&["test"]).is_err());
     assert_eq!(
-        Opt::parse_from(&["test", "bla"]).c_string.to_bytes(),
+        Opt::try_parse_from(&["test", "bla"])
+            .unwrap()
+            .c_string
+            .to_bytes(),
         b"bla"
     );
     assert!(Opt::try_parse_from(&["test", "bla\0bla"]).is_err());

--- a/clap_derive/tests/default_value.rs
+++ b/clap_derive/tests/default_value.rs
@@ -11,8 +11,8 @@ fn default_value() {
         #[clap(default_value = "3")]
         arg: i32,
     }
-    assert_eq!(Opt { arg: 3 }, Opt::parse_from(&["test"]));
-    assert_eq!(Opt { arg: 1 }, Opt::parse_from(&["test", "1"]));
+    assert_eq!(Opt { arg: 3 }, Opt::try_parse_from(&["test"]).unwrap());
+    assert_eq!(Opt { arg: 1 }, Opt::try_parse_from(&["test", "1"]).unwrap());
 
     let help = get_long_help::<Opt>();
     assert!(help.contains("[default: 3]"));
@@ -25,8 +25,8 @@ fn default_value_t() {
         #[clap(default_value_t = 3)]
         arg: i32,
     }
-    assert_eq!(Opt { arg: 3 }, Opt::parse_from(&["test"]));
-    assert_eq!(Opt { arg: 1 }, Opt::parse_from(&["test", "1"]));
+    assert_eq!(Opt { arg: 3 }, Opt::try_parse_from(&["test"]).unwrap());
+    assert_eq!(Opt { arg: 1 }, Opt::try_parse_from(&["test", "1"]).unwrap());
 
     let help = get_long_help::<Opt>();
     assert!(help.contains("[default: 3]"));
@@ -39,8 +39,8 @@ fn auto_default_value_t() {
         #[clap(default_value_t)]
         arg: i32,
     }
-    assert_eq!(Opt { arg: 0 }, Opt::parse_from(&["test"]));
-    assert_eq!(Opt { arg: 1 }, Opt::parse_from(&["test", "1"]));
+    assert_eq!(Opt { arg: 0 }, Opt::try_parse_from(&["test"]).unwrap());
+    assert_eq!(Opt { arg: 1 }, Opt::try_parse_from(&["test", "1"]).unwrap());
 
     let help = get_long_help::<Opt>();
     assert!(help.contains("[default: 0]"));

--- a/clap_derive/tests/deny-warnings.rs
+++ b/clap_derive/tests/deny-warnings.rs
@@ -31,7 +31,7 @@ fn warning_never_struct() {
         Opt {
             s: "foo".to_string()
         },
-        Opt::parse_from(&["test", "foo"])
+        Opt::try_parse_from(&["test", "foo"]).unwrap()
     );
 }
 
@@ -48,6 +48,6 @@ fn warning_never_enum() {
         Opt::Foo {
             s: "foo".to_string()
         },
-        Opt::parse_from(&["test", "foo", "foo"])
+        Opt::try_parse_from(&["test", "foo", "foo"]).unwrap()
     );
 }

--- a/clap_derive/tests/explicit_name_no_renaming.rs
+++ b/clap_derive/tests/explicit_name_no_renaming.rs
@@ -15,7 +15,7 @@ fn explicit_short_long_no_rename() {
         Opt {
             foo: vec!["short".into(), "long".into()]
         },
-        Opt::parse_from(&["test", "-.", "short", "--.foo", "long"])
+        Opt::try_parse_from(&["test", "-.", "short", "--.foo", "long"]).unwrap()
     );
 }
 

--- a/clap_derive/tests/flags.rs
+++ b/clap_derive/tests/flags.rs
@@ -22,9 +22,18 @@ fn unique_flag() {
         alice: bool,
     }
 
-    assert_eq!(Opt { alice: false }, Opt::parse_from(&["test"]));
-    assert_eq!(Opt { alice: true }, Opt::parse_from(&["test", "-a"]));
-    assert_eq!(Opt { alice: true }, Opt::parse_from(&["test", "--alice"]));
+    assert_eq!(
+        Opt { alice: false },
+        Opt::try_parse_from(&["test"]).unwrap()
+    );
+    assert_eq!(
+        Opt { alice: true },
+        Opt::try_parse_from(&["test", "-a"]).unwrap()
+    );
+    assert_eq!(
+        Opt { alice: true },
+        Opt::try_parse_from(&["test", "--alice"]).unwrap()
+    );
     assert!(Opt::try_parse_from(&["test", "-i"]).is_err());
     assert!(Opt::try_parse_from(&["test", "-a", "foo"]).is_err());
     assert!(Opt::try_parse_from(&["test", "-a", "-a"]).is_err());
@@ -41,19 +50,25 @@ fn multiple_flag() {
         bob: u8,
     }
 
-    assert_eq!(Opt { alice: 0, bob: 0 }, Opt::parse_from(&["test"]));
-    assert_eq!(Opt { alice: 1, bob: 0 }, Opt::parse_from(&["test", "-a"]));
+    assert_eq!(
+        Opt { alice: 0, bob: 0 },
+        Opt::try_parse_from(&["test"]).unwrap()
+    );
+    assert_eq!(
+        Opt { alice: 1, bob: 0 },
+        Opt::try_parse_from(&["test", "-a"]).unwrap()
+    );
     assert_eq!(
         Opt { alice: 2, bob: 0 },
-        Opt::parse_from(&["test", "-a", "-a"])
+        Opt::try_parse_from(&["test", "-a", "-a"]).unwrap()
     );
     assert_eq!(
         Opt { alice: 2, bob: 2 },
-        Opt::parse_from(&["test", "-a", "--alice", "-bb"])
+        Opt::try_parse_from(&["test", "-a", "--alice", "-bb"]).unwrap()
     );
     assert_eq!(
         Opt { alice: 3, bob: 1 },
-        Opt::parse_from(&["test", "-aaa", "--bob"])
+        Opt::try_parse_from(&["test", "-aaa", "--bob"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["test", "-i"]).is_err());
     assert!(Opt::try_parse_from(&["test", "-a", "foo"]).is_err());
@@ -73,19 +88,19 @@ fn non_bool_flags() {
         bob: std::sync::atomic::AtomicBool,
     }
 
-    let falsey = Opt::parse_from(&["test"]);
+    let falsey = Opt::try_parse_from(&["test"]).unwrap();
     assert!(!falsey.alice.load(std::sync::atomic::Ordering::Relaxed));
     assert!(!falsey.bob.load(std::sync::atomic::Ordering::Relaxed));
 
-    let alice = Opt::parse_from(&["test", "-a"]);
+    let alice = Opt::try_parse_from(&["test", "-a"]).unwrap();
     assert!(alice.alice.load(std::sync::atomic::Ordering::Relaxed));
     assert!(!alice.bob.load(std::sync::atomic::Ordering::Relaxed));
 
-    let bob = Opt::parse_from(&["test", "-b"]);
+    let bob = Opt::try_parse_from(&["test", "-b"]).unwrap();
     assert!(!bob.alice.load(std::sync::atomic::Ordering::Relaxed));
     assert!(bob.bob.load(std::sync::atomic::Ordering::Relaxed));
 
-    let both = Opt::parse_from(&["test", "-b", "-a"]);
+    let both = Opt::try_parse_from(&["test", "-b", "-a"]).unwrap();
     assert!(both.alice.load(std::sync::atomic::Ordering::Relaxed));
     assert!(both.bob.load(std::sync::atomic::Ordering::Relaxed));
 }
@@ -105,41 +120,41 @@ fn combined_flags() {
             alice: false,
             bob: 0
         },
-        Opt::parse_from(&["test"])
+        Opt::try_parse_from(&["test"]).unwrap()
     );
     assert_eq!(
         Opt {
             alice: true,
             bob: 0
         },
-        Opt::parse_from(&["test", "-a"])
+        Opt::try_parse_from(&["test", "-a"]).unwrap()
     );
     assert_eq!(
         Opt {
             alice: true,
             bob: 0
         },
-        Opt::parse_from(&["test", "-a"])
+        Opt::try_parse_from(&["test", "-a"]).unwrap()
     );
     assert_eq!(
         Opt {
             alice: false,
             bob: 1
         },
-        Opt::parse_from(&["test", "-b"])
+        Opt::try_parse_from(&["test", "-b"]).unwrap()
     );
     assert_eq!(
         Opt {
             alice: true,
             bob: 1
         },
-        Opt::parse_from(&["test", "--alice", "--bob"])
+        Opt::try_parse_from(&["test", "--alice", "--bob"]).unwrap()
     );
     assert_eq!(
         Opt {
             alice: true,
             bob: 4
         },
-        Opt::parse_from(&["test", "-bb", "-a", "-bb"])
+        Opt::try_parse_from(&["test", "-bb", "-a", "-bb"]).unwrap()
     );
 }

--- a/clap_derive/tests/flatten.rs
+++ b/clap_derive/tests/flatten.rs
@@ -33,7 +33,7 @@ fn flatten() {
         Opt {
             common: Common { arg: 42 }
         },
-        Opt::parse_from(&["test", "42"])
+        Opt::try_parse_from(&["test", "42"]).unwrap()
     );
     assert!(Opt::try_parse_from(&["test"]).is_err());
     assert!(Opt::try_parse_from(&["test", "42", "24"]).is_err());
@@ -56,7 +56,7 @@ fn flatten_twice() {
         #[clap(flatten)]
         c2: Common,
     }
-    Opt::parse_from(&["test", "42", "43"]);
+    Opt::try_parse_from(&["test", "42", "43"]).unwrap();
 }
 
 #[test]
@@ -91,14 +91,14 @@ fn flatten_in_subcommand() {
             all: false,
             common: Common { arg: 42 }
         },
-        Opt::parse_from(&["test", "fetch", "42"])
+        Opt::try_parse_from(&["test", "fetch", "42"]).unwrap()
     );
     assert_eq!(
         Opt::Add(Add {
             interactive: true,
             common: Common { arg: 43 }
         }),
-        Opt::parse_from(&["test", "add", "-i", "43"])
+        Opt::try_parse_from(&["test", "add", "-i", "43"]).unwrap()
     );
 }
 
@@ -119,13 +119,13 @@ fn update_args_with_flatten() {
         common: Common { arg: 42 },
     };
     opt.try_update_from(&["test"]).unwrap();
-    assert_eq!(Opt::parse_from(&["test", "42"]), opt);
+    assert_eq!(Opt::try_parse_from(&["test", "42"]).unwrap(), opt);
 
     let mut opt = Opt {
         common: Common { arg: 42 },
     };
     opt.try_update_from(&["test", "52"]).unwrap();
-    assert_eq!(Opt::parse_from(&["test", "52"]), opt);
+    assert_eq!(Opt::try_parse_from(&["test", "52"]).unwrap(), opt);
 }
 
 #[derive(Subcommand, PartialEq, Debug)]
@@ -155,11 +155,11 @@ enum Opt {
 fn merge_subcommands_with_flatten() {
     assert_eq!(
         Opt::BaseCli(BaseCli::Command1(Command1 { arg1: 42, arg2: 44 })),
-        Opt::parse_from(&["test", "command1", "42", "44"])
+        Opt::try_parse_from(&["test", "command1", "42", "44"]).unwrap()
     );
     assert_eq!(
         Opt::Command2(Command2 { arg2: 43 }),
-        Opt::parse_from(&["test", "command2", "43"])
+        Opt::try_parse_from(&["test", "command2", "43"]).unwrap()
     );
 }
 
@@ -168,15 +168,24 @@ fn update_subcommands_with_flatten() {
     let mut opt = Opt::BaseCli(BaseCli::Command1(Command1 { arg1: 12, arg2: 14 }));
     opt.try_update_from(&["test", "command1", "42", "44"])
         .unwrap();
-    assert_eq!(Opt::parse_from(&["test", "command1", "42", "44"]), opt);
+    assert_eq!(
+        Opt::try_parse_from(&["test", "command1", "42", "44"]).unwrap(),
+        opt
+    );
 
     let mut opt = Opt::BaseCli(BaseCli::Command1(Command1 { arg1: 12, arg2: 14 }));
     opt.try_update_from(&["test", "command1", "42"]).unwrap();
-    assert_eq!(Opt::parse_from(&["test", "command1", "42", "14"]), opt);
+    assert_eq!(
+        Opt::try_parse_from(&["test", "command1", "42", "14"]).unwrap(),
+        opt
+    );
 
     let mut opt = Opt::BaseCli(BaseCli::Command1(Command1 { arg1: 12, arg2: 14 }));
     opt.try_update_from(&["test", "command2", "43"]).unwrap();
-    assert_eq!(Opt::parse_from(&["test", "command2", "43"]), opt);
+    assert_eq!(
+        Opt::try_parse_from(&["test", "command2", "43"]).unwrap(),
+        opt
+    );
 }
 
 #[test]
@@ -198,7 +207,7 @@ fn flatten_with_doc_comment() {
         Opt {
             common: Common { arg: 42 }
         },
-        Opt::parse_from(&["test", "42"])
+        Opt::try_parse_from(&["test", "42"]).unwrap()
     );
 
     let help = utils::get_help::<Opt>();

--- a/clap_derive/tests/nested-subcommands.rs
+++ b/clap_derive/tests/nested-subcommands.rs
@@ -51,7 +51,7 @@ fn test_no_cmd() {
             verbose: 0,
             cmd: None
         },
-        Opt2::parse_from(&["test"])
+        Opt2::try_parse_from(&["test"]).unwrap()
     );
 }
 
@@ -63,7 +63,7 @@ fn test_fetch() {
             verbose: 3,
             cmd: Sub::Fetch {}
         },
-        Opt::parse_from(&["test", "-vvv", "fetch"])
+        Opt::try_parse_from(&["test", "-vvv", "fetch"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -71,7 +71,7 @@ fn test_fetch() {
             verbose: 0,
             cmd: Sub::Fetch {}
         },
-        Opt::parse_from(&["test", "--force", "fetch"])
+        Opt::try_parse_from(&["test", "--force", "fetch"]).unwrap()
     );
 }
 
@@ -83,7 +83,7 @@ fn test_add() {
             verbose: 0,
             cmd: Sub::Add {}
         },
-        Opt::parse_from(&["test", "add"])
+        Opt::try_parse_from(&["test", "add"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -91,7 +91,7 @@ fn test_add() {
             verbose: 2,
             cmd: Sub::Add {}
         },
-        Opt::parse_from(&["test", "-vv", "add"])
+        Opt::try_parse_from(&["test", "-vv", "add"]).unwrap()
     );
 }
 
@@ -141,7 +141,7 @@ fn test_subsubcommand() {
                 cmd: Sub3::Quux {}
             }
         },
-        Opt3::parse_from(&["test", "--all", "foo", "lib.rs", "quux"])
+        Opt3::try_parse_from(&["test", "--all", "foo", "lib.rs", "quux"]).unwrap()
     );
 }
 

--- a/clap_derive/tests/non_literal_attributes.rs
+++ b/clap_derive/tests/non_literal_attributes.rs
@@ -49,7 +49,7 @@ fn test_slice() {
             files: Vec::new(),
             values: vec![],
         },
-        Opt::parse_from(&["test", "-l", "1"])
+        Opt::try_parse_from(&["test", "-l", "1"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -58,7 +58,7 @@ fn test_slice() {
             files: Vec::new(),
             values: vec![],
         },
-        Opt::parse_from(&["test", "--level", "1"])
+        Opt::try_parse_from(&["test", "--level", "1"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -67,7 +67,7 @@ fn test_slice() {
             files: Vec::new(),
             values: vec![],
         },
-        Opt::parse_from(&["test", "--set-level", "1"])
+        Opt::try_parse_from(&["test", "--set-level", "1"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -76,7 +76,7 @@ fn test_slice() {
             files: Vec::new(),
             values: vec![],
         },
-        Opt::parse_from(&["test", "--lvl", "1"])
+        Opt::try_parse_from(&["test", "--lvl", "1"]).unwrap()
     );
 }
 
@@ -89,7 +89,7 @@ fn test_multi_args() {
             files: vec!["file".to_string()],
             values: vec![],
         },
-        Opt::parse_from(&["test", "-l", "1", "file"])
+        Opt::try_parse_from(&["test", "-l", "1", "file"]).unwrap()
     );
     assert_eq!(
         Opt {
@@ -98,7 +98,7 @@ fn test_multi_args() {
             files: vec!["FILE".to_string()],
             values: vec![1],
         },
-        Opt::parse_from(&["test", "-l", "1", "--values", "1", "--", "FILE"])
+        Opt::try_parse_from(&["test", "-l", "1", "--values", "1", "--", "FILE"]).unwrap()
     );
 }
 
@@ -117,7 +117,7 @@ fn test_bool() {
             files: vec![],
             values: vec![],
         },
-        Opt::parse_from(&["test", "-l", "1", "--x=1"])
+        Opt::try_parse_from(&["test", "-l", "1", "--x=1"]).unwrap()
     );
     let result = Opt::try_parse_from(&["test", "-l", "1", "--x", "1"]);
     assert!(result.is_err());
@@ -138,13 +138,13 @@ struct HexOpt {
 fn test_parse_hex_function_path() {
     assert_eq!(
         HexOpt { number: 5 },
-        HexOpt::parse_from(&["test", "-n", "5"])
+        HexOpt::try_parse_from(&["test", "-n", "5"]).unwrap()
     );
     assert_eq!(
         HexOpt {
             number: 0x00ab_cdef
         },
-        HexOpt::parse_from(&["test", "-n", "abcdef"])
+        HexOpt::try_parse_from(&["test", "-n", "abcdef"]).unwrap()
     );
 
     let err = HexOpt::try_parse_from(&["test", "-n", "gg"]).unwrap_err();

--- a/clap_derive/tests/options.rs
+++ b/clap_derive/tests/options.rs
@@ -26,9 +26,18 @@ fn required_option() {
         #[clap(short, long)]
         arg: i32,
     }
-    assert_eq!(Opt { arg: 42 }, Opt::parse_from(&["test", "-a42"]));
-    assert_eq!(Opt { arg: 42 }, Opt::parse_from(&["test", "-a", "42"]));
-    assert_eq!(Opt { arg: 42 }, Opt::parse_from(&["test", "--arg", "42"]));
+    assert_eq!(
+        Opt { arg: 42 },
+        Opt::try_parse_from(&["test", "-a42"]).unwrap()
+    );
+    assert_eq!(
+        Opt { arg: 42 },
+        Opt::try_parse_from(&["test", "-a", "42"]).unwrap()
+    );
+    assert_eq!(
+        Opt { arg: 42 },
+        Opt::try_parse_from(&["test", "--arg", "42"]).unwrap()
+    );
     assert!(Opt::try_parse_from(&["test"]).is_err());
     assert!(Opt::try_parse_from(&["test", "-a42", "-a24"]).is_err());
 }
@@ -40,8 +49,11 @@ fn optional_option() {
         #[clap(short)]
         arg: Option<i32>,
     }
-    assert_eq!(Opt { arg: Some(42) }, Opt::parse_from(&["test", "-a42"]));
-    assert_eq!(Opt { arg: None }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: Some(42) },
+        Opt::try_parse_from(&["test", "-a42"]).unwrap()
+    );
+    assert_eq!(Opt { arg: None }, Opt::try_parse_from(&["test"]).unwrap());
     assert!(Opt::try_parse_from(&["test", "-a42", "-a24"]).is_err());
 }
 
@@ -52,8 +64,11 @@ fn option_with_default() {
         #[clap(short, default_value = "42")]
         arg: i32,
     }
-    assert_eq!(Opt { arg: 24 }, Opt::parse_from(&["test", "-a24"]));
-    assert_eq!(Opt { arg: 42 }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: 24 },
+        Opt::try_parse_from(&["test", "-a24"]).unwrap()
+    );
+    assert_eq!(Opt { arg: 42 }, Opt::try_parse_from(&["test"]).unwrap());
     assert!(Opt::try_parse_from(&["test", "-a42", "-a24"]).is_err());
 }
 
@@ -64,8 +79,11 @@ fn option_with_raw_default() {
         #[clap(short, default_value = "42")]
         arg: i32,
     }
-    assert_eq!(Opt { arg: 24 }, Opt::parse_from(&["test", "-a24"]));
-    assert_eq!(Opt { arg: 42 }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: 24 },
+        Opt::try_parse_from(&["test", "-a24"]).unwrap()
+    );
+    assert_eq!(Opt { arg: 42 }, Opt::try_parse_from(&["test"]).unwrap());
     assert!(Opt::try_parse_from(&["test", "-a42", "-a24"]).is_err());
 }
 
@@ -76,11 +94,14 @@ fn options() {
         #[clap(short, long, multiple_occurrences(true))]
         arg: Vec<i32>,
     }
-    assert_eq!(Opt { arg: vec![24] }, Opt::parse_from(&["test", "-a24"]));
-    assert_eq!(Opt { arg: vec![] }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: vec![24] },
+        Opt::try_parse_from(&["test", "-a24"]).unwrap()
+    );
+    assert_eq!(Opt { arg: vec![] }, Opt::try_parse_from(&["test"]).unwrap());
     assert_eq!(
         Opt { arg: vec![24, 42] },
-        Opt::parse_from(&["test", "-a24", "--arg", "42"])
+        Opt::try_parse_from(&["test", "-a24", "--arg", "42"]).unwrap()
     );
 }
 
@@ -91,10 +112,13 @@ fn default_value() {
         #[clap(short, default_value = "test")]
         arg: String,
     }
-    assert_eq!(Opt { arg: "test".into() }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: "test".into() },
+        Opt::try_parse_from(&["test"]).unwrap()
+    );
     assert_eq!(
         Opt { arg: "foo".into() },
-        Opt::parse_from(&["test", "-afoo"])
+        Opt::try_parse_from(&["test", "-afoo"]).unwrap()
     );
 }
 
@@ -115,8 +139,11 @@ fn option_from_str() {
         a: Option<A>,
     }
 
-    assert_eq!(Opt { a: None }, Opt::parse_from(&["test"]));
-    assert_eq!(Opt { a: Some(A) }, Opt::parse_from(&["test", "foo"]));
+    assert_eq!(Opt { a: None }, Opt::try_parse_from(&["test"]).unwrap());
+    assert_eq!(
+        Opt { a: Some(A) },
+        Opt::try_parse_from(&["test", "foo"]).unwrap()
+    );
 }
 
 #[test]
@@ -131,10 +158,13 @@ fn optional_argument_for_optional_option() {
         Opt {
             arg: Some(Some(42))
         },
-        Opt::parse_from(&["test", "-a42"])
+        Opt::try_parse_from(&["test", "-a42"]).unwrap()
     );
-    assert_eq!(Opt { arg: Some(None) }, Opt::parse_from(&["test", "-a"]));
-    assert_eq!(Opt { arg: None }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: Some(None) },
+        Opt::try_parse_from(&["test", "-a"]).unwrap()
+    );
+    assert_eq!(Opt { arg: None }, Opt::try_parse_from(&["test"]).unwrap());
     assert!(Opt::try_parse_from(&["test", "-a42", "-a24"]).is_err());
 }
 
@@ -165,42 +195,42 @@ fn two_option_options() {
             arg: Some(Some(42)),
             field: Some(Some("f".into()))
         },
-        Opt::parse_from(&["test", "-a42", "--field", "f"])
+        Opt::try_parse_from(&["test", "-a42", "--field", "f"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: Some(Some(42)),
             field: Some(None)
         },
-        Opt::parse_from(&["test", "-a42", "--field"])
+        Opt::try_parse_from(&["test", "-a42", "--field"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: Some(None),
             field: Some(None)
         },
-        Opt::parse_from(&["test", "-a", "--field"])
+        Opt::try_parse_from(&["test", "-a", "--field"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: Some(None),
             field: Some(Some("f".into()))
         },
-        Opt::parse_from(&["test", "-a", "--field", "f"])
+        Opt::try_parse_from(&["test", "-a", "--field", "f"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: None,
             field: Some(None)
         },
-        Opt::parse_from(&["test", "--field"])
+        Opt::try_parse_from(&["test", "--field"]).unwrap()
     );
     assert_eq!(
         Opt {
             arg: None,
             field: None
         },
-        Opt::parse_from(&["test"])
+        Opt::try_parse_from(&["test"]).unwrap()
     );
 }
 
@@ -213,52 +243,55 @@ fn optional_vec() {
     }
     assert_eq!(
         Opt { arg: Some(vec![1]) },
-        Opt::parse_from(&["test", "-a", "1"])
+        Opt::try_parse_from(&["test", "-a", "1"]).unwrap()
     );
 
     assert_eq!(
         Opt {
             arg: Some(vec![1, 2])
         },
-        Opt::parse_from(&["test", "-a1", "-a2"])
+        Opt::try_parse_from(&["test", "-a1", "-a2"]).unwrap()
     );
 
     assert_eq!(
         Opt {
             arg: Some(vec![1, 2])
         },
-        Opt::parse_from(&["test", "-a1", "-a2", "-a"])
+        Opt::try_parse_from(&["test", "-a1", "-a2", "-a"]).unwrap()
     );
 
     assert_eq!(
         Opt {
             arg: Some(vec![1, 2])
         },
-        Opt::parse_from(&["test", "-a1", "-a", "-a2"])
+        Opt::try_parse_from(&["test", "-a1", "-a", "-a2"]).unwrap()
     );
 
     assert_eq!(
         Opt {
             arg: Some(vec![1, 2])
         },
-        Opt::parse_from(&["test", "-a", "1", "2"])
+        Opt::try_parse_from(&["test", "-a", "1", "2"]).unwrap()
     );
 
     assert_eq!(
         Opt {
             arg: Some(vec![1, 2, 3])
         },
-        Opt::parse_from(&["test", "-a", "1", "2", "-a", "3"])
+        Opt::try_parse_from(&["test", "-a", "1", "2", "-a", "3"]).unwrap()
     );
-
-    assert_eq!(Opt { arg: Some(vec![]) }, Opt::parse_from(&["test", "-a"]));
 
     assert_eq!(
         Opt { arg: Some(vec![]) },
-        Opt::parse_from(&["test", "-a", "-a"])
+        Opt::try_parse_from(&["test", "-a"]).unwrap()
     );
 
-    assert_eq!(Opt { arg: None }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: Some(vec![]) },
+        Opt::try_parse_from(&["test", "-a", "-a"]).unwrap()
+    );
+
+    assert_eq!(Opt { arg: None }, Opt::try_parse_from(&["test"]).unwrap());
 }
 
 #[test]
@@ -277,7 +310,7 @@ fn two_optional_vecs() {
             arg: Some(vec![1]),
             b: Some(vec![])
         },
-        Opt::parse_from(&["test", "-a", "1", "-b"])
+        Opt::try_parse_from(&["test", "-a", "1", "-b"]).unwrap()
     );
 
     assert_eq!(
@@ -285,7 +318,7 @@ fn two_optional_vecs() {
             arg: Some(vec![1]),
             b: Some(vec![])
         },
-        Opt::parse_from(&["test", "-a", "-b", "-a1"])
+        Opt::try_parse_from(&["test", "-a", "-b", "-a1"]).unwrap()
     );
 
     assert_eq!(
@@ -293,10 +326,13 @@ fn two_optional_vecs() {
             arg: Some(vec![1, 2]),
             b: Some(vec![1, 2])
         },
-        Opt::parse_from(&["test", "-a1", "-a2", "-b1", "-b2"])
+        Opt::try_parse_from(&["test", "-a1", "-a2", "-b1", "-b2"]).unwrap()
     );
 
-    assert_eq!(Opt { arg: None, b: None }, Opt::parse_from(&["test"]));
+    assert_eq!(
+        Opt { arg: None, b: None },
+        Opt::try_parse_from(&["test"]).unwrap()
+    );
 }
 
 #[test]
@@ -324,7 +360,7 @@ fn required_option_type() {
             req_str: Some(("arg").into()),
             cmd: None,
         },
-        Opt::parse_from(&["test", "arg"])
+        Opt::try_parse_from(&["test", "arg"]).unwrap()
     );
 
     assert_eq!(
@@ -332,7 +368,7 @@ fn required_option_type() {
             req_str: None,
             cmd: Some(SubCommands::ExSub { verbose: 1 }),
         },
-        Opt::parse_from(&["test", "ex-sub", "-v"])
+        Opt::try_parse_from(&["test", "ex-sub", "-v"]).unwrap()
     );
 
     assert!(Opt::try_parse_from(&["test"]).is_err());

--- a/clap_derive/tests/raw_bool_literal.rs
+++ b/clap_derive/tests/raw_bool_literal.rs
@@ -24,6 +24,6 @@ fn raw_bool_literal() {
             a: "one".into(),
             b: "--help".into()
         },
-        Opt::parse_from(&["test", "one", "--", "--help"])
+        Opt::try_parse_from(&["test", "one", "--", "--help"]).unwrap()
     );
 }

--- a/clap_derive/tests/raw_idents.rs
+++ b/clap_derive/tests/raw_idents.rs
@@ -12,6 +12,6 @@ fn raw_idents() {
         Opt {
             r#type: vec!["long".into(), "short".into()]
         },
-        Opt::parse_from(&["test", "--type", "long", "-t", "short"])
+        Opt::try_parse_from(&["test", "--type", "long", "-t", "short"]).unwrap()
     );
 }

--- a/clap_derive/tests/skip.rs
+++ b/clap_derive/tests/skip.rs
@@ -20,7 +20,7 @@ fn skip_1() {
 
     assert!(Opt::try_parse_from(&["test", "-x", "10", "20"]).is_err());
 
-    let mut opt = Opt::parse_from(&["test", "-x", "10"]);
+    let mut opt = Opt::try_parse_from(&["test", "-x", "10"]).unwrap();
     assert_eq!(
         opt,
         Opt {
@@ -52,7 +52,7 @@ fn skip_2() {
     }
 
     assert_eq!(
-        Opt::parse_from(&["test", "-x", "10", "20", "30"]),
+        Opt::try_parse_from(&["test", "-x", "10", "20", "30"]).unwrap(),
         Opt {
             x: 10,
             ss: String::from(""),
@@ -90,7 +90,7 @@ fn skip_enum() {
     }
 
     assert_eq!(
-        Opt::parse_from(&["test", "-n", "10"]),
+        Opt::try_parse_from(&["test", "-n", "10"]).unwrap(),
         Opt {
             number: 10,
             k: Kind::B,
@@ -120,7 +120,7 @@ fn skip_help_doc_comments() {
     }
 
     assert_eq!(
-        Opt::parse_from(&["test", "-n", "10"]),
+        Opt::try_parse_from(&["test", "-n", "10"]).unwrap(),
         Opt {
             n: 10,
             a: 0,
@@ -145,7 +145,7 @@ fn skip_val() {
     }
 
     assert_eq!(
-        Opt::parse_from(&["test", "-n", "10"]),
+        Opt::try_parse_from(&["test", "-n", "10"]).unwrap(),
         Opt {
             number: 10,
             k: "key".to_string(),

--- a/clap_derive/tests/special_types.rs
+++ b/clap_derive/tests/special_types.rs
@@ -28,7 +28,7 @@ fn special_types_bool() {
         Opt {
             arg: inner::bool("success".into())
         },
-        Opt::parse_from(&["test", "success"])
+        Opt::try_parse_from(&["test", "success"]).unwrap()
     );
 }
 
@@ -48,7 +48,7 @@ fn special_types_option() {
         Opt {
             arg: Some("success".into())
         },
-        Opt::parse_from(&["test", "success"])
+        Opt::try_parse_from(&["test", "success"]).unwrap()
     );
 }
 
@@ -68,6 +68,6 @@ fn special_types_vec() {
         Opt {
             arg: vec!["success".into()]
         },
-        Opt::parse_from(&["test", "success"])
+        Opt::try_parse_from(&["test", "success"]).unwrap()
     );
 }


### PR DESCRIPTION
`Parser::parse_from` will call `exit` on failure and we don't just lose
backtrace information but we don't even know which of the tests running
in parallel panicked.  I ran into this when experimenting with
`clap_derive` and I couldn't tell what actually failed.

So let's switch to `Parse::try_parse_from`.

Errors went from:
```
test option_option ... ok
error: Found argument 'bar' which wasn't expected, or isn't valid in this context

USAGE:
    clap_derive [OPTIONS]

For more information try --help
error: test failed, to rerun pass '--test arg_enum'
```
To:
```
test option_option ... ok
test variant_with_defined_casing ... ok
test skip_variant ... ok
test default_value ... ok
test vector ... FAILED
test option_vector ... ok

failures:

---- vector stdout ----
thread 'vector' panicked at 'called `Result::unwrap()` on an `Err` value: Error { message: Formatted(Colorizer { use_stderr: true, color_when: Auto
, pieces: [("error:", Some(Red)), (" ", None), ("Found argument '", None), ("bar", Some(Yellow)), ("' which wasn't expected, or isn't valid in this
 context", None), ("\n\n", None), ("USAGE:\n    clap_derive [OPTIONS]", None), ("\n\nFor more information try ", None), ("--help", Some(Green)), ("
\n", None)] }), kind: UnknownArgument, info: ["bar"], source: None, backtrace: Backtrace }', clap_derive/tests/arg_enum.rs:388:56
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    vector

test result: FAILED. 15 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass '--test arg_enum'
```

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
