### PR TITLE
fix(complete): Use Elvish v0.17 lambda syntax

### DIFF
--- a/clap_complete/src/shells/elvish.rs
+++ b/clap_complete/src/shells/elvish.rs
@@ -25,11 +25,11 @@ impl Generator for Elvish {
 use builtin;
 use str;
 
-set edit:completion:arg-completer[{bin_name}] = [@words]{{
-    fn spaces [n]{{
+set edit:completion:arg-completer[{bin_name}] = {{|@words|
+    fn spaces {{|n|
         builtin:repeat $n ' ' | str:join ''
     }}
-    fn cand [text desc]{{
+    fn cand {{|text desc|
         edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }}
     var command = '{bin_name}'

--- a/clap_complete/tests/completions/elvish.rs
+++ b/clap_complete/tests/completions/elvish.rs
@@ -34,11 +34,11 @@ static ELVISH: &str = r#"
 use builtin;
 use str;
 
-set edit:completion:arg-completer[my_app] = [@words]{
-    fn spaces [n]{
+set edit:completion:arg-completer[my_app] = {|@words|
+    fn spaces {|n|
         builtin:repeat $n ' ' | str:join ''
     }
-    fn cand [text desc]{
+    fn cand {|text desc|
         edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }
     var command = 'my_app'
@@ -94,11 +94,11 @@ static ELVISH_SPECIAL_CMDS: &str = r#"
 use builtin;
 use str;
 
-set edit:completion:arg-completer[my_app] = [@words]{
-    fn spaces [n]{
+set edit:completion:arg-completer[my_app] = {|@words|
+    fn spaces {|n|
         builtin:repeat $n ' ' | str:join ''
     }
-    fn cand [text desc]{
+    fn cand {|text desc|
         edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }
     var command = 'my_app'
@@ -180,11 +180,11 @@ static ELVISH_ALIASES: &str = r#"
 use builtin;
 use str;
 
-set edit:completion:arg-completer[cmd] = [@words]{
-    fn spaces [n]{
+set edit:completion:arg-completer[cmd] = {|@words|
+    fn spaces {|n|
         builtin:repeat $n ' ' | str:join ''
     }
-    fn cand [text desc]{
+    fn cand {|text desc|
         edit:complex-candidate $text &display=$text' '(spaces (- 14 (wcswidth $text)))$desc
     }
     var command = 'cmd'


### PR DESCRIPTION
[Elvish v0.17](https://elv.sh/blog/0.17.0-release-notes.html#deprecated-features) deprecated the old lambda syntax (`[arg1 arg2] { body }`) in favour of the new `{|arg1 arg2| body }` syntax. This PR uses the new syntax to stop deprecation warnings.