### PR TITLE
docs: Parent SubcommandPrecedenceOverArg under AppSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,7 +347,7 @@ Added `std`, `cargo`, `derive` features.
   * `AppSettings::HelpRequired`
   * `AppSettings::NoAutoHelp`
   * `AppSettings::NoAutoVersion`
-  * `ArgSettings::SubcommandPrecedenceOverArg`
+  * `AppSettings::SubcommandPrecedenceOverArg`
 
 #### Enhancements
 


### PR DESCRIPTION
We have it marked as an `ArgSettings` when it is an `AppSettings`.

<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->
