### PR TITLE
refactor: Remove dead code

### DIFF
--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -380,15 +380,6 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                             c.insert(g.id.clone());
                         }
                     }
-                } else if let Some(g) = self
-                    .p
-                    .app
-                    .groups
-                    .iter()
-                    .find(|g| !g.multiple && g.id == *name)
-                {
-                    debug!("Validator::gather_conflicts:iter:{:?}:group", name);
-                    c.insert(g.id.clone());
                 }
             });
 


### PR DESCRIPTION
We are looping over the arguments set by the parser.  In one case, we
are checking to see if the argument is a group.  I am not seeing us set
groups in the matcher when parsing and we have a debug assert ensuring
arg and group names don't conflict.  This looks like dead code to me.

I am hesitant making a change like this right before release but this is
part of trying to make the code understandable for root causing and
fixing #3197