### PR TITLE
refactor: Allow partially used genned code

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -536,18 +536,22 @@ macro_rules! impl_settings {
         ),+
     ) => {
         impl $flags {
+            #[allow(dead_code)]
             pub(crate) fn empty() -> Self {
                 $flags(Flags::empty())
             }
 
+            #[allow(dead_code)]
             pub(crate) fn insert(&mut self, rhs: Self) {
                 self.0.insert(rhs.0);
             }
 
+            #[allow(dead_code)]
             pub(crate) fn remove(&mut self, rhs: Self) {
                 self.0.remove(rhs.0);
             }
 
+            #[allow(dead_code)]
             pub(crate) fn set(&mut self, s: $settings) {
                 match s {
                     $(
@@ -557,6 +561,7 @@ macro_rules! impl_settings {
                 }
             }
 
+            #[allow(dead_code)]
             pub(crate) fn unset(&mut self, s: $settings) {
                 match s {
                     $(
@@ -566,6 +571,7 @@ macro_rules! impl_settings {
                 }
             }
 
+            #[allow(dead_code)]
             pub(crate) fn is_set(&self, s: $settings) -> bool {
                 match s {
                     $(


### PR DESCRIPTION
Wow, I'm having a hard time summarizing this for the summary.

When we code-gen Settings using `impl_settings`, we have no control over
whether one instance of a Settings will use some or all functions.  I
have a fix that removes the one `ArgSettings::unset`, causing warnings
for `ArgSettings` despite needing it for `AppSettings`.

So I'm making it less dependent on how each instantiation uses it.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
