### PR TITLE
fix(help): Optional arg values in brackets

### DIFF
--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -5013,9 +5013,19 @@ impl<'help> Display for Arg<'help> {
         } else if let Some(s) = self.short {
             write!(f, "-{}", s)?;
         }
+        let mut need_closing_bracket = false;
         if !self.is_positional() && self.is_set(ArgSettings::TakesValue) {
+            let is_optional_val = self.min_vals == Some(0);
             let sep = if self.is_set(ArgSettings::RequireEquals) {
-                "="
+                if is_optional_val {
+                    need_closing_bracket = true;
+                    "[="
+                } else {
+                    "="
+                }
+            } else if is_optional_val {
+                need_closing_bracket = true;
+                " ["
             } else {
                 " "
             };
@@ -5023,6 +5033,9 @@ impl<'help> Display for Arg<'help> {
         }
         if self.is_set(ArgSettings::TakesValue) || self.is_positional() {
             display_arg_val(self, |s, _| write!(f, "{}", s))?;
+        }
+        if need_closing_bracket {
+            write!(f, "]")?;
         }
 
         Ok(())

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -38,6 +38,8 @@ OPTIONS:
         --multvalsmo <one> <two>     Tests multiple values, and mult occs
     -o, --option <opt>...            tests options
     -O, --option3 <option3>          specific vals [possible values: fast, slow]
+        --optvaleq[=<optval>]        Tests optional value, require = sign
+        --optvalnoeq [<optval>]      Tests optional value
     -V, --version                    Print version information
 
 SUBCOMMANDS:

--- a/tests/builder/utils.rs
+++ b/tests/builder/utils.rs
@@ -94,6 +94,15 @@ pub fn complex_app() -> App<'static> {
             arg!(--maxvals3 <maxvals> "Tests 3 max vals")
                 .required(false)
                 .max_values(3),
+            arg!(--optvaleq <optval> "Tests optional value, require = sign")
+                .required(false)
+                .min_values(0)
+                .number_of_values(1)
+                .require_equals(true),
+            arg!(--optvalnoeq <optval> "Tests optional value")
+                .required(false)
+                .min_values(0)
+                .number_of_values(1),
         ])
         .subcommand(
             App::new("subcmd")

--- a/tests/derive/options.rs
+++ b/tests/derive/options.rs
@@ -199,8 +199,8 @@ fn option_option_type_help() {
         arg: Option<Option<i32>>,
     }
     let help = utils::get_help::<Opt>();
-    assert!(help.contains("--arg <val>"));
-    assert!(!help.contains("--arg <val>..."));
+    assert!(help.contains("--arg [<val>]"));
+    assert!(!help.contains("--arg [<val>]..."));
 }
 
 #[test]


### PR DESCRIPTION
When an Arg uses .min_values(0), that arg's value(s) are effectively
optional. This is conventionaly denoted in help messages by wrapping the
arg's values in square brackets. For example:

    --foo[=value]
    --bar [value]

This kind of argument can be seen in the wild in many git commands; e.g.
git-status(1).

Signed-off-by: Peter Grayson <pete@jpgrayson.net>