### PR TITLE
fix(derive): Allow aliased Option with ArgEnum

### DIFF
--- a/clap_derive/src/derives/arg_enum.rs
+++ b/clap_derive/src/derives/arg_enum.rs
@@ -114,7 +114,7 @@ fn gen_to_possible_value(lits: &[(TokenStream, Ident)]) -> TokenStream {
     let (lit, variant): (Vec<TokenStream>, Vec<Ident>) = lits.iter().cloned().unzip();
 
     quote! {
-        fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
+        fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::PossibleValue<'a>> {
             match self {
                 #(Self::#variant => Some(#lit),)*
                 _ => None

--- a/tests/derive/type_alias_regressions.rs
+++ b/tests/derive/type_alias_regressions.rs
@@ -1,12 +1,14 @@
 /// Regression test to ensure that type aliases do not cause compilation failures.
-use clap::Parser;
 use std::str::FromStr;
+
+use clap::{ArgEnum, Parser, Subcommand};
 
 // Result type alias
 #[allow(dead_code)]
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 // Wrapper to use for Option type alias
+#[derive(Debug, PartialEq, Eq)]
 struct Wrapper<T>(T);
 
 impl<T: FromStr> FromStr for Wrapper<T> {
@@ -21,11 +23,25 @@ type Option<T> = std::option::Option<Wrapper<T>>;
 
 #[derive(Parser)]
 pub struct Opts {
-    another_string: Option<String>,
-    strings: Vec<String>,
+    another_string: String,
+    #[clap(subcommand)]
+    command: Command,
+    #[clap(short, long, arg_enum)]
+    choice: ArgChoice,
+}
+
+#[derive(Subcommand, PartialEq, Debug)]
+enum Command {
+    DoSomething { arg: Option<String> },
+}
+
+#[derive(ArgEnum, PartialEq, Debug, Clone)]
+enum ArgChoice {
+    Foo,
+    Bar,
 }
 
 #[test]
 fn type_alias_regressions() {
-    Opts::parse_from(["test"]);
+    Opts::try_parse_from(["test", "value", "--choice=foo", "do-something"]).unwrap();
 }

--- a/tests/derive/type_alias_regressions.rs
+++ b/tests/derive/type_alias_regressions.rs
@@ -27,5 +27,5 @@ pub struct Opts {
 
 #[test]
 fn type_alias_regressions() {
-    Opts::parse();
+    Opts::parse_from(["test"]);
 }


### PR DESCRIPTION
My goal was just to expand the tests from #3142 to cover the basic derives but apparently, I found another case to qualify.