### PR TITLE
revert(help): Partial revert of 3c049b4

### DIFF
--- a/examples/demo.md
+++ b/examples/demo.md
@@ -6,7 +6,6 @@ Used to validate README.md's content
 ```bash
 $ demo --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/examples/derive_ref/custom_bool.md
+++ b/examples/derive_ref/custom_bool.md
@@ -5,7 +5,6 @@ Example of overriding the magic `bool` behavior
 ```bash
 $ custom_bool --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/examples/escaped_positional.md
+++ b/examples/escaped_positional.md
@@ -8,7 +8,6 @@ Let's see what this looks like in the help:
 ```bash
 $ escaped_positional --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/examples/escaped_positional_derive.md
+++ b/examples/escaped_positional_derive.md
@@ -8,7 +8,6 @@ Let's see what this looks like in the help:
 ```bash
 $ escaped_positional_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/examples/git.md
+++ b/examples/git.md
@@ -7,7 +7,6 @@ Help:
 $ git
 ? failed
 git 
-
 A fictional versioning CLI
 
 USAGE:
@@ -23,7 +22,6 @@ SUBCOMMANDS:
     push     pushes things
 $ git help
 git 
-
 A fictional versioning CLI
 
 USAGE:
@@ -39,7 +37,6 @@ SUBCOMMANDS:
     push     pushes things
 $ git help add
 git[EXE]-add 
-
 adds things
 
 USAGE:
@@ -57,7 +54,6 @@ A basic argument:
 $ git add
 ? failed
 git[EXE]-add 
-
 adds things
 
 USAGE:

--- a/examples/git_derive.md
+++ b/examples/git_derive.md
@@ -9,7 +9,6 @@ Help:
 $ git_derive
 ? failed
 git 
-
 A fictional versioning CLI
 
 USAGE:
@@ -25,7 +24,6 @@ SUBCOMMANDS:
     push     pushes things
 $ git_derive help
 git 
-
 A fictional versioning CLI
 
 USAGE:
@@ -41,7 +39,6 @@ SUBCOMMANDS:
     push     pushes things
 $ git_derive help add
 git_derive[EXE]-add 
-
 adds things
 
 USAGE:
@@ -59,7 +56,6 @@ A basic argument:
 $ git_derive add
 ? failed
 git_derive[EXE]-add 
-
 adds things
 
 USAGE:

--- a/examples/tutorial_builder/README.md
+++ b/examples/tutorial_builder/README.md
@@ -25,7 +25,6 @@ You can create an application with several arguments using usage strings.
 ```bash
 $ 01_quick --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -66,9 +65,7 @@ You use the `App` the start building a parser.
 ```bash
 $ 02_apps --help
 MyApp 1.0
-
 Kevin K. <kbknapp@gmail.com>
-
 Does awesome things
 
 USAGE:
@@ -90,7 +87,6 @@ file.  **This requires the `cargo` feature flag.**
 ```bash
 $ 02_crate --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -113,7 +109,6 @@ all subcommands (`app.global_setting()`).
 ```bash
 $ 02_app_settings --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -139,7 +134,6 @@ Flags are switches that can be on/off:
 ```bash
 $ 03_01_flag_bool --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -169,7 +163,6 @@ Or counted.
 ```bash
 $ 03_01_flag_count --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -195,7 +188,6 @@ Flags can also accept a value.
 ```bash
 $ 03_02_option --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -227,7 +219,6 @@ Or you can have users specify values by their position on the command-line:
 ```bash
 $ 03_03_positional --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -256,7 +247,6 @@ subcommands.
 $ 03_04_subcommands
 ? failed
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -271,7 +261,6 @@ SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)
 $ 03_04_subcommands help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -286,7 +275,6 @@ SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)
 $ 03_04_subcommands help add
 03_04_subcommands[EXE]-add [..]
-
 Adds files to myapp
 
 USAGE:
