### PR TITLE
feat(complete): Fix `clap_fig_complete` output formatting and add conflicts

### DIFF
--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -109,10 +109,9 @@ fn gen_fig_inner(
 fn gen_options(app: &App, indent: usize) -> String {
     let mut buffer = String::new();
 
-    let options: Vec<_> = app.get_opts().collect();
     let flags = generator::utils::flags(app);
 
-    if !options.is_empty() || !flags.is_empty() {
+    if app.get_opts().next().is_some() || !flags.is_empty() {
         buffer.push_str(&format!("{:indent$}options: [\n", "", indent = indent));
 
         for option in app.get_opts() {
@@ -158,7 +157,7 @@ fn gen_options(app: &App, indent: usize) -> String {
                 ));
             }
 
-            let conflicts = arg_conflicts(app, &option);
+            let conflicts = arg_conflicts(app, option);
 
             if !conflicts.is_empty() {
                 buffer.push_str(&format!(

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -158,16 +158,16 @@ fn gen_options(app: &App, indent: usize) -> String {
                 ));
             }
 
-            let conficts = arg_conflicts(app, &option);
+            let conflicts = arg_conflicts(app, &option);
 
-            if !conficts.is_empty() {
+            if !conflicts.is_empty() {
                 buffer.push_str(&format!(
                     "{:indent$}exclusiveOn: [\n",
                     "",
                     indent = indent + 4
                 ));
 
-                for conflict in conficts {
+                for conflict in conflicts {
                     buffer.push_str(&format!(
                         "{:indent$}\"{}\",\n",
                         "",
@@ -237,16 +237,16 @@ fn gen_options(app: &App, indent: usize) -> String {
                 ));
             }
 
-            let conficts = arg_conflicts(app, &flag);
+            let conflicts = arg_conflicts(app, &flag);
 
-            if !conficts.is_empty() {
+            if !conflicts.is_empty() {
                 buffer.push_str(&format!(
                     "{:indent$}exclusiveOn: [\n",
                     "",
                     indent = indent + 4
                 ));
 
-                for conflict in conficts {
+                for conflict in conflicts {
                     buffer.push_str(&format!(
                         "{:indent$}\"{}\",\n",
                         "",

--- a/clap_complete_fig/tests/completions/fig.rs
+++ b/clap_complete_fig/tests/completions/fig.rs
@@ -60,8 +60,6 @@ static FIG: &str = r#"const completion: Fig.Spec = {
     {
       name: "help",
       description: "Print this message or the help of the given subcommand(s)",
-      options: [
-      ],
       args: {
         name: "subcommand",
         isOptional: true,
@@ -171,8 +169,6 @@ static FIG_SPECIAL_CMDS: &str = r#"const completion: Fig.Spec = {
     {
       name: "help",
       description: "Print this message or the help of the given subcommand(s)",
-      options: [
-      ],
       args: {
         name: "subcommand",
         isOptional: true,
@@ -448,8 +444,6 @@ static FIG_SUB_SUBCMDS: &str = r#"const completion: Fig.Spec = {
     {
       name: "help",
       description: "Print this message or the help of the given subcommand(s)",
-      options: [
-      ],
       args: {
         name: "subcommand",
         isOptional: true,
@@ -464,6 +458,100 @@ static FIG_SUB_SUBCMDS: &str = r#"const completion: Fig.Spec = {
     {
       name: ["-V", "--version"],
       description: "Print version information",
+    },
+  ],
+  args: {
+    name: "file",
+    isOptional: true,
+    template: "filepaths",
+  },
+};
+
+export default completion;
+"#;
+
+#[test]
+fn fig_with_conficts() {
+    let mut app = build_app_with_conflicts();
+    common(Fig, &mut app, "my_app", FIG_CONFLICTS);
+}
+
+fn build_app_with_conflicts() -> App<'static> {
+    build_app_with_name("my_app")
+        .arg(
+            Arg::new("config")
+                .long("--config")
+                .takes_value(true)
+                .conflicts_with("config2")
+                .help("some help"),
+        )
+        .arg(
+            Arg::new("config2")
+                .long("--config2")
+                .conflicts_with("config"),
+        )
+}
+
+static FIG_CONFLICTS: &str = r#"const completion: Fig.Spec = {
+  name: "my_app",
+  description: "Tests completions",
+  subcommands: [
+    {
+      name: "test",
+      description: "tests things",
+      options: [
+        {
+          name: "--case",
+          description: "the case to test",
+          args: {
+            name: "case",
+            isOptional: true,
+          },
+        },
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-V", "--version"],
+          description: "Print version information",
+        },
+      ],
+    },
+    {
+      name: "help",
+      description: "Print this message or the help of the given subcommand(s)",
+      args: {
+        name: "subcommand",
+        isOptional: true,
+      },
+    },
+  ],
+  options: [
+    {
+      name: "--config",
+      description: "some help",
+      exclusiveOn: [
+        "--config2",
+      ],
+      args: {
+        name: "config",
+        isOptional: true,
+      },
+    },
+    {
+      name: ["-h", "--help"],
+      description: "Print help information",
+    },
+    {
+      name: ["-V", "--version"],
+      description: "Print version information",
+    },
+    {
+      name: "--config2",
+      exclusiveOn: [
+        "--config",
+      ],
     },
   ],
   args: {

--- a/clap_complete_fig/tests/value_hints.rs
+++ b/clap_complete_fig/tests/value_hints.rs
@@ -90,16 +90,10 @@ static FIG_VALUE_HINTS: &str = r#"const completion: Fig.Spec = {
         name: "choice",
         isOptional: true,
         suggestions: [
-          {
-            name: "bash",
-          },
-          {
-            name: "fish",
-          },
-          {
-            name: "zsh",
-          },
-        ]
+          "bash",
+          "fish",
+          "zsh",
+        ],
       },
     },
     {


### PR DESCRIPTION
Clap is now being used internally in Fig! This has led to me finding some ways to improve `clap_fig_complete`.

This PR adds the following:
* Support for `exclusiveOn` via clap conflicts
* Support for `isRepeatable` on flags and options
* Fixes multiple formatting issues including: making sure all of the code is properly indented, has all commas, and does not output unused arrays.
