### PR TITLE
Allow creating flag-only subcommands

### DIFF
--- a/examples/pacman.rs
+++ b/examples/pacman.rs
@@ -13,6 +13,7 @@ fn main() {
             App::new("query")
                 .short_flag('Q')
                 .long_flag("query")
+                .no_positional_subcommand()
                 .about("Query the package database.")
                 .arg(
                     Arg::new("search")
@@ -40,6 +41,7 @@ fn main() {
             App::new("sync")
                 .short_flag('S')
                 .long_flag("sync")
+                .no_positional_subcommand()
                 .about("Synchronize packages.")
                 .arg(
                     Arg::new("search")

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -950,6 +950,8 @@ pub enum AppSettings {
     /// ```
     NoAutoVersion,
 
+    NoPositionalSubcommand,
+
     /// Deprecated, replaced with [`AppSettings::AllowHyphenValues`]
     #[deprecated(
         since = "3.0.0",
@@ -1067,6 +1069,7 @@ bitflags! {
         const USE_LONG_FORMAT_FOR_HELP_SC    = 1 << 42;
         const INFER_LONG_ARGS                = 1 << 43;
         const IGNORE_ERRORS                  = 1 << 44;
+        const NO_POS_SUBCOMMAND              = 1 << 45;
         #[cfg(feature = "unstable-multicall")]
         const MULTICALL                      = 1 << 45;
         const NO_OP                          = 0;
@@ -1169,7 +1172,9 @@ impl_settings! { AppSettings, AppFlags,
     AllArgsOverrideSelf
         => Flags::ARGS_OVERRIDE_SELF,
     InferLongArgs
-        => Flags::INFER_LONG_ARGS
+        => Flags::INFER_LONG_ARGS,
+    NoPositionalSubcommand
+        => Flags::NO_POS_SUBCOMMAND
 }
 
 /// Deprecated in [Issue #3087](https://github.com/clap-rs/clap/issues/3087), maybe [`clap::Parser`][crate::Parser] would fit your use case?

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -828,17 +828,18 @@ impl<'help, 'app, 'parser, 'writer> Help<'help, 'app, 'parser, 'writer> {
                 .entry(subcommand.get_display_order())
                 .or_insert_with(BTreeMap::new);
             let mut sc_str = String::new();
+            let show_name = subcommand.subcommand_is_positional();
             sc_str.push_str(
                 &subcommand
                     .short_flag
                     .map_or(String::new(), |c| format!("-{}, ", c)),
             );
-            sc_str.push_str(
-                &subcommand
-                    .long_flag
-                    .map_or(String::new(), |c| format!("--{}, ", c)),
-            );
-            sc_str.push_str(&subcommand.name);
+            sc_str.push_str(&subcommand.long_flag.map_or(String::new(), |c| {
+                format!("--{}{}", c, if show_name { ", " } else { "" })
+            }));
+            if show_name {
+                sc_str.push_str(&subcommand.name);
+            }
             longest = longest.max(display_width(&sc_str));
             btm.insert(sc_str, subcommand.clone());
         }


### PR DESCRIPTION
This is a WIP; I obviously need to add docs and find more edge cases but I was
wondering whether this seems like the right way to go about this/if this is
desirable at all? This seemed to be the only way to accurately recreate a
pacman-like ux where subcommands are just flags.

wrt 'right way to go about this'; _should_ this be an `AppSetting` or should I
go some other route? I considered making `App.name` an Option but that seemed
to break a _lot_ of code in the codebase that wasn't particularly relevant to
handling these correctly.
