### PR TITLE
test: Easier to test with minimal features

### DIFF
--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -39,7 +39,7 @@ heck = "0.3.0"
 proc-macro-error = "1"
 
 [dev-dependencies]
-clap = { path = "../" }
+clap = { path = "../", default-features = false, features = ["std", "derive", "env"] }
 trybuild = "1.0"
 rustversion = "1"
 version-sync = "0.9"

--- a/clap_derive/tests/help.rs
+++ b/clap_derive/tests/help.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, Args, ColorChoice, IntoApp, Parser, Subcommand};
+use clap::{AppSettings, Args, IntoApp, Parser, Subcommand};
 
 #[test]
 fn arg_help_heading_applied() {
@@ -191,7 +191,7 @@ fn flatten_field_with_help_heading() {
 #[test]
 fn derive_generated_error_has_full_context() {
     #[derive(Debug, Parser)]
-    #[clap(setting(AppSettings::SubcommandsNegateReqs), color = ColorChoice::Never)]
+    #[clap(setting(AppSettings::SubcommandsNegateReqs))]
     struct Opts {
         #[clap(long)]
         req_str: String,

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use clap::{App, Arg, ColorChoice, Error, ErrorKind};
+use clap::{App, Arg, Error, ErrorKind};
 
 fn compare_error(
     err: Error,
@@ -52,8 +52,6 @@ For more information try --help
                 .long("no-git-push")
                 .about("Do not push generated commit and tags to git remote"),
         );
-    #[cfg(feature = "color")]
-    let app = app.color(ColorChoice::Never);
     let mut app = app;
     let expected_kind = ErrorKind::InvalidValue;
     let err = app.error(expected_kind, "Failed for mysterious reasons");


### PR DESCRIPTION
PR #2979 reduced what dependencies we push on users and made us one step
closer to being able to test more with fewer features.  Looks like I
also need to update `clap_derive`.  I verified locally that #2976 fails
with this.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
