### PR TITLE
docs: arg! macro uses double quotes for help string

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -633,7 +633,7 @@ macro_rules! arg_impl {
 ///
 /// ### Help String
 ///
-/// The help string is denoted between a pair of single quotes `''` and may contain any
+/// The help string is denoted between a pair of double quotes `""` and may contain any
 /// characters.
 ///
 /// # Examples


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Small documentation fix, help string in `arg!()` must be double-quoted.
