### PR TITLE
docs(derive): add note that "from_occurrences" does nothing with "default_value_t"

### DIFF
--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -224,9 +224,11 @@ Notes:
 - `from_occurrences`:
   - Implies `arg.takes_value(false).multiple_occurrences(true)`
   - Reads from `clap::ArgMatches::occurrences_of` rather than a `value_of` function
+  - Because `takes_value(false)` is implied, it makes it incompatible with Defaulting (e.g. `default_value` & `default_value_t`)
 - `from_flag`
   - Implies `arg.takes_value(false)`
   - Reads from `clap::ArgMatches::is_present` rather than a `value_of` function
+  - Because `takes_value(false)` is implied, it makes it incompatible with Defaulting (e.g. `default_value` & `default_value_t`)
 
 **Warning:**
 - To support non-UTF8 paths, you must use `parse(from_os_str)`, otherwise


### PR DESCRIPTION
like the title says, i add a note that `parse(from_occurrences)` does not work when `default_value_t` is also defined

current behavior when both are defined:
- default is used and value is set to `takes_value` and is not counted