### PR TITLE
Expand clap_generate's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ CLI parsers optimized for other use cases.
 ### Related Projects
 
 - [wild](https://crates.io/crates/wild) for supporting wildcards (`*`) on Windows like you do Linux
-- [argfile](https://github.com/rust-cli/argfile) for loading additional arguments from a file (aka response files)
-- [clap-verbosity-flag](https://github.com/rust-cli/clap-verbosity-flag)
-- [clap-cargo](https://github.com/crate-ci/clap-cargo)
-- [concolor-clap](https://github.com/rust-cli/concolor/tree/main/crates/clap)
+- [argfile](https://crates.io/crates/argfile) for loading additional arguments from a file (aka response files)
+- [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag)
+- [clap-cargo](https://crates.io/crates/clap-cargo)
+- [concolor-clap](https://crates.io/crates/concolor-clap)
 - [Command-line Apps for Rust](https://rust-cli.github.io/book/index.html) book
-- [`trycmd`](https://github.com/epage/trycmd):  Snapshot testing
-  - Or for more control, [`assert_cmd`](https://github.com/assert-rs/assert_cmd) and [`assert_fs`](https://github.com/assert-rs/assert_fs)
+- [`trycmd`](https://crates.io/crates/trycmd):  Snapshot testing
+  - Or for more control, [`assert_cmd`](https://crates.io/crates/assert_cmd) and [`assert_fs`](https://crates.io/crates/assert_fs)
 
 ## Feature Flags
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ CLI parsers optimized for other use cases.
 
 - [wild](https://crates.io/crates/wild) for supporting wildcards (`*`) on Windows like you do Linux
 - [argfile](https://crates.io/crates/argfile) for loading additional arguments from a file (aka response files)
+- [clap-generate](https://crates.io/crates/clap-generate) for shell completion support
 - [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag)
 - [clap-cargo](https://crates.io/crates/clap-cargo)
 - [concolor-clap](https://crates.io/crates/concolor-clap)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ CLI parsers optimized for other use cases.
 
 - [wild](https://crates.io/crates/wild) for supporting wildcards (`*`) on Windows like you do Linux
 - [argfile](https://crates.io/crates/argfile) for loading additional arguments from a file (aka response files)
-- [clap-generate](https://crates.io/crates/clap-generate) for shell completion support
+- [clap_generate](https://crates.io/crates/clap_generate) for shell completion support
 - [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag)
 - [clap-cargo](https://crates.io/crates/clap-cargo)
 - [concolor-clap](https://crates.io/crates/concolor-clap)

--- a/clap_generate/CONTRIBUTING.md
+++ b/clap_generate/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# How to Contribute
+
+See the [clap-wide CONTRIBUTING.md](../CONTRIBUTING.md).  This will contain `clap_generate` specific notes.
+
+### Scope
+
+`clap_generate` contains the core completion generators, meaning ones
+maintained by the clap maintainers that get priority for features and fixes.
+Additional, including contributor-maintained generators can also be contributed
+to the clap repo and sit alongside `clap_generate` in a `clap_generate_<name>`
+crate.

--- a/clap_generate/README.md
+++ b/clap_generate/README.md
@@ -9,4 +9,4 @@ Generates completions (and other things) for [`clap`](https://github.com/clap-rs
 
 - [Documentation](https://docs.rs/clap_generate)
 - [Questions & Discussions](https://github.com/clap-rs/clap/discussions)
-- [CONTRIBUTING](../CONTRIBUTING.md)
+- [CONTRIBUTING](CONTRIBUTING.md)

--- a/clap_generate/README.md
+++ b/clap_generate/README.md
@@ -1,12 +1,23 @@
+<!-- omit in TOC -->
 # clap_generate
+
+> **Shell completion generation for `clap`**
 
 [![Crates.io](https://img.shields.io/crates/v/clap_generate?style=flat-square)](https://crates.io/crates/clap_generate)
 [![Crates.io](https://img.shields.io/crates/d/clap_generate?style=flat-square)](https://crates.io/crates/clap_generate)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/clap-rs/clap/blob/master/LICENSE-MIT)
 
-Generates completions (and other things) for [`clap`](https://github.com/clap-rs/clap) based CLIs
+Dual-licensed under [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT).
 
-- [Documentation](https://docs.rs/clap_generate)
-- [Questions & Discussions](https://github.com/clap-rs/clap/discussions)
-- [CONTRIBUTING](CONTRIBUTING.md)
+1. [About](#about)
+2. [API Reference](https://docs.rs/clap_generate)
+3. [Questions & Discussions](https://github.com/clap-rs/clap/discussions)
+4. [CONTRIBUTING](CONTRIBUTING.md)
+5. [Sponsors](../README.md#sponsors)
+
+## About
+
+### Related Projects
+
+- [clap_generate_fig](https://crates.io/crates/clap_generate_fig) for [fig](https://fig.io/) shell completion support


### PR DESCRIPTION
Inspired by #2828, this connects clap to clap_generate to clap_generate_fig as well as lists out our current policy for shell completion crates.