### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,13 @@ on:
     branches: [master]
   schedule:
   - cron: '3 3 3 * *'
+permissions:
+  contents: read
+
 jobs:
   ci:
+    permissions:
+      contents: none
     name: CI
     needs: [test, check, docs, rustfmt, clippy]
     runs-on: ubuntu-latest

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,8 +3,13 @@ on:
   push:
     tags:
     - "v*"
+permissions:
+  contents: read
+
 jobs:
   create-release:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: create-release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -2,6 +2,9 @@ name: rust-next
 on:
   schedule:
   - cron: '3 3 3 * *'
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,6 +1,9 @@
 name: Spelling
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   spelling:
     name: Spell Check with Typos


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
