### PR TITLE
docs(gen): Use absolute paths for docs.rs sake

### DIFF
--- a/clap_generate/Cargo.toml
+++ b/clap_generate/Cargo.toml
@@ -22,6 +22,11 @@ categories = ["command-line-interface"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
+[package.metadata.release]
+pre-release-replacements = [
+  {file="README.md", search="github.com/clap-rs/clap/blob/[^/]+/", replace="github.com/clap-rs/clap/blob/{{tag_name}}/", exactly=4, prerelease = true},
+]
+
 [lib]
 bench = false
 

--- a/clap_generate/README.md
+++ b/clap_generate/README.md
@@ -13,8 +13,8 @@ Dual-licensed under [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT).
 1. [About](#about)
 2. [API Reference](https://docs.rs/clap_generate)
 3. [Questions & Discussions](https://github.com/clap-rs/clap/discussions)
-4. [CONTRIBUTING](CONTRIBUTING.md)
-5. [Sponsors](../README.md#sponsors)
+4. [CONTRIBUTING](https://github.com/clap-rs/clap/blob/v3.0.0-rc.4/clap_generate/CCONTRIBUTING.md)
+5. [Sponsors](https://github.com/clap-rs/clap/blob/v3.0.0-rc.4/README.md#sponsors)
 
 ## About
 


### PR DESCRIPTION
Using relative paths will work from github but when we include
`README.md` into `lib.rs`, they will break.