### PR TITLE
Revert:  Add new App::mut_args for mutating all arguments #2966 

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1824,7 +1824,7 @@ impl<'help> App<'help> {
     ///
     /// let res = app.try_get_matches_from_mut(vec!["foo", "-x"]);
     ///
-    /// // Since we changed `foo`'s short to "f" this should err as there
+    /// // Since we changed `bar`'s short to "f" this should err as there
     /// // is no `-x` anymore, only `-f`
     ///
     /// assert!(res.is_err());

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1808,45 +1808,6 @@ impl<'help> App<'help> {
         self
     }
 
-    /// Allows one to mutate all arguments after they've been added to an [`App`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg};
-    ///
-    /// let mut app = App::new("foo")
-    ///     .arg(Arg::new("foo")
-    ///         .short('x'))
-    ///     .arg(Arg::new("bar")
-    ///         .short('y'))
-    ///     .mut_args(|a| (a.get_name() == "foo").then(|| a.short('f')));
-    ///
-    /// let res = app.try_get_matches_from_mut(vec!["foo", "-x"]);
-    ///
-    /// // Since we changed `bar`'s short to "f" this should err as there
-    /// // is no `-x` anymore, only `-f`
-    ///
-    /// assert!(res.is_err());
-    ///
-    /// let res = app.try_get_matches_from_mut(vec!["foo", "-f"]);
-    /// assert!(res.is_ok());
-    /// ```
-    pub fn mut_args<F>(mut self, f: F) -> Self
-    where
-        F: Fn(Arg<'help>) -> Option<Arg<'help>>,
-    {
-        for a in self.args.args_mut() {
-            if let Some(arg) = f(a.clone()) {
-                *a = arg;
-                if a.provider == ArgProvider::Generated {
-                    a.provider = ArgProvider::GeneratedMutated;
-                }
-            }
-        }
-        self
-    }
-
     /// Custom error message for post-parsing validation
     ///
     /// # Examples

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -1216,23 +1216,3 @@ fn no_auto_version_mut_arg() {
     assert!(result.is_ok());
     assert!(result.unwrap().is_present("version"));
 }
-
-#[test]
-fn no_auto_version_mut_args() {
-    let app = App::new("myprog")
-        .version("3.0")
-        .mut_args(|v| Some(v.about("custom about")))
-        .setting(AppSettings::NoAutoVersion);
-
-    let result = app
-        .clone()
-        .try_get_matches_from("myprog --version".split(" "));
-
-    assert!(result.is_ok());
-    assert!(result.unwrap().is_present("version"));
-
-    let result = app.clone().try_get_matches_from("myprog -V".split(" "));
-
-    assert!(result.is_ok());
-    assert!(result.unwrap().is_present("version"));
-}

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -138,7 +138,7 @@ USAGE:
 OPTIONS:
         --first      first about
     -h, --help       Print help information
-    -s, --second     
+        --second     [env: ENV_REPLACED=]
         --third      third arg
     -V, --version    Print version information
 ";
@@ -1257,11 +1257,11 @@ fn partial_mut_args() {
         .arg(
             Arg::new("first").long("first").about("first arg"), // this about will be replaced
         )
-        .arg(Arg::new("second").long("second").short('r')) // this short will be replaced
+        .arg(Arg::new("second").long("second").env("ENV_SECOND")) // this env will be replaced
         .arg(Arg::new("third").long("third").about("third arg")) // this will not be mutated
         .mut_args(|v| match v.get_name() {
             "first" => Some(v.about("first about")),
-            "second" => Some(v.short('s')),
+            "second" => Some(v.env("ENV_REPLACED")),
             _ => None,
         });
 

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -130,19 +130,6 @@ SUBCOMMANDS:
             
 ";
 
-static PARTIAL_MUT_ARGS: &str = "myprog 3.0
-
-USAGE:
-    myprog [OPTIONS]
-
-OPTIONS:
-        --first      first about
-    -h, --help       Print help information
-        --second     [env: ENV_REPLACED=]
-        --third      third arg
-    -V, --version    Print version information
-";
-
 #[test]
 fn setting() {
     let m = App::new("setting").setting(AppSettings::AllArgsOverrideSelf);
@@ -1248,27 +1235,4 @@ fn no_auto_version_mut_args() {
 
     assert!(result.is_ok());
     assert!(result.unwrap().is_present("version"));
-}
-
-#[test]
-fn partial_mut_args() {
-    let app = App::new("myprog")
-        .version("3.0")
-        .arg(
-            Arg::new("first").long("first").about("first arg"), // this about will be replaced
-        )
-        .arg(Arg::new("second").long("second").env("ENV_SECOND")) // this env will be replaced
-        .arg(Arg::new("third").long("third").about("third arg")) // this will not be mutated
-        .mut_args(|v| match v.get_name() {
-            "first" => Some(v.about("first about")),
-            "second" => Some(v.env("ENV_REPLACED")),
-            _ => None,
-        });
-
-    assert!(utils::compare_output(
-        app,
-        "myprog -h",
-        PARTIAL_MUT_ARGS,
-        false
-    ));
 }


### PR DESCRIPTION
While #2966 communicated and solved a need, the API is fairly niche and has nuance that isn't quite clear.

#2976 generalized clap's API to allow filling the same need, lowering our reliance on `App::mut_args`, so I propose we go ahead and revert it.