### PR TITLE
Use ArgSettings to store Arg::exclusive

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -99,7 +99,6 @@ pub struct Arg<'help> {
     pub(crate) terminator: Option<&'help str>,
     pub(crate) index: Option<usize>,
     pub(crate) help_heading: Option<Option<&'help str>>,
-    pub(crate) exclusive: bool,
     pub(crate) value_hint: ValueHint,
 }
 
@@ -702,9 +701,12 @@ impl<'help> Arg<'help> {
     /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
     /// ```
     #[inline]
-    pub fn exclusive(mut self, yes: bool) -> Self {
-        self.exclusive = yes;
-        self
+    pub fn exclusive(self, yes: bool) -> Self {
+        if yes {
+            self.setting(ArgSettings::Exclusive)
+        } else {
+            self.unset_setting(ArgSettings::Exclusive)
+        }
     }
 
     /// Specifies that an argument can be matched to all child [`Subcommand`]s.
@@ -4961,7 +4963,6 @@ impl<'help> fmt::Debug for Arg<'help> {
             .field("terminator", &self.terminator)
             .field("index", &self.index)
             .field("help_heading", &self.help_heading)
-            .field("exclusive", &self.exclusive)
             .field("value_hint", &self.value_hint)
             .field("default_missing_vals", &self.default_missing_vals);
 

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -88,7 +88,7 @@ pub enum ArgSettings {
     /// Specifies that option values that are invalid UTF-8 should *not* be treated as an error.
     AllowInvalidUtf8,
     /// Specifies that option should exist on its own.
-    /// Having any othe arguments present at runtime is an error.
+    /// Having any other arguments present at runtime is an error.
     Exclusive,
 }
 

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -87,6 +87,9 @@ pub enum ArgSettings {
     HiddenLongHelp,
     /// Specifies that option values that are invalid UTF-8 should *not* be treated as an error.
     AllowInvalidUtf8,
+    /// Specifies that option should exist on its own.
+    /// Having any othe arguments present at runtime is an error.
+    Exclusive,
 }
 
 bitflags! {
@@ -116,6 +119,7 @@ bitflags! {
         #[cfg(feature = "env")]
         const HIDE_ENV         = 1 << 21;
         const UTF8_NONE        = 1 << 22;
+        const EXCLUSIVE        = 1 << 23;
         const NO_OP            = 0;
     }
 }
@@ -147,7 +151,8 @@ impl_settings! { ArgSettings, ArgFlags,
     HideDefaultValue("hidedefaultvalue") => Flags::HIDE_DEFAULT_VAL,
     HiddenShortHelp("hiddenshorthelp") => Flags::HIDDEN_SHORT_H,
     HiddenLongHelp("hiddenlonghelp") => Flags::HIDDEN_LONG_H,
-    AllowInvalidUtf8("allowinvalidutf8") => Flags::UTF8_NONE
+    AllowInvalidUtf8("allowinvalidutf8") => Flags::UTF8_NONE,
+    Exclusive("exclusive") => Flags::EXCLUSIVE
 }
 
 #[cfg(test)]
@@ -226,6 +231,10 @@ mod test {
         assert_eq!(
             "allowinvalidutf8".parse::<ArgSettings>().unwrap(),
             ArgSettings::AllowInvalidUtf8
+        );
+        assert_eq!(
+            "exclusive".parse::<ArgSettings>().unwrap(),
+            ArgSettings::Exclusive
         );
         assert!("hahahaha".parse::<ArgSettings>().is_err());
     }

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -315,7 +315,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                     .app
                     .find(name)
                     // Find `arg`s which are exclusive but also appear with other args.
-                    .filter(|&arg| arg.exclusive && args_count > 1)
+                    .filter(|&arg| arg.is_set(ArgSettings::Exclusive) && args_count > 1)
             })
             // Throw an error for the first conflict found.
             .try_for_each(|arg| {


### PR DESCRIPTION
Intends to close #3072

Packs `Arg::exclusive` into `ArgSettings` to reduce memory overhead.