### PR TITLE
Add support for configuring colors and styles

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -23,7 +23,7 @@ use os_str_bytes::RawOsStr;
 use yaml_rust::Yaml;
 
 // Internal
-use crate::build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings};
+use crate::{build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings}, output::fmt::Style};
 use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::MKeyMap;
@@ -97,6 +97,7 @@ pub struct App<'help> {
     pub(crate) current_help_heading: Option<&'help str>,
     pub(crate) subcommand_value_name: Option<&'help str>,
     pub(crate) subcommand_heading: Option<&'help str>,
+    pub(crate) output_style: StyleSpec,
 }
 
 impl<'help> App<'help> {
@@ -1321,6 +1322,33 @@ impl<'help> App<'help> {
         }
     }
 
+    /// Sets the `ColorSpec` for the associated style
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// **NOTE:** Default behavior is to use green for Good, yellow for Warning, b
+    /// old red for Error, and dimmed for hint_style. 
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::App;
+    /// let mut color = termcolor::ColorSpec::new();
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .style(Style::Error, color)
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn style(mut self, style: Style, spec: termcolor::ColorSpec) -> Self {
+        self.output_style.set_style_for(style, spec);
+        self
+    }
+
     /// Set the default section heading for future args.
     ///
     /// This will be used for any arg that hasn't had [`Arg::help_heading`] called.
@@ -2246,7 +2274,7 @@ impl<'help> App<'help> {
     }
 
     pub(crate) fn get_style_spec(&self) -> StyleSpec {
-        StyleSpec::default()
+        self.output_style.clone()
     }
 
     /// Iterate through the set of subcommands, getting a reference to each.

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -27,7 +27,7 @@ use crate::build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings};
 use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::MKeyMap;
-use crate::output::{fmt::Colorizer, Help, HelpWriter, Usage};
+use crate::output::{fmt::Colorizer, fmt::StyleSpec, Help, HelpWriter, Usage};
 use crate::parse::{ArgMatcher, ArgMatches, Input, Parser};
 use crate::util::{color::ColorChoice, Id, Key};
 use crate::{Error, INTERNAL_ERROR_MSG};
@@ -677,8 +677,9 @@ impl<'help> App<'help> {
     pub fn print_help(&mut self) -> io::Result<()> {
         self._build();
         let color = self.get_color();
+        let style = self.get_style_spec();
 
-        let mut c = Colorizer::new(false, color);
+        let mut c = Colorizer::new(false, color, style);
         let parser = Parser::new(self);
         let usage = Usage::new(parser.app, &parser.required);
         Help::new(HelpWriter::Buffer(&mut c), parser.app, &usage, false).write_help()?;
@@ -703,8 +704,8 @@ impl<'help> App<'help> {
     pub fn print_long_help(&mut self) -> io::Result<()> {
         self._build();
         let color = self.get_color();
-
-        let mut c = Colorizer::new(false, color);
+        let style = self.get_style_spec();
+        let mut c = Colorizer::new(false, color, style);
         let parser = Parser::new(self);
         let usage = Usage::new(parser.app, &parser.required);
         Help::new(HelpWriter::Buffer(&mut c), parser.app, &usage, true).write_help()?;
@@ -2242,6 +2243,10 @@ impl<'help> App<'help> {
         } else {
             ColorChoice::Never
         }
+    }
+
+    pub(crate) fn get_style_spec(&self) -> StyleSpec {
+        StyleSpec::default()
     }
 
     /// Iterate through the set of subcommands, getting a reference to each.

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -23,7 +23,8 @@ use os_str_bytes::RawOsStr;
 use yaml_rust::Yaml;
 
 // Internal
-use crate::{build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings}, output::fmt::Style};
+use crate::output::fmt::Style;
+use crate::{build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings}};
 use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::MKeyMap;

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -5,6 +5,7 @@ mod settings;
 mod tests;
 
 pub use self::settings::{AppFlags, AppSettings};
+use termcolor::Color;
 
 // Std
 use std::{
@@ -23,11 +24,11 @@ use os_str_bytes::RawOsStr;
 use yaml_rust::Yaml;
 
 // Internal
-use crate::output::fmt::Style;
-use crate::{build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings}};
+use crate::build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings};
 use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::MKeyMap;
