### PR TITLE
feat(derive): Don't require Display for default ArgEnum

### DIFF
--- a/clap_derive/src/derives/arg_enum.rs
+++ b/clap_derive/src/derives/arg_enum.rs
@@ -51,7 +51,7 @@ pub fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStr
     let to_possible_value = gen_to_possible_value(&lits);
 
     quote! {
-        #[allow(dead_code, unreachable_code, unused_variables)]
+        #[allow(dead_code, unreachable_code, unused_variables, unused_braces)]
         #[allow(
             clippy::style,
             clippy::complexity,

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -73,7 +73,7 @@ pub fn gen_for_struct(
     quote! {
         #from_arg_matches
 
-        #[allow(dead_code, unreachable_code, unused_variables)]
+        #[allow(dead_code, unreachable_code, unused_variables, unused_braces)]
         #[allow(
             clippy::style,
             clippy::complexity,

--- a/clap_derive/src/parse.rs
+++ b/clap_derive/src/parse.rs
@@ -21,6 +21,7 @@ pub fn parse_clap_attributes(all_attrs: &[Attribute]) -> Vec<ClapAttr> {
 }
 
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 pub enum ClapAttr {
     // single-identifier attributes
     Short(Ident),

--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -174,7 +174,7 @@ In addition to the raw attributes, the following magic attributes are supported:
   - Without `<expr>`: fills the field with `Default::default()`
 - `default_value = <str>`: `clap::Arg::default_value` and `clap::Arg::required(false)`
 - `default_value_t [= <expr>]`: `clap::Arg::default_value` and `clap::Arg::required(false)`
-  - Requires `std::fmt::Display`
+  - Requires `std::fmt::Display` or `#[clap(arg_enum)]`
   - Without `<expr>`, relies on `Default::default()`
 
 ### Arg Types

--- a/src/build/arg/possible_value.rs
+++ b/src/build/arg/possible_value.rs
@@ -134,13 +134,13 @@ impl<'help> PossibleValue<'help> {
 impl<'help> PossibleValue<'help> {
     /// Get the name of the argument value
     #[inline]
-    pub fn get_name(&self) -> &str {
+    pub fn get_name(&self) -> &'help str {
         self.name
     }
 
     /// Get the help specified for this argument, if any
     #[inline]
-    pub fn get_help(&self) -> Option<&str> {
+    pub fn get_help(&self) -> Option<&'help str> {
         self.help
     }
 
@@ -151,7 +151,7 @@ impl<'help> PossibleValue<'help> {
     }
 
     /// Get the name if argument value is not hidden, `None` otherwise
-    pub fn get_visible_name(&self) -> Option<&str> {
+    pub fn get_visible_name(&self) -> Option<&'help str> {
         if self.hide {
             None
         } else {
@@ -162,7 +162,7 @@ impl<'help> PossibleValue<'help> {
     /// Returns all valid values of the argument value.
     ///
     /// Namely the name and all aliases.
-    pub fn get_name_and_aliases(&self) -> impl Iterator<Item = &str> {
+    pub fn get_name_and_aliases(&self) -> impl Iterator<Item = &'help str> + '_ {
         iter::once(&self.name).chain(&self.aliases).copied()
     }
 

--- a/tests/derive/arg_enum.rs
+++ b/tests/derive/arg_enum.rs
@@ -52,12 +52,6 @@ fn default_value() {
         }
     }
 
-    impl std::fmt::Display for ArgChoice {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-            std::fmt::Display::fmt(self.to_possible_value().unwrap().get_name(), f)
-        }
-    }
-
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(arg_enum, default_value_t)]


### PR DESCRIPTION
While I'm unsure how much type specialization we should do, we
intentionally have the `arg_enum` attribute for doing special behavior
based on it, so let's take advantage of it.

By loosening `PossibleValue`s lifetimes for this, we also avoid a `lazy_static!` and string allocation.

Fixes #3185