### PR TITLE
Fix unqualified result types causing compilation failures with derive implementations

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -602,7 +602,7 @@ fn gen_parsers(
         Ty::OptionVec => quote_spanned! { ty.span()=>
             if #arg_matches.is_present(#name) {
                 Some(#arg_matches.#values_of(#name)
-                    .map(|v| v.map::<Result<#convert_type, clap::Error>, _>(#parse).collect::<Result<Vec<_>, clap::Error>>())
+                    .map(|v| v.map::<::std::result::Result<#convert_type, clap::Error>, _>(#parse).collect::<::std::result::Result<Vec<_>, clap::Error>>())
                     .transpose()?
                     .unwrap_or_else(Vec::new))
             } else {
@@ -613,7 +613,7 @@ fn gen_parsers(
         Ty::Vec => {
             quote_spanned! { ty.span()=>
                 #arg_matches.#values_of(#name)
-                    .map(|v| v.map::<Result<#convert_type, clap::Error>, _>(#parse).collect::<Result<Vec<_>, clap::Error>>())
+                    .map(|v| v.map::<::std::result::Result<#convert_type, clap::Error>, _>(#parse).collect::<::std::result::Result<Vec<_>, clap::Error>>())
                     .transpose()?
                     .unwrap_or_else(Vec::new)
             }

--- a/tests/derive/main.rs
+++ b/tests/derive/main.rs
@@ -28,5 +28,6 @@ mod rename_all_env;
 mod skip;
 mod structopt;
 mod subcommands;
+mod type_alias_regressions;
 mod utf8;
 mod utils;

--- a/tests/derive/type_alias_regressions.rs
+++ b/tests/derive/type_alias_regressions.rs
@@ -1,0 +1,31 @@
+/// Regression test to ensure that type aliases do not cause compilation failures.
+use clap::Parser;
+use std::str::FromStr;
+
+// Result type alias
+#[allow(dead_code)]
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+// Wrapper to use for Option type alias
+struct Wrapper<T>(T);
+
+impl<T: FromStr> FromStr for Wrapper<T> {
+    type Err = <T as FromStr>::Err;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        T::from_str(s).map(Wrapper)
+    }
+}
+
+type Option<T> = std::option::Option<Wrapper<T>>;
+
+#[derive(Parser)]
+pub struct Opts {
+    another_string: Option<String>,
+    strings: Vec<String>,
+}
+
+#[test]
+fn type_alias_regressions() {
+    Opts::parse();
+}


### PR DESCRIPTION
Fixes some additional unqualified types in the derive macros and adds a regression test case.