+use crate::output::fmt::Style;
 use crate::output::{fmt::Colorizer, fmt::StyleSpec, Help, HelpWriter, Usage};
 use crate::parse::{ArgMatcher, ArgMatches, Input, Parser};
 use crate::util::{color::ColorChoice, Id, Key};
@@ -1328,7 +1329,7 @@ impl<'help> App<'help> {
     /// **NOTE:** This style is propagated to all child subcommands
     ///
     /// **NOTE:** Default behavior is to use green for Good, yellow for Warning, b
-    /// old red for Error, and dimmed for hint_style. 
+    /// old red for Error, and dimmed for hint_style.
     ///
     /// # Examples
     ///
@@ -1461,6 +1462,52 @@ impl<'help> App<'help> {
     #[must_use]
     pub fn intense(mut self, style: Style, value: bool) -> Self {
         self.output_style.style(style).set_intense(value);
+        self
+    }
+
+    /// Sets the color for the foreground of a style
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::{App, Style};
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .style_color(Style::Good, Some(Color::Green))
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn foreground(mut self, style: Style, color: Option<Color>) -> Self {
+        self.output_style.style(style).set_fg(color);
+        self
+    }
+
+    /// Sets the color for the background of a style
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::{App, Style};
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .style_color(Style::Good, Some(Color::Green))
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn background(mut self, style: Style, color: Option<Color>) -> Self {
+        self.output_style.style(style).set_bg(color);
         self
     }
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1334,19 +1334,133 @@ impl<'help> App<'help> {
     ///
     /// ```no_run
     ///
-    /// # use clap::App;
-    /// let mut color = termcolor::ColorSpec::new();
+    /// # use clap::{App, Style};
     ///
     /// // Do stuff to color
     /// App::new("myprog")
-    ///     .style(Style::Error, color)
+    ///     .style(Style::Good, color)
     ///     .get_matches();
     /// ```
     #[cfg(feature = "color")]
     #[inline]
     #[must_use]
     pub fn style(mut self, style: Style, spec: termcolor::ColorSpec) -> Self {
-        self.output_style.set_style_for(style, spec);
+        self.output_style.set_style(style, spec);
+        self
+    }
+
+    /// Sets whether the associated `Style` should be displayed as bold
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::{App, Style};
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .bold(Style::Good, true)
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn bold(mut self, style: Style, value: bool) -> Self {
+        self.output_style.style(style).set_bold(value);
+        self
+    }
+
+    /// Sets whether the associated `Style` should be displayed as italic
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::{App, Style};
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .italic(Style::Good, true)
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn italic(mut self, style: Style, value: bool) -> Self {
+        self.output_style.style(style).set_italic(value);
+        self
+    }
+
+    /// Sets whether the associated `Style` should be displayed as underlined
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::{App, Style};
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .underline(Style::Good, true)
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn underline(mut self, style: Style, value: bool) -> Self {
+        self.output_style.style(style).set_underline(value);
+        self
+    }
+
+    /// Sets whether the associated `Style` should be displayed as dimmed
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::{App, Style};
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .dimmed(Style::Good, true)
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn dimmed(mut self, style: Style, value: bool) -> Self {
+        self.output_style.style(style).set_dimmed(value);
+        self
+    }
+
+    /// Sets whether the associated `Style` should be displayed as dimmed
+    ///
+    /// **NOTE:** This style is propagated to all child subcommands
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    ///
+    /// # use clap::{App, Style};
+    ///
+    /// // Do stuff to color
+    /// App::new("myprog")
+    ///     .intense(Style::Good, true)
+    ///     .get_matches();
+    /// ```
+    #[cfg(feature = "color")]
+    #[inline]
+    #[must_use]
+    pub fn intense(mut self, style: Style, value: bool) -> Self {
+        self.output_style.style(style).set_intense(value);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ pub use crate::parse::{ArgMatches, Indices, OsValues, Values};
 pub use crate::util::color::ColorChoice;
 
 #[cfg(feature = "color")]
+pub use termcolor::Color;
+
+#[cfg(feature = "color")]
 pub use crate::output::fmt::Style;
 
 pub use crate::derive::{ArgEnum, Args, FromArgMatches, IntoApp, Parser, Subcommand};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,9 @@ pub use crate::parse::{ArgMatches, Indices, OsValues, Values};
 #[cfg(feature = "color")]
 pub use crate::util::color::ColorChoice;
 
+#[cfg(feature = "color")]
+pub use crate::output::fmt::Style;
+
 pub use crate::derive::{ArgEnum, Args, FromArgMatches, IntoApp, Parser, Subcommand};
 
 pub use crate::error::{ErrorKind, Result};

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -5,7 +5,7 @@ use std::{
     io::{self, Write},
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct StyleSpec {
     pub good_style: termcolor::ColorSpec,
     pub warning_style: termcolor::ColorSpec,
@@ -32,6 +32,16 @@ impl StyleSpec {
             Style::Hint => &self.hint_style,
             Style::Default => &self.default_style,
         }
+    }
+    pub(crate) fn set_style_for(&mut self, style: Style, spec: termcolor::ColorSpec) -> &mut Self {
+        match style {
+            Style::Good => self.good_style = spec,
+            Style::Warning => self.warning_style = spec,
+            Style::Error => self.error_style = spec,
+            Style::Hint => self.hint_style = spec,
+            Style::Default => self.default_style = spec,
+        }
+        self
     }
 }
 

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -24,7 +24,7 @@ impl StyleSpec {
             default_style: termcolor::ColorSpec::new(),
         }
     }
-    pub(crate) fn spec_for(&self, style: Style) -> &termcolor::ColorSpec {
+    pub(crate) fn get_style(&self, style: Style) -> &termcolor::ColorSpec {
         match style {
             Style::Good => &self.good_style,
             Style::Warning => &self.warning_style,
@@ -33,7 +33,7 @@ impl StyleSpec {
             Style::Default => &self.default_style,
         }
     }
-    pub(crate) fn set_style_for(&mut self, style: Style, spec: termcolor::ColorSpec) -> &mut Self {
+    pub(crate) fn set_style(&mut self, style: Style, spec: termcolor::ColorSpec) -> &mut Self {
         match style {
             Style::Good => self.good_style = spec,
             Style::Warning => self.warning_style = spec,
@@ -42,6 +42,15 @@ impl StyleSpec {
             Style::Default => self.default_style = spec,
         }
         self
+    }
+    pub(crate) fn style(&mut self, style: Style) -> &mut termcolor::ColorSpec {
+        match style {
+            Style::Good => &mut self.good_style,
+            Style::Warning => &mut self.warning_style,
+            Style::Error => &mut self.error_style,
+            Style::Hint => &mut self.hint_style,
+            Style::Default => &mut self.default_style,
+        }
     }
 }
 
@@ -83,7 +92,7 @@ pub(crate) struct Colorizer {
 impl Colorizer {
     /// Get the `ColorSpec` used for a particular style
     pub(crate) fn spec_for(&self, style: Style) -> &termcolor::ColorSpec {
-        self.style_spec.spec_for(style)
+        self.style_spec.get_style(style)
     }
 
     #[inline(never)]

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -183,6 +183,8 @@ impl Display for Colorizer {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+
+/// Style categories for output
 pub enum Style {
     Good,
     Warning,

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -15,6 +15,15 @@ pub(crate) struct StyleSpec {
 }
 
 impl StyleSpec {
+    pub(crate) fn empty() -> StyleSpec {
+        StyleSpec {
+            good_style: termcolor::ColorSpec::new(),
+            warning_style: termcolor::ColorSpec::new(),
+            error_style: termcolor::ColorSpec::new(),
+            hint_style: termcolor::ColorSpec::new(),
+            default_style: termcolor::ColorSpec::new(),
+        }
+    }
     pub(crate) fn spec_for(&self, style: Style) -> &termcolor::ColorSpec {
         match style {
             Style::Good => &self.good_style,
@@ -68,13 +77,13 @@ impl Colorizer {
     }
 
     #[inline(never)]
-    pub(crate) fn new(use_stderr: bool, color_when: ColorChoice) -> Self {
+    pub(crate) fn new(use_stderr: bool, color_when: ColorChoice, style_spec: StyleSpec) -> Self {
         // Construct the Colorizer
         Colorizer {
             use_stderr,
             color_when,
             pieces: vec![],
-            style_spec: StyleSpec::default(),
+            style_spec,
         }
     }
 

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -15,7 +15,7 @@ use crate::error::Error as ClapError;
 use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::KeyType;
-use crate::output::{fmt::Colorizer, Help, HelpWriter, Usage};
+use crate::output::{fmt::Colorizer, fmt::StyleSpec, Help, HelpWriter, Usage};
 use crate::parse::features::suggestions;
 use crate::parse::{ArgMatcher, SubCommand};
 use crate::parse::{Validator, ValueType};
@@ -74,6 +74,11 @@ impl<'help, 'app> Parser<'help, 'app> {
         }
 
         self.app.get_color()
+    }
+
+    // Returns the style spec used to define how output is colored
+    pub(crate) fn style_spec(&self) -> StyleSpec {
+        self.app.get_style_spec()
     }
 }
 
@@ -1562,7 +1567,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
     pub(crate) fn write_help_err(&self) -> ClapResult<Colorizer> {
         let usage = Usage::new(self.app, &self.required);
-        let mut c = Colorizer::new(true, self.color_help());
+        let mut c = Colorizer::new(true, self.color_help(), self.style_spec());
         Help::new(HelpWriter::Buffer(&mut c), self.app, &usage, false).write_help()?;
         Ok(c)
     }
@@ -1575,7 +1580,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         use_long = use_long && self.use_long_help();
         let usage = Usage::new(self.app, &self.required);
-        let mut c = Colorizer::new(false, self.color_help());
+        let mut c = Colorizer::new(false, self.color_help(), self.style_spec());
 
         match Help::new(HelpWriter::Buffer(&mut c), self.app, &usage, use_long).write_help() {
             Err(e) => e.into(),
@@ -1587,7 +1592,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         debug!("Parser::version_err");
 
         let msg = self.app._render_version(use_long);
-        let mut c = Colorizer::new(false, self.color_help());
+        let mut c = Colorizer::new(false, self.color_help(), self.style_spec());
         c.none(msg);
         ClapError::for_app(self.app, c, ErrorKind::DisplayVersion, vec![])
     }


### PR DESCRIPTION
This pull request adds support for configuring colors and styles in Clap. It does this by adding a `StyleSpec` class that holds information about the `termcolor::ColorSpec`s associated with various styles. This is added as a component of the App class, and it allows users to set colors, styles, and other such aspects of Clap.

For example, I can now write the following:

```rust
use clap::{Color, IntoApp, Parser, Style};

fn main() {
    let app = Args::into_app()
        .bold(Style::Good, true)
        .bold(Style::Warning, true)
        .foreground(Style::Warning, Some(Color::Green));

    // ...
```
In this example, this will set text displayed in Style::Good and Style::Warning to bold, and also update the warning style color to Green.

Before Customization:
![image](https://user-images.githubusercontent.com/36810712/152632759-f59c14f7-97fc-4f47-8f56-c71fcbac7e6b.png)

After Customization:
![image](https://user-images.githubusercontent.com/36810712/152632772-0257ec78-17cf-40e9-ab66-4df092180c41.png)

## A note on styles

This pull request functions within the bounds of the Style enum already defined by Clap, inside `src/output/fmt.rs`. We may want to give the options defined in this enum more descriptive names (for example, `Style::Warning` would become `Style::SectionHeader`, which is what it's used for when printing `--help`). We may also want to increase the number of styles (so that there's a `Warning` style and a `SectionHeader` style)

## Considerations on the API

This adds Style as part of clap`s public API, and it also exposes `termcolor::Color` as `clap::Color`. 