### PR TITLE
Add mention of cargo feature flag for Builder example 1

### DIFF
--- a/examples/tutorial_builder/README.md
+++ b/examples/tutorial_builder/README.md
@@ -22,7 +22,6 @@
 
 You can create an application with several arguments using usage strings.
 
-Note: This example uses the `command!()` macro. This requires the `cargo` feature flag.
 
 [Example:](01_quick.rs)
 ```console
@@ -47,6 +46,7 @@ SUBCOMMANDS:
     test    does testing things
 
 ```
+_Note: The `command!()` macro requires the `cargo` feature flag._
 
 By default, the program does nothing:
 ```console
@@ -89,7 +89,7 @@ MyApp 1.0
 ```
 
 You can use `command!()` to fill these fields in from your `Cargo.toml`
-file.  This requires the `cargo` feature flag.
+file.
 
 [Example:](02_crate.rs)
 ```console

--- a/examples/tutorial_builder/README.md
+++ b/examples/tutorial_builder/README.md
@@ -22,6 +22,8 @@
 
 You can create an application with several arguments using usage strings.
 
+Note: This example uses the `command!()` macro. This requires the `cargo` feature flag.
+
 [Example:](01_quick.rs)
 ```console
 $ 01_quick --help
@@ -87,7 +89,7 @@ MyApp 1.0
 ```
 
 You can use `command!()` to fill these fields in from your `Cargo.toml`
-file.  **This requires the `cargo` feature flag.**
+file.  This requires the `cargo` feature flag.
 
 [Example:](02_crate.rs)
 ```console


### PR DESCRIPTION
PR for #3534 

Example 1 uses the `command!()` macro but does not mention the `cargo` feature flag. 

- added a mention for the `cargo` feature flag
- removed the bold face in the mention in Example 3


