### PR TITLE
docs: Remove unnecessary backtick in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixes
 
-- `*(derive)* Abort, rather than ignore, when deriving `ArgEnum` with non-unit unskipped variants
+- *(derive)* Abort, rather than ignore, when deriving `ArgEnum` with non-unit unskipped variants
 
 ## [3.1.6] - 2022-03-07
 


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

I found unnecessary backtick in changelog breaks one of items. This PR fixes it. No issue is linked to this PR because this is very small typo fix.
