### PR TITLE
fix(complete): Use "expect" instead of "unwrap"

### DIFF
--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -14,7 +14,9 @@ impl Generator for Bash {
     }
 
     fn generate(&self, app: &App, buf: &mut dyn Write) {
-        let bin_name = app.get_bin_name().unwrap();
+        let bin_name = app
+            .get_bin_name()
+            .expect("Getting the App's \"bin_name\" failed");
 
         w!(
             buf,

--- a/clap_complete/src/shells/elvish.rs
+++ b/clap_complete/src/shells/elvish.rs
@@ -15,7 +15,9 @@ impl Generator for Elvish {
     }
 
     fn generate(&self, app: &App, buf: &mut dyn Write) {
-        let bin_name = app.get_bin_name().unwrap();
+        let bin_name = app
+            .get_bin_name()
+            .expect("Getting the App's \"bin_name\" failed");
 
         let mut names = vec![];
         let subcommands_cases = generate_inner(app, "", &mut names);

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -16,7 +16,9 @@ impl Generator for Fish {
     }
 
     fn generate(&self, app: &App, buf: &mut dyn Write) {
-        let command = app.get_bin_name().unwrap();
+        let command = app
+            .get_bin_name()
+            .expect("Getting the App's \"bin_name\" failed");
         let mut buffer = String::new();
 
         gen_fish_inner(command, &[], app, &mut buffer);

--- a/clap_complete/src/shells/powershell.rs
+++ b/clap_complete/src/shells/powershell.rs
@@ -15,7 +15,9 @@ impl Generator for PowerShell {
     }
 
     fn generate(&self, app: &App, buf: &mut dyn Write) {
-        let bin_name = app.get_bin_name().unwrap();
+        let bin_name = app
+            .get_bin_name()
+            .expect("Getting the App's \"bin_name\" failed");
 
         let mut names = vec![];
         let subcommands_cases = generate_inner(app, "", &mut names);

--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -41,7 +41,9 @@ _{name}() {{
 
 _{name} \"$@\"
 ",
-                name = app.get_bin_name().unwrap(),
+                name = app
+                    .get_bin_name()
+                    .expect("Getting the App's \"bin_name\" failed"),
                 initial_args = get_args_of(app, None),
                 subcommands = get_subcommands_of(app),
                 subcommand_details = subcommand_details(app)


### PR DESCRIPTION
Use `expect` instead of `unwrap` to provide context in case it does fail

fixes #3319

---

i know that @epage said at https://github.com/clap-rs/clap/issues/3319#issuecomment-1017065049

> The reason the error message isn't better is that it isn't intended for this case. Same for why the bin_name is required

but i still think it is better to use `expect` instead of `unwrap` to get a better debugging experience in case *it does fail* (like accidental misuse in my case)