### PR TITLE
fix(derive): Couple derive version to clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ name = "06_rustup"
 path = "benches/06_rustup.rs"
 
 [dependencies]
-clap_derive = { path = "./clap_derive", version = "3.1.7", optional = true }
+clap_derive = { path = "./clap_derive", version = "=3.1.7", optional = true }
 clap_lex = { path = "./clap_lex", version = "0.1.0" }
 bitflags = "1.2"
 textwrap = { version = "0.15.0", default-features = false, features = [] }


### PR DESCRIPTION
While `clap` depends on `clap_derive`, `clap_derive` inherently has a
dependency on `clap` because it generates code assuming at least a
specific clap version.  If a new `clap_derive` is used with an old
`clap`, it'll generate code that won't compile.

We've kept things loose because of
- Bad experiences with overly constrained version reqs
- To not force new `clap` versions to release `clap_derive`.
- People should have a lock file anyways

The downsides:
- `cargo install` does not use `Cargo.lock` by default, required
  `--locked`
- If we want people to not skip non-patch releases when upgrading, we
  need it to not be a pain

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
