### PR TITLE
docs: Add key-value derive example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,10 @@ name = "git_derive"
 required-features = ["derive"]
 
 [[example]]
+name = "keyvalue_derive"
+required-features = ["derive"]
+
+[[example]]
 name = "busybox"
 path = "examples/multicall_busybox.rs"
 required-features = ["unstable-multicall"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 # Examples
 
 - Basic demo: [derive](demo.md)
+- Key-value pair arguments: [derive](keyvalue_derive.md)
 - git-like interface: [builder](git.md), [derive](git_derive.md)
 - pacman-like interface: [builder](git.md)
 - Escaped positionals with `--`: [builder](escaped_positional.md), [derive](escaped_positional_derive.md)

--- a/examples/keyvalue_derive.md
+++ b/examples/keyvalue_derive.md
@@ -1,0 +1,25 @@
+*Jump to [source](keyvalue_derive.rs)*
+
+```bash
+$ keyvalue_derive --help
+clap 
+
+USAGE:
+    keyvalue_derive[EXE] [OPTIONS]
+
+OPTIONS:
+    -D <DEFINES>        
+    -h, --help          Print help information
+$ keyvalue_derive -D Foo=10 -D Alice=30
+Args { defines: [("Foo", 10), ("Alice", 30)] }
+$ keyvalue_derive -D Foo
+? failed
+error: Invalid value for '-D <DEFINES>': invalid KEY=value: no `=` found in `Foo`
+
+For more information try --help
+$ keyvalue_derive -D Foo=Bar
+? failed
+error: Invalid value for '-D <DEFINES>': invalid digit found in string
+
+For more information try --help
+```

--- a/examples/keyvalue_derive.rs
+++ b/examples/keyvalue_derive.rs
@@ -1,0 +1,27 @@
+use clap::Parser;
+use std::error::Error;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(short = 'D', parse(try_from_str = parse_key_val), multiple_occurrences(true))]
+    defines: Vec<(String, i32)>,
+}
+
+/// Parse a single key-value pair
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + Send + Sync + 'static,
+{
+    let pos = s
+        .find('=')
+        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{}`", s))?;
+    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}
+
+fn main() {
+    let args = Args::parse();
+    println!("{:?}", args);
+}


### PR DESCRIPTION
This is carried over from the clap_derive examples.  Looking over the
other examples, I feel like they are covered by other examples or by the
derive reference.  We should call out deny missing docs though.