### PR TITLE
feat(clap_complete_fig): support `hide` and `require_equals`

### DIFF
--- a/clap_complete/tests/common.rs
+++ b/clap_complete/tests/common.rs
@@ -46,11 +46,18 @@ pub fn special_commands_command(name: &'static str) -> clap::Command<'static> {
                 .arg(
                     clap::Arg::new("config")
                         .long("--config")
+                        .hide(true)
                         .takes_value(true)
                         .help("the other case to test"),
+                )
+                .arg(
+                    clap::Arg::new("path")
+                        .takes_value(true)
+                        .require_equals(true),
                 ),
         )
         .subcommand(clap::Command::new("some-cmd-with-hyphens").alias("hyphen"))
+        .subcommand(clap::Command::new("some-hidden-cmd").hide(true))
 }
 
 pub fn quoting_command(name: &'static str) -> clap::Command<'static> {

--- a/clap_complete/tests/snapshots/special_commands.bash.log
+++ b/clap_complete/tests/snapshots/special_commands.bash.log
@@ -18,6 +18,9 @@ _my-app() {
             some-cmd-with-hyphens)
                 cmd+="__some__cmd__with__hyphens"
                 ;;
+            some-hidden-cmd)
+                cmd+="__some__hidden__cmd"
+                ;;
             some_cmd)
                 cmd+="__some_cmd"
                 ;;
