### PR TITLE
fix(help): Subcommand `help` looks like `--help`

### DIFF
--- a/examples/tutorial_builder/03_04_subcommands.rs
+++ b/examples/tutorial_builder/03_04_subcommands.rs
@@ -3,7 +3,6 @@ use clap::{app_from_crate, arg, App, AppSettings};
 fn main() {
     let matches = app_from_crate!()
         .propagate_version(true)
-        .global_setting(AppSettings::UseLongFormatForHelpSubcommand)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
             App::new("add")

--- a/examples/tutorial_derive/03_04_subcommands.rs
+++ b/examples/tutorial_derive/03_04_subcommands.rs
@@ -1,9 +1,8 @@
-use clap::{AppSettings, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
-#[clap(global_setting(AppSettings::UseLongFormatForHelpSubcommand))]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,

--- a/src/build/app_settings.rs
+++ b/src/build/app_settings.rs
@@ -176,26 +176,8 @@ pub enum AppSettings {
     )]
     AllowInvalidUtf8ForExternalSubcommands,
 
-    /// Specifies that the help subcommand should print the long help message (`--help`).
-    ///
-    /// **NOTE:** This setting is useless if [`AppSettings::DisableHelpSubcommand`] or [`AppSettings::NoAutoHelp`] is set,
-    /// or if the app contains no subcommands at all.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{App, Arg, AppSettings};
-    /// App::new("myprog")
-    ///     .global_setting(AppSettings::UseLongFormatForHelpSubcommand)
-    ///     .subcommand(App::new("test")
-    ///         .arg(Arg::new("foo")
-    ///             .help("short form about message")
-    ///             .long_help("long form about message")
-    ///         )
-    ///     )
-    ///     .get_matches();
-    /// ```
-    /// [long format]: crate::App::long_about
+    /// Deprecated, this is now the default
+    #[deprecated(since = "3.1.0", note = "This is now the default")]
     UseLongFormatForHelpSubcommand,
 
     /// Deprecated, replaced with [`App::subcommand_negates_reqs`] and

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -661,7 +661,7 @@ impl<'help, 'app> Parser<'help, 'app> {
 
         let parser = Parser::new(&mut sc);
 
-        Err(parser.help_err(self.app.is_set(AS::UseLongFormatForHelpSubcommand)))
+        Err(parser.help_err(true))
     }
 
     fn is_new_arg(&self, next: &RawOsStr, current_positional: &Arg) -> bool {

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -79,54 +79,6 @@ SUBCOMMANDS:
     info    
 ";
 
-static LONG_FORMAT_FOR_HELP_SUBCOMMAND: &str = "myprog-test 
-
-USAGE:
-    myprog test [foo]
-
-ARGS:
-    <foo>
-            long form help message
-
-OPTIONS:
-    -h, --help
-            Print help information
-";
-
-static LONG_FORMAT_FOR_NESTED_HELP_SUBCOMMAND: &str = "myprog-test-nested 
-long form about message
-
-USAGE:
-    myprog test nested
-
-OPTIONS:
-    -h, --help
-            Print help information
-";
-
-static LONG_FORMAT_SINGLE_ARG_HELP_SUBCOMMAND: &str = "myprog 1.0
-
-USAGE:
-    myprog [foo] [SUBCOMMAND]
-
-ARGS:
-    <foo>
-            long form help message
-
-OPTIONS:
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
-
-SUBCOMMANDS:
-    help
-            Print this message or the help of the given subcommand(s)
-    test
-            
-";
-
 #[test]
 fn setting() {
     #![allow(deprecated)]
@@ -1135,63 +1087,6 @@ fn aaos_option_use_delim_false() {
         m.values_of("opt").unwrap().collect::<Vec<_>>(),
         &["one,two"]
     );
-}
-
-#[test]
-fn nested_help_subcommand_with_global_setting() {
-    let m = App::new("myprog")
-        .global_setting(AppSettings::UseLongFormatForHelpSubcommand)
-        .subcommand(
-            App::new("test").subcommand(
-                App::new("nested")
-                    .about("short form about message")
-                    .long_about("long form about message"),
-            ),
-        );
-    assert!(utils::compare_output(
-        m,
-        "myprog test help nested",
-        LONG_FORMAT_FOR_NESTED_HELP_SUBCOMMAND,
-        false
-    ));
-}
-
-#[test]
-fn single_arg_help_with_long_format_setting() {
-    let m = App::new("myprog")
-        .version("1.0")
-        .setting(AppSettings::UseLongFormatForHelpSubcommand)
-        .subcommand(App::new("test"))
-        .arg(
-            Arg::new("foo")
-                .help("short form help message")
-                .long_help("long form help message"),
-        );
-    assert!(utils::compare_output(
-        m,
-        "myprog help",
-        LONG_FORMAT_SINGLE_ARG_HELP_SUBCOMMAND,
-        false
-    ));
-}
-
-#[test]
-fn use_long_format_for_help_subcommand_with_setting() {
-    let m = App::new("myprog")
-        .setting(AppSettings::UseLongFormatForHelpSubcommand)
-        .subcommand(
-            App::new("test").arg(
-                Arg::new("foo")
-                    .help("short form help message")
-                    .long_help("long form help message"),
-            ),
-        );
-    assert!(utils::compare_output(
-        m,
-        "myprog help test",
-        LONG_FORMAT_FOR_HELP_SUBCOMMAND,
-        false
-    ));
 }
 
 #[test]

--- a/tests/derive/structopt.rs
+++ b/tests/derive/structopt.rs
@@ -7,7 +7,6 @@ fn compatible() {
     #[derive(StructOpt)]
     #[structopt(author, version, about)]
     #[structopt(global_setting(AppSettings::PropagateVersion))]
-    #[structopt(global_setting(AppSettings::UseLongFormatForHelpSubcommand))]
     struct Cli {
         #[structopt(subcommand)]
         command: Commands,


### PR DESCRIPTION
Like was said in #2435, this is what people would expect.

While we should note this in a compatibility section in the changelog, I
do not consider this a breaking change since we should be free to adjust
the help output as needed.  We are cautious when people might build up
their own content around it (like #3312) but apps should already handle
this with `--help` so this shouldn't be a major change.

We aren't offering a way for people to disable this, assuming people
won't need to.  Longer term, we are looking at support "Actions" (#3405)
and expect those to help customize the flags.  We'll need something
similar for the `help` subcommand.

Fixes #3440

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
