### PR TITLE
fix(man): Explicitly depend on clap 3.1.10

### DIFF
--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -36,11 +36,11 @@ bench = false
 
 [dependencies]
 roff = "0.2.1"
-clap = { path = "../", version = "3.1", default-features = false, features = ["std", "env"] }
+clap = { path = "../", version = "3.1.10", default-features = false, features = ["std", "env"] }
 
 [dev-dependencies]
 snapbox = { version = "0.2", features = ["diff"] }
-clap = { path = "../", version = "3.1", default-features = false, features = ["std"] }
+clap = { path = "../", version = "3.1.10", default-features = false, features = ["std"] }
 
 [features]
 default = []


### PR DESCRIPTION
`Command.build()` is not available in 3.1.9.

Fixes: 8f182067e345 ("feat(clap): Publicly expose `Command::build`")