### PR TITLE
fix: Don't panic on lack of conflicts 

### DIFF
--- a/examples/tutorial_builder/README.md
+++ b/examples/tutorial_builder/README.md
@@ -476,7 +476,7 @@ $ 04_03_relations --major --minor
 error: The argument '--major' cannot be used with '--minor'
 
 USAGE:
-    04_03_relations[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
+    04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch>
 
 For more information try --help
 $ 04_03_relations --major -c config.toml

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -444,7 +444,7 @@ $ 04_03_relations_derive --major --minor
 error: The argument '--major' cannot be used with '--minor'
 
 USAGE:
-    04_03_relations_derive[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
+    04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch>
 
 For more information try --help
 $ 04_03_relations_derive --major -c config.toml

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -3055,6 +3055,10 @@ impl<'help> App<'help> {
             .map(|grp| grp.id.clone())
     }
 
+    pub(crate) fn find_group(&self, group_id: &Id) -> Option<&ArgGroup<'help>> {
+        self.groups.iter().find(|g| g.id == *group_id)
+    }
+
     /// Iterate through all the names of all subcommands (not recursively), including aliases.
     /// Used for suggestions.
     pub(crate) fn all_subcommand_names(&self) -> impl Iterator<Item = &str> + Captures<'help> {

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -94,6 +94,13 @@ impl ArgMatcher {
         self.0.args.contains_key(arg)
     }
 
+    pub(crate) fn contains_explicit(&self, arg: &Id) -> bool {
+        self.0
+            .args
+            .get(arg)
+            .map_or(false, |a| a.ty != ValueType::DefaultValue)
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.0.args.is_empty()
     }

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -549,34 +549,40 @@ impl Error {
     pub(crate) fn argument_conflict(
         app: &App,
         arg: &Arg,
-        other: Option<String>,
+        others: Vec<String>,
         usage: String,
     ) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
         let arg = arg.to_string();
 
         start_error(&mut c, "The argument '");
-        c.warning(arg.clone());
-        c.none("' cannot be used with ");
+        c.warning(arg);
+        c.none("' cannot be used with");
 
-        match other {
-            Some(ref name) => {
-                c.none("'");
-                c.warning(name);
-                c.none("'");
+        let mut info = vec![];
+        match others.len() {
+            0 => {
+                c.none(" one or more of the other specified arguments");
             }
-            None => {
-                c.none("one or more of the other specified arguments");
+            1 => {
+                let v = &others[0];
+                c.none(" '");
+                c.warning(v.clone());
+                c.none("'");
+                info.push(v.clone());
             }
-        };
+            _ => {
+                c.none(":");
+                for v in others {
+                    c.none("\n    ");
+                    c.warning(v.to_string());
+                    info.push(v.to_string());
+                }
+            }
+        }
 
         put_usage(&mut c, usage);
         try_help(app, &mut c);
-
-        let mut info = vec![arg];
-        if let Some(other) = other {
-            info.push(other);
-        }
 
         Self::new(
             c,

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -224,7 +224,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                     Err(Error::argument_conflict(
                         self.p.app,
                         latter_arg,
-                        Some(former_arg.to_string()),
+                        vec![former_arg.to_string()],
                         usg,
                     ))
                 })
@@ -243,7 +243,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             Err(Error::argument_conflict(
                 self.p.app,
                 &self.p.app[first],
-                c_with,
+                c_with.into_iter().collect(),
                 usg,
             ))
         } else {
@@ -319,7 +319,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 Err(Error::argument_conflict(
                     self.p.app,
                     arg,
-                    None,
+                    Vec::new(),
                     Usage::new(self.p).create_usage_with_title(&[]),
                 ))
             })

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -1,12 +1,12 @@
 // Internal
 use crate::{
-    build::{arg::PossibleValue, AppSettings as AS, Arg, ArgSettings},
+    build::{arg::PossibleValue, App, AppSettings as AS, Arg, ArgSettings},
     output::Usage,
     parse::{
         errors::{Error, ErrorKind, Result as ClapResult},
-        ArgMatcher, MatchedArg, ParseState, Parser, ValueType,
+        ArgMatcher, MatchedArg, ParseState, Parser,
     },
-    util::{ChildGraph, Id},
+    util::Id,
     INTERNAL_ERROR_MSG, INVALID_UTF8,
 };
 
@@ -172,131 +172,20 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         Ok(())
     }
 
