### PR TITLE
fix(help): Always respect DisableColoredHelp

### DIFF
--- a/clap_complete/tests/completions/bash.rs
+++ b/clap_complete/tests/completions/bash.rs
@@ -72,7 +72,7 @@ static BASH: &str = r#"_myapp() {
             return 0
             ;;
         myapp__help)
-            opts=""
+            opts="<SUBCOMMAND>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -175,7 +175,7 @@ static BASH_SPECIAL_CMDS: &str = r#"_my_app() {
             return 0
             ;;
         my_app__help)
-            opts=""
+            opts="<SUBCOMMAND>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/completions/zsh.rs
+++ b/clap_complete/tests/completions/zsh.rs
@@ -72,6 +72,7 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
+'*::subcommand -- The subcommand whose help message to display:' \
 && ret=0
 ;;
         esac
@@ -191,6 +192,7 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
+'*::subcommand -- The subcommand whose help message to display:' \
 && ret=0
 ;;
         esac
@@ -382,6 +384,7 @@ _arguments "${_arguments_options[@]}" \
 '--version[Print version information]' \
 '-h[Print help information]' \
 '--help[Print help information]' \
+'*::subcommand -- The subcommand whose help message to display:' \
 && ret=0
 ;;
         esac
@@ -390,6 +393,7 @@ esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" \
+'*::subcommand -- The subcommand whose help message to display:' \
 && ret=0
 ;;
         esac

--- a/clap_complete_fig/tests/completions/fig.rs
+++ b/clap_complete_fig/tests/completions/fig.rs
@@ -62,6 +62,10 @@ static FIG: &str = r#"const completion: Fig.Spec = {
       description: "Print this message or the help of the given subcommand(s)",
       options: [
       ],
+      args: {
+        name: "subcommand",
+        isOptional: true,
+      },
     },
   ],
   options: [
@@ -169,6 +173,10 @@ static FIG_SPECIAL_CMDS: &str = r#"const completion: Fig.Spec = {
       description: "Print this message or the help of the given subcommand(s)",
       options: [
       ],
+      args: {
+        name: "subcommand",
+        isOptional: true,
+      },
     },
   ],
   options: [
@@ -420,6 +428,10 @@ static FIG_SUB_SUBCMDS: &str = r#"const completion: Fig.Spec = {
               description: "Print version information",
             },
           ],
+          args: {
+            name: "subcommand",
+            isOptional: true,
+          },
         },
       ],
       options: [
@@ -438,6 +450,10 @@ static FIG_SUB_SUBCMDS: &str = r#"const completion: Fig.Spec = {
       description: "Print this message or the help of the given subcommand(s)",
       options: [
       ],
+      args: {
+        name: "subcommand",
+        isOptional: true,
+      },
     },
   ],
   options: [

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2902,11 +2902,18 @@ impl<'help> App<'help> {
             && !self.subcommands.iter().any(|s| s.id == Id::help_hash())
         {
             debug!("App::_check_help_and_version: Building help subcommand");
-            let help_subcmd = App::new("help")
-                .about("Print this message or the help of the given subcommand(s)")
-                // The parser acts like this is set, so let's set it so we don't falsely
-                // advertise it to the user
-                .setting(AppSettings::DisableHelpFlag);
+            let mut help_subcmd =
+                App::new("help").about("Print this message or the help of the given subcommand(s)");
+            self._propagate_subcommand(&mut help_subcmd);
+
+            // The parser acts like this is set, so let's set it so we don't falsely
+            // advertise it to the user
+            help_subcmd.version = None;
+            help_subcmd.long_version = None;
+            help_subcmd = help_subcmd
+                .setting(AppSettings::DisableHelpFlag)
+                .unset_setting(AppSettings::PropagateVersion);
+
             self.subcommands.push(help_subcmd);
         }
     }

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2902,8 +2902,16 @@ impl<'help> App<'help> {
             && !self.subcommands.iter().any(|s| s.id == Id::help_hash())
         {
             debug!("App::_check_help_and_version: Building help subcommand");
-            let mut help_subcmd =
-                App::new("help").about("Print this message or the help of the given subcommand(s)");
+            let mut help_subcmd = App::new("help")
+                .about("Print this message or the help of the given subcommand(s)")
+                .arg(
+                    Arg::new("subcommand")
+                        .index(1)
+                        .takes_value(true)
+                        .multiple_occurrences(true)
+                        .value_name("SUBCOMMAND")
+                        .help("The subcommand whose help message to display"),
+                );
             self._propagate_subcommand(&mut help_subcmd);
 
             // The parser acts like this is set, so let's set it so we don't falsely

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2902,13 +2902,12 @@ impl<'help> App<'help> {
             && !self.subcommands.iter().any(|s| s.id == Id::help_hash())
         {
             debug!("App::_check_help_and_version: Building help subcommand");
-            self.subcommands.push(
-                App::new("help")
-                    .about("Print this message or the help of the given subcommand(s)")
-                    // The parser acts like this is set, so let's set it so we don't falsely
-                    // advertise it to the user
-                    .setting(AppSettings::DisableHelpFlag),
-            );
+            let help_subcmd = App::new("help")
+                .about("Print this message or the help of the given subcommand(s)")
+                // The parser acts like this is set, so let's set it so we don't falsely
+                // advertise it to the user
+                .setting(AppSettings::DisableHelpFlag);
+            self.subcommands.push(help_subcmd);
         }
     }
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -665,16 +665,6 @@ impl<'help, 'app> Parser<'help, 'app> {
                 }
                 .clone();
 
-                if cmd == OsStr::new("help") {
-                    let pb = Arg::new("subcommand")
-                        .index(1)
-                        .takes_value(true)
-                        .multiple_occurrences(true)
-                        .value_name("SUBCOMMAND")
-                        .help("The subcommand whose help message to display");
-                    sc = sc.arg(pb);
-                }
-
                 sc._build();
                 bin_name.push(' ');
                 bin_name.push_str(&sc.name);


### PR DESCRIPTION
We might be able to handle version/help before propagation but I didn't
want to hold up this fix for that to happen and increase the risk
associated with this fix.

Fixes #3298