### PR TITLE
docs: Call out features used in root examples

### DIFF
--- a/examples/demo.md
+++ b/examples/demo.md
@@ -1,5 +1,7 @@
 *Jump to [source](demo.rs)*
 
+**This requires enabling the `derive` feature flag.**
+
 Used to validate README.md's content
 ```bash
 $ demo --help

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,3 +1,5 @@
+// Note: this requires the `derive` attribute
+
 use clap::Parser;
 
 /// Simple program to greet a person

--- a/examples/escaped_positional.md
+++ b/examples/escaped_positional.md
@@ -1,5 +1,7 @@
 *Jump to [source](escaped_positional.rs)*
 
+**This requires enabling the `cargo` feature flag.**
+
 You can use `--` to escape further arguments.
 
 Let's see what this looks like in the help:

--- a/examples/escaped_positional.rs
+++ b/examples/escaped_positional.rs
@@ -1,3 +1,5 @@
+// Note: this requires the `cargo` feature
+
 use clap::{app_from_crate, arg};
 
 fn main() {

--- a/examples/escaped_positional_derive.md
+++ b/examples/escaped_positional_derive.md
@@ -1,5 +1,7 @@
 *Jump to [source](escaped_positional_derive.rs)*
 
+**This requires enabling the `derive` feature flag.**
+
 You can use `--` to escape further arguments.
 
 Let's see what this looks like in the help:

--- a/examples/escaped_positional_derive.rs
+++ b/examples/escaped_positional_derive.rs
@@ -1,3 +1,5 @@
+// Note: this requires the `derive` attribute
+
 use clap::Parser;
 
 #[derive(Parser)]

--- a/examples/git_derive.md
+++ b/examples/git_derive.md
@@ -1,5 +1,7 @@
 *Jump to [source](git_derive.rs)*
 
+**This requires enabling the `derive` feature flag.**
+
 Git is an example of several common subcommand patterns.
 
 Help:

--- a/examples/git_derive.rs
+++ b/examples/git_derive.rs
@@ -1,3 +1,5 @@
+// Note: this requires the `derive` attribute
+
 use std::ffi::OsString;
 use std::path::PathBuf;
 

--- a/examples/keyvalue_derive.md
+++ b/examples/keyvalue_derive.md
@@ -1,5 +1,7 @@
 *Jump to [source](keyvalue_derive.rs)*
 
+**This requires enabling the `derive` feature flag.**
+
 ```bash
 $ keyvalue_derive --help
 clap 

--- a/examples/keyvalue_derive.rs
+++ b/examples/keyvalue_derive.rs
@@ -1,3 +1,5 @@
+// Note: this requires the `derive` attribute
+
 use clap::Parser;
 use std::error::Error;
 


### PR DESCRIPTION
mitsuhiko immediately jumped into the examples and got tripped up by the
lack of documentation on feature flags needed.

I limited this to just the root ones because the rest are in a more
proper tutorial that steps through it all.