### PR TITLE
Revert "Automatically read license field from Cargo.toml"

### DIFF
--- a/examples/01a_quick_example.rs
+++ b/examples/01a_quick_example.rs
@@ -33,7 +33,6 @@ fn main() {
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
-        .license("MIT OR Apache-2.0")
         .arg("-c, --config=[FILE] 'Sets a custom config file'")
         .arg("<output> 'Sets an optional output file'")
         .arg("-d..., --debug... 'Turn debugging information on'")

--- a/examples/01b_quick_example.rs
+++ b/examples/01b_quick_example.rs
@@ -35,7 +35,6 @@ fn main() {
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
-        .license("MIT OR Apache-2.0")
         .arg(
             Arg::new("config")
                 .short('c')

--- a/examples/02_apps.rs
+++ b/examples/02_apps.rs
@@ -20,7 +20,6 @@ fn main() {
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
-        .license("MIT OR Apache-2.0")
         .get_matches();
 
     // This example doesn't do much, but it *does* give automatic -h, --help, -V, and --version functionality ;)

--- a/examples/04_using_matches.rs
+++ b/examples/04_using_matches.rs
@@ -16,7 +16,6 @@ fn main() {
     // argument.
     let matches = App::new("MyApp")
         .about("Parses an input file to do awesome things")
-        .license("MIT OR Apache-2.0")
         .version("1.0")
         .author("Kevin K. <kbknapp@gmail.com>")
         .arg(

--- a/examples/08_subcommands.rs
+++ b/examples/08_subcommands.rs
@@ -24,7 +24,6 @@ fn main() {
             App::new("add") // The name we call argument with
                 .about("Adds files to myapp") // The message displayed in "myapp -h"
                 // or "myapp help"
-                .license("MIT OR Apache-2.0")
                 .version("0.1") // Subcommands can have independent version
                 .author("Kevin K.") // And authors
                 .arg(

--- a/examples/20_subcommands.rs
+++ b/examples/20_subcommands.rs
@@ -49,7 +49,6 @@ fn main() {
         .subcommand(
             App::new("clone")
                 .about("clones repos")
-                .license("MIT OR Apache-2.0")
                 .arg(Arg::new("repo").about("The repo to clone").required(true)),
         )
         .subcommand(

--- a/examples/21_aliases.rs
+++ b/examples/21_aliases.rs
@@ -6,7 +6,6 @@ fn main() {
             App::new("ls")
                 .aliases(&["list", "dir"])
                 .about("Adds files to myapp")
-                .license("MIT OR Apache-2.0")
                 .version("0.1")
                 .author("Kevin K.")
                 .arg(

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -71,7 +71,6 @@ pub struct App<'help> {
     pub(crate) author: Option<&'help str>,
     pub(crate) version: Option<&'help str>,
     pub(crate) long_version: Option<&'help str>,
-    pub(crate) license: Option<&'help str>,
     pub(crate) about: Option<&'help str>,
     pub(crate) long_about: Option<&'help str>,
     pub(crate) before_help: Option<&'help str>,
@@ -744,27 +743,6 @@ impl<'help> App<'help> {
     /// [`App::version`]: App::version()
     pub fn long_version<S: Into<&'help str>>(mut self, ver: S) -> Self {
         self.long_version = Some(ver.into());
-        self
-    }
-
-    /// Sets a string of the license to be displayed when displaying help information.
-    ///
-    /// **Pro-tip:** Use `clap`s convenience macro [`crate_license!`] to automatically set your
-    /// application's license to the same thing as your crate at compile time. See the
-    /// [`examples/`] directory for more information
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{App, Arg};
-    /// App::new("myprog")
-    ///     .license("MIT OR Apache-2.0")
-    /// # ;
-    /// ```
-    /// [`crate_license!`]: ./macro.crate_license!.html
-    /// [`examples/`]: https://github.com/clap-rs/clap/tree/master/examples
-    pub fn license<S: Into<&'help str>>(mut self, license: S) -> Self {
-        self.license = Some(license.into());
         self
     }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,37 +32,6 @@ macro_rules! load_yaml {
     };
 }
 
-/// Allows you to pull the licence from your Cargo.toml at compile time. If the `license` field is
-/// empty, then the `licence-field` is read. If both fields are empty, then an empty string is
-/// returned.
-///
-/// # Examples
-///
-/// ```no_run
-/// # #[macro_use]
-/// # extern crate clap;
-/// # use clap::App;
-/// # fn main() {
-/// let m = App::new("app")
-///             .license(crate_license!())
-///             .get_matches();
-/// # }
-/// ```
-#[cfg(feature = "cargo")]
-#[macro_export]
-macro_rules! crate_license {
-    () => {{
-        let mut license = env!("CARGO_PKG_LICENSE");
-        if license.is_empty() {
-            license = env!("CARGO_PKG_LICENSE_FILE");
-        }
-        if license.is_empty() {
-            license = "";
-        }
-        license
-    }};
-}
-
 /// Allows you to pull the version from your Cargo.toml at compile time as
 /// `MAJOR.MINOR.PATCH_PKGVERSION_PRE`
 ///
@@ -197,14 +166,12 @@ macro_rules! app_from_crate {
             .version($crate::crate_version!())
             .author($crate::crate_authors!())
             .about($crate::crate_description!())
-            .license($crate::crate_license!())
     };
     ($sep:expr) => {
         $crate::App::new($crate::crate_name!())
             .version($crate::crate_version!())
             .author($crate::crate_authors!($sep))
             .about($crate::crate_description!())
-            .license($crate::crate_license!())
     };
 }
 


### PR DESCRIPTION
This reverts commit 6898fbde334a46185d07bb40f51e4160ff67963f.

PR #2144 added the `license` field but no consumer has been added since
the (like Issue #1768).  Since this is not ready yet, I am pulling it
from the 3.0 release.

So far, our main route for pulling a feature from the release has
been to put it behind a `unstable-*` feature flag and to create a
stablization tracking issue.  I chose to instead remove the feature
because a write-only field with no effect does not provide values for
people to use in as an early access and so doesn't outweight the cost of
the extra documentation noise and code noise it creates.  Additionally,
keeping an `unstable-` feature around when it has such an unknown path
(and time table) to stalbization feels like it violates YAGNI.  I'm
uncertain how much of this feature we can implement and not create a
legal trap for users because the crate's license is insufficient for the
final artifact's license.  I feel our stabliazation process sshould be
about iteration and collecting user feedback which this doesn't line up
with.

When someone is ready to tackle #1768, it will be easy to revert this
commit and pick up the work again.

Fixes #3001

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
