### PR TITLE
Rewrite Multicall handling to just strip path off argv0

### DIFF
--- a/examples/multicall_busybox.md
+++ b/examples/multicall_busybox.md
@@ -12,7 +12,7 @@ $ busybox true
 $ busybox false
 ? 1
 ```
-*Note: without the links setup, we can't demonostrate the multicall behavior*
+*Note: without the links setup, we can't demonstrate the multicall behavior*
 
 But includes the `--install` option as an example of why it can be useful
 for the main program to take arguments that aren't applet subcommands.

--- a/examples/multicall_busybox.md
+++ b/examples/multicall_busybox.md
@@ -6,7 +6,7 @@ See the documentation for clap::AppSettings::Multicall for rationale.
 
 This example omits every command except true and false,
 which are the most trivial to implement,
-```bash,ignore
+```bash
 $ busybox true
 ? 0
 $ busybox false
@@ -16,20 +16,20 @@ $ busybox false
 
 But includes the `--install` option as an example of why it can be useful
 for the main program to take arguments that aren't applet subcommands.
-```bash,ignore
+```bash
 $ busybox --install
 ? failed
 ...
 ```
 
 Though users must pass something:
-```bash,ignore
+```bash
 $ busybox
 ? failed
 busybox 
 
 USAGE:
-    busybox[EXE] [OPTIONS] [APPLET]
+    busybox [OPTIONS] [APPLET]
 
 OPTIONS:
     -h, --help                 Print help information

--- a/examples/multicall_busybox.md
+++ b/examples/multicall_busybox.md
@@ -29,13 +29,13 @@ $ busybox
 busybox 
 
 USAGE:
-    busybox[EXE] [OPTIONS] [SUBCOMMAND]
+    busybox[EXE] [OPTIONS] [APPLET]
 
 OPTIONS:
     -h, --help                 Print help information
         --install <install>    Install hardlinks for all subcommands in path
 
-SUBCOMMANDS:
+APPLETS:
     false    does nothing unsuccessfully
     help     Print this message or the help of the given subcommand(s)
     true     does nothing successfully

--- a/examples/multicall_busybox.rs
+++ b/examples/multicall_busybox.rs
@@ -2,32 +2,45 @@ use std::process::exit;
 
 use clap::{App, AppSettings, Arg};
 
