### PR TITLE
Update link to explicit bool parser example

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -317,7 +317,7 @@ impl Attrs {
                                 help = "if you want to create a flag add `long` or `short`";
                                 help = "If you really want a boolean parameter \
                                     add an explicit parser, for example `parse(try_from_str)`";
-                                note = "see also https://github.com/clap-rs/clap_derive/tree/master/examples/true_or_false.rs";
+                                note = "see also https://github.com/clap-rs/clap/blob/master/examples/derive_ref/custom-bool.md";
                             )
                         }
                         if res.is_enum {

--- a/tests/derive_ui/positional_bool.stderr
+++ b/tests/derive_ui/positional_bool.stderr
@@ -2,7 +2,7 @@ error: `bool` cannot be used as positional parameter with default parser
 
   = help: if you want to create a flag add `long` or `short`
   = help: If you really want a boolean parameter add an explicit parser, for example `parse(try_from_str)`
-  = note: see also https://github.com/clap-rs/clap_derive/tree/master/examples/true_or_false.rs
+  = note: see also https://github.com/clap-rs/clap/blob/master/examples/derive_ref/custom-bool.md
 
  --> $DIR/positional_bool.rs:5:14
   |


### PR DESCRIPTION
The example at https://github.com/clap-rs/clap_derive/tree/master/examples/true_or_false.rs has been superseded by the combination of [custom-bool.md](https://github.com/clap-rs/clap/blob/master/examples/derive_ref/custom-bool.md) and [custom-bool.rs](https://github.com/clap-rs/clap/blob/master/examples/derive_ref/custom-bool.rs).

Instead of updating the link to point to the example source, I updated the link to point to the new Markdown since the Markdown includes the rendered `--help` as well as a link to the source.