### PR TITLE
fix(help): Prefer short version over long version

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -634,11 +634,7 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
     }
 
     fn write_version(&mut self) -> io::Result<()> {
-        let version = if self.use_long {
-            self.parser.app.long_version.or(self.parser.app.version)
-        } else {
-            self.parser.app.version
-        };
+        let version = self.parser.app.version.or(self.parser.app.long_version);
         if let Some(output) = version {
             self.none(text_wrapper(output, self.term_w))?;
         }


### PR DESCRIPTION
When we got #3193, we decided in #3196 that `--help` will give a summary
for other commands (`subcmd --help` in this case) but not show the long
version of the output for that other command.

Now with #3215, I think the case is similar for `--help` not showing the
long version but instead preferring the short version and encouraging
people to run `--version`.

Originally. clap only showed the short version or nothing.  This was
changed in #2369 without fanfare to prefer the long version over short.
Now are we preferring short version over the long version always, just
like all other help.

Fixes #3215