+fn applet_commands() -> [App<'static>; 2] {
+    [
+        App::new("true").about("does nothing successfully"),
+        App::new("false").about("does nothing unsuccessfully"),
+    ]
+}
+
 fn main() {
     let app = App::new(env!("CARGO_CRATE_NAME"))
-        .setting(AppSettings::ArgRequiredElseHelp)
-        .subcommand_value_name("APPLET")
-        .subcommand_help_heading("APPLETS")
-        .arg(
-            Arg::new("install")
-                .long("install")
-                .help("Install hardlinks for all subcommands in path")
-                .exclusive(true)
-                .takes_value(true)
-                .default_missing_value("/usr/local/bin")
-                .use_delimiter(false),
+        .setting(AppSettings::Multicall)
+        .subcommand(
+            App::new("busybox")
+                .setting(AppSettings::ArgRequiredElseHelp)
+                .subcommand_value_name("APPLET")
+                .subcommand_help_heading("APPLETS")
+                .arg(
+                    Arg::new("install")
+                        .long("install")
+                        .help("Install hardlinks for all subcommands in path")
+                        .exclusive(true)
+                        .takes_value(true)
+                        .default_missing_value("/usr/local/bin")
+                        .use_delimiter(false),
+                )
+                .subcommands(applet_commands()),
         )
-        .subcommand(App::new("true").about("does nothing successfully"))
-        .subcommand(App::new("false").about("does nothing unsuccessfully"));
+        .subcommands(applet_commands());
 
-    let app = app.setting(AppSettings::Multicall);
     let matches = app.get_matches();
-    if matches.occurrences_of("install") > 0 {
-        unimplemented!("Make hardlinks to the executable here");
+    let mut subcommand = matches.subcommand();
+    if let Some(("busybox", cmd)) = subcommand {
+        if cmd.occurrences_of("install") > 0 {
+            unimplemented!("Make hardlinks to the executable here");
+        }
+        subcommand = cmd.subcommand();
     }
-
-    match matches.subcommand_name() {
-        Some("true") => exit(0),
-        Some("false") => exit(1),
+    match subcommand {
+        Some(("false", _)) => exit(1),
+        Some(("true", _)) => exit(0),
         _ => unreachable!("parser should ensure only valid subcommand names are used"),
     }
 }

--- a/examples/multicall_hostname.md
+++ b/examples/multicall_hostname.md
@@ -10,4 +10,4 @@ This example omits the implementation of displaying address config
 $ hostname
 www
 ```
-*Note: without the links setup, we can't demonostrate the multicall behavior*
+*Note: without the links setup, we can't demonstrate the multicall behavior*

--- a/examples/multicall_hostname.md
+++ b/examples/multicall_hostname.md
@@ -6,7 +6,7 @@ See the documentation for clap::AppSettings::Multicall for rationale.
 
 This example omits the implementation of displaying address config
 
-```bash,ignore
+```bash
 $ hostname
 www
 ```

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -607,7 +607,7 @@ impl<'help> App<'help> {
         if self.settings.is_set(AppSettings::Multicall) {
             if let Some((argv0, _)) = it.next() {
                 let argv0 = Path::new(&argv0);
-                if let Some(command) = argv0.file_name().and_then(|f| f.to_str()) {
+                if let Some(command) = argv0.file_stem().and_then(|f| f.to_str()) {
                     // Stop borrowing command so we can get another mut ref to it.
                     let command = command.to_owned();
                     debug!(

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -615,39 +615,12 @@ impl<'help> App<'help> {
                         command
                     );
 
-                    let subcommand = self
-                        .subcommands
-                        .iter_mut()
-                        .find(|subcommand| subcommand.aliases_to(&command));
-                    debug!(
-                        "App::try_get_matches_from_mut: Matched subcommand {:?}",
-                        subcommand
-                    );
-
-                    match subcommand {
-                        None if command == self.name => {
-                            debug!("App::try_get_matches_from_mut: no existing applet but matches name");
-                            debug!(
-                                "App::try_get_matches_from_mut: Setting bin_name to command name"
-                            );
-                            self.bin_name.get_or_insert(command);
-                            debug!(
-                                "App::try_get_matches_from_mut: Continuing with top-level parser."
-                            );
-                            return self._do_parse(&mut it);
-                        }
-                        _ => {
-                            debug!(
-                                "App::try_get_matches_from_mut: existing applet or no program name"
-                            );
-                            debug!("App::try_get_matches_from_mut: Reinserting command into arguments so subcommand parser matches it");
-                            it.insert(&[&command]);
-                            debug!("App::try_get_matches_from_mut: Clearing name and bin_name so that displayed command name starts with applet name");
-                            self.name.clear();
-                            self.bin_name = None;
-                            return self._do_parse(&mut it);
-                        }
-                    };
+                    debug!("App::try_get_matches_from_mut: Reinserting command into arguments so subcommand parser matches it");
+                    it.insert(&[&command]);
+                    debug!("App::try_get_matches_from_mut: Clearing name and bin_name so that displayed command name starts with applet name");
+                    self.name.clear();
+                    self.bin_name = None;
+                    return self._do_parse(&mut it);
                 }
             }
         };

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -511,13 +511,17 @@ For more information try --help
 #[cfg(feature = "unstable-multicall")]
 #[test]
 fn busybox_like_multicall() {
+    fn applet_commands() -> [App<'static>; 2] {
+        [App::new("true"), App::new("false")]
+    }
     let app = App::new("busybox")
         .setting(AppSettings::Multicall)
-        .subcommand(App::new("true"))
-        .subcommand(App::new("false"));
+        .subcommand(App::new("busybox").subcommands(applet_commands()))
+        .subcommands(applet_commands());
 
     let m = app.clone().get_matches_from(&["busybox", "true"]);
-    assert_eq!(m.subcommand_name(), Some("true"));
+    assert_eq!(m.subcommand_name(), Some("busybox"));
+    assert_eq!(m.subcommand().unwrap().1.subcommand_name(), Some("true"));
 
     let m = app.clone().get_matches_from(&["true"]);
     assert_eq!(m.subcommand_name(), Some("true"));


### PR DESCRIPTION
This follows the suggestion of Ed Page in #2861 that simplifying the behaviour and making it less magic could solve some problems.
Having spent some time writing an app to try it out this has proven correct.
Now if you want busybox-style where each applet is also available as a subcommand, you have to code it explicitly.
This is inconvenient when using it as a builder, but not too much trouble with `clap_derive`

```rust

#[derive(Args)]
struct False {}

#[derive(Args)]
struct True {}

#[derive(Parser)]
enum Busybox {
    False(False),
    True(True),
}

#[derive(Parser)]
#[clap(setting = AppSettings::Multicall)]
enum Applet {
    #[clap(subcommand)]
    Busybox(Busybox),
    False(False),
    True(True),
}

let applet = Applet::parse();
match applet {
    Applet::Busybox(Busybox::True(true_args)) | Applet::True(true_args) {
        std::process:exit(0)
    }
    Applet::Busybox(Busybox::False(false_args)) | Applet::False(false_args) {
        std::process:exit(1)
    }
}
```

# Prefix stripping

Support for prefix stripping becomes easier because now the prefix may be explicitly added to the beginning of the applet name without it being added to the subcommand name.
This is more convenient with `clap_derive` since the name only needs to be set in the struct definition and the result is accessed symbolically.

Assuming the `PROGRAM_PREFIX` variable is set by `build.rs`, the busybox definition is modified to become:
```rust
#[derive(Parser)]
#[clap(setting = AppSettings::Multicall)]
enum Applet {
    #[clap(name = concat!(env!("PROGRAM_PREFIX"), "busybox"), subcommand)]
    Busybox(Busybox),
    #[clap(name = concat!(env!("PROGRAM_PREFIX"), "false"))]
    False(False),
    #[clap(name = concat!(env!("PROGRAM_PREFIX"), "true"))]
    True(True),
}
```

Closes #2864

# Support programs with a subcommand of the same name

This becomes trivial because the main applet and its subcommands are added explicitly.

Closes #2865

# Performance impact on startup

This was because deciding whether to run the main applet or not was conditional on whether the subcommand matched.
Now that it depends on the developer specifying the mechanism for how to run the main applet, if you don't have a main applet you don't waste time checking for it.

Closes #2866
Closes #3074 