### PR TITLE
refactor: Avoid direct member access

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -2659,7 +2659,7 @@ impl<'help> App<'help> {
             .filter(|a| a.get_global())
             .map(|ga| ga.id.clone())
             .collect();
-        if let Some(used_subcommand) = matcher.0.subcommand.as_ref() {
+        if let Some(used_subcommand) = matcher.subcommand.as_ref() {
             if let Some(used_subcommand) = self
                 .subcommands
                 .iter()

--- a/src/build/app/settings.rs
+++ b/src/build/app/settings.rs
@@ -328,7 +328,7 @@ pub enum AppSettings {
     ///         "myprog",
     ///     ]);
     /// assert!(err.is_err());
-    /// assert_eq!(err.unwrap_err().kind, ErrorKind::MissingSubcommand);
+    /// assert_eq!(err.unwrap_err().kind(), ErrorKind::MissingSubcommand);
     /// # ;
     /// ```
     ///
@@ -434,7 +434,7 @@ pub enum AppSettings {
     ///     .subcommand(App::new("dnsdomainname"));
     /// let m = app.try_get_matches_from_mut(&["/usr/bin/hostname", "dnsdomainname"]);
     /// assert!(m.is_err());
-    /// assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// let m = app.get_matches_from(&["/usr/bin/dnsdomainname"]);
     /// assert_eq!(m.subcommand_name(), Some("dnsdomainname"));
     /// ```
@@ -574,7 +574,7 @@ pub enum AppSettings {
     ///         "myprog"
     ///     ]);
     /// assert!(err.is_err());
-    /// assert_eq!(err.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(err.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// # ;
     /// ```
     ///
@@ -766,7 +766,7 @@ pub enum AppSettings {
     ///         "myprog", "-h"
     ///     ]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     DisableHelpFlag,
 
@@ -785,7 +785,7 @@ pub enum AppSettings {
     ///         "myprog", "help"
     ///     ]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     ///
     /// [`subcommand`]: crate::App::subcommand()
@@ -803,7 +803,7 @@ pub enum AppSettings {
     ///         "myprog", "-V"
     ///     ]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     DisableVersionFlag,
 

--- a/src/build/arg/mod.rs
+++ b/src/build/arg/mod.rs
@@ -542,7 +542,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     /// [index]: Arg::index()
     /// [`UnknownArgument`]: crate::ErrorKind::UnknownArgument
@@ -607,7 +607,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     #[inline]
     #[must_use]
@@ -672,7 +672,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [`Arg::requires(name)`]: Arg::requires()
     /// [Conflicting]: Arg::conflicts_with()
@@ -713,7 +713,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
     /// ```
     #[inline]
     #[must_use]
@@ -869,7 +869,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooManyOccurrences);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::TooManyOccurrences);
     /// ```
     /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
     #[inline]
@@ -1083,7 +1083,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnexpectedMultipleUsage)
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnexpectedMultipleUsage)
     /// ```
     ///
     /// A common mistake is to define an option which allows multiple values, and a positional
@@ -1151,7 +1151,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     ///
     /// [`subcommands`]: crate::App::subcommand()
@@ -1206,7 +1206,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
     /// ```
     /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
     #[inline]
@@ -1270,7 +1270,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
     #[inline]
@@ -1335,7 +1335,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::TooFewValues);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::TooFewValues);
     /// ```
     /// [`Arg::multiple_occurrences(true)`]: Arg::multiple_occurrences()
     #[inline]
@@ -1635,7 +1635,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "12345"
     ///     ]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.err().unwrap().kind, ErrorKind::ValueValidation)
+    /// assert_eq!(res.err().unwrap().kind(), ErrorKind::ValueValidation)
     /// ```
     #[cfg(feature = "regex")]
     #[must_use]
@@ -1720,7 +1720,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "--mode", "wrong"
     ///     ]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::InvalidValue);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::InvalidValue);
     /// ```
     /// [options]: Arg::takes_value()
     /// [positional arguments]: Arg::index()
@@ -1796,7 +1796,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "--mode", "wrong"
     ///     ]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::InvalidValue);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::InvalidValue);
     /// ```
     /// [options]: Arg::takes_value()
     /// [positional arguments]: Arg::index()
@@ -1916,7 +1916,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     /// [`Arg::number_of_values(1)`]: Arg::number_of_values()
     #[inline]
@@ -2013,7 +2013,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::EmptyValue);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::EmptyValue);
     /// ```
     #[inline]
     #[must_use]
@@ -2065,7 +2065,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::NoEquals);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::NoEquals);
     /// ```
     #[inline]
     #[must_use]
@@ -2223,7 +2223,7 @@ impl<'help> Arg<'help> {
     ///
     /// assert!(res.is_err());
     /// let err = res.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(err.kind(), ErrorKind::UnknownArgument);
     /// ```
     ///
     /// What's happening is `-o` is getting `val1`, and because delimiters are required yet none
@@ -3643,7 +3643,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required]: Arg::required()
     #[must_use]
@@ -3712,7 +3712,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required]: Arg::required()
     /// [`Arg::required_unless_present_any`]: Arg::required_unless_present_any()
@@ -3789,7 +3789,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required]: Arg::required()
     /// [`Arg::required_unless_present_any(names)`]: Arg::required_unless_present_any()
@@ -3848,7 +3848,7 @@ impl<'help> Arg<'help> {
     ///
     /// // We did use --other=special so "cfg" had become required but was missing.
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     ///
     /// let res = App::new("prog")
     ///     .arg(Arg::new("cfg")
@@ -3880,7 +3880,7 @@ impl<'help> Arg<'help> {
     ///
     /// // However, case-insensitive comparisons can be enabled.  This typically occurs when using Arg::possible_values().
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [`Arg::requires(name)`]: Arg::requires()
     /// [Conflicting]: Arg::conflicts_with()
@@ -3959,7 +3959,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [`Arg::requires(name)`]: Arg::requires()
     /// [Conflicting]: Arg::conflicts_with()
@@ -4039,7 +4039,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required]: Arg::required()
     #[must_use]
@@ -4101,7 +4101,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [`Arg::requires(name)`]: Arg::requires()
     /// [Conflicting]: Arg::conflicts_with()
@@ -4153,7 +4153,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err()); // We  used --config=special.conf so --option <val> is required
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [`Arg::requires(name)`]: Arg::requires()
     /// [Conflicting]: Arg::conflicts_with()
