### PR TITLE
test: Add UI test for unsupported parsers.

### DIFF
--- a/tests/derive_ui/unsupported_parser.rs
+++ b/tests/derive_ui/unsupported_parser.rs
@@ -1,0 +1,11 @@
+use clap::Parser;
+
+#[derive(Parser, Clone, Debug)]
+struct Opt {
+    #[clap(parse(not_a_valid_parser))]
+    value: i8,
+}
+
+fn main() {
+    println!("{:?}", Opt::parse());
+}

--- a/tests/derive_ui/unsupported_parser.stderr
+++ b/tests/derive_ui/unsupported_parser.stderr
@@ -1,0 +1,5 @@
+error: unsupported parser `not_a_valid_parser`
+ --> tests/derive_ui/unsupported_parser.rs:5:18
+  |
+5 |     #[clap(parse(not_a_valid_parser))]
+  |                  ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds a UI test for the `unsupported parser` error.

I noticed that the span of the error was set to the call site rather than the parser tokens. I wanted to fix that, but when doing so I noticed that is has already been fixed on the main branch,

Nevertheless, I already added a UI test for it. So if you feel the UI test is useful to prevent regressions, here it is :)