-    fn build_conflict_err_usage(
-        &self,
-        matcher: &ArgMatcher,
-        retained_arg: &Arg,
-        conflicting_key: &Id,
-    ) -> String {
-        let retained_blacklist = &retained_arg.blacklist;
-        let used_filtered: Vec<Id> = matcher
-            .arg_names()
-            .filter(|key| *key != conflicting_key && !retained_blacklist.contains(key))
-            .cloned()
-            .collect();
-        let required: Vec<Id> = used_filtered
-            .iter()
-            .filter_map(|key| self.p.app.find(key))
-            .flat_map(|arg| arg.requires.iter().map(|item| &item.1))
-            .filter(|key| {
-                !used_filtered.contains(key)
-                    && *key != conflicting_key
-                    && !retained_blacklist.contains(key)
-            })
-            .chain(used_filtered.iter())
-            .cloned()
-            .collect();
-        Usage::new(self.p).create_usage_with_title(&required)
-    }
-
-    fn build_conflict_err(&self, name: &Id, matcher: &ArgMatcher) -> ClapResult<()> {
-        debug!("Validator::build_conflict_err: name={:?}", name);
-        if let Some(checked_arg) = self.p.app.find(name) {
-            matcher
-                .arg_names()
-                .filter_map(|k| {
-                    let arg = self.p.app.find(k);
-                    // For an arg that blacklists `name`, this will return `Some((k, a))` to indicate a conflict.
-                    arg.filter(|a| a.blacklist.contains(name)).map(|a| (k, a))
-                })
-                .try_for_each(|(k, a)| {
-                    // The error will be then constructed according to the first conflict.
-                    let (_former, former_arg, latter, latter_arg) = {
-                        let name_pos = matcher.arg_names().position(|key| key == name);
-                        let k_pos = matcher.arg_names().position(|key| key == k);
-                        if name_pos < k_pos {
-                            (name, checked_arg, k, a)
-                        } else {
-                            (k, a, name, checked_arg)
-                        }
-                    };
-                    let usg = self.build_conflict_err_usage(matcher, former_arg, latter);
-                    Err(Error::argument_conflict(
-                        self.p.app,
-                        latter_arg,
-                        vec![former_arg.to_string()],
-                        usg,
-                    ))
-                })
-        } else if let Some(g) = self.p.app.find_group(name) {
-            let usg = Usage::new(self.p).create_usage_with_title(&[]);
-            let args_in_group = self.p.app.unroll_args_in_group(&g.id);
-            let first = matcher
-                .arg_names()
-                .find(|x| args_in_group.contains(x))
-                .expect(INTERNAL_ERROR_MSG);
-            let c_with = matcher
-                .arg_names()
-                .find(|x| x != &first && args_in_group.contains(x))
-                .map(|x| self.p.app[x].to_string());
-            debug!("Validator::build_conflict_err: c_with={:?}:group", c_with);
-            Err(Error::argument_conflict(
-                self.p.app,
-                &self.p.app[first],
-                c_with.into_iter().collect(),
-                usg,
-            ))
-        } else {
-            Ok(())
-        }?;
-
-        panic!("{}", INTERNAL_ERROR_MSG);
-    }
-
     fn validate_conflicts(&self, matcher: &ArgMatcher) -> ClapResult<()> {
         debug!("Validator::validate_conflicts");
 
         self.validate_exclusive(matcher)?;
 
-        let c = self.gather_conflicts(matcher);
-        c.iter()
-            .filter(|&name| {
-                debug!("Validator::validate_conflicts:iter:{:?}", name);
-                // Filter out the conflicting cases.
-                if let Some(g) = self.p.app.find_group(name) {
-                    if !g.multiple {
-                        let conf_with_self = || {
-                            self.p
-                                .app
-                                .unroll_args_in_group(&g.id)
-                                .iter()
-                                .filter(|&a| matcher.contains(a))
-                                .count()
-                                > 1
-                        };
-                        let conf_with_arg = || g.conflicts.iter().any(|x| matcher.contains(x));
-                        let arg_conf_with_gr = || {
-                            matcher
-                                .arg_names()
-                                .filter_map(|x| self.p.app.find(x))
-                                .any(|x| x.blacklist.iter().any(|c| *c == g.id))
-                        };
-                        conf_with_self() || conf_with_arg() || arg_conf_with_gr()
-                    } else {
-                        false
-                    }
-                } else if let Some(ma) = matcher.get(name) {
-                    debug!(
-                        "Validator::validate_conflicts:iter:{:?}: matcher contains it...",
-                        name
-                    );
-                    ma.occurs > 0
-                } else {
-                    false
-                }
-            })
-            // Throw an error for the first conflict found.
-            .try_for_each(|odd| self.build_conflict_err(odd, matcher))?;
+        let mut conflicts = Conflicts::new();
+        for arg_id in matcher
+            .arg_names()
+            .filter(|arg_id| matcher.contains_explicit(arg_id) && self.p.app.find(arg_id).is_some())
+        {
+            debug!("Validator::validate_conflicts::iter: id={:?}", arg_id);
+            let conflicts = conflicts.gather_conflicts(self.p.app, matcher, arg_id);
+            self.build_conflict_err(arg_id, &conflicts, matcher)?;
+        }
 
         Ok(())
     }
