### PR TITLE
fix(error): Consistently respect possible values order

### DIFF
--- a/src/parse/errors.rs
+++ b/src/parse/errors.rs
@@ -642,7 +642,7 @@ impl Error {
         let suffix = suggestions::did_you_mean(&bad_val, good_vals.iter()).pop();
         let arg = arg.to_string();
 
-        let mut sorted: Vec<String> = good_vals
+        let good_vals: Vec<String> = good_vals
             .iter()
             .map(|&v| {
                 if v.contains(char::is_whitespace) {
@@ -652,7 +652,6 @@ impl Error {
                 }
             })
             .collect();
-        sorted.sort();
 
         start_error(&mut c, "");
         c.warning(format!("{:?}", bad_val));
@@ -660,7 +659,7 @@ impl Error {
         c.warning(&*arg);
         c.none("'\n\t[possible values: ");
 
-        if let Some((last, elements)) = sorted.split_last() {
+        if let Some((last, elements)) = good_vals.split_last() {
             for v in elements {
                 c.good(v);
                 c.none(", ");
@@ -681,7 +680,7 @@ impl Error {
         try_help(app, &mut c);
 
         let mut info = vec![arg, bad_val];
-        info.extend(sorted);
+        info.extend(good_vals);
 
         Self::for_app(app, c, ErrorKind::InvalidValue, info)
     }

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -4,7 +4,7 @@ use clap::{App, Arg, ErrorKind, PossibleValue};
 
 #[cfg(feature = "suggestions")]
 static PV_ERROR: &str = "error: \"slo\" isn't a valid value for '-O <option>'
-\t[possible values: \"ludicrous speed\", fast, slow]
+\t[possible values: slow, fast, \"ludicrous speed\"]
 
 \tDid you mean \"slow\"?
 
@@ -16,7 +16,7 @@ For more information try --help
 
 #[cfg(not(feature = "suggestions"))]
 static PV_ERROR: &str = "error: \"slo\" isn't a valid value for '-O <option>'
-\t[possible values: \"ludicrous speed\", fast, slow]
+\t[possible values: slow, fast, \"ludicrous speed\"]
 
 USAGE:
     clap-test -O <option>
@@ -26,7 +26,7 @@ For more information try --help
 
 #[cfg(feature = "suggestions")]
 static PV_ERROR_ESCAPED: &str = "error: \"ludicrous\" isn't a valid value for '-O <option>'
-\t[possible values: \"ludicrous speed\", fast, slow]
+\t[possible values: slow, fast, \"ludicrous speed\"]
 
 \tDid you mean \"ludicrous speed\"?
 
@@ -38,7 +38,7 @@ For more information try --help
 
 #[cfg(not(feature = "suggestions"))]
 static PV_ERROR_ESCAPED: &str = "error: \"ludicrous\" isn't a valid value for '-O <option>'
-\t[possible values: \"ludicrous speed\", fast, slow]
+\t[possible values: slow, fast, \"ludicrous speed\"]
 
 USAGE:
     clap-test -O <option>


### PR DESCRIPTION
We respected it for `--help` but not error messages.

Fixes #1549