### PR TITLE
Allow bash completions to work with an alias

### DIFF
--- a/clap_generate/src/generators/shells/bash.rs
+++ b/clap_generate/src/generators/shells/bash.rs
@@ -33,7 +33,7 @@ impl Generator for Bash {
     for i in ${{COMP_WORDS[@]}}
     do
         case \"${{i}}\" in
-            {name})
+            \"$1\")
                 cmd=\"{cmd}\"
                 ;;{subcmds}
             *)

--- a/clap_generate/tests/completions/bash.rs
+++ b/clap_generate/tests/completions/bash.rs
@@ -42,7 +42,7 @@ static BASH: &str = r#"_myapp() {
     for i in ${COMP_WORDS[@]}
     do
         case "${i}" in
-            myapp)
+            "$1")
                 cmd="myapp"
                 ;;
             help)
@@ -139,7 +139,7 @@ static BASH_SPECIAL_CMDS: &str = r#"_my_app() {
     for i in ${COMP_WORDS[@]}
     do
         case "${i}" in
-            my_app)
+            "$1")
                 cmd="my_app"
                 ;;
             help)
@@ -285,7 +285,7 @@ static BASH_ALIASES: &str = r#"_cmd() {
     for i in ${COMP_WORDS[@]}
     do
         case "${i}" in
-            cmd)
+            "$1")
                 cmd="cmd"
                 ;;
             *)


### PR DESCRIPTION
This issue came up in this pull request: https://github.com/casey/just/pull/1035

Right now bash completions break if you supply an alias to the clap command.

## Reproduction steps
You have a program `just` and an alias `alias j=just`.

1. Source completions to your bash shell.
2. Add to your `~/.bash_profile` this line: `alias j=just`.
3. Add completions to the alias using the same completion function as just: `complete -o bashdefault -o default -F _just j`
2. Run `just <tab><tab>`. Completions appear as expected.
3. Run `j <tab><tab>` No completions appear.

This bug happens because the completion script hardcodes the executable name instead of looking for `$1`.

This PR addresses that bug.