### PR TITLE
fix(parser): Track the most explicit value source

### DIFF
--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -135,7 +135,7 @@ impl ArgMatcher {
         let id = &arg.id;
         debug!("ArgMatcher::inc_occurrence_of_arg: id={:?}", id);
         let ma = self.entry(id).or_insert(MatchedArg::new());
-        ma.set_ty(ValueType::CommandLine);
+        ma.update_ty(ValueType::CommandLine);
         ma.set_ignore_case(arg.is_set(ArgSettings::IgnoreCase));
         ma.invalid_utf8_allowed(arg.is_set(ArgSettings::AllowInvalidUtf8));
         ma.occurs += 1;
@@ -144,7 +144,7 @@ impl ArgMatcher {
     pub(crate) fn inc_occurrence_of_group(&mut self, id: &Id) {
         debug!("ArgMatcher::inc_occurrence_of_group: id={:?}", id);
         let ma = self.entry(id).or_insert(MatchedArg::new());
-        ma.set_ty(ValueType::CommandLine);
+        ma.update_ty(ValueType::CommandLine);
         ma.occurs += 1;
     }
 
@@ -161,13 +161,13 @@ impl ArgMatcher {
         // specific circumstances, like only add one occurrence for flag
         // when we met: `--flag=one,two`).
         let ma = self.entry(arg).or_default();
-        ma.set_ty(ty);
+        ma.update_ty(ty);
         ma.push_val(val);
     }
 
     fn append_val_to(&mut self, arg: &Id, val: OsString, ty: ValueType) {
         let ma = self.entry(arg).or_default();
-        ma.set_ty(ty);
+        ma.update_ty(ty);
         ma.append_val(val);
     }
 
@@ -178,7 +178,7 @@ impl ArgMatcher {
 
     pub(crate) fn add_index_to(&mut self, arg: &Id, idx: usize, ty: ValueType) {
         let ma = self.entry(arg).or_default();
-        ma.set_ty(ty);
+        ma.update_ty(ty);
         ma.push_index(idx);
     }
 

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -119,8 +119,8 @@ impl MatchedArg {
         })
     }
 
-    pub(crate) fn set_ty(&mut self, ty: ValueType) {
-        self.ty = ty;
+    pub(crate) fn update_ty(&mut self, ty: ValueType) {
+        self.ty = self.ty.max(ty);
     }
 
     pub(crate) fn set_ignore_case(&mut self, yes: bool) {
@@ -142,13 +142,13 @@ impl Default for MatchedArg {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum ValueType {
     Unknown,
+    DefaultValue,
     #[cfg(feature = "env")]
     EnvVariable,
     CommandLine,
-    DefaultValue,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We were only tracking the last value source (default, env, cli, etc).
This works for args because they only come from one source.  Groups
however can come from multiple sources and this was making us treat a
group with a default value as being completely from defaults despite
some values maybe being from the commandline.

We now track the highest precedence value for a group.

Fixes #3330