### PR TITLE
refactor(derive): Remove redundant code paths

### DIFF
--- a/clap_derive/src/parse.rs
+++ b/clap_derive/src/parse.rs
@@ -33,11 +33,9 @@ pub enum ClapAttr {
     Subcommand(Ident),
     VerbatimDocComment(Ident),
     ExternalSubcommand(Ident),
-
-    // ident [= "string literal"]
-    About(Ident, Option<LitStr>),
-    Author(Ident, Option<LitStr>),
-    Version(Ident, Option<LitStr>),
+    About(Ident),
+    Author(Ident),
+    Version(Ident),
 
     // ident = "string literal"
     RenameAllEnv(Ident, LitStr),
@@ -75,37 +73,10 @@ impl Parse for ClapAttr {
 
             if input.peek(LitStr) {
                 let lit: LitStr = input.parse()?;
-                let lit_str = lit.value();
-
-                let check_empty_lit = |s| {
-                    if lit_str.is_empty() {
-                        abort!(
-                            lit,
-                            "`#[clap({} = \"\")` is deprecated, \
-                             now it's default behavior",
-                            s
-                        );
-                    }
-                };
 
                 match &*name_str {
                     "rename_all" => Ok(RenameAll(name, lit)),
                     "rename_all_env" => Ok(RenameAllEnv(name, lit)),
-
-                    "version" => {
-                        check_empty_lit("version");
-                        Ok(Version(name, Some(lit)))
-                    }
-
-                    "author" => {
-                        check_empty_lit("author");
-                        Ok(Author(name, Some(lit)))
-                    }
-
-                    "about" => {
-                        check_empty_lit("about");
-                        Ok(About(name, Some(lit)))
-                    }
 
                     "skip" => {
                         let expr = ExprLit {
@@ -227,9 +198,9 @@ impl Parse for ClapAttr {
                 }
                 "default_value_t" => Ok(DefaultValueT(name, None)),
                 "default_value_os_t" => Ok(DefaultValueOsT(name, None)),
-                "about" => (Ok(About(name, None))),
-                "author" => (Ok(Author(name, None))),
-                "version" => Ok(Version(name, None)),
+                "about" => (Ok(About(name))),
+                "author" => (Ok(Author(name))),
+                "version" => Ok(Version(name)),
 
                 "skip" => Ok(Skip(name, None)),
 


### PR DESCRIPTION
I'm assuming this is from when structopt always set author, version, and
about and you had to apply other attributes to remove them.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
