### PR TITLE
feat: Expose clap_lex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
 	"clap_derive",
+	"clap_lex",
 	"clap_complete",
 	"clap_complete_fig",
 	"clap_mangen",
@@ -118,11 +119,11 @@ path = "benches/06_rustup.rs"
 
 [dependencies]
 clap_derive = { path = "./clap_derive", version = "3.1.7", optional = true }
+clap_lex = { path = "./clap_lex", version = "0.1.0" }
 bitflags = "1.2"
 textwrap = { version = "0.15.0", default-features = false, features = [] }
 unicase = { version = "2.6", optional = true }
 indexmap = "1.0"
-os_str_bytes = "6.0"
 strsim = { version = "0.10",  optional = true }
 yaml-rust = { version = "0.4.1",  optional = true }
 atty = { version = "0.2",  optional = true }

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Why use the procedural [Builder API](https://github.com/clap-rs/clap/blob/v3.1.8
 - [wild](https://crates.io/crates/wild) for supporting wildcards (`*`) on Windows like you do Linux
 - [argfile](https://crates.io/crates/argfile) for loading additional arguments from a file (aka response files)
 - [shadow-rs](https://crates.io/crates/shadow-rs) for generating `Command::long_version`
+- [clap_lex](https://crates.io/crates/clap_lex) for a lighter-weight, battle-tested CLI parser
 - [clap_mangen](https://crates.io/crates/clap_mangen) for generating man page source (roff)
 - [clap_complete](https://crates.io/crates/clap_complete) for shell completion support
 - [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag)

--- a/clap_lex/CHANGELOG.md
+++ b/clap_lex/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+<!-- next-header -->
+## [Unreleased] - ReleaseDate
+
+<!-- next-url -->
+[Unreleased]: https://github.com/clap-rs/clap/compare/ce71b08a3fe28c640dc6e17f6f5bb1452bd6d6d8...HEAD

--- a/clap_lex/CONTRIBUTING.md
+++ b/clap_lex/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# How to Contribute
+
+See the [clap-wide CONTRIBUTING.md](../CONTRIBUTING.md).  This will contain `clap_lex` specific notes.

--- a/clap_lex/Cargo.toml
+++ b/clap_lex/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "clap_lex"
+version = "0.1.0"
+edition = "2018"
+include = [
+	"src/**/*",
+	"Cargo.toml",
+	"LICENSE-*",
+	"README.md"
+]
+description = "Minimal, flexible command line parser"
+repository = "https://github.com/clap-rs/clap/tree/master/clap_lex"
+documentation = "https://docs.rs/clap_lex"
+keywords = [
+	"argument",
+	"cli",
+	"arg",
+	"parser",
+	"parse"
+]
+categories = ["command-line-interface"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+
+[package.metadata.release]
+pre-release-replacements = [
+  {file="CHANGELOG.md", search="Unreleased", replace="{{version}}", min=1},
+  {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
+  {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}", min=1},
+  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n## [Unreleased] - ReleaseDate\n", exactly=1},
+  {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/clap-rs/clap/compare/{{tag_name}}...HEAD", exactly=1},
+  {file="README.md", search="github.com/clap-rs/clap/blob/[^/]+/", replace="github.com/clap-rs/clap/blob/{{tag_name}}/", exactly=4, prerelease = true},
+]
+
+[lib]
+bench = false
+
+[dependencies]
+os_str_bytes = "6.0"

--- a/clap_lex/LICENSE-APACHE
+++ b/clap_lex/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/clap_lex/LICENSE-MIT
+++ b/clap_lex/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Kevin B. Knapp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/clap_lex/README.md
+++ b/clap_lex/README.md
@@ -1,0 +1,19 @@
+<!-- omit in TOC -->
+# clap_lex
+
+> **Minimal, flexible command line parser**
+
+[![Crates.io](https://img.shields.io/crates/v/clap_lex?style=flat-square)](https://crates.io/crates/clap_lex)
+[![Crates.io](https://img.shields.io/crates/d/clap_lex?style=flat-square)](https://crates.io/crates/clap_lex)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/clap-rs/clap/blob/clap_lex-v3.1.1/LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/clap-rs/clap/blob/clap_lex-v3.1.1/LICENSE-MIT)
+
+Dual-licensed under [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT).
+
+1. [About](#about)
+2. [API Reference](https://docs.rs/clap_lex)
+3. [Questions & Discussions](https://github.com/clap-rs/clap/discussions)
+4. [CONTRIBUTING](https://github.com/clap-rs/clap/blob/clap_lex-v3.1.1/clap_lex/CONTRIBUTING.md)
+5. [Sponsors](https://github.com/clap-rs/clap/blob/clap_lex-v3.1.1/README.md#sponsors)
+
+## About

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -358,8 +358,8 @@ impl<'s> ParsedArg<'s> {
     /// Treat as a value
     ///
     /// **NOTE:** May return a flag or an escape.
-    pub fn to_value(&self) -> Option<&str> {
-        self.utf8
+    pub fn to_value(&self) -> Result<&str, &RawOsStr> {
+        self.utf8.ok_or(self.inner.as_ref())
     }
 
     /// Safely print an argument that may contain non-UTF8 content

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -174,7 +174,7 @@ impl RawArgs {
         ArgCursor::new()
     }
 
-    /// Advance the cursor, returning the next [`ParsedArgs`]
+    /// Advance the cursor, returning the next [`ParsedArg`]
     pub fn next(&self, cursor: &mut ArgCursor) -> Option<ParsedArg<'_>> {
         self.next_os(cursor).map(ParsedArg::new)
     }
@@ -186,7 +186,7 @@ impl RawArgs {
         next
     }
 
-    /// Return the next [`ParsedArgs`]
+    /// Return the next [`ParsedArg`]
     pub fn peek(&self, cursor: &ArgCursor) -> Option<ParsedArg<'_>> {
         self.peek_os(cursor).map(ParsedArg::new)
     }

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -292,6 +292,9 @@ impl<'s> ParsedArg<'s> {
     /// Treat as a long-flag
     ///
     /// **NOTE:** May return an empty flag.  Check [`ParsedArg::is_escape`] to separately detect `--`.
+    ///
+    /// **NOTE:** Will not match [`ParsedArg::is_stdio`], completion engines will need to check
+    /// that case.
     pub fn to_long(&self) -> Option<(Result<&str, &RawOsStr>, Option<&RawOsStr>)> {
         if let Some(raw) = self.utf8 {
             let remainder = raw.strip_prefix("--")?;

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -3,11 +3,12 @@ use std::ffi::OsString;
 
 pub use std::io::SeekFrom;
 
-use os_str_bytes::RawOsStr;
+pub use os_str_bytes::RawOsStr;
+pub use os_str_bytes::RawOsString;
 
 /// Command-line arguments
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
-pub(crate) struct RawArgs {
+pub struct RawArgs {
     items: Vec<OsString>,
 }
 
@@ -80,7 +81,7 @@ where
 
 /// Position within [`RawArgs`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct ArgCursor {
+pub struct ArgCursor {
     cursor: usize,
 }
 
@@ -92,7 +93,7 @@ impl ArgCursor {
 
 /// Command-line Argument
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct ParsedArg<'s> {
+pub struct ParsedArg<'s> {
     inner: std::borrow::Cow<'s, RawOsStr>,
     utf8: Option<&'s str>,
 }
@@ -204,7 +205,7 @@ impl<'s> ParsedArg<'s> {
 
 /// Walk through short flags within a [`ParsedArg`]
 #[derive(Clone, Debug)]
-pub(crate) struct ShortFlags<'s> {
+pub struct ShortFlags<'s> {
     inner: &'s RawOsStr,
     utf8_prefix: std::str::CharIndices<'s>,
     invalid_suffix: Option<&'s RawOsStr>,

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -1,7 +1,8 @@
 //! Minimal, flexible command-line parser
 //!
-//! As opposed to a declarative parser, this processes arguments as a stream.  The caller
-//! decides when to treat an argument as a flag or value.
+//! As opposed to a declarative parser, this processes arguments as a stream of tokens.  As lexing
+//! a command-line is not context-free, we rely on the caller to decide how to interpret the
+//! arguments.
 //!
 //! # Examples
 //!

--- a/clap_lex/tests/lexer.rs
+++ b/clap_lex/tests/lexer.rs
@@ -1,0 +1,21 @@
+#[test]
+fn insert() {
+    let mut raw = clap_lex::RawArgs::from_iter(["bin", "a", "b", "c"]);
+    let mut cursor = raw.cursor();
+
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("a")));
+    raw.insert(&mut cursor, &["1", "2", "3"]);
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("1")));
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("2")));
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("3")));
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("b")));
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("c")));
+
+    let mut cursor = raw.cursor();
+    let rest = raw
+        .remaining(&mut cursor)
+        .map(|s| s.to_string_lossy())
+        .collect::<Vec<_>>();
+    assert_eq!(rest, vec!["bin", "a", "1", "2", "3", "b", "c"]);
+}

--- a/clap_lex/tests/lexer.rs
+++ b/clap_lex/tests/lexer.rs
@@ -1,11 +1,11 @@
 #[test]
 fn insert() {
-    let mut raw = clap_lex::RawArgs::from_iter(["bin", "a", "b", "c"]);
+    let mut raw = clap_lex::RawArgs::new(["bin", "a", "b", "c"]);
     let mut cursor = raw.cursor();
 
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("a")));
-    raw.insert(&mut cursor, &["1", "2", "3"]);
+    raw.insert(&cursor, &["1", "2", "3"]);
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("1")));
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("2")));
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("3")));

--- a/clap_lex/tests/parsed.rs
+++ b/clap_lex/tests/parsed.rs
@@ -2,7 +2,7 @@
 // the start of a long because there is no valid value to return.
 #[test]
 fn to_long_stdio() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -14,7 +14,7 @@ fn to_long_stdio() {
 
 #[test]
 fn to_long_escape() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -28,7 +28,7 @@ fn to_long_escape() {
 
 #[test]
 fn to_long_no_value() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--long"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--long"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -42,7 +42,7 @@ fn to_long_no_value() {
 
 #[test]
 fn to_long_with_empty_value() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--long="]);
+    let raw = clap_lex::RawArgs::new(["bin", "--long="]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -56,7 +56,7 @@ fn to_long_with_empty_value() {
 
 #[test]
 fn to_long_with_value() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--long=hello"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--long=hello"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -70,7 +70,7 @@ fn to_long_with_value() {
 
 #[test]
 fn to_short_stdio() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -83,7 +83,7 @@ fn to_short_stdio() {
 
 #[test]
 fn to_short_escape() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -95,7 +95,7 @@ fn to_short_escape() {
 
 #[test]
 fn to_short_long() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--long"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--long"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -107,7 +107,7 @@ fn to_short_long() {
 
 #[test]
 fn to_short() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -121,7 +121,7 @@ fn to_short() {
 
 #[test]
 fn is_negative_number() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-10.0"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-10.0"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -131,7 +131,7 @@ fn is_negative_number() {
 
 #[test]
 fn is_positive_number() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "10.0"]);
+    let raw = clap_lex::RawArgs::new(["bin", "10.0"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -141,7 +141,7 @@ fn is_positive_number() {
 
 #[test]
 fn is_not_number() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--10.0"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--10.0"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -151,7 +151,7 @@ fn is_not_number() {
 
 #[test]
 fn is_stdio() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -161,7 +161,7 @@ fn is_stdio() {
 
 #[test]
 fn is_not_stdio() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -171,7 +171,7 @@ fn is_not_stdio() {
 
 #[test]
 fn is_escape() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let raw = clap_lex::RawArgs::new(["bin", "--"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -181,7 +181,7 @@ fn is_escape() {
 
 #[test]
 fn is_not_escape() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();

--- a/clap_lex/tests/parsed.rs
+++ b/clap_lex/tests/parsed.rs
@@ -1,0 +1,191 @@
+#[test]
+#[should_panic] // Our design philosophy is to match X if it can be completed as X which we break here
+fn to_long_stdio() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_long());
+
+    let (key, value) = next.to_long().unwrap();
+    assert_eq!(key, Ok(""));
+    assert_eq!(value, None);
+}
+
+#[test]
+fn to_long_escape() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_long());
+
+    let (key, value) = next.to_long().unwrap();
+    assert_eq!(key, Ok(""));
+    assert_eq!(value, None);
+}
+
+#[test]
+fn to_long_no_value() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--long"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_long());
+
+    let (key, value) = next.to_long().unwrap();
+    assert_eq!(key, Ok("long"));
+    assert_eq!(value, None);
+}
+
+#[test]
+fn to_long_with_empty_value() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--long="]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_long());
+
+    let (key, value) = next.to_long().unwrap();
+    assert_eq!(key, Ok("long"));
+    assert_eq!(value, Some(clap_lex::RawOsStr::from_str("")));
+}
+
+#[test]
+fn to_long_with_value() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--long=hello"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_long());
+
+    let (key, value) = next.to_long().unwrap();
+    assert_eq!(key, Ok("long"));
+    assert_eq!(value, Some(clap_lex::RawOsStr::from_str("hello")));
+}
+
+#[test]
+fn to_short_stdio() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_short());
+
+    let mut shorts = next.to_short().unwrap();
+    assert_eq!(shorts.next_value_os(), None);
+}
+
+#[test]
+fn to_short_escape() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(!next.is_short());
+
+    assert!(next.to_short().is_none());
+}
+
+#[test]
+fn to_short_long() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--long"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(!next.is_short());
+
+    assert!(next.to_short().is_none());
+}
+
+#[test]
+fn to_short() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_short());
+
+    let shorts = next.to_short().unwrap();
+    let actual: String = shorts.map(|s| s.unwrap()).collect();
+    assert_eq!(actual, "short");
+}
+
+#[test]
+fn is_negative_number() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-10.0"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_number());
+}
+
+#[test]
+fn is_positive_number() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "10.0"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_number());
+}
+
+#[test]
+fn is_not_number() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--10.0"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(!next.is_number());
+}
+
+#[test]
+fn is_stdio() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_stdio());
+}
+
+#[test]
+fn is_not_stdio() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(!next.is_stdio());
+}
+
+#[test]
+fn is_escape() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "--"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(next.is_escape());
+}
+
+#[test]
+fn is_not_escape() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+
+    assert!(!next.is_escape());
+}

--- a/clap_lex/tests/parsed.rs
+++ b/clap_lex/tests/parsed.rs
@@ -1,16 +1,15 @@
+// Despite our design philosophy being to support completion generation, we aren't considering `-`
+// the start of a long because there is no valid value to return.
 #[test]
-#[should_panic] // Our design philosophy is to match X if it can be completed as X which we break here
 fn to_long_stdio() {
     let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
 
-    assert!(next.is_long());
+    assert!(!next.is_long());
 
-    let (key, value) = next.to_long().unwrap();
-    assert_eq!(key, Ok(""));
-    assert_eq!(value, None);
+    assert_eq!(next.to_long(), None);
 }
 
 #[test]

--- a/clap_lex/tests/shorts.rs
+++ b/clap_lex/tests/shorts.rs
@@ -1,0 +1,198 @@
+#[test]
+fn iter() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let shorts = next.to_short().unwrap();
+
+    let actual: String = shorts.map(|s| s.unwrap()).collect();
+    assert_eq!(actual, "short");
+}
+
+#[test]
+fn next_flag() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    let mut actual = String::new();
+    actual.push(shorts.next_flag().unwrap().unwrap());
+    actual.push(shorts.next_flag().unwrap().unwrap());
+    actual.push(shorts.next_flag().unwrap().unwrap());
+    actual.push(shorts.next_flag().unwrap().unwrap());
+    actual.push(shorts.next_flag().unwrap().unwrap());
+    assert_eq!(shorts.next_flag(), None);
+
+    assert_eq!(actual, "short");
+}
+
+#[test]
+fn next_value_os() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    let actual = shorts.next_value_os().unwrap().to_str_lossy();
+
+    assert_eq!(actual, "short");
+}
+
+#[test]
+fn next_flag_with_value() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    assert_eq!(shorts.next_flag().unwrap().unwrap(), 's');
+    let actual = shorts.next_value_os().unwrap().to_str_lossy();
+
+    assert_eq!(actual, "hort");
+}
+
+#[test]
+fn next_flag_with_no_value() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    assert_eq!(shorts.next_flag().unwrap().unwrap(), 's');
+    assert_eq!(shorts.next_flag().unwrap().unwrap(), 'h');
+    assert_eq!(shorts.next_flag().unwrap().unwrap(), 'o');
+    assert_eq!(shorts.next_flag().unwrap().unwrap(), 'r');
+    assert_eq!(shorts.next_flag().unwrap().unwrap(), 't');
+
+    assert_eq!(shorts.next_value_os(), None);
+}
+
+#[test]
+fn advance_by_nothing() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    assert_eq!(shorts.advance_by(0), Ok(()));
+
+    let actual: String = shorts.map(|s| s.unwrap()).collect();
+    assert_eq!(actual, "short");
+}
+
+#[test]
+fn advance_by_nothing_with_nothing() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    assert_eq!(shorts.advance_by(0), Ok(()));
+
+    let actual: String = shorts.map(|s| s.unwrap()).collect();
+    assert_eq!(actual, "");
+}
+
+#[test]
+fn advance_by_something() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    assert_eq!(shorts.advance_by(2), Ok(()));
+
+    let actual: String = shorts.map(|s| s.unwrap()).collect();
+    assert_eq!(actual, "ort");
+}
+
+#[test]
+fn advance_by_out_of_bounds() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+
+    assert_eq!(shorts.advance_by(2000), Err(5));
+
+    let actual: String = shorts.map(|s| s.unwrap()).collect();
+    assert_eq!(actual, "");
+}
+
+#[test]
+fn is_empty() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let shorts = next.to_short().unwrap();
+
+    assert!(shorts.is_empty());
+}
+
+#[test]
+fn is_not_empty() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-hello"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let shorts = next.to_short().unwrap();
+
+    assert!(!shorts.is_empty());
+}
+
+#[test]
+fn is_partial_not_empty() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-hello"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+    shorts.advance_by(1).unwrap();
+
+    assert!(!shorts.is_empty());
+}
+
+#[test]
+fn is_exhausted_empty() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let mut shorts = next.to_short().unwrap();
+    shorts.advance_by(20000).unwrap_err();
+
+    assert!(shorts.is_empty());
+}
+
+#[test]
+fn is_number() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-1.0"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let shorts = next.to_short().unwrap();
+
+    assert!(shorts.is_number());
+}
+
+#[test]
+fn is_not_number() {
+    let raw = clap_lex::RawArgs::from_iter(["bin", "-hello"]);
+    let mut cursor = raw.cursor();
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    let next = raw.next(&mut cursor).unwrap();
+    let shorts = next.to_short().unwrap();
+
+    assert!(!shorts.is_number());
+}

