### PR TITLE
fix(help): Don't infer long help from subcommands

### DIFF
--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1072,11 +1072,12 @@ impl<'help, 'app> Parser<'help, 'app> {
                 || v.is_set(ArgSettings::HiddenShortHelp)
         };
 
+        // Subcommands aren't checked because we prefer short help for them, deferring to
+        // `cmd subcmd --help` for more.
         self.app.long_about.is_some()
             || self.app.before_long_help.is_some()
             || self.app.after_long_help.is_some()
             || self.app.args.args().any(should_long)
-            || self.app.subcommands.iter().any(|s| s.long_about.is_some())
     }
 
     fn parse_long_arg(

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -597,14 +597,11 @@ USAGE:
     about-in-subcommands-list [SUBCOMMAND]
 
 OPTIONS:
-    -h, --help
-            Print help information
+    -h, --help    Print help information
 
 SUBCOMMANDS:
-    help
-            Print this message or the help of the given subcommand(s)
-    sub
-            short about sub
+    help    Print this message or the help of the given subcommand(s)
+    sub     short about sub
 ";
 
 fn setup() -> App<'static> {
@@ -2281,7 +2278,7 @@ fn option_usage_order() {
 }
 
 #[test]
-fn about_in_subcommands_list() {
+fn prefer_about_over_long_about_in_subcommands_list() {
     let app = App::new("about-in-subcommands-list").subcommand(
         App::new("sub")
             .long_about("long about sub")


### PR DESCRIPTION
Fixes #3193