### PR TITLE
feat(error): Expose error building blocks

### DIFF
--- a/examples/keyvalue-derive.md
+++ b/examples/keyvalue-derive.md
@@ -18,13 +18,13 @@ Args { defines: [("Foo", 10), ("Alice", 30)] }
 
 $ keyvalue-derive -D Foo
 ? failed
-error: Invalid value for '-D <DEFINES>': invalid KEY=value: no `=` found in `Foo`
+error: Invalid value "Foo" for '-D <DEFINES>': invalid KEY=value: no `=` found in `Foo`
 
 For more information try --help
 
 $ keyvalue-derive -D Foo=Bar
 ? failed
-error: Invalid value for '-D <DEFINES>': invalid digit found in string
+error: Invalid value "Foo=Bar" for '-D <DEFINES>': invalid digit found in string
 
 For more information try --help
 

--- a/examples/tutorial_builder/README.md
+++ b/examples/tutorial_builder/README.md
@@ -472,7 +472,7 @@ PORT = 22
 
 $ 04_02_validate foobar
 ? failed
-error: Invalid value for '<PORT>': invalid digit found in string
+error: Invalid value "foobar" for '<PORT>': invalid digit found in string
 
 For more information try --help
 

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -438,7 +438,7 @@ PORT = 22
 
 $ 04_02_validate_derive foobar
 ? failed
