### PR TITLE
fix(help): Don't commit to '--help' that doesn't work

### DIFF
--- a/clap_generate/tests/completions/bash.rs
+++ b/clap_generate/tests/completions/bash.rs
@@ -72,7 +72,7 @@ static BASH: &str = r#"_myapp() {
             return 0
             ;;
         myapp__help)
-            opts="-h --help"
+            opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -175,7 +175,7 @@ static BASH_SPECIAL_CMDS: &str = r#"_my_app() {
             return 0
             ;;
         my_app__help)
-            opts="-h --help"
+            opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_generate/tests/completions/elvish.rs
+++ b/clap_generate/tests/completions/elvish.rs
@@ -65,8 +65,6 @@ set edit:completion:arg-completer[my_app] = [@words]{
             cand --version 'Print version information'
         }
         &'my_app;help'= {
-            cand -h 'Print help information'
-            cand --help 'Print help information'
         }
     ]
     $completions[$command]
@@ -142,8 +140,6 @@ set edit:completion:arg-completer[my_app] = [@words]{
             cand --version 'Print version information'
         }
         &'my_app;help'= {
-            cand -h 'Print help information'
-            cand --help 'Print help information'
         }
     ]
     $completions[$command]

--- a/clap_generate/tests/completions/fish.rs
+++ b/clap_generate/tests/completions/fish.rs
@@ -37,7 +37,6 @@ complete -c myapp -n "__fish_use_subcommand" -f -a "help" -d 'Print this message
 complete -c myapp -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
 complete -c myapp -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help information'
 complete -c myapp -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version information'
-complete -c myapp -n "__fish_seen_subcommand_from help" -s h -l help -d 'Print help information'
 "#;
 
 #[test]
@@ -73,7 +72,6 @@ complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Pr
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Print version information'
 complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hyphens" -s h -l help -d 'Print help information'
 complete -c my_app -n "__fish_seen_subcommand_from some-cmd-with-hyphens" -s V -l version -d 'Print version information'
-complete -c my_app -n "__fish_seen_subcommand_from help" -s h -l help -d 'Print help information'
 "#;
 
 #[test]
@@ -197,5 +195,4 @@ complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_sub
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version information'
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from help" -s h -l help -d 'Print help information'
 complete -c my_app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from help" -s V -l version -d 'Print version information'
-complete -c my_app -n "__fish_seen_subcommand_from help" -s h -l help -d 'Print help information'
 "#;

--- a/clap_generate/tests/completions/powershell.rs
+++ b/clap_generate/tests/completions/powershell.rs
@@ -81,8 +81,6 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             break
         }
         'my_app;help' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             break
         }
     })
@@ -171,8 +169,6 @@ Register-ArgumentCompleter -Native -CommandName 'my_app' -ScriptBlock {
             break
         }
         'my_app;help' {
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             break
         }
     })

--- a/clap_generate/tests/completions/zsh.rs
+++ b/clap_generate/tests/completions/zsh.rs
@@ -72,8 +72,6 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
-'-h[Print help information]' \
-'--help[Print help information]' \
 && ret=0
 ;;
         esac
@@ -192,8 +190,6 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
-'-h[Print help information]' \
-'--help[Print help information]' \
 && ret=0
 ;;
         esac
@@ -391,8 +387,6 @@ esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
-'-h[Print help information]' \
-'--help[Print help information]' \
 && ret=0
 ;;
         esac

--- a/clap_generate_fig/tests/completions/fig.rs
+++ b/clap_generate_fig/tests/completions/fig.rs
@@ -61,10 +61,6 @@ static FIG: &str = r#"const completion: Fig.Spec = {
       name: "help",
       description: "Print this message or the help of the given subcommand(s)",
       options: [
-        {
-          name: ["-h", "--help"],
-          description: "Print help information",
-        },
       ],
     },
   ],
@@ -172,10 +168,6 @@ static FIG_SPECIAL_CMDS: &str = r#"const completion: Fig.Spec = {
       name: "help",
       description: "Print this message or the help of the given subcommand(s)",
       options: [
-        {
-          name: ["-h", "--help"],
-          description: "Print help information",
-        },
       ],
     },
   ],
@@ -445,10 +437,6 @@ static FIG_SUB_SUBCMDS: &str = r#"const completion: Fig.Spec = {
       name: "help",
       description: "Print this message or the help of the given subcommand(s)",
       options: [
-        {
-          name: ["-h", "--help"],
-          description: "Print help information",
-        },
       ],
     },
   ],

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2839,7 +2839,11 @@ impl<'help> App<'help> {
         {
             debug!("App::_check_help_and_version: Building help subcommand");
             self.subcommands.push(
-                App::new("help").about("Print this message or the help of the given subcommand(s)"),
+                App::new("help")
+                    .about("Print this message or the help of the given subcommand(s)")
+                    // The parser acts like this is set, so let's set it so we don't falsely
+                    // advertise it to the user
+                    .setting(AppSettings::DisableHelpFlag),
             );
         }
     }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2680,3 +2680,46 @@ fn override_help_flag_using_short() {
     let matches = app.get_matches_from(&["foo", "-h"]);
     assert!(matches.subcommand_matches("help").is_some());
 }
+
+#[test]
+fn subcommand_help_doesnt_have_useless_help_flag() {
+    // The main care-about is that the docs and behavior match.  Since the `help` subcommand
+    // currently ignores the `--help` flag, the output shouldn't have it.
+    let app = App::new("test_app").subcommand(App::new("test").about("Subcommand"));
+
+    assert!(utils::compare_output(
+        app,
+        "example help help",
+        "example-help 
+
+Print this message or the help of the given subcommand(s)
+
+USAGE:
+    example help [SUBCOMMAND]...
+
+ARGS:
+    <SUBCOMMAND>...    The subcommand whose help message to display
+",
+        false
+    ));
+}
+
+#[test]
+fn disable_help_flag_affects_help_subcommand() {
+    let mut app = App::new("test_app")
+        .global_setting(AppSettings::DisableHelpFlag)
+        .subcommand(App::new("test").about("Subcommand"));
+    app._build_all();
+
+    let args = app
+        .find_subcommand("help")
+        .unwrap()
+        .get_arguments()
+        .map(|a| a.get_name())
+        .collect::<Vec<_>>();
+    assert!(
+        !args.contains(&"help"),
+        "`help` should not be present: {:?}",
+        args
+    );
+}


### PR DESCRIPTION
We have two ways of fixing this
- Making `--help` work
- Don't put `--help` in the help output

For now, I went with the latter.  I tried to make it clear what the
actual requirement is so we can pivot if needed.

Fixes #2892

This happens to also fix the interaction of `DisableHelpFlag` with the
help subcommand and complcations.  I've added a test to help catch if we
break this by changing how we fixed the original issue.

Fixes #2724

These issues were reported against clap3.  I've not tried to reproduce
these in clap2 to see if they should show up in the release notes.