### PR TITLE
Add `validator_all`, `validator_all_os`

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -45,6 +45,9 @@ pub use self::regex::RegexRef;
 
 type Validator<'a> = dyn FnMut(&str) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
 type ValidatorOs<'a> = dyn FnMut(&OsStr) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
+type ValidatorAll<'a> = dyn FnMut(&[&str]) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
+type ValidatorAllOs<'a> =
+    dyn FnMut(&[&OsStr]) -> Result<(), Box<dyn Error + Send + Sync>> + Send + 'a;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum ArgProvider {
@@ -110,6 +113,8 @@ pub struct Arg<'help> {
     pub(crate) min_vals: Option<usize>,
     pub(crate) validator: Option<Arc<Mutex<Validator<'help>>>>,
     pub(crate) validator_os: Option<Arc<Mutex<ValidatorOs<'help>>>>,
+    pub(crate) validator_all: Option<Arc<Mutex<ValidatorAll<'help>>>>,
+    pub(crate) validator_all_os: Option<Arc<Mutex<ValidatorAllOs<'help>>>>,
     pub(crate) val_delim: Option<char>,
     pub(crate) default_vals: Vec<&'help OsStr>,
     pub(crate) default_vals_ifs: Vec<(Id, Option<&'help OsStr>, Option<&'help OsStr>)>,
@@ -2342,6 +2347,30 @@ impl<'help> Arg<'help> {
         E: Into<Box<dyn Error + Send + Sync + 'static>>,
     {
         self.validator_os = Some(Arc::new(Mutex::new(move |s: &OsStr| {
+            f(s).map(|_| ()).map_err(|e| e.into())
+        })));
+        self
+    }
+
+    /// Works identically to `validator` but is passed all the values sent.
+    pub fn validator_all<F, O, E>(mut self, mut f: F) -> Self
+    where
+        F: FnMut(&[&str]) -> Result<O, E> + Send + 'help,
+        E: Into<Box<dyn Error + Send + Sync + 'static>>,
+    {
+        self.validator_all = Some(Arc::new(Mutex::new(move |s: &[&str]| {
+            f(s).map(|_| ()).map_err(|e| e.into())
+        })));
+        self
+    }
+
+    /// Works identically to `validator_all` but is passed all the values sent as `OsString`'s.
+    pub fn validator_all_os<F, O, E>(mut self, mut f: F) -> Self
+    where
+        F: FnMut(&[&OsStr]) -> Result<O, E> + Send + 'help,
+        E: Into<Box<dyn Error + Send + Sync + 'static>>,
+    {
+        self.validator_all_os = Some(Arc::new(Mutex::new(move |s: &[&OsStr]| {
             f(s).map(|_| ()).map_err(|e| e.into())
         })));
         self

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -919,6 +919,7 @@ impl Error {
         arg: String,
         val: String,
         err: Box<dyn error::Error + Send + Sync>,
+        multiple: bool,
     ) -> Self {
         let mut err = Self::value_validation_with_color(
             arg,
@@ -926,6 +927,7 @@ impl Error {
             err,
             app.get_color(),
             app.settings.is_set(AppSettings::WaitOnError),
+            multiple,
         );
         match &mut err.message {
             Message::Raw(_) => {
@@ -941,7 +943,7 @@ impl Error {
         val: String,
         err: Box<dyn error::Error + Send + Sync>,
     ) -> Self {
-        Self::value_validation_with_color(arg, val, err, ColorChoice::Never, false)
+        Self::value_validation_with_color(arg, val, err, ColorChoice::Never, false, false)
     }
 
     fn value_validation_with_color(
@@ -950,10 +952,15 @@ impl Error {
         err: Box<dyn error::Error + Send + Sync>,
         color: ColorChoice,
         wait_on_exit: bool,
+        multiple: bool,
     ) -> Self {
         let mut c = Colorizer::new(true, color);
 
         start_error(&mut c, "Invalid value");
+
+        if multiple {
+            c.none("s");
+        }
 
         c.none(" for '");
         c.warning(arg.clone());


### PR DESCRIPTION
<!--
If your PR closes some issues, please write `Closes #XXXX`
where `XXXX` is the number of the issue you want to fix.
Each issue goes on its own line.
-->

For MFEKstroke's new dash mode, I needed to be able to write a validator that would check and make sure that the number of values I had for an argument **was divisible by two**. Unable to do this with e.g. `min_values` etc. I decided to add new functions `validator_all` and an `_os` counterpart as that is "the `clap` way". Although I could've solved it just for me with `validator_num`, I believe this is better because it puts the whole issue to bed.

Also added tests for the new functions.