### PR TITLE
fix: Remove overriden occurrences as we go 

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2601,6 +2601,7 @@ impl<'help> App<'help> {
             self._derive_display_order();
 
             let mut pos_counter = 1;
+            let self_override = self.is_set(AppSettings::AllArgsOverrideSelf);
             for a in self.args.args_mut() {
                 // Fill in the groups
                 for g in &a.groups {
@@ -2618,6 +2619,10 @@ impl<'help> App<'help> {
                     // if an arg has `Last` set, we need to imply DontCollapseArgsInUsage so that args
                     // in the usage string don't get confused or left out.
                     self.settings.set(AppSettings::DontCollapseArgsInUsage);
+                }
+                if self_override {
+                    let self_id = a.id.clone();
+                    a.overrides.push(self_id);
                 }
                 a._build();
                 if a.is_positional() && a.index.is_none() {

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -4808,6 +4808,16 @@ impl<'help> Arg<'help> {
                 self.num_vals = Some(val_names_len);
             }
         }
+
+        let self_id = self.id.clone();
+        if self.is_positional() || self.is_set(ArgSettings::MultipleOccurrences) {
+            // Remove self-overrides where they don't make sense.
+            //
+            // We can evaluate switching this to a debug assert at a later time (though it will
+            // require changing propagation of `AllArgsOverrideSelf`).  Being conservative for now
+            // due to where we are at in the release.
+            self.overrides.retain(|e| *e != self_id);
+        }
     }
 
     pub(crate) fn generated(mut self) -> Self {

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -176,8 +176,11 @@ impl ArgMatcher {
         ma.push_index(idx);
     }
 
-    pub(crate) fn arg_have_val(&mut self, arg: &Id) -> bool {
-        matches!(self.entry(arg), Entry::Occupied(_))
+    pub(crate) fn has_val_groups(&mut self, arg: &Id) -> bool {
+        match self.entry(arg) {
+            Entry::Occupied(e) => e.get().has_val_groups(),
+            Entry::Vacant(_) => false,
+        }
     }
 
     pub(crate) fn needs_more_vals(&self, o: &Arg) -> bool {

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -108,13 +108,6 @@ impl MatchedArg {
         }
     }
 
-    pub(crate) fn override_vals(&mut self) {
-        let len = self.vals.len();
-        if len > 1 {
-            self.vals.drain(0..len - 1);
-        }
-    }
-
     pub(crate) fn contains_val(&self, val: &str) -> bool {
         self.vals_flatten().any(|v| {
             if self.ignore_case {
@@ -161,47 +154,6 @@ pub(crate) enum ValueType {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_vals_override() {
-        let mut m = MatchedArg::new();
-        m.push_val("aaa".into());
-        m.new_val_group();
-        m.append_val("bbb".into());
-        m.append_val("ccc".into());
-        m.new_val_group();
-        m.append_val("ddd".into());
-        m.push_val("eee".into());
-        m.new_val_group();
-        m.append_val("fff".into());
-        m.append_val("ggg".into());
-        m.append_val("hhh".into());
-        m.append_val("iii".into());
-
-        m.override_vals();
-        let vals: Vec<&Vec<OsString>> = m.vals().collect();
-        assert_eq!(
-            vals,
-            vec![&vec![
-                OsString::from("fff"),
-                OsString::from("ggg"),
-                OsString::from("hhh"),
-                OsString::from("iii"),
-            ]]
-        );
-        m.override_vals();
-
-        let vals: Vec<&Vec<OsString>> = m.vals().collect();
-        assert_eq!(
-            vals,
-            vec![&vec![
-                OsString::from("fff"),
-                OsString::from("ggg"),
-                OsString::from("hhh"),
-                OsString::from("iii"),
-            ]]
-        );
-    }
 
     #[test]
     fn test_grouped_vals_first() {

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -81,6 +81,10 @@ impl MatchedArg {
         self.vals.iter().flatten().count() == 0
     }
 
+    pub(crate) fn has_val_groups(&self) -> bool {
+        !self.vals.is_empty()
+    }
+
     // Will be used later
     #[allow(dead_code)]
     pub(crate) fn remove_vals(&mut self, len: usize) {

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -77,7 +77,7 @@ impl MatchedArg {
         self.vals.last().map(|x| x.len()).unwrap_or(0)
     }
 
-    pub(crate) fn is_vals_empty(&self) -> bool {
+    pub(crate) fn all_val_groups_empty(&self) -> bool {
         self.vals.iter().flatten().count() == 0
     }
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1638,7 +1638,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                 arg.name
             );
             match matcher.get(&arg.id) {
-                Some(ma) if ma.is_vals_empty() => {
+                Some(ma) if ma.all_val_groups_empty() => {
                     debug!(
                         "Parser::add_value:iter:{}: has no user defined vals",
                         arg.name

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -591,6 +591,10 @@ impl<'help, 'app> Parser<'help, 'app> {
                 }
 
                 self.seen.push(p.id.clone());
+                // Increase occurrence no matter if we are appending, occurrences
+                // of positional argument equals to number of values rather than
+                // the number of value groups.
+                self.inc_occurrence_of_arg(matcher, p);
                 // Creating new value group rather than appending when the arg
                 // doesn't have any value. This behaviour is right because
                 // positional arguments are always present continuously.
@@ -603,11 +607,6 @@ impl<'help, 'app> Parser<'help, 'app> {
                     append,
                     trailing_values,
                 );
-
-                // Increase occurrence no matter if we are appending, occurrences
-                // of positional argument equals to number of values rather than
-                // the number of value groups.
-                self.inc_occurrence_of_arg(matcher, p);
 
                 // Only increment the positional counter if it doesn't allow multiples
                 if !p.is_multiple() {
@@ -1302,6 +1301,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         if opt.is_set(ArgSettings::RequireEquals) && !has_eq {
             if opt.min_vals == Some(0) {
                 debug!("Requires equals, but min_vals == 0");
+                self.inc_occurrence_of_arg(matcher, opt);
                 // We assume this case is valid: require equals, but min_vals == 0.
                 if !opt.default_missing_vals.is_empty() {
                     debug!("Parser::parse_opt: has default_missing_vals");
@@ -1313,7 +1313,6 @@ impl<'help, 'app> Parser<'help, 'app> {
                         false,
                     );
                 };
-                self.inc_occurrence_of_arg(matcher, opt);
                 if attached_value.is_some() {
                     ParseResult::AttachedValueNotConsumed
                 } else {
@@ -1333,6 +1332,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                 fv,
                 fv.starts_with("=")
             );
+            self.inc_occurrence_of_arg(matcher, opt);
             self.add_val_to_arg(
                 opt,
                 v,
@@ -1341,7 +1341,6 @@ impl<'help, 'app> Parser<'help, 'app> {
                 false,
                 trailing_values,
             );
-            self.inc_occurrence_of_arg(matcher, opt);
             ParseResult::ValuesDone
         } else {
             debug!("Parser::parse_opt: More arg vals required...");
@@ -1470,8 +1469,8 @@ impl<'help, 'app> Parser<'help, 'app> {
     fn parse_flag(&self, flag: &Arg<'help>, matcher: &mut ArgMatcher) -> ParseResult {
         debug!("Parser::parse_flag");
 
-        matcher.add_index_to(&flag.id, self.cur_idx.get(), ValueType::CommandLine);
         self.inc_occurrence_of_arg(matcher, flag);
+        matcher.add_index_to(&flag.id, self.cur_idx.get(), ValueType::CommandLine);
 
         ParseResult::ValuesDone
     }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -594,7 +594,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                 // Creating new value group rather than appending when the arg
                 // doesn't have any value. This behaviour is right because
                 // positional arguments are always present continuously.
-                let append = self.arg_have_val(matcher, p);
+                let append = self.has_val_groups(matcher, p);
                 self.add_val_to_arg(
                     p,
                     &arg_os,
@@ -1463,8 +1463,8 @@ impl<'help, 'app> Parser<'help, 'app> {
         matcher.add_index_to(&arg.id, self.cur_idx.get(), ty);
     }
 
-    fn arg_have_val(&self, matcher: &mut ArgMatcher, arg: &Arg<'help>) -> bool {
-        matcher.arg_have_val(&arg.id)
+    fn has_val_groups(&self, matcher: &mut ArgMatcher, arg: &Arg<'help>) -> bool {
+        matcher.has_val_groups(&arg.id)
     }
 
     fn parse_flag(&self, flag: &Arg<'help>, matcher: &mut ArgMatcher) -> ParseResult {

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1496,12 +1496,7 @@ impl<'help, 'app> Parser<'help, 'app> {
                         arg_overrides.push((overridee.clone(), &overrider.id));
                     }
                 }
-                // Only do self override for argument that is not positional
-                // argument or flag with MultipleOccurrences setting enabled.
-                if (self.is_set(AS::AllArgsOverrideSelf) || override_self)
-                    && !overrider.is_set(ArgSettings::MultipleOccurrences)
-                    && !overrider.is_positional()
-                {
+                if override_self {
                     debug!(
                         "Parser::remove_overrides:iter:{:?}:iter:{:?}: self override",
                         name, overrider

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -457,7 +457,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
 
     fn is_missing_required_ok(&self, a: &Arg<'help>, matcher: &ArgMatcher) -> bool {
         debug!("Validator::is_missing_required_ok: {}", a.name);
-        self.validate_arg_conflicts(a, matcher) || self.p.overridden.contains(&a.id)
+        self.validate_arg_conflicts(a, matcher) || self.p.overridden.borrow().contains(&a.id)
     }
 
     fn validate_arg_conflicts(&self, a: &Arg<'help>, matcher: &ArgMatcher) -> bool {

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -42,7 +42,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             let o = &self.p.app[&a];
             reqs_validated = true;
             let should_err = if let Some(v) = matcher.0.args.get(&o.id) {
-                v.is_vals_empty() && !(o.min_vals.is_some() && o.min_vals.unwrap() == 0)
+                v.all_val_groups_empty() && !(o.min_vals.is_some() && o.min_vals.unwrap() == 0)
             } else {
                 true
             };
@@ -396,7 +396,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         };
         // Issue 665 (https://github.com/clap-rs/clap/issues/665)
         // Issue 1105 (https://github.com/clap-rs/clap/issues/1105)
-        if a.is_set(ArgSettings::TakesValue) && !min_vals_zero && ma.is_vals_empty() {
+        if a.is_set(ArgSettings::TakesValue) && !min_vals_zero && ma.all_val_groups_empty() {
             return Err(Error::empty_value(
                 self.p.app,
                 a,

--- a/tests/builder/posix_compatible.rs
+++ b/tests/builder/posix_compatible.rs
@@ -387,3 +387,15 @@ fn issue_1374_overrides_self_with_multiple_values() {
         &["c", "d"]
     );
 }
+
+#[test]
+fn incremental_override() {
+    let mut app = App::new("test")
+        .arg(arg!(--name <NAME>).multiple_occurrences(true))
+        .arg(arg!(--"no-name").overrides_with("name"));
+    let m = app
+        .try_get_matches_from_mut(&["test", "--name=ahmed", "--no-name", "--name=ali"])
+        .unwrap();
+    assert_eq!(m.values_of("name").unwrap().collect::<Vec<_>>(), &["ali"]);
+    assert!(!m.is_present("no-name"));
+}


### PR DESCRIPTION
This allows two overriding args to interact with each other mid-line.
This was broken in 7673dfc / #1154.  Before that, we duplicated the override
logic in several places.

Now we plug into the start of a new arg which allows us to do this
incrementally without making the logic complex or inefficient, thanks to
the refactors in this PR.

Fixes #3217