### PR TITLE
fix(app): Propogate color 

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -315,6 +315,28 @@ impl<'help> App<'help> {
         self.settings.is_set(s) || self.g_settings.is_set(s)
     }
 
+    /// Should we color the output?
+    #[inline]
+    pub fn get_color(&self) -> ColorChoice {
+        debug!("App::color: Color setting...");
+
+        if cfg!(feature = "color") {
+            #[allow(deprecated)]
+            if self.is_set(AppSettings::ColorNever) {
+                debug!("Never");
+                ColorChoice::Never
+            } else if self.is_set(AppSettings::ColorAlways) {
+                debug!("Always");
+                ColorChoice::Always
+            } else {
+                debug!("Auto");
+                ColorChoice::Auto
+            }
+        } else {
+            ColorChoice::Never
+        }
+    }
+
     /// Returns `true` if this `App` has subcommands.
     #[inline]
     pub fn has_subcommands(&self) -> bool {
@@ -2779,24 +2801,6 @@ impl<'help> App<'help> {
 
     pub(crate) fn find(&self, arg_id: &Id) -> Option<&Arg<'help>> {
         self.args.args().find(|a| a.id == *arg_id)
-    }
-
-    #[inline]
-    // Should we color the output?
-    pub(crate) fn get_color(&self) -> ColorChoice {
-        debug!("App::color: Color setting...");
-
-        #[allow(deprecated)]
-        if self.is_set(AppSettings::ColorNever) {
-            debug!("Never");
-            ColorChoice::Never
-        } else if self.is_set(AppSettings::ColorAlways) {
-            debug!("Always");
-            ColorChoice::Always
-        } else {
-            debug!("Auto");
-            ColorChoice::Auto
-        }
     }
 
     #[inline]

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1045,9 +1045,9 @@ impl<'help> App<'help> {
     pub fn color(self, color: ColorChoice) -> Self {
         #[allow(deprecated)]
         match color {
-            ColorChoice::Auto => self.setting(AppSettings::ColorAuto),
-            ColorChoice::Always => self.setting(AppSettings::ColorAlways),
-            ColorChoice::Never => self.setting(AppSettings::ColorNever),
+            ColorChoice::Auto => self.global_setting(AppSettings::ColorAuto),
+            ColorChoice::Always => self.global_setting(AppSettings::ColorAlways),
+            ColorChoice::Never => self.global_setting(AppSettings::ColorNever),
         }
     }
 

--- a/tests/app_settings.rs
+++ b/tests/app_settings.rs
@@ -1216,3 +1216,16 @@ fn no_auto_version_mut_arg() {
     assert!(result.is_ok());
     assert!(result.unwrap().is_present("version"));
 }
+
+#[test]
+#[cfg(feature = "color")]
+fn color_is_global() {
+    let mut app = App::new("myprog")
+        .color(clap::ColorChoice::Never)
+        .subcommand(App::new("foo"));
+    app._build_all();
+    assert_eq!(app.get_color(), clap::ColorChoice::Never);
+
+    let sub = app.get_subcommands().collect::<Vec<_>>()[0];
+    assert_eq!(sub.get_color(), clap::ColorChoice::Never);
+}


### PR DESCRIPTION
In #2851, we moved color from an AppSetting to function (with some
tweaks in #2907).  When doing this, we documented `App::color` to be
equivalent of `App::global_settings(Color...)` but never actually
propagated it.

We are now propagating it.  A test is added to ensure that no matter
how we store the color choice, we continue to propagate it.  This
required exposing `App::get_color`.