### PR TITLE
feat: add default_value_os_t

### DIFF
--- a/clap_derive/src/parse.rs
+++ b/clap_derive/src/parse.rs
@@ -53,6 +53,7 @@ pub enum ClapAttr {
     // ident = arbitrary_expr
     NameExpr(Ident, Expr),
     DefaultValueT(Ident, Option<Expr>),
+    DefaultValueOsT(Ident, Option<Expr>),
     HelpHeading(Ident, Expr),
 
     // ident(arbitrary_expr,*)
@@ -129,6 +130,7 @@ impl Parse for ClapAttr {
                     Ok(expr) => match &*name_str {
                         "skip" => Ok(Skip(name, Some(expr))),
                         "default_value_t" => Ok(DefaultValueT(name, Some(expr))),
+                        "default_value_os_t" => Ok(DefaultValueOsT(name, Some(expr))),
                         "help_heading" => Ok(HelpHeading(name, expr)),
                         _ => Ok(NameExpr(name, expr)),
                     },
@@ -203,6 +205,7 @@ impl Parse for ClapAttr {
                     )
                 }
                 "default_value_t" => Ok(DefaultValueT(name, None)),
+                "default_value_os_t" => Ok(DefaultValueOsT(name, None)),
                 "about" => (Ok(About(name, None))),
                 "author" => (Ok(Author(name, None))),
                 "version" => Ok(Version(name, None)),

--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -185,6 +185,9 @@ In addition to the raw attributes, the following magic attributes are supported:
 - `default_value_t [= <expr>]`: `clap::Arg::default_value` and `clap::Arg::required(false)`
   - Requires `std::fmt::Display` or `#[clap(arg_enum)]`
   - Without `<expr>`, relies on `Default::default()`
+- `default_value_os_t [= <expr>]`: `clap::Arg::default_value_os` and `clap::Arg::required(false)`
+  - Requires `std::convert::Into<OsString>` or `#[clap(arg_enum)]`
+  - Without `<expr>`, relies on `Default::default()`
 
 ### Arg Types
 


### PR DESCRIPTION
Add `default_value_os_t` attribute

The order of suffixes allows us to preserve the original builder function name.

This is a part of #2813