### PR TITLE
fix: Don't panic when propagating

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2932,7 +2932,7 @@ impl<'help> App<'help> {
             help_subcmd.long_version = None;
             help_subcmd = help_subcmd
                 .setting(AppSettings::DisableHelpFlag)
-                .unset_setting(AppSettings::PropagateVersion);
+                .unset_global_setting(AppSettings::PropagateVersion);
 
             self.subcommands.push(help_subcmd);
         }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2734,3 +2734,28 @@ fn disable_help_flag_affects_help_subcommand() {
         args
     );
 }
+
+#[test]
+fn dont_propagate_version_to_help_subcommand() {
+    let app = clap::App::new("test")
+        .version("1.0")
+        .global_setting(clap::AppSettings::PropagateVersion)
+        .subcommand(clap::App::new("subcommand"));
+
+    assert!(utils::compare_output(
+        app.clone(),
+        "example help help",
+        "example-help 
+Print this message or the help of the given subcommand(s)
+
+USAGE:
+    example help [SUBCOMMAND]...
+
+ARGS:
+    <SUBCOMMAND>...    The subcommand whose help message to display
+",
+        false
+    ));
+
+    app.debug_assert();
+}


### PR DESCRIPTION
I thought I was adding a test in #3305.  Maybe I considered the
clap_complete changes sufficient for this.  Doing more `debug_assert`s
would be good also.

Unsetting `PropagateVersion` helps in some cases but we need to unset it
globally to override the global propagation.

Fixes #3310