### PR TITLE
docs: Auto-tag feature flags 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,4 +180,4 @@ jobs:
     - name: Lint (minimal)
       run: make clippy-minimal
     - name: Lint (all)
-      run: make clippy-all
+      run: make clippy-full

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -105,4 +105,4 @@ jobs:
     - name: Lint Minimal
       run: make clippy-minimal
     - name: Lint All
-      run: make clippy-all
+      run: make clippy-full

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ include = [
 
 [package.metadata.docs.rs]
 features = ["unstable-doc"]
+rustc-args = ["--cfg", "docsrs"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [package.metadata.playground]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-features = ["doc"]
+features = ["unstable-doc"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [package.metadata.playground]
-features = ["doc"]
+features = ["unstable-doc"]
 
 [package.metadata.release]
 shared-version = true
@@ -57,7 +57,7 @@ default = [
 	"suggestions",
 ]
 debug = ["clap_derive/debug", "backtrace"] # Enables debug messages
-doc = ["derive", "cargo", "wrap_help", "yaml", "env", "unicode", "regex", "unstable-replace", "unstable-multicall", "unstable-grouped"] # for docs.rs
+unstable-doc = ["derive", "cargo", "wrap_help", "yaml", "env", "unicode", "regex", "unstable-replace", "unstable-multicall", "unstable-grouped"] # for docs.rs
 
 # Used in default
 std = ["indexmap/std"] # support for no_std in a backwards-compatible way

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,6 @@ _FEATURES_full = --features "derive cargo env unicode yaml regex unstable-replac
 _FEATURES_debug = ${_FEATURES_full} --features debug
 _FEATURES_release = ${_FEATURES_full} --release
 
-_FEATURES_all = --all-features
-
 check-%:
 	cargo check ${_FEATURES_${@:check-%=%}} --all-targets ${ARGS}
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ _FEATURES = minimal default wasm full debug release
 _FEATURES_minimal = --no-default-features --features "std"
 _FEATURES_default =
 _FEATURES_wasm = --features "derive cargo env unicode yaml regex unstable-replace unstable-multicall unstable-grouped"
-_FEATURES_full = --features "derive cargo env unicode yaml regex unstable-replace unstable-multicall unstable-grouped wrap_help doc"
+_FEATURES_full = --features "derive cargo env unicode yaml regex unstable-replace unstable-multicall unstable-grouped wrap_help unstable-doc"
 _FEATURES_debug = ${_FEATURES_full} --features debug
 _FEATURES_release = ${_FEATURES_full} --release
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // (see LICENSE or <http://opensource.org/licenses/MIT>) All files in the project carrying such
 // notice may not be copied, modified, or distributed except according to those terms.
 
+#![cfg_attr(feature = "docsrs", feature(doc_auto_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/clap-rs/clap/master/assets/clap.png")]
 #![cfg_attr(feature = "derive", doc = include_str!("../README.md"))]
 //! <https://github.com/clap-rs/clap>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // notice may not be copied, modified, or distributed except according to those terms.
 
 #![doc(html_logo_url = "https://raw.githubusercontent.com/clap-rs/clap/master/assets/clap.png")]
-#![cfg_attr(feature = "unstable-doc", doc = include_str!("../README.md"))]
+#![cfg_attr(feature = "derive", doc = include_str!("../README.md"))]
 //! <https://github.com/clap-rs/clap>
 #![warn(
     missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 // notice may not be copied, modified, or distributed except according to those terms.
 
 #![doc(html_logo_url = "https://raw.githubusercontent.com/clap-rs/clap/master/assets/clap.png")]
-#![cfg_attr(feature = "doc", doc = include_str!("../README.md"))]
+#![cfg_attr(feature = "unstable-doc", doc = include_str!("../README.md"))]
 //! <https://github.com/clap-rs/clap>
 #![warn(
     missing_docs,

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -6,8 +6,8 @@ fn example_tests() {
     let features = [
         #[cfg(feature = "debug")]
         "debug",
-        #[cfg(feature = "doc")]
-        "doc",
+        #[cfg(feature = "unstable-doc")]
+        "unstable-doc",
         #[cfg(feature = "std")]
         "std",
         #[cfg(feature = "derive")]


### PR DESCRIPTION
My route to this was meandering as I played with how I wanted this enabled (e.g. I was playing with a `unstable-nightly` feature).  I figured the changes along the way were still worthwhile and kept them.

Fixes #3095
