### PR TITLE
fix: Allow unicode aware case insensitivity

### DIFF
--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -5,6 +5,7 @@ use std::{
     slice::Iter,
 };
 
+use crate::util::eq_ignore_case;
 use crate::INTERNAL_ERROR_MSG;
 
 // TODO: Maybe make this public?
@@ -127,7 +128,8 @@ impl MatchedArg {
     pub(crate) fn contains_val(&self, val: &str) -> bool {
         self.vals_flatten().any(|v| {
             if self.case_insensitive {
-                v.eq_ignore_ascii_case(val)
+                // If `v` isn't utf8, it can't match `val`, so `OsStr::to_str` should be fine
+                v.to_str().map_or(false, |v| eq_ignore_case(v, val))
             } else {
                 OsString::as_os_str(v) == OsStr::new(val)
             }


### PR DESCRIPTION
In #2985, I noticed #2834 was incomplete, there were case-insensitive
comparisons we were doing without being unicode aware (when compile
options are set).

The downside is that each comparison will require a UTF-8 validation.
These seem to be in more of corners of the API, rather than in common
calls in common usages, so hopefully that isn't too much of a problem.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
