### PR TITLE
fix(man): show the environment info with separate paragraph

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -112,16 +112,15 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
             body.push(roman(help));
         }
 
-        if let Some(mut env) = option_environment(opt) {
-            if !body.is_empty() {
-                body.push(roman(". "));
-            }
-            body.append(&mut env);
-        }
-
         roff.control("TP", []);
         roff.text(header);
         roff.text(body);
+
+        if let Some(env) = option_environment(opt) {
+            roff.control("RS", []);
+            roff.text(env);
+            roff.control("RE", []);
+        }
     }
 
     for pos in items.iter().filter(|a| a.is_positional()) {
@@ -144,16 +143,15 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
             body.push(roman(&help.to_string()));
         }
 
-        if let Some(mut env) = option_environment(pos) {
-            if !body.is_empty() {
-                body.push(roman(". "));
-            }
-            body.append(&mut env);
-        }
-
         roff.control("TP", []);
         roff.text(header);
         roff.text(body);
+
+        if let Some(env) = option_environment(pos) {
+            roff.control("RS", []);
+            roff.text(env);
+            roff.control("RE", []);
+        }
     }
 }
 

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -113,6 +113,9 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
         }
 
         if let Some(mut env) = option_environment(opt) {
+            if !body.is_empty() {
+                body.push(roman(". "));
+            }
             body.append(&mut env);
         }
 
@@ -142,6 +145,9 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
         }
 
         if let Some(mut env) = option_environment(pos) {
+            if !body.is_empty() {
+                body.push(roman(". "));
+            }
             body.append(&mut env);
         }
 

--- a/clap_mangen/tests/common.rs
+++ b/clap_mangen/tests/common.rs
@@ -231,6 +231,18 @@ pub fn hidden_option_command(name: &'static str) -> clap::Command<'static> {
         )
 }
 
+pub fn env_value_command(name: &'static str) -> clap::Command<'static> {
+    clap::Command::new(name).arg(
+        clap::Arg::new("config")
+            .short('c')
+            .long_help("Set configuration file path")
+            .required(false)
+            .takes_value(true)
+            .default_value("config.toml")
+            .env("CONFIG_FILE"),
+    )
+}
+
 pub fn assert_matches_path(expected_path: impl AsRef<std::path::Path>, cmd: clap::Command) {
     let mut buf = vec![];
     clap_mangen::Man::new(cmd).render(&mut buf).unwrap();

--- a/clap_mangen/tests/roff.rs
+++ b/clap_mangen/tests/roff.rs
@@ -55,3 +55,10 @@ fn hidden_options() {
     let cmd = common::hidden_option_command(name);
     common::assert_matches_path("tests/snapshots/hidden_option.bash.roff", cmd);
 }
+
+#[test]
+fn value_env() {
+    let name = "my-app";
+    let cmd = common::env_value_command(name);
+    common::assert_matches_path("tests/snapshots/value_env.bash.roff", cmd);
+}

--- a/clap_mangen/tests/snapshots/value_env.bash.roff
+++ b/clap_mangen/tests/snapshots/value_env.bash.roff
@@ -12,4 +12,7 @@ my/-app
 Print help information
 .TP
 /fB/-c/fR [default: config.toml]
-Set configuration file path. May also be specified with the /fBCONFIG_FILE/fR environment variable. 
+Set configuration file path
+.RS
+May also be specified with the /fBCONFIG_FILE/fR environment variable. 
+.RE

--- a/clap_mangen/tests/snapshots/value_env.bash.roff
+++ b/clap_mangen/tests/snapshots/value_env.bash.roff
@@ -1,0 +1,15 @@
+.ie /n(.g .ds Aq /(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my/-app
+.SH SYNOPSIS
+/fBmy/-app/fR [/fB/-h/fR|/fB/-/-help/fR] [/fB/-c /fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+/fB/-h/fR, /fB/-/-help/fR
+Print help information
+.TP
+/fB/-c/fR [default: config.toml]
+Set configuration file path. May also be specified with the /fBCONFIG_FILE/fR environment variable. 


### PR DESCRIPTION
This PR updates the man page renderer to add a space between argument help text and environment variable information. There is also a new test-case added for testing this change.

fixes #3630