### PR TITLE
feat(error): Show possible values when none are supplied

### DIFF
--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -49,6 +49,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             if should_err {
                 return Err(Error::empty_value(
                     self.p.app,
+                    &o.possible_vals
+                        .iter()
+                        .filter_map(PossibleValue::get_visible_name)
+                        .collect::<Vec<_>>(),
                     o,
                     Usage::new(self.p.app, &self.p.required).create_usage_with_title(&[]),
                 ));
@@ -133,6 +137,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 debug!("Validator::validate_arg_values: illegal empty val found");
                 return Err(Error::empty_value(
                     self.p.app,
+                    &arg.possible_vals
+                        .iter()
+                        .filter_map(PossibleValue::get_visible_name)
+                        .collect::<Vec<_>>(),
                     arg,
                     Usage::new(self.p.app, &self.p.required).create_usage_with_title(&[]),
                 ));
@@ -407,6 +415,10 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         if a.is_set(ArgSettings::TakesValue) && !min_vals_zero && ma.all_val_groups_empty() {
             return Err(Error::empty_value(
                 self.p.app,
+                &a.possible_vals
+                    .iter()
+                    .filter_map(PossibleValue::get_visible_name)
+                    .collect::<Vec<_>>(),
                 a,
                 Usage::new(self.p.app, &self.p.required).create_usage_with_title(&[]),
             ));

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -266,6 +266,33 @@ fn escaped_possible_values_output() {
 }
 
 #[test]
+fn missing_possible_value_error() {
+    assert!(utils::compare_output(
+        App::new("test").arg(
+            Arg::new("option")
+                .short('O')
+                .possible_value("slow")
+                .possible_value(PossibleValue::new("fast").alias("fost"))
+                .possible_value(PossibleValue::new("ludicrous speed"))
+                .possible_value(PossibleValue::new("forbidden speed").hide(true))
+        ),
+        "clap-test -O",
+        MISSING_PV_ERROR,
+        true
+    ));
+}
+
+static MISSING_PV_ERROR: &str =
+    "error: The argument '-O <option>' requires a value but none was supplied
+\t[possible values: slow, fast, \"ludicrous speed\"]
+
+USAGE:
+    clap-test [OPTIONS]
+
+For more information try --help
+";
+
+#[test]
 fn alias() {
     let m = App::new("pv")
         .arg(


### PR DESCRIPTION
This is inspired by cargo which allows you to run `cargo test --test`
and it will list the possible tests (obviously we can't support that atm
because that requires a lot of runtime processing).  When we do have a
static list of possible values, we can at least show those.

Fixes #3320