### PR TITLE
refactor: Reduce visibility on App members 

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -2,7 +2,7 @@ use clap::AppSettings;
 use roff::{bold, italic, roman, Inline, Roff};
 
 pub(crate) fn subcommand_heading(app: &clap::App) -> String {
-    match app.get_subommand_help_heading() {
+    match app.get_subcommand_help_heading() {
         Some(title) => title.to_string(),
         None => "SUBCOMMANDS".to_string(),
     }

--- a/src/build/app_tests.rs
+++ b/src/build/app_tests.rs
@@ -7,7 +7,10 @@ fn propagate_version() {
         .version("1.1")
         .subcommand(App::new("sub1"));
     app._propagate();
-    assert_eq!(app.subcommands[0].version, Some("1.1"));
+    assert_eq!(
+        app.get_subcommands().next().unwrap().get_version(),
+        Some("1.1")
+    );
 }
 
 #[test]
@@ -17,9 +20,8 @@ fn global_setting() {
         .subcommand(App::new("subcmd"));
     app._propagate();
     assert!(app
-        .subcommands
-        .iter()
-        .find(|s| s.name == "subcmd")
+        .get_subcommands()
+        .find(|s| s.get_name() == "subcmd")
         .unwrap()
         .is_disable_version_flag_set());
 }
@@ -38,5 +40,9 @@ fn issue_2090() {
         .subcommand(App::new("sub"));
     app._build();
 
-    assert!(app.subcommands[0].is_disable_version_flag_set());
+    assert!(app
+        .get_subcommands()
+        .next()
+        .unwrap()
+        .is_disable_version_flag_set());
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -182,7 +182,7 @@ impl Error {
     }
 
     pub(crate) fn with_app(self, app: &App) -> Self {
-        self.set_wait_on_exit(app.settings.is_set(AppSettings::WaitOnError))
+        self.set_wait_on_exit(app.is_set(AppSettings::WaitOnError))
             .set_color(app.get_color())
             .set_help_flag(get_help_flag(app))
     }
@@ -1047,9 +1047,9 @@ fn put_usage(c: &mut Colorizer, usage: impl Into<String>) {
 }
 
 fn get_help_flag(app: &App) -> Option<&'static str> {
-    if !app.settings.is_set(AppSettings::DisableHelpFlag) {
+    if !app.is_disable_help_flag_set() {
         Some("--help")
-    } else if app.has_subcommands() && !app.settings.is_set(AppSettings::DisableHelpSubcommand) {
+    } else if app.has_subcommands() && !app.is_disable_help_subcommand_set() {
         Some("help")
     } else {
         None

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -19,12 +19,12 @@ impl ArgMatcher {
         ArgMatcher(ArgMatches {
             #[cfg(debug_assertions)]
             valid_args: {
-                let args = _app.args.args().map(|a| a.id.clone());
-                let groups = _app.groups.iter().map(|g| g.id.clone());
+                let args = _app.get_arguments().map(|a| a.id.clone());
+                let groups = _app.get_groups().map(|g| g.id.clone());
                 args.chain(groups).collect()
             },
             #[cfg(debug_assertions)]
-            valid_subcommands: _app.subcommands.iter().map(|sc| sc.id.clone()).collect(),
+            valid_subcommands: _app.get_subcommands().map(|sc| sc.get_id()).collect(),
             // HACK: Allow an external subcommand's ArgMatches be a stand-in for any ArgMatches
             // since users can't detect it and avoid the asserts.
             //

--- a/src/parse/features/suggestions.rs
+++ b/src/parse/features/suggestions.rs
@@ -33,13 +33,14 @@ where
 }
 
 /// Returns a suffix that can be empty, or is the standard 'did you mean' phrase
-pub(crate) fn did_you_mean_flag<I, T>(
+pub(crate) fn did_you_mean_flag<'a, 'help, I, T>(
     arg: &str,
     remaining_args: &[&str],
     longs: I,
-    subcommands: &mut [App],
+    subcommands: impl IntoIterator<Item = &'a mut App<'help>>,
 ) -> Option<(String, Option<String>)>
 where
+    'help: 'a,
     T: AsRef<str>,
     I: IntoIterator<Item = T>,
 {
@@ -48,11 +49,11 @@ where
     match did_you_mean(arg, longs).pop() {
         Some(candidate) => Some((candidate, None)),
         None => subcommands
-            .iter_mut()
+            .into_iter()
             .filter_map(|subcommand| {
                 subcommand._build();
 
-                let longs = subcommand.args.keys().filter_map(|a| {
+                let longs = subcommand.get_keymap().keys().filter_map(|a| {
                     if let KeyType::Long(v) = a {
                         Some(v.to_string_lossy().into_owned())
                     } else {

--- a/src/parse/validator.rs
+++ b/src/parse/validator.rs
@@ -68,7 +68,11 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         }
         #[allow(deprecated)]
         if !has_subcmd && self.p.app.is_subcommand_required_set() {
-            let bn = self.p.app.bin_name.as_ref().unwrap_or(&self.p.app.name);
+            let bn = self
+                .p
+                .app
+                .get_bin_name()
+                .unwrap_or_else(|| self.p.app.get_name());
             return Err(Error::missing_subcommand(
                 self.p.app,
                 bn.to_string(),
@@ -487,7 +491,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         }
 
         // Validate the conditionally required args
-        for a in self.p.app.args.args() {
+        for a in self.p.app.get_arguments() {
             for (other, val) in &a.r_ifs {
                 if matcher.check_explicit(other, ArgPredicate::Equals(std::ffi::OsStr::new(*val)))
                     && !matcher.contains(&a.id)
@@ -531,8 +535,7 @@ impl<'help, 'app, 'parser> Validator<'help, 'app, 'parser> {
         let failed_args: Vec<_> = self
             .p
             .app
-            .args
-            .args()
+            .get_arguments()
             .filter(|&a| {
                 (!a.r_unless.is_empty() || !a.r_unless_all.is_empty())
                     && !matcher.contains(&a.id)


### PR DESCRIPTION
The long term goals are
- Easier refactoring
- Identify needs for reflection API

Shorter term, if I want to rename `App` to `Command` and deprecate
`App`, it will mark all member access as deprecated.  This works around
that.

I gave up in exploring abstractions when it came to `MKeyMap` access.
This can be refined in the future.