--- a/clap_lex/tests/shorts.rs
+++ b/clap_lex/tests/shorts.rs
@@ -1,6 +1,6 @@
 #[test]
 fn iter() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -12,7 +12,7 @@ fn iter() {
 
 #[test]
 fn next_flag() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -31,7 +31,7 @@ fn next_flag() {
 
 #[test]
 fn next_value_os() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -44,7 +44,7 @@ fn next_value_os() {
 
 #[test]
 fn next_flag_with_value() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -58,7 +58,7 @@ fn next_flag_with_value() {
 
 #[test]
 fn next_flag_with_no_value() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -75,7 +75,7 @@ fn next_flag_with_no_value() {
 
 #[test]
 fn advance_by_nothing() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -89,7 +89,7 @@ fn advance_by_nothing() {
 
 #[test]
 fn advance_by_nothing_with_nothing() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -103,7 +103,7 @@ fn advance_by_nothing_with_nothing() {
 
 #[test]
 fn advance_by_something() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -117,7 +117,7 @@ fn advance_by_something() {
 
 #[test]
 fn advance_by_out_of_bounds() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-short"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-short"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -131,7 +131,7 @@ fn advance_by_out_of_bounds() {
 
 #[test]
 fn is_empty() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -142,7 +142,7 @@ fn is_empty() {
 
 #[test]
 fn is_not_empty() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-hello"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-hello"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -153,7 +153,7 @@ fn is_not_empty() {
 
 #[test]
 fn is_partial_not_empty() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-hello"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-hello"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -165,7 +165,7 @@ fn is_partial_not_empty() {
 
 #[test]
 fn is_exhausted_empty() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -177,7 +177,7 @@ fn is_exhausted_empty() {
 
 #[test]
 fn is_number() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-1.0"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-1.0"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
@@ -188,7 +188,7 @@ fn is_number() {
 
 #[test]
 fn is_not_number() {
-    let raw = clap_lex::RawArgs::from_iter(["bin", "-hello"]);
+    let raw = clap_lex::RawArgs::new(["bin", "-hello"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -3,7 +3,6 @@
 // Std
 use std::collections::HashMap;
 use std::env;
-use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fmt;
 use std::io;
@@ -101,7 +100,7 @@ pub struct App<'help> {
     g_settings: AppFlags,
     args: MKeyMap<'help>,
     subcommands: Vec<App<'help>>,
-    replacers: HashMap<&'help OsStr, &'help [&'help str]>,
+    replacers: HashMap<&'help str, &'help [&'help str]>,
     groups: Vec<ArgGroup<'help>>,
     current_help_heading: Option<&'help str>,
     current_disp_ord: Option<usize>,
@@ -1945,7 +1944,7 @@ impl<'help> App<'help> {
     #[cfg(feature = "unstable-replace")]
     #[must_use]
     pub fn replace(mut self, name: &'help str, target: &'help [&'help str]) -> Self {
-        self.replacers.insert(OsStr::new(name), target);
+        self.replacers.insert(name, target);
         self
     }
 
@@ -3933,7 +3932,7 @@ impl<'help> App<'help> {
         self.max_w
     }
 
-    pub(crate) fn get_replacement(&self, key: &OsStr) -> Option<&[&str]> {
+    pub(crate) fn get_replacement(&self, key: &str) -> Option<&[&str]> {
         self.replacers.get(key).copied()
     }
 

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -637,7 +637,7 @@ impl<'help> App<'help> {
 
         #[cfg(feature = "unstable-multicall")]
         if self.settings.is_set(AppSettings::Multicall) {
-            if let Some(argv0) = raw_args.next(&mut cursor) {
+            if let Some(argv0) = raw_args.next_os(&mut cursor) {
                 let argv0 = Path::new(&argv0);
                 if let Some(command) = argv0.file_stem().and_then(|f| f.to_str()) {
                     // Stop borrowing command so we can get another mut ref to it.

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -10,7 +10,6 @@ use std::ops::Index;
 use std::path::Path;
 
 // Third Party
-use os_str_bytes::RawOsStr;
 #[cfg(feature = "yaml")]
 use yaml_rust::Yaml;
 
@@ -4655,7 +4654,7 @@ impl<'help> App<'help> {
     }
 
     /// Find a flag subcommand name by long flag or an alias
-    pub(crate) fn find_long_subcmd(&self, long: &RawOsStr) -> Option<&str> {
+    pub(crate) fn find_long_subcmd(&self, long: &str) -> Option<&str> {
         self.get_subcommands()
             .find(|sc| sc.long_flag_aliases_to(long))
             .map(|sc| sc.get_name())

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -631,7 +631,7 @@ impl<'help> App<'help> {
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        let mut raw_args = clap_lex::RawArgs::from(itr.into_iter());
+        let mut raw_args = clap_lex::RawArgs::new(itr.into_iter());
         let mut cursor = raw_args.cursor();
 
         #[cfg(feature = "unstable-multicall")]

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -665,7 +665,7 @@ impl<'help> App<'help> {
         // to display
         // the full path when displaying help messages and such
         if !self.settings.is_set(AppSettings::NoBinaryName) {
-            if let Some(name) = raw_args.next(&mut cursor) {
+            if let Some(name) = raw_args.next_os(&mut cursor) {
                 let p = Path::new(name);
 
                 if let Some(f) = p.file_name() {

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -21,7 +21,7 @@ use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::MKeyMap;
 use crate::output::{fmt::Colorizer, Help, HelpWriter, Usage};
-use crate::parse::{lexer, ArgMatcher, ArgMatches, Parser};
+use crate::parse::{ArgMatcher, ArgMatches, Parser};
 use crate::util::ChildGraph;
 use crate::util::{color::ColorChoice, Id, Key};
 use crate::{Error, INTERNAL_ERROR_MSG};
@@ -631,7 +631,7 @@ impl<'help> App<'help> {
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        let mut raw_args = lexer::RawArgs::from(itr.into_iter());
+        let mut raw_args = clap_lex::RawArgs::from(itr.into_iter());
         let mut cursor = raw_args.cursor();
 
         #[cfg(feature = "unstable-multicall")]
@@ -3955,8 +3955,8 @@ impl<'help> App<'help> {
 
     fn _do_parse(
         &mut self,
-        raw_args: &mut lexer::RawArgs,
-        args_cursor: lexer::ArgCursor,
+        raw_args: &mut clap_lex::RawArgs,
+        args_cursor: clap_lex::ArgCursor,
     ) -> ClapResult<ArgMatches> {
         debug!("App::_do_parse");
 

--- a/src/build/debug_asserts.rs
+++ b/src/build/debug_asserts.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use os_str_bytes::RawOsStr;
+use clap_lex::RawOsStr;
 
 use crate::build::arg::ArgProvider;
 use crate::mkeymap::KeyType;

--- a/src/mkeymap.rs
+++ b/src/mkeymap.rs
@@ -49,6 +49,15 @@ impl PartialEq<&str> for KeyType {
     }
 }
 
+impl PartialEq<str> for KeyType {
+    fn eq(&self, rhs: &str) -> bool {
+        match self {
+            KeyType::Long(l) => l == rhs,
+            _ => false,
+        }
+    }
+}
+
 impl PartialEq<OsStr> for KeyType {
     fn eq(&self, rhs: &OsStr) -> bool {
         match self {

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -10,7 +10,7 @@ pub(crate) struct Input {
 impl<I, T> From<I> for Input
 where
     I: Iterator<Item = T>,
-    T: Into<OsString> + Clone,
+    T: Into<OsString>,
 {
     fn from(val: I) -> Self {
         Self {

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -3,6 +3,8 @@ use std::ffi::OsString;
 
 pub use std::io::SeekFrom;
 
+use os_str_bytes::RawOsStr;
+
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct RawArgs {
     items: Vec<OsString>,
@@ -13,13 +15,21 @@ impl RawArgs {
         ArgCursor::new()
     }
 
-    pub fn next(&self, cursor: &mut ArgCursor) -> Option<&OsStr> {
+    pub fn next(&self, cursor: &mut ArgCursor) -> Option<ParsedArg<'_>> {
+        self.next_os(cursor).map(ParsedArg::new)
+    }
+
+    pub fn next_os(&self, cursor: &mut ArgCursor) -> Option<&OsStr> {
         let next = self.items.get(cursor.cursor).map(|s| s.as_os_str());
         cursor.cursor = cursor.cursor.saturating_add(1);
         next
     }
 
-    pub fn peek(&self, cursor: &ArgCursor) -> Option<&OsStr> {
+    pub fn peek(&self, cursor: &ArgCursor) -> Option<ParsedArg<'_>> {
+        self.peek_os(cursor).map(ParsedArg::new)
+    }
+
+    pub fn peek_os(&self, cursor: &ArgCursor) -> Option<&OsStr> {
         self.items.get(cursor.cursor).map(|s| s.as_os_str())
     }
 
@@ -60,7 +70,7 @@ where
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct ArgCursor {
     cursor: usize,
 }
@@ -68,5 +78,184 @@ pub(crate) struct ArgCursor {
 impl ArgCursor {
     fn new() -> Self {
         Default::default()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct ParsedArg<'s> {
+    inner: std::borrow::Cow<'s, RawOsStr>,
+    utf8: Option<&'s str>,
+}
+
+impl<'s> ParsedArg<'s> {
+    fn new(inner: &'s OsStr) -> Self {
+        let utf8 = inner.to_str();
+        let inner = RawOsStr::new(inner);
+        Self { inner, utf8 }
+    }
+
+    pub fn is_stdio(&self) -> bool {
+        self.inner.as_ref() == "-"
+    }
+
+    pub fn is_escape(&self) -> bool {
+        self.inner.as_ref() == "--"
+    }
+
+    pub fn is_number(&self) -> bool {
+        self.to_value()
+            .map(|s| s.parse::<f64>().is_ok())
+            .unwrap_or_default()
+    }
+
+    /// Treat as a long-flag
+    ///
+    /// **NOTE:** May return an empty flag.  Check [`ParsedArg::is_escape`] to separately detect `--`.
+    pub fn to_long(&self) -> Option<(&RawOsStr, Option<&RawOsStr>)> {
+        let remainder = self.inner.as_ref().strip_prefix("--")?;
+        let parts = if let Some((p0, p1)) = remainder.split_once("=") {
+            (p0, Some(p1))
+        } else {
+            (remainder, None)
+        };
+        Some(parts)
+    }
+
+    /// Can treat as a long-flag
+    ///
+    /// **NOTE:** May return an empty flag.  Check [`ParsedArg::is_escape`] to separately detect `--`.
+    pub fn is_long(&self) -> bool {
+        self.inner.as_ref().starts_with("--")
+    }
+
+    /// Treat as a short-flag
+    ///
+    /// **NOTE:** Maybe return an empty flag.  Check [`ParsedArg::is_stdio`] to separately detect
+    /// `-`.
+    pub fn to_short(&self) -> Option<ShortFlags<'_>> {
+        if let Some(remainder_os) = self.inner.as_ref().strip_prefix('-') {
+            if remainder_os.starts_with('-') {
+                None
+            } else {
+                let remainder = self.utf8.map(|s| &s[1..]);
+                Some(ShortFlags::new(remainder_os, remainder))
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Can treat as a short-flag
+    ///
+    /// **NOTE:** Maybe return an empty flag.  Check [`ParsedArg::is_stdio`] to separately detect
+    /// `-`.
+    pub fn is_short(&self) -> bool {
+        self.inner.as_ref().starts_with('-') && !self.is_long()
+    }
+
+    /// Treat as a value
+    ///
+    /// **NOTE:** May return a flag or an escape.
+    pub fn to_value_os(&self) -> &RawOsStr {
+        self.inner.as_ref()
+    }
+
+    /// Treat as a value
+    ///
+    /// **NOTE:** May return a flag or an escape.
+    pub fn to_value(&self) -> Option<&str> {
+        self.utf8
+    }
+
+    /// Safely print an argument that may contain non-UTF8 content
+    ///
+    /// This may perform lossy conversion, depending on the platform. If you would like an implementation which escapes the path please use Debug instead.
+    pub fn display(&self) -> impl std::fmt::Display + '_ {
+        self.inner.to_str_lossy()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ShortFlags<'s> {
+    inner: &'s RawOsStr,
+    utf8_prefix: std::str::CharIndices<'s>,
+    invalid_suffix: Option<&'s RawOsStr>,
+}
+
+impl<'s> ShortFlags<'s> {
+    fn new(inner: &'s RawOsStr, utf8: Option<&'s str>) -> Self {
+        let (utf8_prefix, invalid_suffix) = if let Some(utf8) = utf8 {
+            (utf8, None)
+        } else {
+            split_nonutf8_once(inner)
+        };
+        let utf8_prefix = utf8_prefix.char_indices();
+        Self {
+            inner,
+            utf8_prefix,
+            invalid_suffix,
+        }
+    }
+
+    pub fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+        for i in 0..n {
+            self.next().ok_or(i)?.map_err(|_| i)?;
+        }
+        Ok(())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.invalid_suffix.is_none() && self.utf8_prefix.as_str().is_empty()
+    }
+
+    pub fn is_number(&self) -> bool {
+        self.invalid_suffix.is_none() && self.utf8_prefix.as_str().parse::<f64>().is_ok()
+    }
+
+    pub fn next(&mut self) -> Option<Result<char, &'s RawOsStr>> {
+        if let Some((_, flag)) = self.utf8_prefix.next() {
+            return Some(Ok(flag));
+        }
+
+        if let Some(suffix) = self.invalid_suffix {
+            self.invalid_suffix = None;
+            return Some(Err(suffix));
+        }
+
+        None
+    }
+
+    pub fn value_os(&mut self) -> Option<&'s RawOsStr> {
+        if let Some((index, _)) = self.utf8_prefix.next() {
+            self.utf8_prefix = "".char_indices();
+            self.invalid_suffix = None;
+            return Some(&self.inner[index..]);
+        }
+
+        if let Some(suffix) = self.invalid_suffix {
+            self.invalid_suffix = None;
+            return Some(suffix);
+        }
+
+        None
+    }
+}
+
+impl<'s> Iterator for ShortFlags<'s> {
+    type Item = Result<char, &'s RawOsStr>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+}
+
+fn split_nonutf8_once(b: &RawOsStr) -> (&str, Option<&RawOsStr>) {
+    match std::str::from_utf8(b.as_raw_bytes()) {
+        Ok(s) => (s, None),
+        Err(err) => {
+            let (valid, after_valid) = b.split_at(err.valid_up_to());
+            let valid = std::str::from_utf8(valid.as_raw_bytes()).unwrap();
+            (valid, Some(after_valid))
+        }
     }
 }

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -212,7 +212,7 @@ impl<'s> ShortFlags<'s> {
         self.invalid_suffix.is_none() && self.utf8_prefix.as_str().parse::<f64>().is_ok()
     }
 
-    pub fn next(&mut self) -> Option<Result<char, &'s RawOsStr>> {
+    pub fn next_flag(&mut self) -> Option<Result<char, &'s RawOsStr>> {
         if let Some((_, flag)) = self.utf8_prefix.next() {
             return Some(Ok(flag));
         }
@@ -225,7 +225,7 @@ impl<'s> ShortFlags<'s> {
         None
     }
 
-    pub fn value_os(&mut self) -> Option<&'s RawOsStr> {
+    pub fn next_value_os(&mut self) -> Option<&'s RawOsStr> {
         if let Some((index, _)) = self.utf8_prefix.next() {
             self.utf8_prefix = "".char_indices();
             self.invalid_suffix = None;
@@ -245,7 +245,7 @@ impl<'s> Iterator for ShortFlags<'s> {
     type Item = Result<char, &'s RawOsStr>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next()
+        self.next_flag()
     }
 }
 

--- a/src/parse/lexer.rs
+++ b/src/parse/lexer.rs
@@ -1,0 +1,49 @@
+use std::ffi::OsStr;
+use std::ffi::OsString;
+
+#[derive(Debug)]
+pub(crate) struct Input {
+    items: Vec<OsString>,
+    cursor: usize,
+}
+
+impl<I, T> From<I> for Input
+where
+    I: Iterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    fn from(val: I) -> Self {
+        Self {
+            items: val.map(|x| x.into()).collect(),
+            cursor: 0,
+        }
+    }
+}
+
+impl Input {
+    pub(crate) fn next(&mut self) -> Option<(&OsStr, &[OsString])> {
+        if self.cursor >= self.items.len() {
+            None
+        } else {
+            let current = &self.items[self.cursor];
+            self.cursor += 1;
+            let remaining = &self.items[self.cursor..];
+            Some((current, remaining))
+        }
+    }
+
+    pub(crate) fn previous(&mut self) {
+        self.cursor -= 1;
+    }
+
+    /// Insert some items to the Input items just after current parsing cursor.
+    /// Usually used by replaced items recovering.
+    pub(crate) fn insert(&mut self, insert_items: &[&str]) {
+        self.items = insert_items
+            .iter()
+            .map(OsString::from)
+            .chain(self.items.drain(self.cursor..))
+            .collect();
+        self.cursor = 0;
+    }
+}

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,13 +1,15 @@
-pub mod features;
-
 mod arg_matcher;
-pub mod matches;
+mod lexer;
 mod parser;
 mod validator;
 
+pub mod features;
+pub mod matches;
+
 pub(crate) use self::arg_matcher::ArgMatcher;
+pub(crate) use self::lexer::Input;
 pub(crate) use self::matches::{MatchedArg, SubCommand};
-pub(crate) use self::parser::{Input, ParseState, Parser};
+pub(crate) use self::parser::{ParseState, Parser};
 pub(crate) use self::validator::Validator;
 
 pub use self::matches::{ArgMatches, Indices, OsValues, ValueSource, Values};

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -1,13 +1,12 @@
 mod arg_matcher;
-mod lexer;
 mod parser;
 mod validator;
 
 pub mod features;
+pub(crate) mod lexer;
 pub mod matches;
 
 pub(crate) use self::arg_matcher::ArgMatcher;
-pub(crate) use self::lexer::Input;
 pub(crate) use self::matches::{MatchedArg, SubCommand};
 pub(crate) use self::parser::{ParseState, Parser};
 pub(crate) use self::validator::Validator;

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -3,7 +3,6 @@ mod parser;
 mod validator;
 
 pub mod features;
-pub(crate) mod lexer;
 pub mod matches;
 
 pub(crate) use self::arg_matcher::ArgMatcher;

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 // Third Party
-use os_str_bytes::RawOsStr;
+use clap_lex::RawOsStr;
 
 // Internal
 use crate::build::{Arg, Command};
@@ -14,7 +14,6 @@ use crate::error::Result as ClapResult;
 use crate::mkeymap::KeyType;
 use crate::output::{fmt::Colorizer, Help, HelpWriter, Usage};
 use crate::parse::features::suggestions;
-use crate::parse::lexer;
 use crate::parse::{ArgMatcher, SubCommand};
 use crate::parse::{Validator, ValueSource};
 use crate::util::{color::ColorChoice, Id};
@@ -64,8 +63,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
     pub(crate) fn get_matches_with(
         &mut self,
         matcher: &mut ArgMatcher,
-        raw_args: &mut lexer::RawArgs,
-        mut args_cursor: lexer::ArgCursor,
+        raw_args: &mut clap_lex::RawArgs,
+        mut args_cursor: clap_lex::ArgCursor,
     ) -> ClapResult<()> {
         debug!("Parser::get_matches_with");
         // Verify all positional assertions pass
@@ -307,7 +306,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                             keep_state = self
                                 .flag_subcmd_at
                                 .map(|at| {
-                                    raw_args.seek(&mut args_cursor, lexer::SeekFrom::Current(-1));
+                                    raw_args
+                                        .seek(&mut args_cursor, clap_lex::SeekFrom::Current(-1));
                                     // Since we are now saving the current state, the number of flags to skip during state recovery should
                                     // be the current index (`cur_idx`) minus ONE UNIT TO THE LEFT of the starting position.
                                     self.flag_subcmd_skip = self.cur_idx.get() - at + 1;
@@ -479,7 +479,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
 
     fn match_arg_error(
         &self,
-        arg_os: &lexer::ParsedArg<'_>,
+        arg_os: &clap_lex::ParsedArg<'_>,
         valid_arg_found: bool,
         trailing_values: bool,
     ) -> ClapError {
@@ -644,7 +644,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         Err(parser.help_err(true))
     }
 
-    fn is_new_arg(&self, next: &lexer::ParsedArg<'_>, current_positional: &Arg) -> bool {
+    fn is_new_arg(&self, next: &clap_lex::ParsedArg<'_>, current_positional: &Arg) -> bool {
         debug!(
             "Parser::is_new_arg: {:?}:{:?}",
             next.to_value_os(),
@@ -686,8 +686,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         &mut self,
         sc_name: &str,
         matcher: &mut ArgMatcher,
-        raw_args: &mut lexer::RawArgs,
-        args_cursor: lexer::ArgCursor,
+        raw_args: &mut clap_lex::RawArgs,
+        args_cursor: clap_lex::ArgCursor,
         keep_state: bool,
     ) -> ClapResult<()> {
         debug!("Parser::parse_subcommand");
@@ -924,7 +924,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
     fn parse_short_arg(
         &mut self,
         matcher: &mut ArgMatcher,
-        mut short_arg: lexer::ShortFlags<'_>,
+        mut short_arg: clap_lex::ShortFlags<'_>,
         parse_state: &ParseState,
         // change this to possible pos_arg when removing the usage of &mut Parser.
         pos_counter: usize,

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -969,7 +969,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             "tracking of `flag_subcmd_skip` is off for `{:?}`",
             short_arg
         );
-        while let Some(c) = short_arg.next() {
+        while let Some(c) = short_arg.next_flag() {
             let c = match c {
                 Ok(c) => c,
                 Err(rest) => {
@@ -1010,7 +1010,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 // Check for trailing concatenated value
                 //
                 // Cloning the iterator, so we rollback if it isn't there.
-                let val = short_arg.clone().value_os().unwrap_or_default();
+                let val = short_arg.clone().next_value_os().unwrap_or_default();
                 debug!(
                     "Parser::parse_short_arg:iter:{}: val={:?} (bytes), val={:?} (ascii), short_arg={:?}",
                     c, val, val.as_raw_bytes(), short_arg

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -90,7 +90,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         // If any arg sets .last(true)
         let contains_last = self.cmd.get_arguments().any(|x| x.is_last_set());
 
-        while let Some(arg_os) = raw_args.next(&mut args_cursor) {
+        while let Some(arg_os) = raw_args.next_os(&mut args_cursor) {
             // Recover the replaced items if any.
             if let Some(replaced_items) = arg_os.to_str().and_then(|a| self.cmd.get_replacement(a))
             {
@@ -140,7 +140,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 );
 
                 if low_index_mults || missing_pos {
-                    let skip_current = if let Some(n) = raw_args.peek(&args_cursor) {
+                    let skip_current = if let Some(n) = raw_args.peek_os(&args_cursor) {
                         if let Some(p) = self
                             .cmd
                             .get_positionals()

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -304,7 +304,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                             keep_state = self
                                 .flag_subcmd_at
                                 .map(|at| {
-                                    raw_args.previous(&mut args_cursor);
+                                    raw_args.seek(&mut args_cursor, lexer::SeekFrom::Current(-1));
                                     // Since we are now saving the current state, the number of flags to skip during state recovery should
                                     // be the current index (`cur_idx`) minus ONE UNIT TO THE LEFT of the starting position.
                                     self.flag_subcmd_skip = self.cur_idx.get() - at + 1;

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -92,7 +92,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
 
         while let Some(arg_os) = raw_args.next(&mut args_cursor) {
             // Recover the replaced items if any.
-            if let Some(replaced_items) = self.cmd.get_replacement(arg_os) {
+            if let Some(replaced_items) = arg_os.to_str().and_then(|a| self.cmd.get_replacement(a))
+            {
                 debug!(
                     "Parser::get_matches_with: found replacer: {:?}, target: {:?}",
                     arg_os, replaced_items

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -651,6 +651,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
     }
 
     fn is_new_arg(&self, next: &clap_lex::ParsedArg<'_>, current_positional: &Arg) -> bool {
+        #![allow(clippy::needless_bool)] // Prefer consistent if/else-if ladder
+
         debug!(
             "Parser::is_new_arg: {:?}:{:?}",
             next.to_value_os(),


### PR DESCRIPTION
This splits out a `clap_lex`, somewhat inspired by `lexopt`.  The main difference is that `lexopt` manages all state in one object while we have to split out the state to support:
- Peeking to know if we should treat a flag as a flag
- Inserting replacements

This was also done with an eye towards rust-driven completions.  This will let the completion engine reuse the same lexer.  The parsers will be different for now but as we learn more about a completion parser, we can look to see if and how we can use the same parser between the two.  One side effect of this is that we treat `--` as potentially a long and `-` as potentially a short.  The problem with this approach is we aren't treating `-` as a long as well because there is nothing good for us to return.  We might need to reconsider that approach due to the inconsistency.

Benefits of factoring out `clap_lex`:
- Clap users have a lighterweight option to drop down to if they don't need data-driven help, man pages, completions, etc
- Separation of concerns for cleaner code
- Share the foundation with #3166 (see also #1232)

Deferred:
- #1210, #3309, #2468: Ideally we simplify things down to support a `Box<dyn Lexer>` which will require some work redesigning the API to take this into account
- Factor our tracking of parse position for short-flag subcommands.  This could clean up the code but has some complications with insertions / replacements.

Fixes #2915