### PR TITLE
Fix unused parameter warning

### DIFF
--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -15,16 +15,16 @@ use indexmap::map::Entry;
 pub(crate) struct ArgMatcher(pub(crate) ArgMatches);
 
 impl ArgMatcher {
-    pub(crate) fn new(app: &App) -> Self {
+    pub(crate) fn new(_app: &App) -> Self {
         ArgMatcher(ArgMatches {
             #[cfg(debug_assertions)]
             valid_args: {
-                let args = app.args.args().map(|a| a.id.clone());
-                let groups = app.groups.iter().map(|g| g.id.clone());
+                let args = _app.args.args().map(|a| a.id.clone());
+                let groups = _app.groups.iter().map(|g| g.id.clone());
                 args.chain(groups).collect()
             },
             #[cfg(debug_assertions)]
-            valid_subcommands: app.subcommands.iter().map(|sc| sc.id.clone()).collect(),
+            valid_subcommands: _app.subcommands.iter().map(|sc| sc.id.clone()).collect(),
             ..Default::default()
         })
     }


### PR DESCRIPTION
I found one warning from `cargo check --release`. This PR fixes it.

```
warning: unused variable: `app`
  --> src/parse/arg_matcher.rs:19:23
   |
19 |     pub(crate) fn new(app: &App) -> Self {
   |                       ^^^ help: if this is intentional, prefix it with an underscore: `_app`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: `clap` (lib) generated 1 warning
```