### PR TITLE
Fix `termcolor` minimal version at `1.1.1` and add `minimal_versions` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   ci:
     name: CI
-    needs: [test, check, docs, rustfmt, clippy]
+    needs: [test, check, docs, rustfmt, clippy, minimal_versions]
     runs-on: ubuntu-latest
     steps:
       - name: Done
@@ -183,3 +183,49 @@ jobs:
       run: make clippy-full
     - name: Lint (release)
       run: make clippy-release
+  minimal_versions:
+    name: Minimal versions
+    strategy:
+      matrix:
+        build: [ linux, windows, mac, minimal, default ]
+        include:
+          - build: linux
+            os: ubuntu-latest
+            rust: "stable"
+            features: "full"
+          - build: windows
+            os: windows-latest
+            rust: "stable"
+            features: "full"
+          - build: mac
+            os: macos-latest
+            rust: "stable"
+            features: "full"
+          - build: minimal
+            os: ubuntu-latest
+            rust: "stable"
+            features: "minimal"
+          - build: default
+            os: ubuntu-latest
+            rust: "stable"
+            features: "default"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.54.0  # MSRV
+          override: true
+      - name: Downgrade crates to minimal supported versions
+        run: cargo +nightly update -Z minimal-versions
+      - uses: Swatinem/rust-cache@v1
+      - name: Build
+        run: make build-${{matrix.features}}
+      - name: Test
+        run: make test-${{matrix.features}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ os_str_bytes = "6.0"
 strsim = { version = "0.10",  optional = true }
 yaml-rust = { version = "0.4.1",  optional = true }
 atty = { version = "0.2",  optional = true }
-termcolor = { version = "1.1", optional = true }
+termcolor = { version = "1.1.1", optional = true }
 terminal_size = { version = "0.1.12", optional = true }
 lazy_static = { version = "1", optional = true }
 regex = { version = "1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ backtrace = { version = "0.3", optional = true }
 regex = "1.0"
 lazy_static = "1"
 criterion = "0.3.2"
-trybuild = "1.0"
+trybuild = "1.0.18"
 rustversion = "1"
 # Cutting out `filesystem` feature
 trycmd = { version = "0.8.2", default-features = false, features = ["color-auto", "diff", "examples"] }


### PR DESCRIPTION
For now `termcolor` dependency is at version `1.1`. The issue is, the actual minimal usable version is `1.1.1`, because of [`set_dimmed()`](https://docs.rs/termcolor/latest/termcolor/struct.ColorSpec.html#method.set_dimmed), which is not available on `1.1.0`. This was found, as we lint against minimal crates versions in [`cucumber`](https://github.com/cucumber-rs/cucumber/pull/188) crate. 
To avoid similar issues, I've also added `minimal_versions` CI job, which downgrades all crates to minimal compatible versions and runs tests on them. Although it's `nightly` feature for `cargo`, we use it throughout multiple projects and never had any issues with it. 