### PR TITLE
fix(derive)!: Set both about/long_about with doc comments 

### DIFF
--- a/clap_derive/src/utils/doc_comments.rs
+++ b/clap_derive/src/utils/doc_comments.rs
@@ -61,7 +61,10 @@ pub fn process_doc_comment(lines: Vec<String>, name: &str, preprocess: bool) -> 
             lines.join("\n")
         };
 
-        vec![Method::new(short_name, quote!(#short))]
+        vec![
+            Method::new(short_name, quote!(#short)),
+            Method::new(long_name, quote!(None)),
+        ]
     }
 }
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -896,8 +896,8 @@ impl<'help> App<'help> {
     ///     .about("Does really amazing things for great people")
     /// # ;
     /// ```
-    pub fn about<S: Into<&'help str>>(mut self, about: S) -> Self {
-        self.about = Some(about.into());
+    pub fn about<O: Into<Option<&'help str>>>(mut self, about: O) -> Self {
+        self.about = about.into();
         self
     }
 
@@ -920,8 +920,8 @@ impl<'help> App<'help> {
     /// # ;
     /// ```
     /// [`App::about`]: App::about()
-    pub fn long_about<S: Into<&'help str>>(mut self, about: S) -> Self {
-        self.long_about = Some(about.into());
+    pub fn long_about<O: Into<Option<&'help str>>>(mut self, long_about: O) -> Self {
+        self.long_about = long_about.into();
         self
     }
 

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -2712,8 +2712,8 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::long_help`]: Arg::long_help()
     #[inline]
-    pub fn help(mut self, h: &'help str) -> Self {
-        self.help = Some(h);
+    pub fn help(mut self, h: impl Into<Option<&'help str>>) -> Self {
+        self.help = h.into();
         self
     }
 
@@ -2773,8 +2773,8 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Arg::help`]: Arg::help()
     #[inline]
-    pub fn long_help(mut self, h: &'help str) -> Self {
-        self.long_help = Some(h);
+    pub fn long_help(mut self, h: impl Into<Option<&'help str>>) -> Self {
+        self.long_help = h.into();
         self
     }
 

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -14,7 +14,7 @@
 
 use crate::utils;
 
-use clap::{ArgEnum, Parser};
+use clap::{ArgEnum, IntoApp, Parser};
 
 #[test]
 fn doc_comments() {
@@ -213,4 +213,29 @@ fn argenum_multiline_doc_comment() {
         /// Doc comment
         Bar,
     }
+}
+
+#[test]
+fn doc_comment_about_handles_both_abouts() {
+    /// Opts doc comment summary
+    #[derive(Parser, Debug)]
+    pub struct Opts {
+        #[clap(subcommand)]
+        pub cmd: Sub,
+    }
+
+    /// Sub doc comment summary
+    ///
+    /// Sub doc comment body
+    #[derive(Parser, PartialEq, Eq, Debug)]
+    pub enum Sub {
+        Compress { output: String },
+    }
+
+    let app = Opts::into_app();
+    assert_eq!(app.get_about(), Some("Opts doc comment summary"));
+    assert_eq!(
+        app.get_long_about(),
+        Some("Sub doc comment summary\n\nSub doc comment body")
+    );
 }

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -234,8 +234,7 @@ fn doc_comment_about_handles_both_abouts() {
 
     let app = Opts::into_app();
     assert_eq!(app.get_about(), Some("Opts doc comment summary"));
-    assert_eq!(
-        app.get_long_about(),
-        Some("Sub doc comment summary\n\nSub doc comment body")
-    );
+    // clap will fallback to `about` on `None`.  The main care about is not providing a `Sub` doc
+    // comment.
+    assert_eq!(app.get_long_about(), None);
 }


### PR DESCRIPTION
The main care about is that when we override a `flatten` / `subcommand` doc comment in a parent
container, that we make sure we take nothing from the child container,
rather than implicitly taking one `about` ut not `long_about`.

To do this, and to play the most safe with long help detection, we reset
`long_about` to default when there is no doc comment body to use for
`long_about`.

Fixes #2983

BREAKING CHANGE: We changed the signatures for `App::about`,
`App::long_about`, `Arg::help`, and `Arg::long_help` from accepting anything `Into<&str>` to `&str`.