@@ -320,7 +308,6 @@ set `Arg::default_value`.
 ```bash
 $ 03_05_default_values --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -353,7 +340,6 @@ of the mistake, and what the possible valid values are
 ```bash
 $ 04_01_possible --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -386,7 +372,6 @@ When enabling the `derive` feature, you can use `ArgEnum` to take care of the bo
 ```bash
 $ 04_01_enum --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -421,7 +406,6 @@ More generally, you can validate and parse into any data type.
 ```bash
 $ 04_02_validate --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -458,7 +442,6 @@ each other.
 ```bash
 $ 04_03_relations --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -517,7 +500,6 @@ As a last resort, you can create custom errors with the basics of clap's formatt
 ```bash
 $ 04_04_custom --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -26,7 +26,6 @@ attributes.  **This requires enabling the `derive` feature flag.**
 ```bash
 $ 01_quick_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -67,9 +66,7 @@ You use the `App` the start building a parser.
 ```bash
 $ 02_apps_derive --help
 MyApp 1.0
-
 Kevin K. <kbknapp@gmail.com>
-
 Does awesome things
 
 USAGE:
@@ -90,7 +87,6 @@ You can use `app_from_crate!()` to fill these fields in from your `Cargo.toml` f
 ```bash
 $ 02_crate_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -113,7 +109,6 @@ all subcommands (`app.global_setting()`).
 ```bash
 $ 02_app_settings_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -139,7 +134,6 @@ Flags are switches that can be on/off:
 ```bash
 $ 03_01_flag_bool_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -169,7 +163,6 @@ Or counted.
 ```bash
 $ 03_01_flag_count_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -195,7 +188,6 @@ Flags can also accept a value.
 ```bash
 $ 03_02_option_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -227,7 +219,6 @@ Or you can have users specify values by their position on the command-line:
 ```bash
 $ 03_03_positional_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -256,7 +247,6 @@ subcommands.
 $ 03_04_subcommands_derive
 ? failed
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -271,7 +261,6 @@ SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)
 $ 03_04_subcommands_derive help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -286,7 +275,6 @@ SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)
 $ 03_04_subcommands_derive help add
 03_04_subcommands_derive[EXE]-add [..]
-
 Adds files to myapp
 
 USAGE:
