### PR TITLE
fix: Switch sub-commands from multi-val to multi-occur

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -923,7 +923,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                     let pb = Arg::new("subcommand")
                         .index(1)
                         .setting(ArgSettings::TakesValue)
-                        .setting(ArgSettings::MultipleValues)
+                        .setting(ArgSettings::MultipleOccurrences)
                         .value_name("SUBCOMMAND")
                         .about("The subcommand whose help message to display");
                     sc = sc.arg(pb);


### PR DESCRIPTION
Similar to #2977, this changes positional argument `<subcmd>` in
`help <subcmd>` to be multiple occurrences, from being multiple values.

This is what identified the usage generation bug fixed in #2978 and was
isolated into the test case `positional_multiple_occurrences_is_dotted`.

This is part of #2692 where we re-evaluate the usage of multiple values
for positionals now that we accept multiple occurrences.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
