### PR TITLE
Added proc_macro attribute for the main function

### DIFF
--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -19,7 +19,8 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use proc_macro_error::proc_macro_error;
+use proc_macro_error::{abort_call_site, proc_macro_error};
+use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 mod attrs;
@@ -63,4 +64,77 @@ pub fn subcommand(input: TokenStream) -> TokenStream {
 pub fn args(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
     derives::derive_args(&input).into()
+}
+
+/// Adds an argument to the main function, the argument type must implement [`clap::Parser`][clap::Parser]
+/// ## Examples
+/// ```rust
+///
+/// #[derive(clap::Parser)]
+/// #[clap(name = "demo")]
+/// struct Context {
+///     /// More verbose output
+///     #[clap(long)]
+///     verbose: bool,
+///     /// An optional name
+///     #[clap(short, long)]
+///     name: Option<String>,
+/// }
+///
+///
+/// #[clap::main]
+/// fn main(args: Context) {
+///     println!("{:?}", args.name);
+/// }
+/// ```
+#[proc_macro_attribute]
+#[proc_macro_error]
+pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as syn::ItemFn);
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let body = &input.block;
+    let asyncness = &input.sig.asyncness;
+    let attrs = &input.attrs;
+
+    if name != "main" {
+        abort_call_site!("only fn main can be tagged with #[clap::main]");
+    }
+    let end = match ret {
+        syn::ReturnType::Default => quote! {.unwrap()},
+        _ => quote! {?},
+    };
+    let inputs = &input.sig.inputs;
+    let result = match inputs.len() {
+        0 => {
+            quote! {
+                #(#attrs)*
+                #asyncness fn main() #ret {
+                    #body
+                }
+            }
+        }
+        1 => {
+            let arg = match inputs.first().unwrap() {
+                syn::FnArg::Typed(arg) => arg,
+                _ => {
+                    abort_call_site!("fn main should take a fully formed argument");
+                }
+            };
+            let arg_name = &arg.pat;
+            let arg_type = &arg.ty;
+            quote! {
+                #(#attrs)*
+                #asyncness fn main() #ret {
+                    let #arg_name = <#arg_type as clap::Parser>::try_parse()#end;
+                    #body
+                }
+
+            }
+        }
+        _ => {
+            abort_call_site!("fn main can take 0 or 1 arguments");
+        }
+    };
+    result.into()
 }


### PR DESCRIPTION

This adds a proc_macro similar to the one used by the [`paw`](https://crates.io/crates/paw) crate.
The user adds a `[clap::main]` attribute to the main function which allows adding an argument for the main function that implements Parser.
Example:
```rust
use clap::Parser;

#[derive(Parser)]
struct Command {
   pub arg: String
}

#[clap::main]
fn main(argv: Command) {
   println!("{}", argv.arg)
}
```

Another way to do it would be to implement the trait used by paw but that would require the end user to pull the paw crate which adds to the dependencies so it's easier to do it internally in clap.