-error: Invalid value for '<PORT>': invalid digit found in string
+error: Invalid value "foobar" for '<PORT>': invalid digit found in string
 
 For more information try --help
 

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -20,6 +20,8 @@ pub enum ContextKind {
     MinValue,
     /// Potential fix for the user
     SuggestedCommand,
+    /// Trailing argument
+    TrailingArg,
     /// A usage string
     Usage,
     /// An opaque message to the user
@@ -32,6 +34,8 @@ pub enum ContextKind {
 pub enum ContextValue {
     /// [`ContextKind`] is self-sufficient, no additional information needed
     None,
+    /// A single value
+    Bool(bool),
     /// A single value
     String(String),
     /// Many values

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -2,6 +2,12 @@
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ContextKind {
+    /// The cause of the error
+    InvalidArg,
+    /// Existing value arguments
+    ValidArg,
+    /// A usage string
+    Usage,
     /// An opaque message to the user
     Custom,
 }
@@ -14,4 +20,6 @@ pub enum ContextValue {
     None,
     /// A single value
     Value(String),
+    /// Many values
+    Values(Vec<String>),
 }

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -1,0 +1,17 @@
+/// Semantics for a piece of error information
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContextKind {
+    /// An opaque message to the user
+    Custom,
+}
+
+/// A piece of error information
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContextValue {
+    /// [`ContextKind`] is self-sufficient, no additional information needed
+    None,
+    /// A single value
+    Value(String),
+}

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -4,6 +4,8 @@
 pub enum ContextKind {
     /// The cause of the error
     InvalidArg,
+    /// The cause of the error
+    InvalidSubcommand,
     /// Existing value arguments
     ValidArg,
     /// Accepted values

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -6,6 +6,8 @@ pub enum ContextKind {
     InvalidArg,
     /// Existing value arguments
     ValidArg,
+    /// Valid accepted values
+    PossibleValues,
     /// A usage string
     Usage,
     /// An opaque message to the user

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -14,6 +14,8 @@ pub enum ContextKind {
     ValidValue,
     /// Rejected values
     InvalidValue,
+    /// Highest allowed
+    MaxValue,
     /// Potential fix for the user
     SuggestedCommand,
     /// A usage string
@@ -32,4 +34,6 @@ pub enum ContextValue {
     String(String),
     /// Many values
     Strings(Vec<String>),
+    /// A single value
+    Number(isize),
 }

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -3,15 +3,19 @@
 #[non_exhaustive]
 pub enum ContextKind {
     /// The cause of the error
-    InvalidArg,
-    /// The cause of the error
     InvalidSubcommand,
-    /// Existing value arguments
+    /// Existing subcommand
+    ValidSubcommand,
+    /// The cause of the error
+    InvalidArg,
+    /// Existing arguments
     ValidArg,
     /// Accepted values
     ValidValue,
     /// Rejected values
     InvalidValue,
+    /// Potential fix for the user
+    SuggestedCommand,
     /// A usage string
     Usage,
     /// An opaque message to the user

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -29,7 +29,7 @@ pub enum ContextValue {
     /// [`ContextKind`] is self-sufficient, no additional information needed
     None,
     /// A single value
-    Value(String),
+    String(String),
     /// Many values
-    Values(Vec<String>),
+    Strings(Vec<String>),
 }

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -7,7 +7,7 @@ pub enum ContextKind {
     /// Existing value arguments
     ValidArg,
     /// Valid accepted values
-    PossibleValues,
+    ValidValue,
     /// A usage string
     Usage,
     /// An opaque message to the user

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -6,8 +6,10 @@ pub enum ContextKind {
     InvalidArg,
     /// Existing value arguments
     ValidArg,
-    /// Valid accepted values
+    /// Accepted values
     ValidValue,
+    /// Rejected values
+    InvalidValue,
     /// A usage string
     Usage,
     /// An opaque message to the user

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -4,22 +4,32 @@
 pub enum ContextKind {
     /// The cause of the error
     InvalidSubcommand,
-    /// Existing subcommand
-    ValidSubcommand,
     /// The cause of the error
     InvalidArg,
     /// Existing arguments
-    ValidArg,
+    PriorArg,
     /// Accepted values
     ValidValue,
     /// Rejected values
     InvalidValue,
-    /// Highest allowed
-    MaxValue,
-    /// Lowest allowed
-    MinValue,
+    /// Number of values present
+    ActualNumValues,
+    /// Number of allowed values
+    ExpectedNumValues,
+    /// Minimum number of allowed values
+    MinValues,
+    /// Number of occurrences present
+    ActualNumOccurrences,
+    /// Maximum number of allowed occurrences
+    MaxOccurrences,
     /// Potential fix for the user
     SuggestedCommand,
+    /// Potential fix for the user
+    SuggestedSubcommand,
+    /// Potential fix for the user
+    SuggestedArg,
+    /// Potential fix for the user
+    SuggestedValue,
     /// Trailing argument
     TrailingArg,
     /// A usage string

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -16,6 +16,8 @@ pub enum ContextKind {
     InvalidValue,
     /// Highest allowed
     MaxValue,
+    /// Lowest allowed
+    MinValue,
     /// Potential fix for the user
     SuggestedCommand,
     /// A usage string

--- a/src/error/kind.rs
+++ b/src/error/kind.rs
@@ -399,3 +399,47 @@ pub enum ErrorKind {
     /// [Format error]: std::fmt::Error
     Format,
 }
+
+impl ErrorKind {
+    /// End-user description of the error case, where relevant
+    pub fn as_str(self) -> Option<&'static str> {
+        match self {
+            Self::InvalidValue => Some("One of the values isn't valid for an argument"),
+            Self::UnknownArgument => {
+                Some("Found an argument which wasn't expected or isn't valid in this context")
+            }
+            Self::InvalidSubcommand => Some("A subcommand wasn't recognized"),
+            Self::UnrecognizedSubcommand => Some("A subcommand wasn't recognized"),
+            Self::EmptyValue => Some("An argument requires a value but none was supplied"),
+            Self::NoEquals => Some("Equal is needed when assigning values to one of the arguments"),
+            Self::ValueValidation => Some("Invalid for for one of the arguments"),
+            Self::TooManyValues => Some("An argument received an unexpected value"),
+            Self::TooFewValues => Some("An argument requires more values"),
+            Self::TooManyOccurrences => Some("An argument occurred too many times"),
+            Self::WrongNumberOfValues => Some("An argument received too many or too few values"),
+            Self::ArgumentConflict => {
+                Some("An argument cannot be used with one or more of the other specified arguments")
+            }
+            Self::MissingRequiredArgument => {
+                Some("One or more required arguments were not provided")
+            }
+            Self::MissingSubcommand => Some("A subcommand is required but one was not provided"),
+            Self::UnexpectedMultipleUsage => {
+                Some("An argument was provided more than once but cannot be used multiple times")
+            }
+            Self::InvalidUtf8 => Some("Invalid UTF-8 was detected in one or more arguments"),
+            Self::DisplayHelp => None,
+            Self::DisplayHelpOnMissingArgumentOrSubcommand => None,
+            Self::DisplayVersion => None,
+            Self::ArgumentNotFound => Some("An argument wasn't found"),
+            Self::Io => None,
+            Self::Format => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_str().unwrap_or_default().fmt(f)
+    }
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -296,7 +296,7 @@ impl Error {
             ]);
         if !good_vals.is_empty() {
             err = err.insert_context_unchecked(
-                ContextKind::PossibleValues,
+                ContextKind::ValidValue,
                 ContextValue::Values(good_vals.iter().map(|s| (*s).to_owned()).collect()),
             );
         }
@@ -770,7 +770,7 @@ impl Error {
                         }
                     }
 
-                    let possible_values = self.get_context(ContextKind::PossibleValues);
+                    let possible_values = self.get_context(ContextKind::ValidValue);
                     if let Some(ContextValue::Values(possible_values)) = possible_values {
                         c.none("\n\t[possible values: ");
                         if let Some((last, elements)) = possible_values.split_last() {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -215,6 +215,7 @@ impl Error {
     }
 
     /// Does not verify if `ContextKind` is already present
+    #[inline(never)]
     pub(crate) fn insert_context_unchecked(
         mut self,
         kind: ContextKind,
@@ -225,6 +226,7 @@ impl Error {
     }
 
     /// Does not verify if `ContextKind` is already present
+    #[inline(never)]
     pub(crate) fn extend_context_unchecked<const N: usize>(
         mut self,
         context: [(ContextKind, ContextValue); N],
@@ -233,6 +235,7 @@ impl Error {
         self
     }
 
+    #[inline(never)]
     fn get_context(&self, kind: ContextKind) -> Option<&ContextValue> {
         self.inner
             .context

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -213,7 +213,8 @@ impl Error {
         let mut c = Colorizer::new(true, app.get_color());
         let arg = arg.to_string();
 
-        start_error(&mut c, "The argument '");
+        start_error(&mut c);
+        c.none("The argument '");
         c.warning(arg);
         c.none("' cannot be used with");
 
@@ -245,7 +246,8 @@ impl Error {
         let mut c = Colorizer::new(true, app.get_color());
         let arg = arg.to_string();
 
-        start_error(&mut c, "The argument '");
+        start_error(&mut c);
+        c.none("The argument '");
         c.warning(&*arg);
         c.none("' requires a value but none was supplied");
         if !good_vals.is_empty() {
@@ -281,7 +283,8 @@ impl Error {
     pub(crate) fn no_equals(app: &App, arg: String, usage: String) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(&mut c, "Equal sign is needed when assigning values to '");
+        start_error(&mut c);
+        c.none("Equal sign is needed when assigning values to '");
         c.warning(&*arg);
         c.none("'.");
 
@@ -313,7 +316,8 @@ impl Error {
             })
             .collect();
 
-        start_error(&mut c, "");
+        start_error(&mut c);
+        c.none("");
         c.warning(format!("{:?}", bad_val));
         c.none(" isn't a valid value for '");
         c.warning(&*arg);
@@ -354,7 +358,8 @@ impl Error {
     ) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(&mut c, "The subcommand '");
+        start_error(&mut c);
+        c.none("The subcommand '");
         c.warning(&*subcmd);
         c.none("' wasn't recognized\n\n\tDid you mean ");
         c.good(did_you_mean);
@@ -374,7 +379,8 @@ impl Error {
     pub(crate) fn unrecognized_subcommand(app: &App, subcmd: String, name: String) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(&mut c, " The subcommand '");
+        start_error(&mut c);
+        c.none(" The subcommand '");
         c.warning(&*subcmd);
         c.none("' wasn't recognized\n\n");
         c.warning("USAGE:");
@@ -391,10 +397,8 @@ impl Error {
     ) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(
-            &mut c,
-            "The following required arguments were not provided:",
-        );
+        start_error(&mut c);
+        c.none("The following required arguments were not provided:");
 
         for v in &required {
             c.none("\n    ");
@@ -410,7 +414,8 @@ impl Error {
     pub(crate) fn missing_subcommand(app: &App, name: String, usage: String) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(&mut c, "'");
+        start_error(&mut c);
+        c.none("'");
         c.warning(name);
         c.none("' requires a subcommand, but one was not provided");
         put_usage(&mut c, usage);
@@ -422,10 +427,8 @@ impl Error {
     pub(crate) fn invalid_utf8(app: &App, usage: String) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(
-            &mut c,
-            "Invalid UTF-8 was detected in one or more arguments",
-        );
+        start_error(&mut c);
+        c.none("Invalid UTF-8 was detected in one or more arguments");
         put_usage(&mut c, usage);
         try_help(app, &mut c);
 
@@ -445,7 +448,8 @@ impl Error {
         let max_occurs = max_occurs.to_string();
         let curr_occurs = curr_occurs.to_string();
 
-        start_error(&mut c, "The argument '");
+        start_error(&mut c);
+        c.none("The argument '");
         c.warning(&*arg);
         c.none("' allows at most ");
         c.warning(&*max_occurs);
@@ -466,7 +470,8 @@ impl Error {
     pub(crate) fn too_many_values(app: &App, val: String, arg: String, usage: String) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(&mut c, "The value '");
+        start_error(&mut c);
+        c.none("The value '");
         c.warning(&*val);
         c.none("' was provided to '");
         c.warning(&*arg);
@@ -490,7 +495,8 @@ impl Error {
         let min_vals = min_vals.to_string();
         let curr_vals = curr_vals.to_string();
 
-        start_error(&mut c, "The argument '");
+        start_error(&mut c);
+        c.none("The argument '");
         c.warning(&*arg);
         c.none("' requires at least ");
         c.warning(&*min_vals);
@@ -556,7 +562,8 @@ impl Error {
     ) -> Self {
         let mut c = Colorizer::new(true, color);
 
-        start_error(&mut c, "Invalid value");
+        start_error(&mut c);
+        c.none("Invalid value");
 
         c.none(" for '");
         c.warning(&*arg);
@@ -583,7 +590,8 @@ impl Error {
         let num_vals = num_vals.to_string();
         let curr_vals = curr_vals.to_string();
 
-        start_error(&mut c, "The argument '");
+        start_error(&mut c);
+        c.none("The argument '");
         c.warning(&*arg);
         c.none("' requires ");
         c.warning(&*num_vals);
@@ -605,7 +613,8 @@ impl Error {
         let mut c = Colorizer::new(true, app.get_color());
         let arg = arg.to_string();
 
-        start_error(&mut c, "The argument '");
+        start_error(&mut c);
+        c.none("The argument '");
         c.warning(&*arg);
         c.none("' was provided more than once, but cannot be used multiple times");
         put_usage(&mut c, usage);
@@ -622,7 +631,8 @@ impl Error {
     ) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(&mut c, "Found argument '");
+        start_error(&mut c);
+        c.none("Found argument '");
         c.warning(&*arg);
         c.none("' which wasn't expected, or isn't valid in this context");
 
@@ -661,7 +671,8 @@ impl Error {
     pub(crate) fn unnecessary_double_dash(app: &App, arg: String, usage: String) -> Self {
         let mut c = Colorizer::new(true, app.get_color());
 
-        start_error(&mut c, "Found argument '");
+        start_error(&mut c);
+        c.none("Found argument '");
         c.warning(&*arg);
         c.none("' which wasn't expected, or isn't valid in this context");
 
@@ -678,7 +689,8 @@ impl Error {
     pub(crate) fn argument_not_found_auto(arg: String) -> Self {
         let mut c = Colorizer::new(true, ColorChoice::Never);
 
-        start_error(&mut c, "The argument '");
+        start_error(&mut c);
+        c.none("The argument '");
         c.warning(&*arg);
         c.none("' wasn't found\n");
 
@@ -731,10 +743,9 @@ impl Display for Error {
     }
 }
 
-fn start_error(c: &mut Colorizer, msg: impl Into<String>) {
+fn start_error(c: &mut Colorizer) {
     c.error("error:");
     c.none(" ");
-    c.none(msg);
 }
 
 fn put_usage(c: &mut Colorizer, usage: impl Into<String>) {
@@ -770,7 +781,8 @@ impl Message {
 
                 let mut message = String::new();
                 std::mem::swap(s, &mut message);
-                start_error(&mut c, message);
+                start_error(&mut c);
+                c.none(message);
                 put_usage(&mut c, usage);
                 try_help(app, &mut c);
                 *self = Self::Formatted(c);
@@ -783,7 +795,8 @@ impl Message {
         match self {
             Message::Raw(s) => {
                 let mut c = Colorizer::new(true, ColorChoice::Never);
-                start_error(&mut c, s);
+                start_error(&mut c);
+                c.none(s);
                 Cow::Owned(c)
             }
             Message::Formatted(c) => Cow::Borrowed(c),

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -708,16 +708,41 @@ impl Error {
         if let Some(message) = self.inner.message.as_ref() {
             message.formatted()
         } else {
-            let mut c = Colorizer::new(true, ColorChoice::Never);
-            start_error(&mut c);
-            if let Some(msg) = self.kind().as_str() {
-                c.none(msg.to_owned());
-            } else if let Some(source) = self.inner.source.as_ref() {
-                c.none(source.to_string());
-            } else {
-                c.none("Unknown cause");
+            match self.kind() {
+                ErrorKind::InvalidValue
+                | ErrorKind::UnknownArgument
+                | ErrorKind::EmptyValue
+                | ErrorKind::ArgumentConflict
+                | ErrorKind::InvalidSubcommand
+                | ErrorKind::UnrecognizedSubcommand
+                | ErrorKind::NoEquals
+                | ErrorKind::ValueValidation
+                | ErrorKind::TooManyValues
+                | ErrorKind::TooFewValues
+                | ErrorKind::TooManyOccurrences
+                | ErrorKind::WrongNumberOfValues
+                | ErrorKind::MissingRequiredArgument
+                | ErrorKind::MissingSubcommand
+                | ErrorKind::UnexpectedMultipleUsage
+                | ErrorKind::InvalidUtf8
+                | ErrorKind::DisplayHelp
+                | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+                | ErrorKind::DisplayVersion
+                | ErrorKind::ArgumentNotFound
+                | ErrorKind::Io
+                | ErrorKind::Format => {
+                    let mut c = Colorizer::new(true, ColorChoice::Never);
+                    start_error(&mut c);
+                    if let Some(msg) = self.kind().as_str() {
+                        c.none(msg.to_owned());
+                    } else if let Some(source) = self.inner.source.as_ref() {
+                        c.none(source.to_string());
+                    } else {
+                        c.none("Unknown cause");
+                    }
+                    Cow::Owned(c)
+                }
             }
-            Cow::Owned(c)
         }
     }
 

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -312,10 +312,7 @@ impl Error {
             .with_app(app)
             .set_info(info)
             .extend_context_unchecked([
-                (
-                    ContextKind::InvalidArg,
-                    ContextValue::String(arg.to_string()),
-                ),
+                (ContextKind::InvalidArg, ContextValue::String(arg)),
                 (ContextKind::Usage, ContextValue::String(usage)),
             ])
     }
@@ -500,10 +497,7 @@ impl Error {
             .set_info(info)
             .set_source(err)
             .extend_context_unchecked([
-                (
-                    ContextKind::InvalidArg,
-                    ContextValue::String(arg.to_string()),
-                ),
+                (ContextKind::InvalidArg, ContextValue::String(arg)),
                 (ContextKind::InvalidValue, ContextValue::String(val)),
             ])
     }
@@ -561,10 +555,7 @@ impl Error {
             .with_app(app)
             .set_info(info)
             .extend_context_unchecked([
-                (
-                    ContextKind::InvalidArg,
-                    ContextValue::String(arg.to_string()),
-                ),
+                (ContextKind::InvalidArg, ContextValue::String(arg)),
                 (ContextKind::Usage, ContextValue::String(usage)),
             ]);
         if let Some((flag, sub)) = did_you_mean {
@@ -588,10 +579,7 @@ impl Error {
             .with_app(app)
             .set_info(info)
             .extend_context_unchecked([
-                (
-                    ContextKind::InvalidArg,
-                    ContextValue::String(arg.to_string()),
-                ),
+                (ContextKind::InvalidArg, ContextValue::String(arg)),
                 (ContextKind::TrailingArg, ContextValue::Bool(true)),
                 (ContextKind::Usage, ContextValue::String(usage)),
             ])
@@ -601,10 +589,7 @@ impl Error {
         let info = vec![arg.to_string()];
         Self::new(ErrorKind::ArgumentNotFound)
             .set_info(info)
-            .extend_context_unchecked([(
-                ContextKind::InvalidArg,
-                ContextValue::String(arg.to_string()),
-            )])
+            .extend_context_unchecked([(ContextKind::InvalidArg, ContextValue::String(arg))])
     }
 
     fn formatted(&self) -> Cow<'_, Colorizer> {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -139,7 +139,7 @@ impl Error {
     /// };
     /// ```
     pub fn print(&self) -> io::Result<()> {
-        self.inner.message.formatted().print()
+        self.formatted().print()
     }
 
     /// Deprecated, replaced with [`App::error`]
@@ -670,6 +670,10 @@ impl Error {
         Self::new(c, ErrorKind::ArgumentNotFound, false).set_info(vec![arg])
     }
 
+    fn formatted(&self) -> Cow<'_, Colorizer> {
+        self.inner.message.formatted()
+    }
+
     /// Returns the singular or plural form on the verb to be based on the argument's value.
     fn singular_or_plural(n: usize) -> &'static str {
         if n > 1 {
@@ -702,7 +706,7 @@ impl error::Error for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Assuming `self.message` already has a trailing newline, from `try_help` or similar
-        write!(f, "{}", self.inner.message.formatted())?;
+        write!(f, "{}", self.formatted())?;
         if let Some(backtrace) = self.inner.backtrace.as_ref() {
             writeln!(f)?;
             writeln!(f, "Backtrace:")?;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -408,14 +408,11 @@ impl Error {
     }
 
     pub(crate) fn invalid_utf8(app: &App, usage: String) -> Self {
-        let mut c = Colorizer::new(true, app.get_color());
-
-        start_error(&mut c);
-        c.none("Invalid UTF-8 was detected in one or more arguments");
-        put_usage(&mut c, usage);
-        try_help(&mut c, get_help_flag(app));
-
-        Self::for_app(ErrorKind::InvalidUtf8, app, c, vec![])
+        let info = vec![];
+        Self::new(ErrorKind::InvalidUtf8)
+            .with_app(app)
+            .set_info(info)
+            .extend_context_unchecked([(ContextKind::Usage, ContextValue::Value(usage))])
     }
 
     pub(crate) fn too_many_occurrences(
@@ -850,6 +847,9 @@ impl Error {
                         c.none(self.kind().as_str().unwrap());
                     }
                 }
+                ErrorKind::InvalidUtf8 => {
+                    c.none(self.kind().as_str().unwrap());
+                }
                 ErrorKind::UnknownArgument
                 | ErrorKind::ValueValidation
                 | ErrorKind::TooManyValues
@@ -857,7 +857,6 @@ impl Error {
                 | ErrorKind::TooManyOccurrences
                 | ErrorKind::WrongNumberOfValues
                 | ErrorKind::UnexpectedMultipleUsage
-                | ErrorKind::InvalidUtf8
                 | ErrorKind::DisplayHelp
                 | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
                 | ErrorKind::DisplayVersion

--- a/src/parse/matches/arg_matches.rs
+++ b/src/parse/matches/arg_matches.rs
@@ -463,7 +463,7 @@ impl ArgMatches {
                 v, name, e
             );
 
-            Error::value_validation_without_app(name.to_string(), v.to_string(), message.into())
+            Error::value_validation(name.to_string(), v.to_string(), message.into())
         })
     }
 
@@ -551,7 +551,7 @@ impl ArgMatches {
             v.parse::<R>().map_err(|e| {
                 let message = format!("The argument '{}' isn't a valid value: {}", v, e);
 
-                Error::value_validation_without_app(name.to_string(), v.to_string(), message.into())
+                Error::value_validation(name.to_string(), v.to_string(), message.into())
             })
         })
         .collect()

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -501,7 +501,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         } else if self.is_set(AS::SubcommandRequiredElseHelp) {
             debug!("Parser::get_matches_with: SubcommandRequiredElseHelp=true");
             let message = self.write_help_err()?;
-            return Err(ClapError::display_help_error(&self.app, message));
+            return Err(ClapError::display_help_error(self.app, message));
         }
 
         Validator::new(self).validate(parse_state, subcmd_name.is_some(), matcher, trailing_values)

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -12,7 +12,6 @@ use os_str_bytes::RawOsStr;
 use crate::build::AppSettings as AS;
 use crate::build::{App, Arg, ArgSettings};
 use crate::error::Error as ClapError;
-use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::KeyType;
 use crate::output::{fmt::Colorizer, Help, HelpWriter, Usage};
@@ -502,11 +501,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         } else if self.is_set(AS::SubcommandRequiredElseHelp) {
             debug!("Parser::get_matches_with: SubcommandRequiredElseHelp=true");
             let message = self.write_help_err()?;
-            return Err(ClapError::new(
-                message,
-                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
-                self.app.settings.is_set(AS::WaitOnError),
-            ));
+            return Err(ClapError::display_help_error(&self.app, message));
         }
 
         Validator::new(self).validate(parse_state, subcmd_name.is_some(), matcher, trailing_values)
@@ -1579,7 +1574,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         match Help::new(HelpWriter::Buffer(&mut c), self.app, &usage, use_long).write_help() {
             Err(e) => e.into(),
-            _ => ClapError::for_app(self.app, c, ErrorKind::DisplayHelp, vec![]),
+            _ => ClapError::display_help(self.app, c),
         }
     }
 
@@ -1589,7 +1584,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         let msg = self.app._render_version(use_long);
         let mut c = Colorizer::new(false, self.color_help());
         c.none(msg);
-        ClapError::for_app(self.app, c, ErrorKind::DisplayVersion, vec![])
+        ClapError::display_version(self.app, c)
     }
 }
 

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -1,6 +1,6 @@
 // Internal
 use crate::build::{arg::PossibleValue, App, AppSettings as AS, Arg, ArgSettings};
-use crate::error::{Error, ErrorKind, Result as ClapResult};
+use crate::error::{Error, Result as ClapResult};
 use crate::output::Usage;
 use crate::parse::{ArgMatcher, MatchedArg, ParseState, Parser};
 use crate::util::Id;
@@ -60,11 +60,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             && self.p.is_set(AS::ArgRequiredElseHelp)
         {
             let message = self.p.write_help_err()?;
-            return Err(Error::new(
-                message,
-                ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
-                self.p.is_set(AS::WaitOnError),
-            ));
+            return Err(Error::display_help_error(&self.p.app, message));
         }
         self.validate_conflicts(matcher)?;
         if !(self.p.is_set(AS::SubcommandsNegateReqs) && is_subcmd || reqs_validated) {

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -144,11 +144,11 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 if let Err(e) = vtor(&*val.to_string_lossy()) {
                     debug!("error");
                     return Err(Error::value_validation(
-                        self.p.app,
                         arg.to_string(),
                         val.to_string_lossy().into_owned(),
                         e,
-                    ));
+                    )
+                    .with_app(self.p.app));
                 } else {
                     debug!("good");
                 }
@@ -159,11 +159,11 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
                 if let Err(e) = vtor(val) {
                     debug!("error");
                     return Err(Error::value_validation(
-                        self.p.app,
                         arg.to_string(),
                         val.to_string_lossy().into(),
                         e,
-                    ));
+                    )
+                    .with_app(self.p.app));
                 } else {
                     debug!("good");
                 }

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -60,7 +60,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
             && self.p.is_set(AS::ArgRequiredElseHelp)
         {
             let message = self.p.write_help_err()?;
-            return Err(Error::display_help_error(&self.p.app, message));
+            return Err(Error::display_help_error(self.p.app, message));
         }
         self.validate_conflicts(matcher)?;
         if !(self.p.is_set(AS::SubcommandsNegateReqs) && is_subcmd || reqs_validated) {

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -511,7 +511,7 @@ fn subcommand_not_recognized() {
     assert!(utils::compare_output(
         app,
         "fake help",
-        "error:  The subcommand 'help' wasn't recognized
+        "error: The subcommand 'help' wasn't recognized
 
 USAGE:
     fake <subcommands>

--- a/tests/builder/validators.rs
+++ b/tests/builder/validators.rs
@@ -41,7 +41,7 @@ fn test_validator_msg_newline() {
 
     assert!(
         err.to_string()
-            .contains("Invalid value for '<test>': invalid digit found in string"),
+            .contains("Invalid value \"f\" for '<test>': invalid digit found in string"),
         "{}",
         err
     );


### PR DESCRIPTION
This has some limited programmatic use but the focus is on allowing people to format the errors as they wish.

Downside is that the `.text` section for the `git` example went from 547.9KiB to 566.8KiB.  `Error::formatted` is the sixth largest clap function at 6.0KiB.

Fixes #2628
Fixes #3227