### PR TITLE
feat(clap_complete_fig): Add subcommand aliases support

### DIFF
--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -52,13 +52,35 @@ fn gen_fig_inner(
         buffer.push_str(&format!("{:indent$}subcommands: [\n", "", indent = indent));
         // generate subcommands
         for subcommand in cmd.get_subcommands() {
-            buffer.push_str(&format!(
-                "{:indent$}{{\n{:indent$}  name: \"{}\",\n",
-                "",
-                "",
-                subcommand.get_name(),
-                indent = indent + 2
-            ));
+            let mut aliases: Vec<&str> = subcommand.get_all_aliases().collect();
+            if !aliases.is_empty() {
+                aliases.insert(0, subcommand.get_name());
+
+                buffer.push_str(&format!(
+                    "{:indent$}{{\n{:indent$}  name: [",
+                    "",
+                    "",
+                    indent = indent + 2
+                ));
+
+                buffer.push_str(
+                    &aliases
+                        .iter()
+                        .map(|name| format!("\"{}\"", name))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+
+                buffer.push_str("],\n");
+            } else {
+                buffer.push_str(&format!(
+                    "{:indent$}{{\n{:indent$}  name: \"{}\",\n",
+                    "",
+                    "",
+                    subcommand.get_name(),
+                    indent = indent + 2
+                ));
+            }
 
             if let Some(data) = subcommand.get_about() {
                 buffer.push_str(&format!(

--- a/clap_complete_fig/tests/snapshots/special_commands.fig.js
+++ b/clap_complete_fig/tests/snapshots/special_commands.fig.js
@@ -53,7 +53,7 @@ const completion: Fig.Spec = {
       },
     },
     {
-      name: "some-cmd-with-hyphens",
+      name: ["some-cmd-with-hyphens", "hyphen"],
       options: [
         {
           name: ["-h", "--help"],


### PR DESCRIPTION
Support printing hidden and non-hidden aliases to fig completion specs.