### PR TITLE
Fix link to example

### DIFF
--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -308,7 +308,7 @@ $ 03_04_subcommands_derive add bob
 
 Above, we used a struct-variant to define the `add` subcommand.  Alternatively,
 you can
-[use a struct for your subcommand's arguments](03_04_subcommands_alt_derive.rs).
+[use a struct for your subcommand's arguments](03_04_subcommands_alt.rs).
 
 Because we used `command: Commands` instead of `command: Option<Commands>`:
 ```console


### PR DESCRIPTION
Hi,

this fixes a link in your documentation that tripped me :-)

Jörg