@@ -4225,7 +4225,7 @@ impl<'help> Arg<'help> {
     ///
     /// assert!(res.is_err());
     /// // We didn't use output
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [Conflicting]: Arg::conflicts_with()
     /// [override]: Arg::overrides_with()
@@ -4275,7 +4275,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
     /// ```
     ///
     /// [`Arg::conflicts_with_all(names)`]: Arg::conflicts_with_all()
@@ -4329,7 +4329,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
     /// ```
     /// [`Arg::conflicts_with`]: Arg::conflicts_with()
     /// [`Arg::exclusive(true)`]: Arg::exclusive()

--- a/src/build/arg/possible_value.rs
+++ b/src/build/arg/possible_value.rs
@@ -26,10 +26,10 @@ use crate::util::eq_ignore_case;
 /// [help]: PossibleValue::help()
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PossibleValue<'help> {
-    pub(crate) name: &'help str,
-    pub(crate) help: Option<&'help str>,
-    pub(crate) aliases: Vec<&'help str>, // (name, visible)
-    pub(crate) hide: bool,
+    name: &'help str,
+    help: Option<&'help str>,
+    aliases: Vec<&'help str>, // (name, visible)
+    hide: bool,
 }
 
 impl<'help> PossibleValue<'help> {

--- a/src/build/arg_group.rs
+++ b/src/build/arg_group.rs
@@ -50,7 +50,7 @@ use yaml_rust::Yaml;
 /// // Because we used two args in the group it's an error
 /// assert!(result.is_err());
 /// let err = result.unwrap_err();
-/// assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+/// assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 /// ```
 /// This next example shows a passing parse of the same scenario
 ///
@@ -220,7 +220,7 @@ impl<'help> ArgGroup<'help> {
     /// // Because we used both args in the group it's an error
     /// assert!(result.is_err());
     /// let err = result.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     /// ```
     ///
     /// [`Arg`]: crate::Arg
@@ -263,7 +263,7 @@ impl<'help> ArgGroup<'help> {
     /// // Because we didn't use any of the args in the group, it's an error
     /// assert!(result.is_err());
     /// let err = result.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     ///
     /// [`Subcommand`]: crate::Subcommand
@@ -306,7 +306,7 @@ impl<'help> ArgGroup<'help> {
     /// // error
     /// assert!(result.is_err());
     /// let err = result.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required group]: ArgGroup::required()
     /// [argument requirement rules]: crate::Arg::requires()
@@ -348,7 +348,7 @@ impl<'help> ArgGroup<'help> {
     /// // yet we only used "-d" it's an error
     /// assert!(result.is_err());
     /// let err = result.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required group]: ArgGroup::required()
     /// [argument requirement rules]: crate::Arg::requires_all()
@@ -389,7 +389,7 @@ impl<'help> ArgGroup<'help> {
     /// // because we used an arg from the group, and the group conflicts with "-d", it's an error
     /// assert!(result.is_err());
     /// let err = result.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     /// ```
     /// [argument exclusion rules]: crate::Arg::conflicts_with()
     #[must_use]
@@ -429,7 +429,7 @@ impl<'help> ArgGroup<'help> {
     /// // it's an error
     /// assert!(result.is_err());
     /// let err = result.unwrap_err();
-    /// assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
     /// ```
     ///
     /// [argument exclusion rules]: crate::Arg::conflicts_with_all()

--- a/src/build/usage_parser.rs
+++ b/src/build/usage_parser.rs
@@ -1249,7 +1249,7 @@ mod test {
             .arg(Arg::from_usage("--pos <who> <what> <why>"))
             .try_get_matches_from(vec!["myprog", "--pos", "val1", "val2", "val3"]);
 
-        assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+        assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
         let m = m.unwrap();
 
         assert_eq!(
@@ -1271,6 +1271,6 @@ mod test {
         .try_get_matches_from(vec!["test", "--subject-prefix", "-v", "2"]);
 
         assert!(res.is_err());
-        assert_eq!(res.unwrap_err().kind, ErrorKind::EmptyValue);
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::EmptyValue);
     }
 }

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -62,7 +62,7 @@ impl ArgMatcher {
                 // a default value of `other` myprog would have an existing MatchedArg for
                 // --global-arg where the value is `other`, however the occurs will be 0.
                 let to_update = if let Some(parent_ma) = vals_map.get(global_arg) {
-                    if parent_ma.occurs > 0 && ma.occurs == 0 {
+                    if parent_ma.get_occurrences() > 0 && ma.get_occurrences() == 0 {
                         parent_ma
                     } else {
                         ma
@@ -105,7 +105,7 @@ impl ArgMatcher {
         self.0
             .args
             .get(arg)
-            .map_or(false, |a| a.ty != ValueType::DefaultValue)
+            .map_or(false, |a| a.source() != ValueType::DefaultValue)
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -139,14 +139,14 @@ impl ArgMatcher {
         ma.update_ty(ValueType::CommandLine);
         ma.set_ignore_case(arg.is_set(ArgSettings::IgnoreCase));
         ma.invalid_utf8_allowed(arg.is_set(ArgSettings::AllowInvalidUtf8));
-        ma.occurs += 1;
+        ma.inc_occurrences();
     }
 
     pub(crate) fn inc_occurrence_of_group(&mut self, id: &Id) {
         debug!("ArgMatcher::inc_occurrence_of_group: id={:?}", id);
         let ma = self.entry(id).or_insert(MatchedArg::new());
         ma.update_ty(ValueType::CommandLine);
-        ma.occurs += 1;
+        ma.inc_occurrences();
     }
 
     pub(crate) fn add_val_to(&mut self, arg: &Id, val: OsString, ty: ValueType, append: bool) {

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -12,7 +12,7 @@ use crate::{
 use indexmap::map::Entry;
 
 #[derive(Debug, Default)]
-pub(crate) struct ArgMatcher(pub(crate) ArgMatches);
+pub(crate) struct ArgMatcher(ArgMatches);
 
 impl ArgMatcher {
     pub(crate) fn new(_app: &App) -> Self {

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -432,13 +432,13 @@ pub enum ErrorKind {
 #[derive(Debug)]
 pub struct Error {
     /// Formatted error message, enhancing the cause message with extra information
-    pub(crate) message: Message,
+    message: Message,
     /// The type of error
     pub kind: ErrorKind,
     /// Additional information depending on the error kind, like values and argument names.
     /// Useful when you want to render an error of your own.
     pub info: Vec<String>,
-    pub(crate) source: Option<Box<dyn error::Error + Send + Sync>>,
+    source: Option<Box<dyn error::Error + Send + Sync>>,
     wait_on_exit: bool,
     backtrace: Option<Backtrace>,
 }

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -466,6 +466,11 @@ impl Error {
         self
     }
 
+    /// Type of error for programmatic processing
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
     /// Should the message be written to `stdout` or not?
     #[inline]
     pub fn use_stderr(&self) -> bool {

--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -39,7 +39,7 @@ pub enum ErrorKind {
     ///         .possible_value("slow"))
     ///     .try_get_matches_from(vec!["prog", "other"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::InvalidValue);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidValue);
     /// ```
     InvalidValue,
 
@@ -53,7 +53,7 @@ pub enum ErrorKind {
     ///     .arg(arg!(--flag "some flag"))
     ///     .try_get_matches_from(vec!["prog", "--other"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::UnknownArgument);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::UnknownArgument);
     /// ```
     UnknownArgument,
 
@@ -75,7 +75,7 @@ pub enum ErrorKind {
     ///             .index(1)))
     ///     .try_get_matches_from(vec!["prog", "confi"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::InvalidSubcommand);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidSubcommand);
     /// ```
     ///
     /// [`Subcommand`]: crate::Subcommand
@@ -102,7 +102,7 @@ pub enum ErrorKind {
     ///             .index(1)))
     ///     .try_get_matches_from(vec!["prog", "help", "nothing"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::UnrecognizedSubcommand);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::UnrecognizedSubcommand);
     /// ```
     ///
     /// [`Subcommand`]: crate::Subcommand
@@ -124,7 +124,7 @@ pub enum ErrorKind {
     ///          .long("color"))
     ///     .try_get_matches_from(vec!["prog", "--color="]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::EmptyValue);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::EmptyValue);
     /// ```
     EmptyValue,
 
@@ -140,7 +140,7 @@ pub enum ErrorKind {
     ///          .long("color"))
     ///     .try_get_matches_from(vec!["prog", "--color", "red"]);
     /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind, ErrorKind::NoEquals);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::NoEquals);
     /// ```
     NoEquals,
 
@@ -163,7 +163,7 @@ pub enum ErrorKind {
     ///          .validator(is_numeric))
     ///     .try_get_matches_from(vec!["prog", "NotANumber"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::ValueValidation);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::ValueValidation);
     /// ```
     ValueValidation,
 
@@ -179,7 +179,7 @@ pub enum ErrorKind {
     ///         .max_values(2))
     ///     .try_get_matches_from(vec!["prog", "too", "many", "values"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::TooManyValues);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::TooManyValues);
     /// ```
     /// [`Arg::max_values`]: Arg::max_values()
     TooManyValues,
@@ -197,7 +197,7 @@ pub enum ErrorKind {
     ///         .min_values(3))
     ///     .try_get_matches_from(vec!["prog", "--opt", "too", "few"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::TooFewValues);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::TooFewValues);
     /// ```
     /// [`Arg::min_values`]: Arg::min_values()
     TooFewValues,
@@ -215,7 +215,7 @@ pub enum ErrorKind {
     ///         .max_occurrences(2))
     ///     .try_get_matches_from(vec!["prog", "-vvv"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::TooManyOccurrences);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::TooManyOccurrences);
     /// ```
     /// [`Arg::max_occurrences`]: Arg::max_occurrences()
     TooManyOccurrences,
@@ -235,7 +235,7 @@ pub enum ErrorKind {
     ///         .number_of_values(2))
     ///     .try_get_matches_from(vec!["prog", "--opt", "wrong"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
     /// ```
     ///
     /// [`Arg::number_of_values`]: Arg::number_of_values()
@@ -257,7 +257,7 @@ pub enum ErrorKind {
     ///         .long("color"))
     ///     .try_get_matches_from(vec!["prog", "--debug", "--color"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::ArgumentConflict);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
     /// ```
     ArgumentConflict,
 
@@ -272,7 +272,7 @@ pub enum ErrorKind {
     ///         .required(true))
     ///     .try_get_matches_from(vec!["prog"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     MissingRequiredArgument,
 
@@ -290,7 +290,7 @@ pub enum ErrorKind {
     ///         "myprog",
     ///     ]);
     /// assert!(err.is_err());
-    /// assert_eq!(err.unwrap_err().kind, ErrorKind::MissingSubcommand);
+    /// assert_eq!(err.unwrap_err().kind(), ErrorKind::MissingSubcommand);
     /// # ;
     /// ```
     ///
@@ -309,7 +309,7 @@ pub enum ErrorKind {
     ///         .multiple_occurrences(false))
     ///     .try_get_matches_from(vec!["prog", "--debug", "--debug"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::UnexpectedMultipleUsage);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::UnexpectedMultipleUsage);
     /// ```
     UnexpectedMultipleUsage,
 
@@ -339,7 +339,7 @@ pub enum ErrorKind {
     ///                                 OsString::from("-u"),
     ///                                 OsString::from_vec(vec![0xE9])]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidUtf8);
     /// ```
     ///
     /// [`Arg::allow_invalid_utf8`]: crate::Arg::allow_invalid_utf8
@@ -359,7 +359,7 @@ pub enum ErrorKind {
     /// let result = App::new("prog")
     ///     .try_get_matches_from(vec!["prog", "--help"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::DisplayHelp);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::DisplayHelp);
     /// ```
     DisplayHelp,
 
@@ -380,7 +380,7 @@ pub enum ErrorKind {
     ///             .help("The configuration file to use")))
     ///     .try_get_matches_from(vec!["prog"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand);
     /// ```
     ///
     /// [`Subcommand`]: crate::Subcommand
@@ -399,7 +399,7 @@ pub enum ErrorKind {
     ///     .version("3.0")
     ///     .try_get_matches_from(vec!["prog", "--version"]);
     /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind, ErrorKind::DisplayVersion);
+    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::DisplayVersion);
     /// ```
     DisplayVersion,
 
@@ -475,7 +475,7 @@ impl Error {
     #[inline]
     pub fn use_stderr(&self) -> bool {
         !matches!(
-            self.kind,
+            self.kind(),
             ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
         )
     }

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -649,7 +649,8 @@ impl ArgMatches {
     /// assert_eq!(m.occurrences_of("flag"), 1);
     /// ```
     pub fn occurrences_of<T: Key>(&self, id: T) -> u64 {
-        self.get_arg(&Id::from(id)).map_or(0, |a| a.occurs)
+        self.get_arg(&Id::from(id))
+            .map_or(0, |a| a.get_occurrences())
     }
 
     /// The first index of that an argument showed up.

--- a/src/parse/matches/matched_arg.rs
+++ b/src/parse/matches/matched_arg.rs
@@ -10,8 +10,8 @@ use crate::INTERNAL_ERROR_MSG;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct MatchedArg {
-    pub(crate) occurs: u64,
-    pub(crate) ty: ValueType,
+    occurs: u64,
+    ty: ValueType,
     indices: Vec<usize>,
     vals: Vec<Vec<OsString>>,
     ignore_case: bool,
@@ -28,6 +28,14 @@ impl MatchedArg {
             ignore_case: false,
             invalid_utf8_allowed: None,
         }
+    }
+
+    pub(crate) fn inc_occurrences(&mut self) {
+        self.occurs += 1;
+    }
+
+    pub(crate) fn get_occurrences(&self) -> u64 {
+        self.occurs
     }
 
     pub(crate) fn indices(&self) -> Cloned<Iter<'_, usize>> {
@@ -117,6 +125,10 @@ impl MatchedArg {
                 OsString::as_os_str(v) == OsStr::new(val)
             }
         })
+    }
+
+    pub(crate) fn source(&self) -> ValueType {
+        self.ty
     }
 
     pub(crate) fn update_ty(&mut self, ty: ValueType) {

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1448,7 +1448,10 @@ impl<'help, 'app> Parser<'help, 'app> {
         self.app.args.args().try_for_each(|a| {
             // Use env only if the arg was absent among command line args,
             // early return if this is not the case.
-            if matcher.get(&a.id).map_or(false, |a| a.occurs != 0) {
+            if matcher
+                .get(&a.id)
+                .map_or(false, |a| a.get_occurrences() != 0)
+            {
                 debug!("Parser::add_env: Skipping existing arg `{}`", a);
                 return Ok(());
             }

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -304,11 +304,15 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
     fn validate_arg_num_occurs(&self, a: &Arg, ma: &MatchedArg) -> ClapResult<()> {
         debug!(
             "Validator::validate_arg_num_occurs: {:?}={}",
-            a.name, ma.occurs
+            a.name,
+            ma.get_occurrences()
         );
         // Occurrence of positional argument equals to number of values rather
         // than number of grouped values.
-        if ma.occurs > 1 && !a.is_set(ArgSettings::MultipleOccurrences) && !a.is_positional() {
+        if ma.get_occurrences() > 1
+            && !a.is_set(ArgSettings::MultipleOccurrences)
+            && !a.is_positional()
+        {
             // Not the first time, and we don't allow multiples
             return Err(Error::unexpected_multiple_usage(
                 self.p.app,
@@ -321,7 +325,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 "Validator::validate_arg_num_occurs: max_occurs set...{}",
                 max_occurs
             );
-            let occurs = ma.occurs as usize;
+            let occurs = ma.get_occurrences() as usize;
             if occurs > max_occurs {
                 return Err(Error::too_many_occurrences(
                     self.p.app,

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -41,7 +41,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
 
             let o = &self.p.app[&a];
             reqs_validated = true;
-            let should_err = if let Some(v) = matcher.0.args.get(&o.id) {
+            let should_err = if let Some(v) = matcher.args.get(&o.id) {
                 v.all_val_groups_empty() && !(o.min_vals.is_some() && o.min_vals.unwrap() == 0)
             } else {
                 true

--- a/tests/builder/app_from_crate.rs
+++ b/tests/builder/app_from_crate.rs
@@ -19,7 +19,7 @@ fn app_from_crate() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayHelp);
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
     assert_eq!(
         err.to_string(),
         EVERYTHING.replace("{{version}}", env!("CARGO_PKG_VERSION"))

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -215,7 +215,7 @@ fn sub_command_negate_required_2() {
         .try_get_matches_from(vec![""]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn sub_command_required() {
         .try_get_matches_from(vec![""]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingSubcommand);
+    assert_eq!(err.kind(), ErrorKind::MissingSubcommand);
 }
 
 #[test]
@@ -239,7 +239,7 @@ fn arg_required_else_help() {
     assert!(result.is_err());
     let err = result.err().unwrap();
     assert_eq!(
-        err.kind,
+        err.kind(),
         ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
     );
 }
@@ -254,7 +254,7 @@ fn arg_required_else_help_over_reqs() {
     assert!(result.is_err());
     let err = result.err().unwrap();
     assert_eq!(
-        err.kind,
+        err.kind(),
         ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
     );
 }
@@ -288,7 +288,7 @@ fn subcommand_required_else_help() {
     assert!(result.is_err());
     let err = result.err().unwrap();
     assert_eq!(
-        err.kind,
+        err.kind(),
         ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
     );
 }
@@ -316,7 +316,7 @@ fn infer_subcommands_fail_no_args() {
         .subcommand(App::new("temp"))
         .try_get_matches_from(vec!["prog", "te"]);
     assert!(m.is_err(), "{:#?}", m.unwrap());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnrecognizedSubcommand);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnrecognizedSubcommand);
 }
 
 #[cfg(feature = "suggestions")]
@@ -328,7 +328,7 @@ fn infer_subcommands_fail_no_args() {
         .subcommand(App::new("temp"))
         .try_get_matches_from(vec!["prog", "te"]);
     assert!(m.is_err(), "{:#?}", m.unwrap());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidSubcommand);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidSubcommand);
 }
 
 #[test]
@@ -339,7 +339,7 @@ fn infer_subcommands_fail_with_args() {
         .subcommand(App::new("test"))
         .subcommand(App::new("temp"))
         .try_get_matches_from(vec!["prog", "t"]);
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     assert_eq!(m.unwrap().value_of("some"), Some("t"));
 }
 
@@ -351,7 +351,7 @@ fn infer_subcommands_fail_with_args2() {
         .subcommand(App::new("test"))
         .subcommand(App::new("temp"))
         .try_get_matches_from(vec!["prog", "te"]);
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     assert_eq!(m.unwrap().value_of("some"), Some("te"));
 }
 
@@ -397,7 +397,7 @@ fn infer_subcommands_fail_suggestions() {
         .subcommand(App::new("temp"))
         .try_get_matches_from(vec!["prog", "temps"]);
     assert!(m.is_err(), "{:#?}", m.unwrap());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidSubcommand);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidSubcommand);
 }
 
 #[cfg(not(feature = "suggestions"))]
@@ -409,7 +409,7 @@ fn infer_subcommands_fail_suggestions() {
         .subcommand(App::new("temp"))
         .try_get_matches_from(vec!["prog", "temps"]);
     assert!(m.is_err(), "{:#?}", m.unwrap());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnrecognizedSubcommand);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnrecognizedSubcommand);
 }
 
 #[test]
@@ -547,7 +547,7 @@ fn leading_hyphen_short() {
         .arg(Arg::new("some"))
         .arg(Arg::new("other").short('o'))
         .try_get_matches_from(vec!["", "-bar", "-o"]);
-    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert!(m.is_present("some"));
     assert!(m.is_present("other"));
@@ -561,7 +561,7 @@ fn leading_hyphen_long() {
         .arg(Arg::new("some"))
         .arg(Arg::new("other").short('o'))
         .try_get_matches_from(vec!["", "--bar", "-o"]);
-    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert!(m.is_present("some"));
     assert!(m.is_present("other"));
@@ -575,7 +575,7 @@ fn leading_hyphen_opt() {
         .arg(Arg::new("some").takes_value(true).long("opt"))
         .arg(Arg::new("other").short('o'))
         .try_get_matches_from(vec!["", "--opt", "--bar", "-o"]);
-    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert!(m.is_present("some"));
     assert!(m.is_present("other"));
@@ -589,7 +589,7 @@ fn allow_negative_numbers() {
         .arg(Arg::new("panum"))
         .arg(Arg::new("onum").short('o').takes_value(true))
         .try_get_matches_from(vec!["negnum", "-20", "-o", "-1.2"]);
-    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "Error: {:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert_eq!(m.value_of("panum").unwrap(), "-20");
     assert_eq!(m.value_of("onum").unwrap(), "-1.2");
@@ -603,7 +603,7 @@ fn allow_negative_numbers_fail() {
         .arg(Arg::new("onum").short('o').takes_value(true))
         .try_get_matches_from(vec!["negnum", "--foo", "-o", "-1.2"]);
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument)
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument)
 }
 
 #[test]
@@ -629,7 +629,7 @@ fn disable_help_subcommand() {
         .try_get_matches_from(vec!["", "help"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -678,7 +678,7 @@ fn args_negate_subcommands_one_level() {
         .arg(arg!(<arg2> "some arg"))
         .subcommand(App::new("sub1").subcommand(App::new("sub2").subcommand(App::new("sub3"))))
         .try_get_matches_from(vec!["", "pickles", "sub1"]);
-    assert!(res.is_ok(), "error: {:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "error: {:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert_eq!(m.value_of("arg2"), Some("sub1"));
 }
@@ -697,7 +697,7 @@ fn args_negate_subcommands_two_levels() {
                 .subcommand(App::new("sub2").subcommand(App::new("sub3"))),
         )
         .try_get_matches_from(vec!["", "sub1", "arg", "sub2"]);
-    assert!(res.is_ok(), "error: {:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "error: {:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert_eq!(
         m.subcommand_matches("sub1").unwrap().value_of("arg2"),
@@ -711,7 +711,7 @@ fn propagate_vals_down() {
         .arg(arg!([cmd] "command to run").global(true))
         .subcommand(App::new("foo"))
         .try_get_matches_from(vec!["myprog", "set", "foo"]);
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
     assert_eq!(m.value_of("cmd"), Some("set"));
     let sub_m = m.subcommand_matches("foo").unwrap();
@@ -725,7 +725,7 @@ fn allow_missing_positional() {
         .arg(arg!([src] "some file").default_value("src"))
         .arg(arg!(<dest> "some file"))
         .try_get_matches_from(vec!["test", "file"]);
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
     assert_eq!(m.value_of("src"), Some("src"));
     assert_eq!(m.value_of("dest"), Some("file"));
@@ -738,7 +738,7 @@ fn allow_missing_positional_no_default() {
         .arg(arg!([src] "some file"))
         .arg(arg!(<dest> "some file"))
         .try_get_matches_from(vec!["test", "file"]);
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
     assert_eq!(m.value_of("src"), None);
     assert_eq!(m.value_of("dest"), Some("file"));
@@ -751,7 +751,7 @@ fn missing_positional_no_hyphen() {
         .arg(arg!([BENCH] "some bench"))
         .arg(arg!([ARGS] ... "some args"))
         .try_get_matches_from(vec!["bench", "foo", "arg1", "arg2", "arg3"]);
-    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind());
 
     let m = r.unwrap();
 
@@ -772,7 +772,7 @@ fn missing_positional_hyphen() {
         .arg(arg!([BENCH] "some bench"))
         .arg(arg!([ARGS] ... "some args"))
         .try_get_matches_from(vec!["bench", "--", "arg1", "arg2", "arg3"]);
-    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind());
 
     let m = r.unwrap();
 
@@ -795,7 +795,7 @@ fn missing_positional_hyphen_far_back() {
         .arg(arg!([BENCH3] "some bench"))
         .arg(arg!([ARGS] ... "some args"))
         .try_get_matches_from(vec!["bench", "foo", "--", "arg1", "arg2", "arg3"]);
-    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind());
 
     let m = r.unwrap();
 
@@ -822,7 +822,7 @@ fn missing_positional_hyphen_req_error() {
         .arg(arg!([ARGS] ... "some args"))
         .try_get_matches_from(vec!["bench", "foo", "--", "arg1", "arg2", "arg3"]);
     assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(r.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -833,7 +833,7 @@ fn issue_1066_allow_leading_hyphen_and_unknown_args() {
         .try_get_matches_from(vec!["prog", "hello"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -844,7 +844,7 @@ fn issue_1066_allow_leading_hyphen_and_unknown_args_no_vals() {
         .try_get_matches_from(vec!["prog", "--hello"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -855,7 +855,7 @@ fn issue_1066_allow_leading_hyphen_and_unknown_args_option() {
         .try_get_matches_from(vec!["prog", "-hello"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]

--- a/tests/builder/cargo.rs
+++ b/tests/builder/cargo.rs
@@ -32,7 +32,7 @@ fn crate_version() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
     assert_eq!(
         err.to_string(),
         format!("prog {}\n", env!("CARGO_PKG_VERSION"))
@@ -48,7 +48,7 @@ fn crate_description() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayHelp);
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
     assert_eq!(err.to_string(), DESCRIPTION_ONLY);
 }
 
@@ -61,7 +61,7 @@ fn crate_authors() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayHelp);
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
     assert_eq!(err.to_string(), AUTHORS_ONLY);
 }
 
@@ -73,6 +73,6 @@ fn crate_name() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
     assert_eq!(err.to_string(), "clap 3.0\n");
 }

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -36,7 +36,7 @@ fn flag_conflict() {
         .try_get_matches_from(vec!["myprog", "-f", "-o"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn flag_conflict_2() {
         .try_get_matches_from(vec!["myprog", "-o", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn flag_conflict_with_all() {
         .try_get_matches_from(vec!["myprog", "-o", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn flag_conflict_with_everything() {
         .try_get_matches_from(vec!["myprog", "-o", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]
@@ -83,12 +83,12 @@ fn arg_conflicts_with_group() {
     let result = app.try_get_matches_from_mut(vec!["myprog", "--other", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "-f", "--some"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
@@ -140,7 +140,7 @@ fn arg_conflicts_with_group_with_multiple_sources() {
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "-f", "--some", "usb1"]);
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]
@@ -159,12 +159,12 @@ fn group_conflicts_with_arg() {
     let result = app.try_get_matches_from_mut(vec!["myprog", "--other", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "-f", "--some"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
@@ -193,12 +193,12 @@ fn arg_conflicts_with_required_group() {
     let result = app.try_get_matches_from_mut(vec!["myprog", "--other", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "-f", "--some"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
@@ -228,12 +228,12 @@ fn required_group_conflicts_with_arg() {
     let result = app.try_get_matches_from_mut(vec!["myprog", "--other", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "-f", "--some"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 
     let result = app.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -28,7 +28,7 @@ fn opt_without_value_fail() {
         .try_get_matches_from(vec!["", "-o"]);
     assert!(r.is_err());
     let err = r.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::EmptyValue);
+    assert_eq!(err.kind(), ErrorKind::EmptyValue);
     assert!(err
         .to_string()
         .contains("The argument '-o <opt>' requires a value but none was supplied"));

--- a/tests/builder/double_require.rs
+++ b/tests/builder/double_require.rs
@@ -67,7 +67,7 @@ fn help_text() {
     let res = app().try_get_matches_from(vec!["prog", "--help"]);
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayHelp);
+    assert_eq!(err.kind(), ErrorKind::DisplayHelp);
     println!("{}", err);
     assert_eq!(err.to_string(), HELP);
 }
@@ -77,12 +77,12 @@ fn no_duplicate_error() {
     let res = app().try_get_matches_from(vec!["", "-b"]);
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     assert_eq!(err.to_string(), ONLY_B_ERROR);
 
     let res = app().try_get_matches_from(vec!["", "-c"]);
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     assert_eq!(err.to_string(), ONLY_C_ERROR);
 }

--- a/tests/builder/empty_values.rs
+++ b/tests/builder/empty_values.rs
@@ -37,7 +37,7 @@ fn no_empty_values() {
         )
         .try_get_matches_from(&["config", "--config", ""]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
 
     let m = App::new("config")
         .arg(
@@ -48,7 +48,7 @@ fn no_empty_values() {
         )
         .try_get_matches_from(&["config", "-c", ""]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::EmptyValue)
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue)
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn no_empty_values_with_equals() {
         )
         .try_get_matches_from(&["config", "--config="]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
 
     let m = App::new("config")
         .arg(
@@ -73,7 +73,7 @@ fn no_empty_values_with_equals() {
         )
         .try_get_matches_from(&["config", "-c="]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn no_empty_values_without_equals() {
         )
         .try_get_matches_from(&["config", "--config"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
 
     let m = App::new("config")
         .arg(
@@ -98,7 +98,7 @@ fn no_empty_values_without_equals() {
         )
         .try_get_matches_from(&["config", "-c"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::EmptyValue)
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue)
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn no_empty_values_without_equals_but_requires_equals() {
     let m = app.clone().try_get_matches_from(&["config", "--config"]);
     // Should error on no equals rather than empty value.
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::NoEquals);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::NoEquals);
 
     static NO_EUQALS_ERROR: &str =
         "error: Equal sign is needed when assigning values to '--config=<config>'.

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -16,7 +16,7 @@ fn compare_error(
         stderr,
         err.use_stderr()
     );
-    assert_eq!(expected_kind, err.kind);
+    assert_eq!(expected_kind, err.kind());
     utils::compare(expected_output, actual_output)
 }
 

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -411,7 +411,7 @@ fn flag_subcommand_long_infer_fail() {
         .subcommand(App::new("temp").long_flag("temp"))
         .try_get_matches_from(vec!["prog", "--te"]);
     assert!(m.is_err(), "{:#?}", m.unwrap());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[cfg(feature = "suggestions")]
@@ -423,7 +423,7 @@ fn flag_subcommand_long_infer_fail() {
         .subcommand(App::new("temp").long_flag("temp"))
         .try_get_matches_from(vec!["prog", "--te"]);
     assert!(m.is_err(), "{:#?}", m.unwrap());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -53,7 +53,7 @@ fn lots_o_flags_sep() {
             "-o", "-o", "-o", "-o", "-o", "-o", "-o", "-o", "-o", "-o", "-o", "-o", "-o", "-o",
             "-o", "-o", "-o",
         ]);
-    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind());
     let m = r.unwrap();
     assert!(m.is_present("o"));
     assert_eq!(m.occurrences_of("o"), 297); // i.e. more than u8
@@ -71,7 +71,7 @@ fn lots_o_flags_combined() {
             "-oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo",
             "-ooooooooooooooooooooooooooooooooooooooooo",
         ]);
-    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind());
     let m = r.unwrap();
     assert!(m.is_present("o"));
     assert_eq!(m.occurrences_of("o"), 297); // i.e. more than u8
@@ -95,7 +95,7 @@ fn flag_using_long_with_literals() {
         .arg(Arg::new("rainbow").long("rainbow"))
         .try_get_matches_from(vec!["", "--rainbow=false"]);
     assert!(m.is_err(), "{:#?}", m.unwrap());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooManyValues);
 }
 
 #[test]

--- a/tests/builder/groups.rs
+++ b/tests/builder/groups.rs
@@ -38,7 +38,7 @@ fn required_group_missing_arg() {
         .try_get_matches_from(vec![""]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[cfg(debug_assertions)]
@@ -134,7 +134,7 @@ fn group_reqired_flags_empty() {
         .try_get_matches_from(vec![""]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -144,7 +144,7 @@ fn group_multi_value_single_arg() {
         .arg(arg!(-c --color <color> "some option").multiple_values(true))
         .group(ArgGroup::new("grp").args(&["flag", "color"]))
         .try_get_matches_from(vec!["", "-c", "blue", "red", "green"]);
-    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
 
     let m = res.unwrap();
     assert!(m.is_present("grp"));
@@ -162,7 +162,7 @@ fn empty_group() {
         .try_get_matches_from(vec!["empty_prog"]);
     assert!(r.is_err());
     let err = r.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -254,7 +254,7 @@ fn group_multiple_args_error() {
         .try_get_matches_from(vec!["group", "-f", "-c"]);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -622,7 +622,7 @@ fn help_short() {
     let m = setup().try_get_matches_from(vec!["myprog", "-h"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::DisplayHelp);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[test]
@@ -630,7 +630,7 @@ fn help_long() {
     let m = setup().try_get_matches_from(vec!["myprog", "--help"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::DisplayHelp);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[test]
@@ -638,7 +638,7 @@ fn help_no_subcommand() {
     let m = setup().try_get_matches_from(vec!["myprog", "help"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -652,7 +652,7 @@ fn help_subcommand() {
         .try_get_matches_from(vec!["myprog", "help"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::DisplayHelp);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[test]
@@ -732,7 +732,7 @@ fn subcommand_short_help() {
     let m = utils::complex_app().try_get_matches_from(vec!["clap-test", "subcmd", "-h"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::DisplayHelp);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[test]
@@ -740,7 +740,7 @@ fn subcommand_long_help() {
     let m = utils::complex_app().try_get_matches_from(vec!["clap-test", "subcmd", "--help"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::DisplayHelp);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[test]
@@ -748,7 +748,7 @@ fn subcommand_help_rev() {
     let m = utils::complex_app().try_get_matches_from(vec!["clap-test", "help", "subcmd"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::DisplayHelp);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[test]
@@ -2642,7 +2642,7 @@ fn disabled_help_flag() {
         .try_get_matches_from("foo a".split(' '));
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::UnrecognizedSubcommand);
+    assert_eq!(err.kind(), ErrorKind::UnrecognizedSubcommand);
     assert_eq!(err.info, &["a"]);
 }
 
@@ -2655,7 +2655,7 @@ fn disabled_help_flag_and_subcommand() {
         .try_get_matches_from("foo help".split(' '));
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::UnrecognizedSubcommand);
+    assert_eq!(err.kind(), ErrorKind::UnrecognizedSubcommand);
     assert_eq!(err.info, &["help"]);
     assert!(
         err.to_string().ends_with('\n'),

--- a/tests/builder/multiple_occurrences.rs
+++ b/tests/builder/multiple_occurrences.rs
@@ -176,7 +176,7 @@ fn max_occurrences_implies_multiple_occurrences() {
     let m = app.try_get_matches_from(vec!["prog", "-vvv"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnexpectedMultipleUsage);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnexpectedMultipleUsage);
 }
 
 #[test]
@@ -201,7 +201,7 @@ fn max_occurrences_try_inputs() {
 
     let m = app.clone().try_get_matches_from(vec!["prog", "-vvvv"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyOccurrences);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooManyOccurrences);
 
     let m = app
         .clone()
@@ -213,7 +213,7 @@ fn max_occurrences_try_inputs() {
         .clone()
         .try_get_matches_from(vec!["prog", "-v", "-vv", "-v"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyOccurrences);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooManyOccurrences);
 }
 
 #[test]
@@ -237,5 +237,5 @@ fn max_occurrences_positional() {
         .clone()
         .try_get_matches_from(vec!["prog", "v", "v", "v", "v"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyOccurrences);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooManyOccurrences);
 }

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -160,7 +160,7 @@ fn option_exact_less() {
         .try_get_matches_from(vec!["", "-o", "val1", "-o", "val2"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
 }
 
 #[test]
@@ -178,7 +178,7 @@ fn option_exact_more() {
         ]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn option_min_less() {
         .try_get_matches_from(vec!["", "-o", "val1", "-o", "val2"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooFewValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooFewValues);
 }
 
 #[test]
@@ -235,7 +235,7 @@ fn option_short_min_more_mult_occurs() {
             "", "pos", "-o", "val1", "-o", "val2", "-o", "val3", "-o", "val4",
         ]);
 
-    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
     let m = res.unwrap();
 
     assert!(m.is_present("option"));
@@ -260,7 +260,7 @@ fn option_short_min_more_single_occur() {
         )
         .try_get_matches_from(vec!["", "pos", "-o", "val1", "val2", "val3", "val4"]);
 
-    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
     let m = res.unwrap();
 
     assert!(m.is_present("option"));
@@ -334,7 +334,7 @@ fn option_max_more() {
         ]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooManyValues);
 }
 
 #[test]
@@ -391,7 +391,7 @@ fn positional_exact_less() {
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
 }
 
 #[test]
@@ -405,7 +405,7 @@ fn positional_exact_more() {
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
 }
 
 #[test]
@@ -432,7 +432,7 @@ fn positional_min_less() {
         .try_get_matches_from(vec!["myprog", "val1", "val2"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooFewValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooFewValues);
 }
 
 #[test]
@@ -493,7 +493,7 @@ fn positional_max_more() {
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3", "val4"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::TooManyValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::TooManyValues);
 }
 
 #[test]
@@ -1018,7 +1018,7 @@ fn low_index_positional() {
         .arg(Arg::new("target").index(2).required(true))
         .try_get_matches_from(vec!["lip", "file1", "file2", "file3", "target"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert!(m.is_present("files"));
@@ -1048,7 +1048,7 @@ fn low_index_positional_in_subcmd() {
         )
         .try_get_matches_from(vec!["lip", "test", "file1", "file2", "file3", "target"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
     let sm = m.subcommand_matches("test").unwrap();
 
@@ -1079,7 +1079,7 @@ fn low_index_positional_with_option() {
             "lip", "file1", "file2", "file3", "target", "--option", "test",
         ]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert!(m.is_present("files"));
@@ -1108,7 +1108,7 @@ fn low_index_positional_with_flag() {
         .arg(Arg::new("flg").long("flag"))
         .try_get_matches_from(vec!["lip", "file1", "file2", "file3", "target", "--flag"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert!(m.is_present("files"));
@@ -1136,7 +1136,7 @@ fn multiple_value_terminator_option() {
         .arg(Arg::new("other"))
         .try_get_matches_from(vec!["lip", "-f", "val1", "val2", ";", "otherval"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert!(m.is_present("other"));
@@ -1163,7 +1163,7 @@ fn multiple_value_terminator_option_other_arg() {
         .arg(Arg::new("flag").short('F'))
         .try_get_matches_from(vec!["lip", "-f", "val1", "val2", "-F", "otherval"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert!(m.is_present("other"));
@@ -1197,7 +1197,7 @@ fn multiple_vals_with_hyphen() {
             ";",
             "/home/clap",
         ]);
-    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
 
     let m = res.unwrap();
     let cmds: Vec<_> = m.values_of("cmds").unwrap().collect();
@@ -1222,7 +1222,7 @@ fn issue_1480_max_values_consumes_extra_arg_2() {
         .try_get_matches_from(vec!["prog", "--field", "1", "2"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -1232,7 +1232,7 @@ fn issue_1480_max_values_consumes_extra_arg_3() {
         .try_get_matches_from(vec!["prog", "--field", "1", "2", "3"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -1248,7 +1248,7 @@ fn issue_2229() {
         ]);
 
     assert!(m.is_err()); // This panics, because `m.is_err() == false`.
-    assert_eq!(m.unwrap_err().kind, ErrorKind::WrongNumberOfValues);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
 }
 
 #[test]
@@ -1261,7 +1261,7 @@ fn value_names_building_num_vals() {
         )
         .try_get_matches_from(vec!["myprog", "--pos", "val1", "val2", "val3"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert_eq!(
@@ -1276,7 +1276,7 @@ fn value_names_building_num_vals_for_positional() {
         .arg(Arg::new("pos").value_names(&["who", "what", "why"]))
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert_eq!(
@@ -1296,7 +1296,7 @@ fn number_of_values_preferred_over_value_names() {
         )
         .try_get_matches_from(vec!["myprog", "--pos", "val1", "val2", "val3", "val4"]);
 
-    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind);
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
     assert_eq!(

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -42,7 +42,7 @@ fn require_equals_fail() {
         )
         .try_get_matches_from(vec!["prog", "--config", "file.conf"]);
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::NoEquals);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::NoEquals);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fn require_equals_no_empty_values_fail() {
         .arg(Arg::new("some"))
         .try_get_matches_from(vec!["prog", "--config=", "file.conf"]);
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::EmptyValue);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::EmptyValue);
 }
 
 #[test]
@@ -329,7 +329,7 @@ fn require_delims_no_delim() {
         .try_get_matches_from(vec!["mvae", "-o", "1", "2", "some"]);
     assert!(r.is_err());
     let err = r.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -373,7 +373,7 @@ fn leading_hyphen_fail() {
         .try_get_matches_from(vec!["", "-o", "-2"]);
     assert!(r.is_err());
     let m = r.unwrap_err();
-    assert_eq!(m.kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -464,7 +464,7 @@ fn issue_1105_setup(argv: Vec<&'static str>) -> Result<ArgMatches, clap::Error> 
 fn issue_1105_empty_value_long_fail() {
     let r = issue_1105_setup(vec!["app", "--option", "--flag"]);
     assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind, ErrorKind::EmptyValue);
+    assert_eq!(r.unwrap_err().kind(), ErrorKind::EmptyValue);
 }
 
 #[test]
@@ -487,7 +487,7 @@ fn issue_1105_empty_value_long_equals() {
 fn issue_1105_empty_value_short_fail() {
     let r = issue_1105_setup(vec!["app", "-o", "--flag"]);
     assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind, ErrorKind::EmptyValue);
+    assert_eq!(r.unwrap_err().kind(), ErrorKind::EmptyValue);
 }
 
 #[test]

--- a/tests/builder/positionals.rs
+++ b/tests/builder/positionals.rs
@@ -140,7 +140,7 @@ fn positional_multiple_2() {
         .try_get_matches_from(vec!["", "-f", "test1", "test2", "test3"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -230,7 +230,7 @@ fn missing_required_2() {
         .arg(arg!(<FILE2> "some file"))
         .try_get_matches_from(vec!["test", "file"]);
     assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(r.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -253,7 +253,7 @@ fn last_positional_no_double_dash() {
         .arg(arg!([ARGS]... "some file").last(true))
         .try_get_matches_from(vec!["test", "tgt", "crp", "arg"]);
     assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(r.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -263,7 +263,7 @@ fn last_positional_second_to_last_mult() {
         .arg(arg!([CORPUS]... "some corpus"))
         .arg(arg!([ARGS]... "some file").last(true))
         .try_get_matches_from(vec!["test", "tgt", "crp1", "crp2", "--", "arg"]);
-    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind);
+    assert!(r.is_ok(), "{:?}", r.unwrap_err().kind());
 }
 
 #[cfg(debug_assertions)]

--- a/tests/builder/posix_compatible.rs
+++ b/tests/builder/posix_compatible.rs
@@ -303,7 +303,7 @@ fn conflict_overridden_3() {
         .try_get_matches_from(vec!["", "-d", "-c", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]
@@ -361,7 +361,7 @@ fn require_overridden_4() {
         .try_get_matches_from(vec!["", "-c", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -85,7 +85,7 @@ fn possible_values_of_positional_fail() {
         .try_get_matches_from(vec!["myprog", "notest"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn possible_values_of_positional_multiple_fail() {
         .try_get_matches_from(vec!["myprog", "test123", "notest"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -160,7 +160,7 @@ fn possible_values_of_option_fail() {
         .try_get_matches_from(vec!["myprog", "--option", "notest"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn possible_values_of_option_multiple_fail() {
         .try_get_matches_from(vec!["", "--option", "test123", "--option", "notest"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -337,7 +337,7 @@ fn ignore_case_fail() {
         .try_get_matches_from(vec!["pv", "--option", "TeSt123"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -377,5 +377,5 @@ fn ignore_case_multiple_fail() {
         .try_get_matches_from(vec!["pv", "--option", "test123", "teST123", "test321"]);
 
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 }

--- a/tests/builder/regex.rs
+++ b/tests/builder/regex.rs
@@ -16,7 +16,7 @@ fn validator_regex() {
         .try_get_matches_from(vec!["prog", "12345"]);
 
     assert!(m.is_err());
-    assert_eq!(m.err().unwrap().kind, ErrorKind::ValueValidation)
+    assert_eq!(m.err().unwrap().kind(), ErrorKind::ValueValidation)
 }
 
 #[test]
@@ -32,5 +32,5 @@ fn validator_regex_with_regex_set() {
         .try_get_matches_from(vec!["prog", "12345"]);
 
     assert!(m.is_err());
-    assert_eq!(m.err().unwrap().kind, ErrorKind::ValueValidation)
+    assert_eq!(m.err().unwrap().kind(), ErrorKind::ValueValidation)
 }

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -57,7 +57,7 @@ fn flag_required() {
         .try_get_matches_from(vec!["", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn option_required() {
         .try_get_matches_from(vec!["", "-f", "val"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn positional_required() {
         .try_get_matches_from(vec![""]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn group_required() {
         .try_get_matches_from(vec!["", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn arg_require_group() {
         .try_get_matches_from(vec!["", "-f"]);
     assert!(result.is_err());
     let err = result.err().unwrap();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -260,7 +260,7 @@ fn required_unless_err() {
         .try_get_matches_from(vec!["unlesstest"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn required_unless_present_with_optional_value() {
         .try_get_matches_from(vec!["unlesstest", "--opt"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 // REQUIRED_UNLESS_ALL
@@ -316,7 +316,7 @@ fn required_unless_all_err() {
         .try_get_matches_from(vec!["unlessall", "--debug"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 // REQUIRED_UNLESS_ONE
@@ -452,7 +452,7 @@ fn required_unless_any_err() {
         .try_get_matches_from(vec!["unlessone"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -480,7 +480,7 @@ fn requires_if_present_val() {
         .try_get_matches_from(vec!["unlessone", "--config=my.cfg"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -497,7 +497,7 @@ fn requires_if_present_mult() {
         .try_get_matches_from(vec!["unlessone", "--config=other.cfg"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -561,7 +561,7 @@ fn required_if_val_present_fail() {
         .try_get_matches_from(vec!["ri", "--extra", "val"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -602,7 +602,7 @@ fn required_if_val_present_ignore_case_fail() {
         .try_get_matches_from(vec!["ri", "--extra", "vaL"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -653,7 +653,7 @@ fn required_if_all_values_present_fail() {
         .try_get_matches_from(vec!["ri", "--extra", "val", "--option", "spec"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -690,7 +690,7 @@ fn required_if_any_all_values_present_fail() {
         .try_get_matches_from(vec!["ri", "--extra", "val", "--option", "spec"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -806,7 +806,7 @@ fn required_ifs_val_present_fail() {
         .try_get_matches_from(vec!["ri", "--option", "spec"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]
@@ -839,7 +839,7 @@ fn required_ifs_wrong_val_mult_fail() {
         .try_get_matches_from(vec!["ri", "--extra", "other", "--option", "spec"]);
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -300,7 +300,7 @@ fn alias_help() {
         .subcommand(App::new("test").alias("do-stuff"))
         .try_get_matches_from(vec!["myprog", "help", "do-stuff"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::DisplayHelp);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::DisplayHelp);
 }
 
 #[test]
@@ -356,7 +356,7 @@ fn issue_1031_args_with_same_name() {
         .subcommand(App::new("signer"))
         .try_get_matches_from(vec!["prog", "--ui-path", "signer"]);
 
-    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert_eq!(m.value_of("ui-path"), Some("signer"));
 }
@@ -368,7 +368,7 @@ fn issue_1031_args_with_same_name_no_more_vals() {
         .subcommand(App::new("signer"))
         .try_get_matches_from(vec!["prog", "--ui-path", "value", "signer"]);
 
-    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
     let m = res.unwrap();
     assert_eq!(m.value_of("ui-path"), Some("value"));
     assert_eq!(m.subcommand_name(), Some("signer"));
@@ -399,7 +399,7 @@ fn issue_1161_multiple_hyphen_hyphen() {
             "args",
         ]);
 
-    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
     let m = res.unwrap();
 
     let expected = Some(vec![
@@ -545,7 +545,7 @@ fn busybox_like_multicall() {
 
     let m = app.clone().try_get_matches_from(&["a.out"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[cfg(feature = "unstable-multicall")]
@@ -567,13 +567,13 @@ fn hostname_like_multicall() {
 
     let m = app.clone().try_get_matches_from(&["a.out"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 
     let m = app.try_get_matches_from_mut(&["hostname", "hostname"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 
     let m = app.try_get_matches_from(&["hostname", "dnsdomainname"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::UnknownArgument);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }

--- a/tests/builder/utf8.rs
+++ b/tests/builder/utf8.rs
@@ -10,7 +10,7 @@ fn invalid_utf8_strict_positional() {
         .arg(Arg::new("arg"))
         .try_get_matches_from(vec![OsString::from(""), OsString::from_vec(vec![0xe9])]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn invalid_utf8_strict_option_short_space() {
             OsString::from_vec(vec![0xe9]),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -35,7 +35,7 @@ fn invalid_utf8_strict_option_short_equals() {
             OsString::from_vec(vec![0x2d, 0x61, 0x3d, 0xe9]),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn invalid_utf8_strict_option_short_no_space() {
             OsString::from_vec(vec![0x2d, 0x61, 0xe9]),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn invalid_utf8_strict_option_long_space() {
             OsString::from_vec(vec![0xe9]),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn invalid_utf8_strict_option_long_equals() {
             OsString::from_vec(vec![0x2d, 0x2d, 0x61, 0x72, 0x67, 0x3d, 0xe9]),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -329,7 +329,7 @@ fn refuse_invalid_utf8_subcommand_with_allow_external_subcommands() {
             OsString::from("normal"),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -343,7 +343,7 @@ fn refuse_invalid_utf8_subcommand_when_args_are_allowed_with_allow_external_subc
             OsString::from("normal"),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -358,7 +358,7 @@ fn refuse_invalid_utf8_subcommand_args_with_allow_external_subcommands() {
             OsString::from("--another_normal"),
         ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]

--- a/tests/builder/version.rs
+++ b/tests/builder/version.rs
@@ -26,7 +26,7 @@ fn no_version_flag_short() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, clap::ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), clap::ErrorKind::UnknownArgument);
     assert_eq!(err.info, ["-V"]);
 }
 
@@ -36,7 +36,7 @@ fn no_version_flag_long() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, clap::ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), clap::ErrorKind::UnknownArgument);
     assert_eq!(err.info, ["--version"]);
 }
 
@@ -46,7 +46,7 @@ fn version_flag_from_version_short() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
     assert_eq!(err.to_string(), "foo 3.0\n");
 }
 
@@ -56,7 +56,7 @@ fn version_flag_from_version_long() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
     assert_eq!(err.to_string(), "foo 3.0\n");
 }
 
@@ -66,7 +66,7 @@ fn version_flag_from_long_version_short() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
     assert_eq!(err.to_string(), "foo 3.0 (abcdefg)\n");
 }
 
@@ -76,7 +76,7 @@ fn version_flag_from_long_version_long() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
     assert_eq!(err.to_string(), "foo 3.0 (abcdefg)\n");
 }
 
@@ -99,7 +99,7 @@ fn override_version_long_with_user_flag_no_version_flag() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn override_version_short_with_user_flag_long_still_works() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
 }
 
 #[test]
@@ -132,7 +132,7 @@ fn mut_version_short() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn mut_version_long() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
 }
 
 static VERSION_ABOUT_MULTI_SC: &str = "foo-bar-baz 3.0
@@ -177,7 +177,7 @@ fn no_propagation_by_default_long() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
     assert_eq!(err.info, &["--version"]);
 }
 
@@ -187,7 +187,7 @@ fn no_propagation_by_default_short() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::UnknownArgument);
+    assert_eq!(err.kind(), ErrorKind::UnknownArgument);
     assert_eq!(err.info, &["-V"]);
 }
 
@@ -199,7 +199,7 @@ fn propagate_version_long() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn propagate_version_short() {
 
     assert!(res.is_err());
     let err = res.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::DisplayVersion);
+    assert_eq!(err.kind(), ErrorKind::DisplayVersion);
 }
 
 #[cfg(debug_assertions)]

--- a/tests/derive/arguments.rs
+++ b/tests/derive/arguments.rs
@@ -115,6 +115,6 @@ fn vec_type_is_multiple_values() {
     );
     assert_eq!(
         clap::ErrorKind::ValueValidation,
-        Opt::try_parse_from(&["test", "NOPE"]).err().unwrap().kind
+        Opt::try_parse_from(&["test", "NOPE"]).err().unwrap().kind()
     );
 }

--- a/tests/derive/non_literal_attributes.rs
+++ b/tests/derive/non_literal_attributes.rs
@@ -121,7 +121,7 @@ fn test_bool() {
     );
     let result = Opt::try_parse_from(&["test", "-l", "1", "--x", "1"]);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().kind, ErrorKind::NoEquals);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NoEquals);
 }
 
 fn parse_hex(input: &str) -> Result<u64, ParseIntError> {

--- a/tests/derive/subcommands.rs
+++ b/tests/derive/subcommands.rs
@@ -534,15 +534,5 @@ fn skip_subcommand() {
     );
 
     let res = Opt::try_parse_from(&["test", "skip"]);
-    assert!(
-        matches!(
-            res,
-            Err(clap::Error {
-                kind: clap::ErrorKind::UnknownArgument,
-                ..
-            })
-        ),
-        "Unexpected result: {:?}",
-        res
-    );
+    assert_eq!(res.unwrap_err().kind(), clap::ErrorKind::UnknownArgument,);
 }

--- a/tests/derive/utf8.rs
+++ b/tests/derive/utf8.rs
@@ -19,7 +19,7 @@ struct Named {
 fn invalid_utf8_strict_positional() {
     let m = Positional::try_parse_from(vec![OsString::from(""), OsString::from_vec(vec![0xe9])]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -30,7 +30,7 @@ fn invalid_utf8_strict_option_short_space() {
         OsString::from_vec(vec![0xe9]),
     ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn invalid_utf8_strict_option_short_equals() {
         OsString::from_vec(vec![0x2d, 0x61, 0x3d, 0xe9]),
     ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn invalid_utf8_strict_option_short_no_space() {
         OsString::from_vec(vec![0x2d, 0x61, 0xe9]),
     ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn invalid_utf8_strict_option_long_space() {
         OsString::from_vec(vec![0xe9]),
     ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn invalid_utf8_strict_option_long_equals() {
         OsString::from_vec(vec![0x2d, 0x2d, 0x61, 0x72, 0x67, 0x3d, 0xe9]),
     ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[derive(Parser, Debug, PartialEq, Eq)]
@@ -183,7 +183,7 @@ fn refuse_invalid_utf8_subcommand_with_allow_external_subcommands() {
         OsString::from("normal"),
     ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn refuse_invalid_utf8_subcommand_args_with_allow_external_subcommands() {
         OsString::from("--another_normal"),
     ]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind, ErrorKind::InvalidUtf8);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidUtf8);
 }
 
 #[derive(Debug, PartialEq, Parser)]

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -217,7 +217,7 @@ fn group_macro_set_not_multiple() {
     let result = app.try_get_matches_from(vec!["bin_name", "--hard", "--easy"]);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::ArgumentConflict);
+    assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
 
 #[test]
@@ -237,7 +237,7 @@ fn group_macro_set_required() {
     let result = app.try_get_matches_from(vec!["bin_name"]);
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert_eq!(err.kind, ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
 }
 
 #[test]


### PR DESCRIPTION
This is the first of a series of PRs to remove `pub(crate)` from struct members.

The goals are
- Make the code more robust / clear by using APIs
- Prepare for the reflection API by seeing what functions we need (see #2913)