### PR TITLE
fix: Always respect positional occurrences

### DIFF
--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -613,7 +613,9 @@ fn write_positionals_of(p: &App) -> String {
     for arg in p.get_positionals() {
         debug!("write_positionals_of:iter: arg={}", arg.get_name());
 
-        let cardinality = if arg.is_set(ArgSettings::MultipleValues) {
+        let cardinality = if arg.is_set(ArgSettings::MultipleValues)
+            || arg.is_set(ArgSettings::MultipleOccurrences)
+        {
             "*:"
         } else if !arg.is_set(ArgSettings::Required) {
             ":"

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -4912,6 +4912,11 @@ impl<'help> Arg<'help> {
             Cow::Borrowed(self.name)
         }
     }
+
+    /// Either multiple values or occurrences
+    pub(crate) fn is_multiple(&self) -> bool {
+        self.is_set(ArgSettings::MultipleValues) | self.is_set(ArgSettings::MultipleOccurrences)
+    }
 }
 
 #[cfg(feature = "yaml")]
@@ -5109,7 +5114,7 @@ where
                         write(&delim.to_string(), false)?;
                     }
                 }
-                if num_val_names == 1 && mult_val {
+                if (num_val_names == 1 && mult_val) || (arg.is_positional() && mult_occ) {
                     write("...", true)?;
                 }
             }

--- a/tests/help.rs
+++ b/tests/help.rs
@@ -2504,6 +2504,106 @@ OPTIONS:
 }
 
 #[test]
+fn positional_multiple_values_is_dotted() {
+    let app = App::new("test").arg(
+        Arg::new("foo")
+            .required(true)
+            .takes_value(true)
+            .multiple_values(true),
+    );
+    assert!(utils::compare_output(
+        app,
+        "test --help",
+        "test 
+
+USAGE:
+    test <foo>...
+
+ARGS:
+    <foo>...    
+
+OPTIONS:
+    -h, --help    Print help information
+",
+        false
+    ));
+
+    let app = App::new("test").arg(
+        Arg::new("foo")
+            .required(true)
+            .takes_value(true)
+            .value_name("BAR")
+            .multiple_values(true),
+    );
+    assert!(utils::compare_output(
+        app,
+        "test --help",
+        "test 
+
+USAGE:
+    test <BAR>...
+
+ARGS:
+    <BAR>...    
+
+OPTIONS:
+    -h, --help    Print help information
+",
+        false
+    ));
+}
+
+#[test]
+fn positional_multiple_occurrences_is_dotted() {
+    let app = App::new("test").arg(
+        Arg::new("foo")
+            .required(true)
+            .takes_value(true)
+            .multiple_occurrences(true),
+    );
+    assert!(utils::compare_output(
+        app,
+        "test --help",
+        "test 
+
+USAGE:
+    test <foo>...
+
+ARGS:
+    <foo>...    
+
+OPTIONS:
+    -h, --help    Print help information
+",
+        false
+    ));
+
+    let app = App::new("test").arg(
+        Arg::new("foo")
+            .required(true)
+            .takes_value(true)
+            .value_name("BAR")
+            .multiple_occurrences(true),
+    );
+    assert!(utils::compare_output(
+        app,
+        "test --help",
+        "test 
+
+USAGE:
+    test <BAR>...
+
+ARGS:
+    <BAR>...    
+
+OPTIONS:
+    -h, --help    Print help information
+",
+        false
+    ));
+}
+
+#[test]
 fn disabled_help_flag() {
     let res = App::new("foo")
         .subcommand(App::new("sub"))


### PR DESCRIPTION
When supporting multiple occurrences for positional arguments in #2804,
I added some tests to cover this but apparently simpler cases fail
despite those more complicated cases being tested.

This adds more multiple-occurrences tests for positional arguments,
fixes them, and in general equates multiple values with occurrences for
positional arguments as part of #2692.  There are a couple more points
for consideration for #2692 for us to decide on once this unblocks them
(usage special case in #2977 and how subcommand help should be handled).

I fully admit I have not fully quantified the impact of all of these
changes and am heavily relying on the quality of our tests to carry this
forward.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
