### PR TITLE
fix(clap_complete_fig): Correct `requiresEquals` name and add it to the right objects

### DIFF
--- a/clap_complete/tests/common.rs
+++ b/clap_complete/tests/common.rs
@@ -51,12 +51,13 @@ pub fn special_commands_command(name: &'static str) -> clap::Command<'static> {
                         .long("--config")
                         .hide(true)
                         .takes_value(true)
+                        .require_equals(true)
                         .help("the other case to test"),
                 )
                 .arg(
                     clap::Arg::new("path")
                         .takes_value(true)
-                        .require_equals(true),
+                        .multiple_occurrences(true),
                 ),
         )
         .subcommand(clap::Command::new("some-cmd-with-hyphens").alias("hyphen"))

--- a/clap_complete/tests/snapshots/special_commands.bash.log
+++ b/clap_complete/tests/snapshots/special_commands.bash.log
@@ -90,7 +90,7 @@ _my-app() {
             return 0
             ;;
         my__app__some_cmd)
-            opts="-h -V --config --help --version <path>"
+            opts="-h -V --config --help --version <path>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/special_commands.zsh.log
+++ b/clap_complete/tests/snapshots/special_commands.zsh.log
@@ -50,7 +50,7 @@ _arguments "${_arguments_options[@]}" /
 '--help[Print help information]' /
 '-V[Print version information]' /
 '--version[Print version information]' /
-'::path:' /
+'*::path:' /
 && ret=0
 ;;
 (some-cmd-with-hyphens)

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -96,14 +96,6 @@ fn gen_fig_inner(
 
     let args = cmd.get_positionals().collect::<Vec<_>>();
 
-    if args.iter().any(|&x| x.is_require_equals_set()) {
-        buffer.push_str(&format!(
-            "{:indent$}requireEquals: true,\n",
-            "",
-            indent = indent
-        ));
-    }
-
     match args.len() {
         0 => {}
         1 => {
@@ -205,6 +197,14 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
             if option.is_multiple_occurrences_set() {
                 buffer.push_str(&format!(
                     "{:indent$}isRepeatable: true,\n",
+                    "",
+                    indent = indent + 4
+                ));
+            }
+
+            if option.is_require_equals_set() {
+                buffer.push_str(&format!(
+                    "{:indent$}requiresEquals: true,\n",
                     "",
                     indent = indent + 4
                 ));

--- a/clap_complete_fig/tests/common.rs
+++ b/clap_complete_fig/tests/common.rs
@@ -51,12 +51,13 @@ pub fn special_commands_command(name: &'static str) -> clap::Command<'static> {
                         .long("--config")
                         .hide(true)
                         .takes_value(true)
+                        .require_equals(true)
                         .help("the other case to test"),
                 )
                 .arg(
                     clap::Arg::new("path")
                         .takes_value(true)
-                        .require_equals(true),
+                        .multiple_occurrences(true),
                 ),
         )
         .subcommand(clap::Command::new("some-cmd-with-hyphens").alias("hyphen"))

--- a/clap_complete_fig/tests/snapshots/special_commands.fig.js
+++ b/clap_complete_fig/tests/snapshots/special_commands.fig.js
@@ -32,6 +32,7 @@ const completion: Fig.Spec = {
           name: "--config",
           description: "the other case to test",
           hidden: true,
+          requiresEquals: true,
           args: {
             name: "config",
             isOptional: true,
@@ -46,7 +47,6 @@ const completion: Fig.Spec = {
           description: "Print version information",
         },
       ],
-      requireEquals: true,
       args: {
         name: "path",
         isOptional: true,


### PR DESCRIPTION
I actually mis-read our docs and used the wrong name + added requiresEqual to the wrong sub-object.
Sorry for that!