@@ -325,51 +214,57 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             })
     }
 
-    // Gathers potential conflicts based on used argument, but without considering requirements
-    // and such
-    fn gather_conflicts(&self, matcher: &ArgMatcher) -> ChildGraph<Id> {
-        debug!("Validator::gather_conflicts");
-        let mut c = ChildGraph::with_capacity(5);
+    fn build_conflict_err(
+        &self,
+        name: &Id,
+        conflict_ids: &[Id],
+        matcher: &ArgMatcher,
+    ) -> ClapResult<()> {
+        if conflict_ids.is_empty() {
+            return Ok(());
+        }
 
-        matcher
-            .arg_names()
-            .filter(|name| {
-                debug!("Validator::gather_conflicts:iter: id={:?}", name);
-                // if arg is "present" only because it got default value
-                // it doesn't conflict with anything and should be skipped
-                let skip = matcher
-                    .get(name)
-                    .map_or(false, |a| a.ty == ValueType::DefaultValue);
-                if skip {
-                    debug!("Validator::gather_conflicts:iter: This is default value, skipping.",);
+        debug!("Validator::build_conflict_err: name={:?}", name);
+        let mut seen = std::collections::HashSet::new();
+        let conflicts = conflict_ids
+            .iter()
+            .flat_map(|c_id| {
+                if self.p.app.find_group(c_id).is_some() {
+                    self.p.app.unroll_args_in_group(c_id)
+                } else {
+                    vec![c_id.clone()]
                 }
-                !skip
             })
-            .for_each(|name| {
-                if let Some(arg) = self.p.app.find(name) {
-                    // Since an arg was used, every arg it conflicts with is added to the conflicts
-                    for conf in &arg.blacklist {
-                        c.insert(conf.clone());
-                    }
-                    // Now we need to know which groups this arg was a member of, to add all other
-                    // args in that group to the conflicts, as well as any args those args conflict
-                    // with
-                    for grp in self.p.app.groups_for_arg(name) {
-                        if let Some(g) = self.p.app.find_group(&grp) {
-                            if !g.multiple {
-                                c.insert(g.id.clone());
-                            }
-                        }
-                    }
-                } else if let Some(g) = self.p.app.find_group(name) {
-                    if !g.multiple {
-                        debug!("Validator::gather_conflicts:iter:{:?}:group", name);
-                        c.insert(g.id.clone());
-                    }
-                }
-            });
+            .filter_map(|c_id| {
+                seen.insert(c_id.clone()).then(|| {
+                    let c_arg = self.p.app.find(&c_id).expect(INTERNAL_ERROR_MSG);
+                    c_arg.to_string()
+                })
+            })
+            .collect();
 
-        c
+        let former_arg = self.p.app.find(name).expect(INTERNAL_ERROR_MSG);
+        let usg = self.build_conflict_err_usage(matcher, conflict_ids);
+        Err(Error::argument_conflict(
+            self.p.app, former_arg, conflicts, usg,
+        ))
+    }
+
+    fn build_conflict_err_usage(&self, matcher: &ArgMatcher, conflicting_keys: &[Id]) -> String {
+        let used_filtered: Vec<Id> = matcher
+            .arg_names()
+            .filter(|key| !conflicting_keys.contains(key))
+            .cloned()
+            .collect();
+        let required: Vec<Id> = used_filtered
+            .iter()
+            .filter_map(|key| self.p.app.find(key))
+            .flat_map(|arg| arg.requires.iter().map(|item| &item.1))
+            .filter(|key| !used_filtered.contains(key) && !conflicting_keys.contains(key))
+            .chain(used_filtered.iter())
+            .cloned()
+            .collect();
+        Usage::new(self.p).create_usage_with_title(&required)
     }
 
     fn gather_requirements(&mut self, matcher: &ArgMatcher) {
@@ -643,5 +538,73 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             req_args,
             usg.create_usage_with_title(&used),
         ))
+    }
+}
+
+#[derive(Default, Clone, Debug)]
+struct Conflicts {
+    potential: std::collections::HashMap<Id, Vec<Id>>,
+}
+
+impl Conflicts {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn gather_conflicts(&mut self, app: &App, matcher: &ArgMatcher, arg_id: &Id) -> Vec<Id> {
+        debug!("Conflicts::gather_conflicts");
+        let mut conflicts = Vec::new();
+        for other_arg_id in matcher
+            .arg_names()
+            .filter(|arg_id| matcher.contains_explicit(arg_id))
+        {
+            if arg_id == other_arg_id {
+                continue;
+            }
+
+            if self
+                .gather_direct_conflicts(app, arg_id)
+                .contains(other_arg_id)
+            {
+                conflicts.push(other_arg_id.clone());
+            }
+            if self
+                .gather_direct_conflicts(app, other_arg_id)
+                .contains(arg_id)
+            {
+                conflicts.push(other_arg_id.clone());
+            }
+        }
+        conflicts
+    }
+
+    fn gather_direct_conflicts(&mut self, app: &App, arg_id: &Id) -> &[Id] {
+        self.potential.entry(arg_id.clone()).or_insert_with(|| {
+            let conf = if let Some(arg) = app.find(arg_id) {
+                let mut conf = arg.blacklist.clone();
+                for group_id in app.groups_for_arg(arg_id) {
+                    let group = app.find_group(&group_id).expect(INTERNAL_ERROR_MSG);
+                    conf.extend(group.conflicts.iter().cloned());
+                    if !group.multiple {
+                        for member_id in &group.args {
+                            if member_id != arg_id {
+                                conf.push(member_id.clone());
+                            }
+                        }
+                    }
+                }
+                conf
+            } else if let Some(group) = app.find_group(arg_id) {
+                group.conflicts.clone()
+            } else {
+                debug_assert!(false, "id={:?} is unknown", arg_id);
+                Vec::new()
+            };
+            debug!(
+                "Conflicts::gather_direct_conflicts id={:?}, conflicts={:?}",
+                arg_id, conf
+            );
+            conf
+        })
     }
 }


### PR DESCRIPTION
After some refactors to pave the way, this re-does the conflict code to disambiguate the groups an argument is a member of from the groups it conflicts with.

Now we only gather real conflicts and then report **all** of them (might as well since we have them and we went through work to do that for requireds).  Behind the scenes, we gather the potential one-way or direct conflicts and cache them.  This let's us both reuse the code and reuse the results for then calculating the reverse conflicts (A conflicts with B, therefore B conflicts with A).  By finding the reverse like this, we avoid needing to check the order of conflicts (and invert them) when reporting errors, simplifying the code.  This isn't too bad because we were able to reuse our iterating over all of the arguments.

Reusable logic/results for conflicts will hopefully make it easier to address #3077 

Fixes #3197