### PR TITLE
Move Positional Arguments into its own section in generated manpages

### DIFF
--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -105,7 +105,11 @@ impl<'a> Man<'a> {
         self._render_synopsis_section(&mut roff);
         self._render_description_section(&mut roff);
 
-        if app_has_arguments(&self.cmd) {
+        if app_has_positionals(&self.cmd) {
+            self._render_positionals_section(&mut roff);
+        }
+
+        if app_has_options(&self.cmd) {
             self._render_options_section(&mut roff);
         }
 
@@ -186,6 +190,18 @@ impl<'a> Man<'a> {
         render::description(roff, &self.cmd);
     }
 
+    /// Render the POSITIONAL ARGUMENTS section into the writer.
+    pub fn render_positionals_section(&self, w: &mut dyn Write) -> Result<(), std::io::Error> {
+        let mut roff = Roff::default();
+        self._render_positionals_section(&mut roff);
+        roff.to_writer(w)
+    }
+
+    fn _render_positionals_section(&self, roff: &mut Roff) {
+        roff.control("SH", ["POSITIONAL ARGUMENTS"]);
+        render::positionals(roff, &self.cmd);
+    }
+
     /// Render the OPTIONS section into the writer.
     pub fn render_options_section(&self, w: &mut dyn Write) -> Result<(), std::io::Error> {
         let mut roff = Roff::default();
@@ -257,9 +273,16 @@ fn app_has_version(cmd: &clap::Command) -> bool {
         .is_some()
 }
 
-// Does the application have any command line arguments?
-fn app_has_arguments(cmd: &clap::Command) -> bool {
-    cmd.get_arguments().any(|i| !i.is_hide_set())
+// Does the application have any option arguments?
+fn app_has_options(cmd: &clap::Command) -> bool {
+    cmd.get_arguments()
+        .any(|i| !i.is_hide_set() && !i.is_positional())
+}
+
+// Does the application have any positional arguments?
+fn app_has_positionals(cmd: &clap::Command) -> bool {
+    cmd.get_arguments()
+        .any(|i| !i.is_hide_set() && i.is_positional())
 }
 
 // Does the application have any subcommands?

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -80,6 +80,36 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     roff.text(line);
 }
 
+pub(crate) fn positionals(roff: &mut Roff, cmd: &clap::Command) {
+    let items: Vec<_> = cmd.get_arguments().filter(|i| !i.is_hide_set()).collect();
+
+    for pos in items.iter().filter(|a| a.is_positional()) {
+        let name = pos
+            .get_value_names()
+            .map_or(pos.get_id(), |value_names| value_names[0]);
+
+        let mut header = vec![italic(name)];
+
+        let mut body = vec![];
+
+        if let Some(defs) = option_default_values(pos) {
+            header.push(roman(&format!(" {}", defs)));
+        }
+
+        if let Some(help) = pos.get_long_help().or_else(|| pos.get_help()) {
+            body.push(roman(&help.to_string()));
+        }
+
+        if let Some(mut env) = option_environment(pos) {
+            body.append(&mut env);
+        }
+
+        roff.control("TP", []);
+        roff.text(header);
+        roff.text(body);
+    }
+}
+
 pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
     let items: Vec<_> = cmd.get_arguments().filter(|i| !i.is_hide_set()).collect();
 
@@ -115,30 +145,6 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
 
         roff.control("TP", []);
         roff.text(header);
-        roff.text(body);
-    }
-
-    for pos in items.iter().filter(|a| a.is_positional()) {
-        let (lhs, rhs) = option_markers(pos);
-        let name = format!("{}{}{}", lhs, pos.get_id(), rhs);
-
-        let mut header = vec![bold(&name)];
-
-        let mut body = vec![];
-
-        if let Some(defs) = option_default_values(pos) {
-            header.push(roman(&format!(" {}", defs)));
-        }
-
-        if let Some(help) = pos.get_long_help().or_else(|| pos.get_help()) {
-            body.push(roman(&help.to_string()));
-        }
-
-        if let Some(mut env) = option_environment(pos) {
-            body.append(&mut env);
-        }
-
-        roff.control("TP", []);
         roff.text(body);
     }
 }


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

This PR also:
- [x] Adds `Man::render_positionals_section()` for rendering docs for positional arguments
- [x] Renders a header for each positional argument
- [x] Attempts to use `Arg::value_name` before falling back to `Arg::id` for the header names

Resolves #3579 