### PR TITLE
docs: Show features in docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ include = [
 
 [package.metadata.docs.rs]
 features = ["unstable-doc"]
-rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [package.metadata.playground]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 // (see LICENSE or <http://opensource.org/licenses/MIT>) All files in the project carrying such
 // notice may not be copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(feature = "docsrs", feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/clap-rs/clap/master/assets/clap.png")]
 #![cfg_attr(feature = "derive", doc = include_str!("../README.md"))]
 //! <https://github.com/clap-rs/clap>


### PR DESCRIPTION
Confirmed this works with [`argfile`](https://docs.rs/argfile/latest/argfile/)

And then running in clap
```
$ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
```
They now show up!