### PR TITLE
fix(help): Improve pacman help output

### DIFF
--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -58,7 +58,7 @@ pacman[EXE]-sync
 Synchronize packages.
 
 USAGE:
-    pacman[EXE] {sync, --sync, -S} [OPTIONS] [--] [package]...
+    pacman[EXE] {sync|--sync|-S} [OPTIONS] [--] [package]...
 
 ARGS:
     <package>...    packages
@@ -77,7 +77,7 @@ $ pacman -S -s foo -i bar
 error: The argument '--search <search>...' cannot be used with '--info'
 
 USAGE:
-    pacman[EXE] {sync, --sync, -S} --search <search>... <package>...
+    pacman[EXE] {sync|--sync|-S} --search <search>... <package>...
 
 For more information try --help
 

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -49,9 +49,9 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    help              Print this message or the help of the given subcommand(s)
-    query-Q--query    Query the package database.
-    sync-S--sync      Synchronize packages.
+    help                Print this message or the help of the given subcommand(s)
+    query -Q --query    Query the package database.
+    sync -S --sync      Synchronize packages.
 
 $ pacman -S -h
 pacman[EXE]-sync 

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -49,9 +49,9 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    -Q--queryquery    Query the package database.
-    -S--syncsync      Synchronize packages.
     help              Print this message or the help of the given subcommand(s)
+    query-Q--query    Query the package database.
+    sync-S--sync      Synchronize packages.
 
 $ pacman -S -h
 pacman[EXE]-sync 

--- a/src/build/app.rs
+++ b/src/build/app.rs
@@ -4003,11 +4003,11 @@ impl<'help> App<'help> {
         let mut sc_names = sc.name.clone();
         let mut flag_subcmd = false;
         if let Some(l) = sc.long_flag {
-            write!(sc_names, ", --{}", l).unwrap();
+            write!(sc_names, "|--{}", l).unwrap();
             flag_subcmd = true;
         }
         if let Some(s) = sc.short_flag {
-            write!(sc_names, ", -{}", s).unwrap();
+            write!(sc_names, "|-{}", s).unwrap();
             flag_subcmd = true;
         }
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -844,13 +844,13 @@ impl<'help, 'app, 'writer> Help<'help, 'app, 'writer> {
             .filter(|subcommand| should_show_subcommand(subcommand))
         {
             let mut sc_str = String::new();
+            sc_str.push_str(subcommand.get_name());
             if let Some(short) = subcommand.get_short_flag() {
                 write!(sc_str, "-{}", short).unwrap();
             }
             if let Some(long) = subcommand.get_long_flag() {
                 write!(sc_str, "--{}", long).unwrap();
             }
-            sc_str.push_str(subcommand.get_name());
             longest = longest.max(display_width(&sc_str));
             ord_v.push((subcommand.get_display_order(), sc_str, subcommand));
         }

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -846,10 +846,10 @@ impl<'help, 'app, 'writer> Help<'help, 'app, 'writer> {
             let mut sc_str = String::new();
             sc_str.push_str(subcommand.get_name());
             if let Some(short) = subcommand.get_short_flag() {
-                write!(sc_str, "-{}", short).unwrap();
+                write!(sc_str, " -{}", short).unwrap();
             }
             if let Some(long) = subcommand.get_long_flag() {
-                write!(sc_str, "--{}", long).unwrap();
+                write!(sc_str, " --{}", long).unwrap();
             }
             longest = longest.max(display_width(&sc_str));
             ord_v.push((subcommand.get_display_order(), sc_str, subcommand));

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -453,7 +453,7 @@ static FLAG_SUBCOMMAND_HELP: &str = "pacman-query
 Query the package database.
 
 USAGE:
-    pacman {query, --query, -Q} [OPTIONS]
+    pacman {query|--query|-Q} [OPTIONS]
 
 OPTIONS:
     -h, --help                  Print help information
@@ -507,7 +507,7 @@ static FLAG_SUBCOMMAND_NO_SHORT_HELP: &str = "pacman-query
 Query the package database.
 
 USAGE:
-    pacman {query, --query} [OPTIONS]
+    pacman {query|--query} [OPTIONS]
 
 OPTIONS:
     -h, --help                  Print help information
@@ -560,7 +560,7 @@ static FLAG_SUBCOMMAND_NO_LONG_HELP: &str = "pacman-query
 Query the package database.
 
 USAGE:
-    pacman {query, -Q} [OPTIONS]
+    pacman {query|-Q} [OPTIONS]
 
 OPTIONS:
     -h, --help                  Print help information


### PR DESCRIPTION
This fixes issues with the output and makes it more consistent.

See #1361 for example pacman output for any concern of inconsistency with that.  Pacman uses a space for alternate.  The original PR used a comma.  This switches to pipe since that is the generally expected alternate character in usage.