@@ -31,7 +34,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-h -V -C -c --help --version --conf --config <file> first second test some_cmd some-cmd-with-hyphens help"
+            opts="-h -V -C -c --help --version --conf --config <file> first second test some_cmd some-cmd-with-hyphens some-hidden-cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -72,8 +75,22 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        my__app__some__hidden__cmd)
+            opts="-h -V --help --version"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         my__app__some_cmd)
-            opts="-h -V --config --help --version"
+            opts="-h -V --config --help --version <path>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/special_commands.elvish.log
+++ b/clap_complete/tests/snapshots/special_commands.elvish.log
@@ -29,6 +29,7 @@ set edit:completion:arg-completer[my-app] = {|@words|
             cand test 'tests things'
             cand some_cmd 'tests other things'
             cand some-cmd-with-hyphens 'some-cmd-with-hyphens'
+            cand some-hidden-cmd 'some-hidden-cmd'
             cand help 'Print this message or the help of the given subcommand(s)'
         }
         &'my-app;test'= {
@@ -46,6 +47,12 @@ set edit:completion:arg-completer[my-app] = {|@words|
             cand --version 'Print version information'
         }
         &'my-app;some-cmd-with-hyphens'= {
+            cand -h 'Print help information'
+            cand --help 'Print help information'
+            cand -V 'Print version information'
+            cand --version 'Print version information'
+        }
+        &'my-app;some-hidden-cmd'= {
             cand -h 'Print help information'
             cand --help 'Print help information'
             cand -V 'Print version information'

--- a/clap_complete/tests/snapshots/special_commands.fish.log
+++ b/clap_complete/tests/snapshots/special_commands.fish.log
@@ -4,6 +4,7 @@ complete -c my-app -n "__fish_use_subcommand" -s c -s C -l config -l conf -d 'so
 complete -c my-app -n "__fish_use_subcommand" -f -a "test" -d 'tests things'
 complete -c my-app -n "__fish_use_subcommand" -f -a "some_cmd" -d 'tests other things'
 complete -c my-app -n "__fish_use_subcommand" -f -a "some-cmd-with-hyphens"
+complete -c my-app -n "__fish_use_subcommand" -f -a "some-hidden-cmd"
 complete -c my-app -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c my-app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
 complete -c my-app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help information'
@@ -13,3 +14,5 @@ complete -c my-app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Pr
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Print version information'
 complete -c my-app -n "__fish_seen_subcommand_from some-cmd-with-hyphens" -s h -l help -d 'Print help information'
 complete -c my-app -n "__fish_seen_subcommand_from some-cmd-with-hyphens" -s V -l version -d 'Print version information'
+complete -c my-app -n "__fish_seen_subcommand_from some-hidden-cmd" -s h -l help -d 'Print help information'
+complete -c my-app -n "__fish_seen_subcommand_from some-hidden-cmd" -s V -l version -d 'Print version information'

--- a/clap_complete/tests/snapshots/special_commands.powershell.log
+++ b/clap_complete/tests/snapshots/special_commands.powershell.log
@@ -32,6 +32,7 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
             [CompletionResult]::new('test', 'test', [CompletionResultType]::ParameterValue, 'tests things')
             [CompletionResult]::new('some_cmd', 'some_cmd', [CompletionResultType]::ParameterValue, 'tests other things')
             [CompletionResult]::new('some-cmd-with-hyphens', 'some-cmd-with-hyphens', [CompletionResultType]::ParameterValue, 'some-cmd-with-hyphens')
+            [CompletionResult]::new('some-hidden-cmd', 'some-hidden-cmd', [CompletionResultType]::ParameterValue, 'some-hidden-cmd')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
@@ -52,6 +53,13 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
             break
         }
         'my-app;some-cmd-with-hyphens' {
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
+            [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
+            [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
+            break
+        }
+        'my-app;some-hidden-cmd' {
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')

--- a/clap_complete/tests/snapshots/special_commands.zsh.log
+++ b/clap_complete/tests/snapshots/special_commands.zsh.log
@@ -50,9 +50,18 @@ _arguments "${_arguments_options[@]}" /
 '--help[Print help information]' /
 '-V[Print version information]' /
 '--version[Print version information]' /
+'::path:' /
 && ret=0
 ;;
 (some-cmd-with-hyphens)
+_arguments "${_arguments_options[@]}" /
+'-h[Print help information]' /
+'--help[Print help information]' /
+'-V[Print version information]' /
+'--version[Print version information]' /
+&& ret=0
+;;
+(some-hidden-cmd)
 _arguments "${_arguments_options[@]}" /
 '-h[Print help information]' /
 '--help[Print help information]' /
@@ -76,6 +85,7 @@ _my-app_commands() {
 'test:tests things' /
 'some_cmd:tests other things' /
 'some-cmd-with-hyphens:' /
+'some-hidden-cmd:' /
 'help:Print this message or the help of the given subcommand(s)' /
     )
     _describe -t commands 'my-app commands' commands "$@"
@@ -89,6 +99,11 @@ _my-app__help_commands() {
 _my-app__some-cmd-with-hyphens_commands() {
     local commands; commands=()
     _describe -t commands 'my-app some-cmd-with-hyphens commands' commands "$@"
+}
+(( $+functions[_my-app__some-hidden-cmd_commands] )) ||
+_my-app__some-hidden-cmd_commands() {
+    local commands; commands=()
+    _describe -t commands 'my-app some-hidden-cmd commands' commands "$@"
 }
 (( $+functions[_my-app__some_cmd_commands] )) ||
 _my-app__some_cmd_commands() {

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -170,12 +170,12 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
         }
 
         if option.is_hide_set() {
-          buffer.push_str(&format!(
-              "{:indent$}hidden: true,\n",
-              "",
-              indent = indent + 4
-          ))
-      }
+            buffer.push_str(&format!(
+                "{:indent$}hidden: true,\n",
+                "",
+                indent = indent + 4
+            ))
+        }
 
         buffer.push_str(&format!("{:indent$}args: ", "", indent = indent + 4));
 

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -69,6 +69,14 @@ fn gen_fig_inner(
                 ));
             }
 
+            if subcommand.is_hide_set() {
+                buffer.push_str(&format!(
+                    "{:indent$}hidden: true,\n",
+                    "",
+                    indent = indent + 4
+                ))
+            }
+
             let mut parent_commands: Vec<_> = parent_commands.into();
             parent_commands.push(subcommand.get_name());
             gen_fig_inner(
@@ -87,6 +95,14 @@ fn gen_fig_inner(
     buffer.push_str(&gen_options(cmd, indent));
 
     let args = cmd.get_positionals().collect::<Vec<_>>();
+
+    if args.iter().any(|&x| x.is_require_equals_set()) {
+        buffer.push_str(&format!(
+            "{:indent$}requireEquals: true,\n",
+            "",
+            indent = indent
+        ));
+    }
 
     match args.len() {
         0 => {}
@@ -152,6 +168,14 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 indent = indent + 4
             ));
         }
+
+        if option.is_hide_set() {
+          buffer.push_str(&format!(
+              "{:indent$}hidden: true,\n",
+              "",
+              indent = indent + 4
+          ))
+      }
 
         buffer.push_str(&format!("{:indent$}args: ", "", indent = indent + 4));
 

--- a/clap_complete_fig/tests/common.rs
+++ b/clap_complete_fig/tests/common.rs
@@ -50,10 +50,11 @@ pub fn special_commands_command(name: &'static str) -> clap::Command<'static> {
                         .takes_value(true)
                         .help("the other case to test"),
                 )
-                .arg(clap::Arg::new("path")
-                    .takes_value(true)
-                    .require_equals(true)
-                )
+                .arg(
+                    clap::Arg::new("path")
+                        .takes_value(true)
+                        .require_equals(true),
+                ),
         )
         .subcommand(clap::Command::new("some-cmd-with-hyphens").alias("hyphen"))
         .subcommand(clap::Command::new("some-hidden-cmd").hide(true))

--- a/clap_complete_fig/tests/common.rs
+++ b/clap_complete_fig/tests/common.rs
@@ -46,11 +46,17 @@ pub fn special_commands_command(name: &'static str) -> clap::Command<'static> {
                 .arg(
                     clap::Arg::new("config")
                         .long("--config")
+                        .hide(true)
                         .takes_value(true)
                         .help("the other case to test"),
-                ),
+                )
+                .arg(clap::Arg::new("path")
+                    .takes_value(true)
+                    .require_equals(true)
+                )
         )
         .subcommand(clap::Command::new("some-cmd-with-hyphens").alias("hyphen"))
+        .subcommand(clap::Command::new("some-hidden-cmd").hide(true))
 }
 
 pub fn quoting_command(name: &'static str) -> clap::Command<'static> {

--- a/clap_complete_fig/tests/snapshots/special_commands.fig.js
+++ b/clap_complete_fig/tests/snapshots/special_commands.fig.js
@@ -31,6 +31,7 @@ const completion: Fig.Spec = {
         {
           name: "--config",
           description: "the other case to test",
+          hidden: true,
           args: {
             name: "config",
             isOptional: true,
@@ -45,9 +46,28 @@ const completion: Fig.Spec = {
           description: "Print version information",
         },
       ],
+      requireEquals: true,
+      args: {
+        name: "path",
+        isOptional: true,
+      },
     },
     {
       name: "some-cmd-with-hyphens",
+      options: [
+        {
+          name: ["-h", "--help"],
+          description: "Print help information",
+        },
+        {
+          name: ["-V", "--version"],
+          description: "Print version information",
+        },
+      ],
+    },
+    {
+      name: "some-hidden-cmd",
+      hidden: true,
       options: [
         {
           name: ["-h", "--help"],


### PR DESCRIPTION
Hi there!
This PR adds support for:
- `.hide(true)` on both subcommands and options
- `require_equals` on args.