### PR TITLE
fix(derive): use full path name for Result type

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -131,12 +131,12 @@ pub fn gen_from_arg_matches_for_struct(
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #struct_name #ty_generics #where_clause {
-            fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+            fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 let v = #struct_name #constructor;
                 ::std::result::Result::Ok(v)
             }
 
-            fn update_from_arg_matches(&mut self, __clap_arg_matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+            fn update_from_arg_matches(&mut self, __clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<(), clap::Error> {
                 #updater
                 ::std::result::Result::Ok(())
             }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -524,7 +524,7 @@ fn gen_from_arg_matches(
     };
 
     quote! {
-        fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
             if let Some((#subcommand_name_var, #sub_arg_matches_var)) = __clap_arg_matches.subcommand() {
                 {
                     let __clap_arg_matches = #sub_arg_matches_var;
@@ -640,7 +640,7 @@ fn gen_update_from_arg_matches(
         fn update_from_arg_matches<'b>(
             &mut self,
             __clap_arg_matches: &clap::ArgMatches,
-        ) -> Result<(), clap::Error> {
+        ) -> ::std::result::Result<(), clap::Error> {
             if let Some((__clap_name, __clap_sub_arg_matches)) = __clap_arg_matches.subcommand() {
                 match self {
                     #( #subcommands ),*

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -82,7 +82,7 @@ pub fn arg_enum(name: &Ident) {
             fn from_str(_input: &str, _ignore_case: bool) -> ::std::result::Result<Self, String> {
                 unimplemented!()
             }
-            fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>>{
+            fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::PossibleValue<'a>>{
                 unimplemented!()
             }
         }

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -32,10 +32,10 @@ pub fn into_app(name: &Ident) {
 pub fn from_arg_matches(name: &Ident) {
     append_dummy(quote! {
         impl clap::FromArgMatches for #name {
-            fn from_arg_matches(_m: &clap::ArgMatches) -> Result<Self, clap::Error> {
+            fn from_arg_matches(_m: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 unimplemented!()
             }
-            fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error>{
+            fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> ::std::result::Result<(), clap::Error>{
                 unimplemented!()
             }
         }
@@ -79,7 +79,7 @@ pub fn arg_enum(name: &Ident) {
             fn value_variants<'a>() -> &'a [Self]{
                 unimplemented!()
             }
-            fn from_str(_input: &str, _ignore_case: bool) -> Result<Self, String> {
+            fn from_str(_input: &str, _ignore_case: bool) -> ::std::result::Result<Self, String> {
                 unimplemented!()
             }
             fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>>{


### PR DESCRIPTION
I use to be define a `Result` type for my application, likes:
```rust
type Result<T = ()> = std::result::Result<T, crate::Error>;
```

But with the RC version, the derive macro generates invalid code:
```rust
error[E0107]: this type alias takes at most 1 generic argument but 2 generic arguments were supplied
  --> cli/src/main.rs:12:17
   |
12 | #[derive(Debug, Parser)]
   |                 ^^^^^^
   |                 |
   |                 expected at most 1 generic argument
   |                 help: remove this generic argument
   |
note: type alias defined here, with at most 1 generic parameter: `T`
  --> cli/src/main.rs:10:6
   |
10 | type Result<T = ()> = std::result::Result<T, crate::Error>;
   |      ^^^^^^ -
   = note: this error originates in the derive macro `Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
```