### PR TITLE
Added basic argument ordering to clap_man

### DIFF
--- a/clap_man/src/render.rs
+++ b/clap_man/src/render.rs
@@ -141,8 +141,6 @@ pub(crate) fn options(roff: &mut Roff, app: &clap::App) {
         }
 
         roff.control("TP", []);
-        dbg!(&header);
-        dbg!(&body);
         roff.text(header);
     }
 

--- a/clap_man/tests/generate.rs
+++ b/clap_man/tests/generate.rs
@@ -31,10 +31,11 @@ fn render_manpage() {
 #[test]
 fn verify_argument_ordering_is_preserved() {
     let app = App::new("prog")
+        .arg(Arg::new("1st").help("1st"))
+        .arg(Arg::new("2nd").help("2nd"))
+        .arg(Arg::new("3rd").help("3rd").last(true))
         .arg(
-            Arg::new("a") // Typically args are grouped alphabetically by name.
-                // Args without a display_order have a value of 999 and are
-                // displayed alphabetically with all other 999 valued args.
+            Arg::new("a")
                 .long("last")
                 .short('o')
                 .takes_value(true)
@@ -69,10 +70,7 @@ fn verify_argument_ordering_is_preserved() {
                 .long("first")
                 .short('O')
                 .takes_value(true)
-                .display_order(1) // In order to force this arg to appear *first*
-                // all we have to do is give it a value lower than 999.
-                // Any other args with a value of 1 will be displayed
-                // alphabetically with this one...then 2 values, then 3, etc.
+                .display_order(1)
                 .help("I should be first!"),
         );
 
@@ -86,14 +84,19 @@ fn verify_argument_ordering_is_preserved() {
     // Split the string at the `DESCRIPTION` heading to access the
     // SYNOPSIS and OPTIONS sections separately
     let split = s.split("DESCRIPTION");
-    let keywords = ["first", "second", "third", "fourth", "last"];
+    // This is the expected keyword order, the optional arguments appear first,
+    // followed by the positional arguments.
+    let keywords = [
+        "first", "second", "third", "fourth", "last", "1st", "2nd", "3rd",
+    ];
     // For the synopsis, and the full output, iterate and confirm that
     // the keywords appear in the correct order
     for mut s in split {
-        println!("{}", s);
+        println!("Here: {}", s);
         for keyword in keywords {
             assert!(s.contains(keyword));
             s = s.split(keyword).last().unwrap();
+            println!("reduced: {}", s);
         }
     }
 }

--- a/clap_man/tests/generate.rs
+++ b/clap_man/tests/generate.rs
@@ -1,4 +1,4 @@
-use clap::{arg, App};
+use clap::{arg, App, Arg};
 use clap_man::Man;
 use std::io;
 
@@ -26,4 +26,74 @@ fn render_manpage() {
         );
 
     Man::new(app).render(&mut io::sink()).unwrap();
+}
+
+#[test]
+fn verify_argument_ordering_is_preserved() {
+    let app = App::new("prog")
+        .arg(
+            Arg::new("a") // Typically args are grouped alphabetically by name.
+                // Args without a display_order have a value of 999 and are
+                // displayed alphabetically with all other 999 valued args.
+                .long("last")
+                .short('o')
+                .takes_value(true)
+                .help("Some help and text: Should be last"),
+        )
+        .arg(
+            Arg::new("e")
+                .long("fourth")
+                .short('R')
+                .takes_value(true)
+                .display_order(4)
+                .help("I should be fourth!"),
+        )
+        .arg(
+            Arg::new("d")
+                .long("third")
+                .short('Q')
+                .takes_value(true)
+                .display_order(3)
+                .help("I should be third!"),
+        )
+        .arg(
+            Arg::new("c")
+                .long("second")
+                .short('P')
+                .takes_value(true)
+                .display_order(2)
+                .help("I should be second!"),
+        )
+        .arg(
+            Arg::new("b")
+                .long("first")
+                .short('O')
+                .takes_value(true)
+                .display_order(1) // In order to force this arg to appear *first*
+                // all we have to do is give it a value lower than 999.
+                // Any other args with a value of 1 will be displayed
+                // alphabetically with this one...then 2 values, then 3, etc.
+                .help("I should be first!"),
+        );
+
+    let mut buf = Vec::new();
+    Man::new(app).render(&mut buf).unwrap();
+    let s = match std::str::from_utf8(&buf) {
+        Ok(v) => v,
+        Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+    };
+
+    // Split the string at the `DESCRIPTION` heading to access the
+    // SYNOPSIS and OPTIONS sections separately
+    let split = s.split("DESCRIPTION");
+    let keywords = ["first", "second", "third", "fourth", "last"];
+    // For the synopsis, and the full output, iterate and confirm that
+    // the keywords appear in the correct order
+    for mut s in split {
+        println!("{}", s);
+        for keyword in keywords {
+            assert!(s.contains(keyword));
+            s = s.split(keyword).last().unwrap();
+        }
+    }
 }

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -4974,7 +4974,8 @@ impl<'help> Arg<'help> {
         self.is_set(ArgSettings::MultipleValues) | self.is_set(ArgSettings::MultipleOccurrences)
     }
 
-    pub(crate) fn get_display_order(&self) -> usize {
+    /// Returns the display order of a given argument, or `999` if unset
+    pub fn get_display_order(&self) -> usize {
         self.disp_ord.unwrap_or(999)
     }
 }


### PR DESCRIPTION
#3362 I have tried to add basic argument ordering to `clap_man`. To do this I had to reach up into the main `clap` crate, to expose the method `get_display_order()`.

The added code is currently quite verbose because I am printing the `--help` argument first, and then printing the remaining arguments in order which has resulted in some duplication... This ordering makes sense to me but might not be the style wanted. I have also added a unit test to verify that the arguments appear in the desired order in both the Synopsis and Options sections of the manual.