@@ -320,7 +308,6 @@ set `Arg::default_value`.
 ```bash
 $ 03_05_default_values_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -353,7 +340,6 @@ of the mistake, and what the possible valid values are
 ```bash
 $ 04_01_enum_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -388,7 +374,6 @@ More generally, you can validate and parse into any data type.
 ```bash
 $ 04_02_validate_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -425,7 +410,6 @@ each other.
 ```bash
 $ 04_03_relations_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -484,7 +468,6 @@ As a last resort, you can create custom errors with the basics of clap's formatt
 ```bash
 $ 04_04_custom_derive --help
 clap [..]
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -34,8 +34,7 @@ pub(crate) struct Help<'help, 'app, 'parser, 'writer> {
 impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
     const DEFAULT_TEMPLATE: &'static str = "\
         {before-help}{bin} {version}\n\
-        {author-section}\
-        {about-section}\n\
+        {author-with-newline}{about-with-newline}\n\
         {usage-heading}\n    {usage}\n\
         \n\
         {all-args}{after-help}\
@@ -43,8 +42,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
 
     const DEFAULT_NO_ARGS_TEMPLATE: &'static str = "\
         {before-help}{bin} {version}\n\
-        {author-section}\
-        {about-section}\n\
+        {author-with-newline}{about-with-newline}\n\
         {usage-heading}\n    {usage}{after-help}\
     ";
 

--- a/tests/builder/app_from_crate.rs
+++ b/tests/builder/app_from_crate.rs
@@ -3,7 +3,6 @@
 use clap::{app_from_crate, ErrorKind};
 
 static EVERYTHING: &str = "clap {{version}}
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -39,9 +39,7 @@ OPTIONS:
 ";
 
 static SKIP_POS_VALS: &str = "test 1.3
-
 Kevin K.
-
 tests stuff
 
 USAGE:
@@ -96,7 +94,6 @@ OPTIONS:
 ";
 
 static LONG_FORMAT_FOR_NESTED_HELP_SUBCOMMAND: &str = "myprog-test-nested 
-
 long form about message
 
 USAGE:

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -3,7 +3,6 @@ use crate::utils;
 use clap::{arg, App, Arg};
 
 static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-
 Some help
 
 USAGE:
@@ -17,7 +16,6 @@ OPTIONS:
 ";
 
 static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-
 Some help
 
 USAGE:

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -3,7 +3,6 @@ use crate::utils;
 use clap::{arg, App, Arg};
 
 static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-
 Some help
 
 USAGE:
@@ -17,7 +16,6 @@ OPTIONS:
 ";
 
 static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-
 Some help
 
 USAGE:

--- a/tests/builder/cargo.rs
+++ b/tests/builder/cargo.rs
@@ -3,7 +3,6 @@
 use clap::{crate_authors, crate_description, crate_name, crate_version, App, ErrorKind};
 
 static DESCRIPTION_ONLY: &str = "prog 1
-
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 USAGE:
@@ -15,7 +14,6 @@ OPTIONS:
 ";
 
 static AUTHORS_ONLY: &str = "prog 1
-
 
 
 USAGE:

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -424,7 +424,6 @@ fn flag_subcommand_long_infer_exact_match() {
 }
 
 static FLAG_SUBCOMMAND_HELP: &str = "pacman-query 
-
 Query the package database.
 
 USAGE:
@@ -479,7 +478,6 @@ fn flag_subcommand_long_short_normal_usage_string() {
 }
 
 static FLAG_SUBCOMMAND_NO_SHORT_HELP: &str = "pacman-query 
-
 Query the package database.
 
 USAGE:
@@ -533,7 +531,6 @@ fn flag_subcommand_long_normal_usage_string() {
 }
 
 static FLAG_SUBCOMMAND_NO_LONG_HELP: &str = "pacman-query 
-
 Query the package database.
 
 USAGE:

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -3,9 +3,7 @@ use crate::utils;
 use clap::{arg, App, AppSettings, Arg, ArgGroup, ErrorKind, PossibleValue};
 
 static REQUIRE_DELIM_HELP: &str = "test 1.3
-
 Kevin K.
-
 tests stuff
 
 USAGE:
@@ -18,9 +16,7 @@ OPTIONS:
 ";
 
 static HELP: &str = "clap-test v1.4.8
-
 Kevin K. <kbknapp@gmail.com>
-
 tests clap library
 
 USAGE:
@@ -91,7 +87,6 @@ SUBCOMMANDS:
 static AFTER_HELP: &str = "some text that comes before the help
 
 clap-test v1.4.8
-
 tests clap library
 
 USAGE:
@@ -107,7 +102,6 @@ some text that comes after the help
 static AFTER_LONG_HELP: &str = "some longer text that comes before the help
 
 clap-test v1.4.8
-
 tests clap library
 
 USAGE:
@@ -136,9 +130,7 @@ OPTIONS:
 ";
 
 static SC_HELP: &str = "clap-test-subcmd 0.1
-
 Kevin K. <kbknapp@gmail.com>
-
 tests subcommands
 
 USAGE:
@@ -197,9 +189,7 @@ OPTIONS:
 ";
 
 static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
-
 Kevin K. <kbknapp@gmail.com>
-
 tests subcommands
 
 USAGE:
@@ -324,9 +314,7 @@ OPTIONS:
 ";
 
 static ISSUE_702: &str = "myapp 1.0
-
 foo
-
 bar
 
 USAGE:
@@ -346,10 +334,8 @@ OPTIONS:
 
 static ISSUE_777: &str = "A app with a crazy very long long
 long name hahaha 1.0
-
 Some Very Long Name and crazy long
 email <email@server.com>
-
 Show how the about text is not
 wrapped
 
@@ -526,9 +512,7 @@ OPTIONS:
 ";
 
 static LONG_ABOUT: &str = "myapp 1.0
-
 foo
-
 something really really long, with
 multiple lines of text
 that should be displayed
@@ -549,9 +533,7 @@ OPTIONS:
 ";
 
 static CUSTOM_HELP_SECTION: &str = "blorp 1.4
-
 Will M.
-
 does stuff
 
 USAGE:
@@ -1789,9 +1771,7 @@ fn custom_headers_headers() {
 }
 
 static MULTIPLE_CUSTOM_HELP_SECTIONS: &str = "blorp 1.4
-
 Will M.
-
 does stuff
 
 USAGE:
@@ -1877,9 +1857,7 @@ fn multiple_custom_help_headers() {
 }
 
 static CUSTOM_HELP_SECTION_HIDDEN_ARGS: &str = "blorp 1.4
-
 Will M.
-
 does stuff
 
 USAGE:
@@ -1937,7 +1915,6 @@ fn custom_help_headers_hide_args() {
 }
 
 static ISSUE_897: &str = "ctest-foo 0.1
-
 Long about foo
 
 USAGE:
@@ -1968,7 +1945,6 @@ fn show_long_about_issue_897() {
 }
 
 static ISSUE_897_SHORT: &str = "ctest-foo 0.1
-
 About foo
 
 USAGE:
@@ -2153,7 +2129,6 @@ fn after_help_no_args() {
 }
 
 static HELP_SUBCMD_HELP: &str = "myapp-help 
-
 Print this message or the help of the given subcommand(s)
 
 USAGE:
@@ -2181,7 +2156,6 @@ fn help_subcmd_help() {
 }
 
 static SUBCMD_HELP_SUBCMD_HELP: &str = "myapp-subcmd-help 
-
 Print this message or the help of the given subcommand(s)
 
 USAGE:
@@ -2691,7 +2665,6 @@ fn subcommand_help_doesnt_have_useless_help_flag() {
         app,
         "example help help",
         "example-help 
-
 Print this message or the help of the given subcommand(s)
 
 USAGE:

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -3,9 +3,7 @@ use crate::utils;
 use clap::{arg, App, AppSettings, Arg};
 
 static HIDDEN_ARGS: &str = "test 1.4
-
 Kevin K.
-
 tests stuff
 
 USAGE:
@@ -39,9 +37,7 @@ fn hide_args() {
 }
 
 static HIDDEN_SHORT_ARGS: &str = "test 2.31.2
-
 Steve P.
-
 hides short args
 
 USAGE:
@@ -54,9 +50,7 @@ OPTIONS:
 ";
 
 static HIDDEN_SHORT_ARGS_LONG_HELP: &str = "test 2.31.2
-
 Steve P.
-
 hides short args
 
 USAGE:
@@ -131,9 +125,7 @@ fn hide_short_args_long_help() {
 }
 
 static HIDDEN_LONG_ARGS: &str = "test 2.31.2
-
 Steve P.
-
 hides long args
 
 USAGE:
@@ -177,9 +169,7 @@ fn hide_long_args() {
 }
 
 static HIDDEN_LONG_ARGS_SHORT_HELP: &str = "test 2.31.2
-
 Steve P.
-
 hides long args
 
 USAGE:

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -59,7 +59,7 @@ fn empty_line_in_doc_comment_is_double_linefeed() {
     struct LoremIpsum {}
 
     let help = utils::get_long_help::<LoremIpsum>();
-    assert!(help.starts_with("lorem-ipsum \n\nFoo.\n\nBar\n\nUSAGE:"));
+    assert!(help.starts_with("lorem-ipsum \nFoo.\n\nBar\n\nUSAGE:"));
 }
 
 #[test]


### PR DESCRIPTION
The extra whitespace was targeted at machine processing for a subset of
users for a subset of runs of CLIs.  On the other hand, there is a lot
of concern over the extra verbose output.

A user can set the help template for man, if desired.  They can even do
something (env? feature flag?) to make it only run when doing man
generation.  We also have #3174 in the works.

So let's focus on the end-user reading `--help`.  People wanting to use
`help2man` have workarounds to do what they need.

Fixes #3096