### PR TITLE
feat(AppSettings): Enable user-defined colors for help message

### DIFF
--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -5,7 +5,13 @@ mod settings;
 mod tests;
 
 pub use self::settings::{AppFlags, AppSettings};
+
+#[cfg(feature = "color")]
 use termcolor::Color;
+#[cfg(feature = "color")]
+use termcolor::ColorSpec;
+#[cfg(feature = "color")]
+use crate::output::fmt::Style;
 
 // Std
 use std::{
@@ -28,7 +34,6 @@ use crate::build::{arg::ArgProvider, Arg, ArgGroup, ArgPredicate, ArgSettings};
 use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::MKeyMap;
-use crate::output::fmt::Style;
 use crate::output::{fmt::Colorizer, fmt::StyleSpec, Help, HelpWriter, Usage};
 use crate::parse::{ArgMatcher, ArgMatches, Input, Parser};
 use crate::util::{color::ColorChoice, Id, Key};
@@ -1335,9 +1340,12 @@ impl<'help> App<'help> {
     ///
     /// ```no_run
     ///
-    /// # use clap::{App, Style};
+    /// # use clap::{App, Style, Color, ColorSpec};
     ///
-    /// // Do stuff to color
+    /// let mut color = ColorSpec::new();
+    /// 
+    /// color.set_fg(Some(Color::Green)).set_bold(true);
+    /// 
     /// App::new("myprog")
     ///     .style(Style::Good, color)
     ///     .get_matches();
@@ -1345,7 +1353,7 @@ impl<'help> App<'help> {
     #[cfg(feature = "color")]
     #[inline]
     #[must_use]
-    pub fn style(mut self, style: Style, spec: termcolor::ColorSpec) -> Self {
+    pub fn style(mut self, style: Style, spec: ColorSpec) -> Self {
         self.output_style.set_style(style, spec);
         self
     }
@@ -1473,11 +1481,11 @@ impl<'help> App<'help> {
     ///
     /// ```no_run
     ///
-    /// # use clap::{App, Style};
+    /// # use clap::{App, Style, Color};
     ///
     /// // Do stuff to color
     /// App::new("myprog")
-    ///     .style_color(Style::Good, Some(Color::Green))
+    ///     .foreground(Style::Good, Some(Color::Green))
     ///     .get_matches();
     /// ```
     #[cfg(feature = "color")]
@@ -1496,11 +1504,11 @@ impl<'help> App<'help> {
     ///
     /// ```no_run
     ///
-    /// # use clap::{App, Style};
+    /// # use clap::{App, Style, Color};
     ///
     /// // Do stuff to color
     /// App::new("myprog")
-    ///     .style_color(Style::Good, Some(Color::Green))
+    ///     .background(Style::Good, Some(Color::Green))
     ///     .get_matches();
     /// ```
     #[cfg(feature = "color")]

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -1354,7 +1354,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn style(mut self, style: Style, spec: ColorSpec) -> Self {
-        self.output_style.set_style(style, spec);
+        self.output_style[style] = spec;
         self
     }
 
@@ -1377,7 +1377,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn bold(mut self, style: Style, value: bool) -> Self {
-        self.output_style.style(style).set_bold(value);
+        self.output_style[style].set_bold(value);
         self
     }
 
@@ -1400,7 +1400,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn italic(mut self, style: Style, value: bool) -> Self {
-        self.output_style.style(style).set_italic(value);
+        self.output_style[style].set_italic(value);
         self
     }
 
@@ -1423,7 +1423,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn underline(mut self, style: Style, value: bool) -> Self {
-        self.output_style.style(style).set_underline(value);
+        self.output_style[style].set_underline(value);
         self
     }
 
@@ -1446,7 +1446,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn dimmed(mut self, style: Style, value: bool) -> Self {
-        self.output_style.style(style).set_dimmed(value);
+        self.output_style[style].set_dimmed(value);
         self
     }
 
@@ -1469,7 +1469,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn intense(mut self, style: Style, value: bool) -> Self {
-        self.output_style.style(style).set_intense(value);
+        self.output_style[style].set_intense(value);
         self
     }
 
@@ -1492,7 +1492,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn foreground(mut self, style: Style, color: Option<Color>) -> Self {
-        self.output_style.style(style).set_fg(color);
+        self.output_style[style].set_fg(color);
         self
     }
 
@@ -1515,7 +1515,7 @@ impl<'help> App<'help> {
     #[inline]
     #[must_use]
     pub fn background(mut self, style: Style, color: Option<Color>) -> Self {
-        self.output_style.style(style).set_bg(color);
+        self.output_style[style].set_bg(color);
         self
     }
 

--- a/src/build/app/mod.rs
+++ b/src/build/app/mod.rs
@@ -7,11 +7,11 @@ mod tests;
 pub use self::settings::{AppFlags, AppSettings};
 
 #[cfg(feature = "color")]
+use crate::output::fmt::Style;
+#[cfg(feature = "color")]
 use termcolor::Color;
 #[cfg(feature = "color")]
 use termcolor::ColorSpec;
-#[cfg(feature = "color")]
-use crate::output::fmt::Style;
 
 // Std
 use std::{
@@ -1343,9 +1343,9 @@ impl<'help> App<'help> {
     /// # use clap::{App, Style, Color, ColorSpec};
     ///
     /// let mut color = ColorSpec::new();
-    /// 
+    ///
     /// color.set_fg(Some(Color::Green)).set_bold(true);
-    /// 
+    ///
     /// App::new("myprog")
     ///     .style(Style::Good, color)
     ///     .get_matches();

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -519,7 +519,7 @@ impl Error {
             val,
             err,
             ColorChoice::Never,
-            StyleSpec::empty(),
+            StyleSpec::new(),
             false,
         );
         match &mut err.inner.message {
@@ -662,7 +662,7 @@ impl Error {
     }
 
     pub(crate) fn argument_not_found_auto(arg: String) -> Self {
-        let mut c = Colorizer::new(true, ColorChoice::Never, StyleSpec::empty());
+        let mut c = Colorizer::new(true, ColorChoice::Never, StyleSpec::new());
 
         start_error(&mut c, "The argument '");
         c.warning(&*arg);
@@ -764,7 +764,7 @@ impl Message {
     fn formatted(&self) -> Cow<Colorizer> {
         match self {
             Message::Raw(s) => {
-                let mut c = Colorizer::new(true, ColorChoice::Never, StyleSpec::empty());
+                let mut c = Colorizer::new(true, ColorChoice::Never, StyleSpec::new());
                 start_error(&mut c, s);
                 Cow::Owned(c)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,15 @@ pub use crate::parse::{ArgMatches, Indices, OsValues, Values};
 #[cfg(feature = "color")]
 pub use crate::util::color::ColorChoice;
 
+#[cfg(feature = "color")]
+pub use termcolor::Color;
+
+#[cfg(feature = "color")]
+pub use termcolor::ColorSpec;
+
+#[cfg(feature = "color")]
+pub use crate::output::fmt::Style;
+
 pub use crate::derive::{ArgEnum, Args, FromArgMatches, IntoApp, Parser, Subcommand};
 
 pub use crate::error::{ErrorKind, Result};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -894,7 +894,10 @@ macro_rules! debug {
     ($($arg:tt)*) => ({
         let prefix = format!("[{:>w$}] \t", module_path!(), w = 28);
         let body = format!($($arg)*);
-        let mut color = $crate::output::fmt::Colorizer::new(true, $crate::ColorChoice::Auto);
+        let mut color = $crate::output::fmt::Colorizer::new(
+            true,
+            $crate::ColorChoice::Auto,
+            $crate::output::fmt::StyleSpec::default());
         color.hint(prefix);
         color.hint(body);
         color.none("\n");

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -1,5 +1,8 @@
 use crate::util::color::ColorChoice;
 
+#[cfg(feature = "color")]
+use termcolor::{Color, ColorSpec};
+
 use std::{
     fmt::{self, Display, Formatter},
     io::{self, Write},
@@ -7,24 +10,41 @@ use std::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct StyleSpec {
-    pub good_style: termcolor::ColorSpec,
-    pub warning_style: termcolor::ColorSpec,
-    pub error_style: termcolor::ColorSpec,
-    pub hint_style: termcolor::ColorSpec,
-    pub default_style: termcolor::ColorSpec,
+    #[cfg(feature = "color")]
+    pub good_style: ColorSpec,
+
+    #[cfg(feature = "color")]
+    pub warning_style: ColorSpec,
+
+    #[cfg(feature = "color")]
+    pub error_style: ColorSpec,
+
+    #[cfg(feature = "color")]
+    pub hint_style: ColorSpec,
+
+    #[cfg(feature = "color")]
+    pub default_style: ColorSpec,
 }
 
 impl StyleSpec {
-    pub(crate) fn empty() -> StyleSpec {
+    #[cfg(not(feature = "color"))]
+    pub(crate) fn new() -> StyleSpec {
+        StyleSpec {}
+    }
+
+    #[cfg(feature = "color")]
+    pub(crate) fn new() -> StyleSpec {
         StyleSpec {
-            good_style: termcolor::ColorSpec::new(),
-            warning_style: termcolor::ColorSpec::new(),
-            error_style: termcolor::ColorSpec::new(),
-            hint_style: termcolor::ColorSpec::new(),
-            default_style: termcolor::ColorSpec::new(),
+            good_style: ColorSpec::new(),
+            warning_style: ColorSpec::new(),
+            error_style: ColorSpec::new(),
+            hint_style: ColorSpec::new(),
+            default_style: ColorSpec::new(),
         }
     }
-    pub(crate) fn get_style(&self, style: Style) -> &termcolor::ColorSpec {
+
+    #[cfg(feature = "color")]
+    pub(crate) fn get_style(&self, style: Style) -> &ColorSpec {
         match style {
             Style::Good => &self.good_style,
             Style::Warning => &self.warning_style,
@@ -33,7 +53,9 @@ impl StyleSpec {
             Style::Default => &self.default_style,
         }
     }
-    pub(crate) fn set_style(&mut self, style: Style, spec: termcolor::ColorSpec) -> &mut Self {
+
+    #[cfg(feature = "color")]
+    pub(crate) fn set_style(&mut self, style: Style, spec: ColorSpec) -> &mut Self {
         match style {
             Style::Good => self.good_style = spec,
             Style::Warning => self.warning_style = spec,
@@ -43,7 +65,9 @@ impl StyleSpec {
         }
         self
     }
-    pub(crate) fn style(&mut self, style: Style) -> &mut termcolor::ColorSpec {
+
+    #[cfg(feature = "color")]
+    pub(crate) fn style(&mut self, style: Style) -> &mut ColorSpec {
         match style {
             Style::Good => &mut self.good_style,
             Style::Warning => &mut self.warning_style,
@@ -55,8 +79,13 @@ impl StyleSpec {
 }
 
 impl Default for StyleSpec {
+    #[cfg(not(feature = "color"))]
     fn default() -> StyleSpec {
-        use termcolor::{Color, ColorSpec};
+        StyleSpec {}
+    }
+
+    #[cfg(feature = "color")]
+    fn default() -> StyleSpec {
         // Declare the styles
         let mut good_style = ColorSpec::new();
         let mut warning_style = ColorSpec::new();
@@ -86,12 +115,16 @@ pub(crate) struct Colorizer {
     #[allow(unused)]
     color_when: ColorChoice,
     pieces: Vec<(String, Style)>,
+
+    // If color is not enabled, then style_spec is never used
+    #[allow(dead_code)]
     style_spec: StyleSpec,
 }
 
 impl Colorizer {
     /// Get the `ColorSpec` used for a particular style
-    pub(crate) fn spec_for(&self, style: Style) -> &termcolor::ColorSpec {
+    #[cfg(feature = "color")]
+    pub(crate) fn spec_for(&self, style: Style) -> &ColorSpec {
         self.style_spec.get_style(style)
     }
 

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -23,7 +23,7 @@ impl StyleSpec {
     #[cfg(feature = "color")]
     pub(crate) fn new() -> StyleSpec {
         StyleSpec {
-            values: [(); NUM_STYLES].map(|_| ColorSpec::new()),
+            values: Default::default(),
         }
     }
 }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -15,7 +15,7 @@ use crate::error::Error as ClapError;
 use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::KeyType;
-use crate::output::{fmt::Colorizer, Help, HelpWriter, Usage};
+use crate::output::{fmt::Colorizer, fmt::StyleSpec, Help, HelpWriter, Usage};
 use crate::parse::features::suggestions;
 use crate::parse::{ArgMatcher, SubCommand};
 use crate::parse::{Validator, ValueType};
@@ -74,6 +74,11 @@ impl<'help, 'app> Parser<'help, 'app> {
         }
 
         self.app.get_color()
+    }
+
+    // Returns the style spec used to define how output is colored
+    pub(crate) fn style_spec(&self) -> StyleSpec {
+        self.app.get_style_spec()
     }
 }
 
@@ -1562,7 +1567,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
     pub(crate) fn write_help_err(&self) -> ClapResult<Colorizer> {
         let usage = Usage::new(self.app, &self.required);
-        let mut c = Colorizer::new(true, self.color_help());
+        let mut c = Colorizer::new(true, self.color_help(), self.style_spec());
         Help::new(HelpWriter::Buffer(&mut c), self.app, &usage, false).write_help()?;
         Ok(c)
     }
@@ -1575,7 +1580,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         use_long = use_long && self.use_long_help();
         let usage = Usage::new(self.app, &self.required);
-        let mut c = Colorizer::new(false, self.color_help());
+        let mut c = Colorizer::new(false, self.color_help(), self.style_spec());
 
         match Help::new(HelpWriter::Buffer(&mut c), self.app, &usage, use_long).write_help() {
             Err(e) => e.into(),
@@ -1587,7 +1592,7 @@ impl<'help, 'app> Parser<'help, 'app> {
         debug!("Parser::version_err");
 
         let msg = self.app._render_version(use_long);
-        let mut c = Colorizer::new(false, self.color_help());
+        let mut c = Colorizer::new(false, self.color_help(), self.style_spec());
         c.none(msg);
         ClapError::for_app(self.app, c, ErrorKind::DisplayVersion, vec![])
     }


### PR DESCRIPTION
## Introduction

This pull request adds support for configuring colors and styles in Clap. It does this by adding a `StyleSpec` class that holds information about the `termcolor::ColorSpec`s associated with various styles. This is added as a component of the App class, and it allows users to set colors, styles, and other such aspects of Clap.

For example, I can now write the following:

```rust
use clap::{Color, IntoApp, Parser, Style};

fn main() {
    let app = Args::into_app()
        .bold(Style::Good, true)
        .bold(Style::Warning, true)
        .foreground(Style::Warning, Some(Color::Green));

    // ...
```
In this example, this will set text displayed in Style::Good and Style::Warning to bold, and also update the warning style color to Green.

Before Customization:
![image](https://user-images.githubusercontent.com/36810712/152632759-f59c14f7-97fc-4f47-8f56-c71fcbac7e6b.png)

After Customization:
![image](https://user-images.githubusercontent.com/36810712/152632772-0257ec78-17cf-40e9-ab66-4df092180c41.png)

### Motivation

I wanted to be able to make help flags and section headers display in bold for greater readability. Adding support for the ability to customize that involved a rework of a lot of Colorizer code, and it wasn't much additional work to enable other customizations as well.

## Changes to clap's API
This section documents changes to the public API of clap

### Newly exposed types:
- Expose clap::output::fmt::Style as clap::Style
- Expose termcolor::Color as clap::Color
- Expose termcolor::ColorSpec as clap::ColorSpec

### Additions to App

The following functions were added to App, to enable users to customize colors and styles:
```rust
pub fn style(mut self, style: Style, spec: termcolor::ColorSpec) -> Self;
pub fn bold(mut self, style: Style, value: bool) -> Self;
pub fn italic(mut self, style: Style, value: bool) -> Self;
pub fn underline(mut self, style: Style, value: bool) -> Self;
pub fn dimmed(mut self, style: Style, value: bool) -> Self;
pub fn intense(mut self, style: Style, value: bool) -> Self;
pub fn foreground(mut self, style: Style, color: Option<Color>) -> Self;
pub fn background(mut self, style: Style, color: Option<Color>) -> Self;
```
### A note on the Style enum

This pull request functions within the bounds of the Style enum already defined by Clap, inside `src/output/fmt.rs`. We may want to give the options defined in this enum more descriptive names (for example, `Style::Warning` would become `Style::SectionHeader`, which is what it's used for when printing `--help`). We may also want to increase the number of styles (so that there's a `Warning` style and a `SectionHeader` style)

### Internal additions / changes
- Create `StyleSpec`, which holds a `ColorSpec` for each `Style`
- Make `StyleSpec` a parameter of Colorizer::new
- Update all uses of `Colorizer::new` to include a `StyleSpec`

## Related issues and discussions

**Issues:**
- **[Resolves #2963: Make colored help output more compatible with an applications overall theme](#2963)** by enabling users to customize colors as necessary to match their application theme

**Discussions:**
- See also **[#2906 Challenges with Colored Help](#2906)**