### PR TITLE
Allow to escape newline with \ like in markdown

### DIFF
--- a/clap_derive/src/utils/doc_comments.rs
+++ b/clap_derive/src/utils/doc_comments.rs
@@ -103,5 +103,5 @@ fn is_blank(s: &str) -> bool {
 }
 
 fn merge_lines(lines: &[&str]) -> String {
-    lines.iter().map(|s| s.trim()).collect::<Vec<_>>().join(" ")
+    lines.iter().map(|s| s.trim().replace("\\n", "\n")).collect::<Vec<_>>().join(" ")
 }


### PR DESCRIPTION
**Edit**: the behavior was changed as I've described [here](https://github.com/clap-rs/clap/issues/3198#issuecomment-1002290706) — backslash escapes newline [as described in CommonMark spec](https://spec.commonmark.org/0.30/#hard-line-break).

---

Syn [transforms](https://docs.rs/syn/latest/syn/struct.Attribute.html#doc-comments) comments into raw string literals before parsing, so \n appears as \\\\n and propagates in `help=...` argument. This PR fixes that.

Related to #3198 and #1810. 

Probably shouldn't be merged in its current form and it's not clear yet what side-effects it might cause...