### PR TITLE
docs: Fix copy paste error in example

### DIFF
--- a/examples/tutorial_builder/04_02_validate.rs
+++ b/examples/tutorial_builder/04_02_validate.rs
@@ -12,6 +12,6 @@ fn main() {
     // Note, it's safe to call unwrap() because the arg is required
     let port: usize = matches
         .value_of_t("PORT")
-        .expect("'MODE' is required and parsing will fail if its missing");
+        .expect("'PORT' is required and parsing will fail if its missing");
     println!("PORT = {}", port);
 }


### PR DESCRIPTION
This PR will fix a small error in one of the builder api examples, which was most likely introduced through copy paste :D 