### PR TITLE
fix(help): Improve multiple usage statements

### DIFF
--- a/benches/04_new_help.rs
+++ b/benches/04_new_help.rs
@@ -202,7 +202,7 @@ pub fn example10(c: &mut Criterion) {
 }
 
 pub fn example4_template(c: &mut Criterion) {
-    let mut app = app_example4().help_template("{bin} {version}\n{author}\n{about}\n\nUSAGE:\n    {usage}\n\nOPTIONS:\n{options}\n\nARGS:\n{args}\n");
+    let mut app = app_example4().help_template("{bin} {version}\n{author}\n{about}\n\nUSAGE:\n{usage-indented}\n\nOPTIONS:\n{options}\n\nARGS:\n{args}\n");
     c.bench_function("example4_template", |b| b.iter(|| build_help(&mut app)));
 }
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1083,6 +1083,10 @@ impl<'help> App<'help> {
 
     /// Overrides the `clap` generated usage string for help and error messages.
     ///
+    /// Some commands may require multiple usage strings. This can be achieved
+    /// by separating usage statements with newlines within the provided usage
+    /// string. The final usage statement *should not* end with a newline.
+    ///
     /// **NOTE:** Using this setting disables `clap`s "context-aware" usage
     /// strings. After this setting is set, this will be *the only* usage string
     /// displayed to the user!
@@ -1093,6 +1097,17 @@ impl<'help> App<'help> {
     /// # use clap::{App, Arg};
     /// App::new("myprog")
     ///     .override_usage("myapp [-clDas] <some_file>")
+    /// # ;
+    /// ```
+    /// or with multiple usage statements
+    /// ```no_run
+    /// # use clap::{App, Arg};
+    /// App::new("myprog")
+    ///     .override_usage(
+    ///         "myapp -X <some_file> <another_file>\n\
+    ///          myapp -Y [-a] [-b] [-c]\n\
+    ///          myapp -Z [-d] [<some_file>]"
+    ///     )
     /// # ;
     /// ```
     /// [`ArgMatches::usage`]: ArgMatches::usage()
@@ -1157,8 +1172,9 @@ impl<'help> App<'help> {
     ///                               [`App::long_about`]).
     ///   * `{about-with-newline}`  - About followed by `\n`.
     ///   * `{about-section}`       - About preceded and followed by '\n'.
-    ///   * `{usage-heading}`       - Automatically generated usage heading.
+    ///   * `{usage-heading}`       - Default usage heading, i.e. "USAGE:".
     ///   * `{usage}`               - Automatically generated or given usage string.
+    ///   * `{usage-indented}`      - Usage string, but with each line indented by four spaces.
     ///   * `{all-args}`            - Help for all arguments (options, flags, positional
     ///                               arguments, and subcommands) including titles.
     ///   * `{options}`             - Help for options.

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -35,7 +35,8 @@ impl<'help, 'app, 'writer> Help<'help, 'app, 'writer> {
     const DEFAULT_TEMPLATE: &'static str = "\
         {before-help}{bin} {version}\n\
         {author-with-newline}{about-with-newline}\n\
-        {usage-heading}\n    {usage}\n\
+        {usage-heading}\n\
+        {usage-indented}\n\
         \n\
         {all-args}{after-help}\
     ";
@@ -43,7 +44,8 @@ impl<'help, 'app, 'writer> Help<'help, 'app, 'writer> {
     const DEFAULT_NO_ARGS_TEMPLATE: &'static str = "\
         {before-help}{bin} {version}\n\
         {author-with-newline}{about-with-newline}\n\
-        {usage-heading}\n    {usage}{after-help}\
+        {usage-heading}\n\
+        {usage-indented}{after-help}\
     ";
 
     /// Create a new `Help` instance.
@@ -953,6 +955,13 @@ impl<'help, 'app, 'writer> Help<'help, 'app, 'writer> {
                     }
                     "usage" => {
                         self.none(self.usage.create_usage_no_title(&[]))?;
+                    }
+                    "usage-indented" => {
+                        let indent = "    ";
+                        for usage_line in self.usage.create_usage_no_title(&[]).split_inclusive('\n') {
+                            self.none(indent)?;
+                            self.none(usage_line.trim_start())?;
+                        }
                     }
                     "all-args" => {
                         self.write_all_args()?;

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -24,8 +24,12 @@ impl<'help, 'app> Usage<'help, 'app> {
     pub(crate) fn create_usage_with_title(&self, used: &[Id]) -> String {
         debug!("Usage::create_usage_with_title");
         let mut usage = String::with_capacity(75);
-        usage.push_str("USAGE:\n    ");
-        usage.push_str(&*self.create_usage_no_title(used));
+        usage.push_str("USAGE:\n");
+        let indent = "    ";
+        for usage_line in self.create_usage_no_title(used).split_inclusive('\n') {
+            usage.push_str(indent);
+            usage.push_str(usage_line.trim_start());
+        }
         usage
     }
 
@@ -140,7 +144,7 @@ impl<'help, 'app> Usage<'help, 'app> {
             if self.app.is_set(AS::SubcommandsNegateReqs)
                 || self.app.is_set(AS::ArgsNegateSubcommands)
             {
-                usage.push_str("\n    ");
+                usage.push('\n');
                 if !self.app.is_set(AS::ArgsNegateSubcommands) {
                     usage.push_str(&*self.create_help_usage(false));
                 } else {

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1336,6 +1336,23 @@ OPTIONS:
 #[test]
 fn ripgrep_usage() {
     let app = App::new("ripgrep").version("0.5").override_usage(
+        "rg [OPTIONS] <pattern> [<path> ...]\n\
+         rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]\n\
+         rg [OPTIONS] --files [<path> ...]\n\
+         rg [OPTIONS] --type-list",
+    );
+
+    assert!(utils::compare_output(
+        app,
+        "rg --help",
+        RIPGREP_USAGE,
+        false
+    ));
+}
+
+#[test]
+fn ripgrep_indented_usage() {
+    let app = App::new("ripgrep").version("0.5").override_usage(
         "rg [OPTIONS] <pattern> [<path> ...]
     rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]
     rg [OPTIONS] --files [<path> ...]
@@ -1352,6 +1369,34 @@ fn ripgrep_usage() {
 
 #[test]
 fn ripgrep_usage_using_templates() {
+    let app = App::new("ripgrep")
+        .version("0.5")
+        .override_usage(
+            "rg [OPTIONS] <pattern> [<path> ...]\n\
+             rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]\n\
+             rg [OPTIONS] --files [<path> ...]\n\
+             rg [OPTIONS] --type-list",
+        )
+        .help_template(
+            "{bin} {version}\n\
+             \n\
+             USAGE:\n\
+             {usage-indented}\n\
+             \n\
+             OPTIONS:\n\
+             {options}",
+        );
+
+    assert!(utils::compare_output(
+        app,
+        "rg --help",
+        RIPGREP_USAGE,
+        false
+    ));
+}
+
+#[test]
+fn ripgrep_usage_using_templates_and_indented_usage() {
     let app = App::new("ripgrep")
         .version("0.5")
         .override_usage(


### PR DESCRIPTION
Repairs #1068

Some applications/subcommands have multiple distinct usages that demand
multiple usage statements. This change attempts to untangle various
assumptions about usage strings being single-line such that multi-line
usage strings are better supported while remaining mostly backwards
compatible with user-provided help templates.

A new template tag, `{usage-indented}` is introduced and replaces `{usage}`
in the default help templates. As its name implies, this new tag displays
each usage line within the usage string with indentation. In the default
templates (DEFAULT_TEMPLATE and DEFAULT_NO_ARGS_TEMPLATE),
`{usage-indented}` replaces the hardwired indentation that only worked for
single-line usage strings.

The documentation for `App::override_usage()` is updated to describe how
to use multiline usage strings along with an example.

COMPATIBILITY

This does not change any API's, so there are no code compatibility
concerns. So the main concern is whether usage is displayed differently
in any scenarios. Special care was taken to cover various scenarios,
including cases where the user may have worked-around this issue (#1068) by
embedding their own indentation (with either tabs or spaces) into their
override usage string. The following scenarios were considered and are
believed to produce compatible usage/help outputs:

[x] User does not use App::override_usage()
[x] User provides a single-line usage string to App::override_usage()
[x] User uses a custom help template with legacy `{usage}` tag
[x] User provides App::override_usage() a multi-line usage string WITH
    their own indentation AND uses the default help templates (which now
    use the `{usage-indented}` tag.

The one scenario that would result in different output is a case where
clap itself generates a multi-line usage string AND the a user-defined
help template uses the `{usage}` tag. In this scenario, all but the first
usage line would be indented differently (not indented). The behavior for
this case is intentional because the benefits outweigh the incompatibility.
The benefit is that clap-generated multi-line usage strings no longer have
inconsistent, baked-in indentation which means that using the `{usage}` tag
in templates will be less surprising to users, especially considering that
`{usage-indented}` now exists. And the incompatibility is unlikely to be
encountered because it requires both using either SubcommandsNegateReqs or
ArgsNegateSubcommands and a custom template. And if a user encounters this
issue, the repair would be to replace `{usage}` with `{usage-indented}` in
their custom help template.

Signed-off-by: Peter Grayson <pete@jpgrayson.net>