### PR TITLE
Ensure trailing newlines at the end of errors

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -1066,7 +1066,7 @@ impl Error {
 
         start_error(&mut c, "The argument '");
         c.warning(arg.clone());
-        c.none("' wasn't found");
+        c.none("' wasn't found\n");
 
         Self::new(c, ErrorKind::ArgumentNotFound, false).set_info(vec![arg])
     }

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -1133,6 +1133,8 @@ fn try_help(app: &App, c: &mut Colorizer) {
         c.none("\n\nFor more information try ");
         c.good("help");
         c.none("\n");
+    } else {
+        c.none("\n");
     }
 }
 

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 
-use clap::{App, Arg, Error, ErrorKind};
+use clap::{arg, App, Arg, Error, ErrorKind};
 
 fn compare_error(
     err: Error,
@@ -56,4 +56,22 @@ For more information try --help
     let expected_kind = ErrorKind::InvalidValue;
     let err = app.error(expected_kind, "Failed for mysterious reasons");
     assert!(compare_error(err, expected_kind, MESSAGE, true));
+}
+
+#[test]
+fn value_validation_has_newline() {
+    let m = App::new("test")
+        .arg(arg!(<PORT>).help("Network port to use"))
+        .try_get_matches_from(["test", "foo"])
+        .unwrap();
+
+    let res = m.value_of_t::<usize>("PORT");
+
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().ends_with('\n'),
+        "Errors should have a trailing newline, got {:?}",
+        err.to_string()
+    );
 }

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -75,3 +75,21 @@ fn value_validation_has_newline() {
         err.to_string()
     );
 }
+
+#[test]
+fn argument_not_found_auto_has_newline() {
+    let m = App::new("test")
+        .arg(arg!([PORT]).help("Network port to use"))
+        .try_get_matches_from(["test"])
+        .unwrap();
+
+    let res = m.value_of_t::<usize>("PORT");
+
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().ends_with('\n'),
+        "Errors should have a trailing newline, got {:?}",
+        err.to_string()
+    );
+}

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2643,6 +2643,11 @@ fn disabled_help_flag_and_subcommand() {
     let err = res.unwrap_err();
     assert_eq!(err.kind, ErrorKind::UnrecognizedSubcommand);
     assert_eq!(err.info, &["help"]);
+    assert!(
+        err.to_string().ends_with('\n'),
+        "Errors should have a trailing newline, got {:?}",
+        err.to_string()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Related to #2787.

I didn't update the CHANGELOG because this looks like a regression; it looks like clap3 always added a newline.