### PR TITLE
fix!: Allow adding new enum variants

### DIFF
--- a/clap_generate/src/generators/shells/zsh.rs
+++ b/clap_generate/src/generators/shells/zsh.rs
@@ -396,6 +396,9 @@ fn value_completion(arg: &Arg) -> Option<String> {
                 ValueHint::Hostname => "_hosts",
                 ValueHint::Url => "_urls",
                 ValueHint::EmailAddress => "_email_addresses",
+                _ => {
+                    return None;
+                }
             }
             .to_string(),
         )

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -23,6 +23,7 @@ impl Default for AppFlags {
 ///
 /// [`App`]: crate::App
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum AppSettings {
     /// Try not to fail on parse errors, like missing option values.
     ///

--- a/src/build/arg/settings.rs
+++ b/src/build/arg/settings.rs
@@ -25,6 +25,7 @@ impl Default for ArgFlags {
 /// [`Arg::unset_setting`]: crate::Arg::unset_setting()
 /// [`Arg::is_set`]: crate::Arg::is_set()
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum ArgSettings {
     /// Specifies that an arg must be used
     Required,

--- a/src/build/arg/value_hint.rs
+++ b/src/build/arg/value_hint.rs
@@ -25,6 +25,7 @@ use std::str::FromStr;
 /// [^1]: fish completions currently only support named arguments (e.g. -o or --opt), not
 ///       positional arguments.
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[non_exhaustive]
 pub enum ValueHint {
     /// Default value if hint is not specified. Follows shell default behavior, which is usually
     /// auto-completing filenames.

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -24,6 +24,7 @@ pub type Result<T> = StdResult<T, Error>;
 
 /// Command line argument parser kind of error
 #[derive(Debug, Copy, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ErrorKind {
     /// Occurs when an [`Arg`] has a set of possible values,
     /// and the user provides a value which isn't in that set.


### PR DESCRIPTION
Without being a breaking change.

This seems minor enough that we can break this during the release
candidates.  For `ValueHint`, the completion scripts are 99% of who
should be `match`ing it.  `AppSettings` as undocumented variants that
people shouldn't use.

BREAKING CHANGE: `clap::{ValueHint, ErrorKind, AppSettings,
ArgSettings}` are now `non_exhaustive`.