### PR TITLE
fix(derive): Use fully qualified types

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -131,12 +131,12 @@ pub fn gen_from_arg_matches_for_struct(
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #struct_name #ty_generics #where_clause {
-            fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+            fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 let v = #struct_name #constructor;
                 ::std::result::Result::Ok(v)
             }
 
-            fn update_from_arg_matches(&mut self, __clap_arg_matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+            fn update_from_arg_matches(&mut self, __clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<(), clap::Error> {
                 #updater
                 ::std::result::Result::Ok(())
             }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -524,7 +524,7 @@ fn gen_from_arg_matches(
     };
 
     quote! {
-        fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
             if let Some((#subcommand_name_var, #sub_arg_matches_var)) = __clap_arg_matches.subcommand() {
                 {
                     let __clap_arg_matches = #sub_arg_matches_var;
@@ -640,7 +640,7 @@ fn gen_update_from_arg_matches(
         fn update_from_arg_matches<'b>(
             &mut self,
             __clap_arg_matches: &clap::ArgMatches,
-        ) -> Result<(), clap::Error> {
+        ) -> ::std::result::Result<(), clap::Error> {
             if let Some((__clap_name, __clap_sub_arg_matches)) = __clap_arg_matches.subcommand() {
                 match self {
                     #( #subcommands ),*

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -32,10 +32,10 @@ pub fn into_app(name: &Ident) {
 pub fn from_arg_matches(name: &Ident) {
     append_dummy(quote! {
         impl clap::FromArgMatches for #name {
-            fn from_arg_matches(_m: &clap::ArgMatches) -> Result<Self, clap::Error> {
+            fn from_arg_matches(_m: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 unimplemented!()
             }
-            fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error>{
+            fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> ::std::result::Result<(), clap::Error>{
                 unimplemented!()
             }
         }
@@ -79,10 +79,10 @@ pub fn arg_enum(name: &Ident) {
             fn value_variants<'a>() -> &'a [Self]{
                 unimplemented!()
             }
-            fn from_str(_input: &str, _ignore_case: bool) -> Result<Self, String> {
+            fn from_str(_input: &str, _ignore_case: bool) -> ::std::result::Result<Self, String> {
                 unimplemented!()
             }
-            fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>>{
+            fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::PossibleValue<'a>>{
                 unimplemented!()
             }
         }


### PR DESCRIPTION
This fixes `#[derive(Parser)]` when a custom `Result` type is in scope.

For example, this code fails to compile without this patch:

```
use clap::Parser;

type Result<T> = result::Result<T, ()>;

#[derive(Parser)]
pub struct Options {}
```