### PR TITLE
fix: Mixup between stderr and stdout introduced in v3.1.11

### DIFF
--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -69,8 +69,8 @@ impl Colorizer {
         };
 
         let writer = match self.stream {
-            Stream::Stdout => BufferWriter::stderr(color_when),
-            Stream::Stderr => BufferWriter::stdout(color_when),
+            Stream::Stderr => BufferWriter::stderr(color_when),
+            Stream::Stdout => BufferWriter::stdout(color_when),
         };
 
         let mut buffer = writer.buffer();


### PR DESCRIPTION
stderr and stdout got mixed up by [6a9a5d05](https://github.com/clap-rs/clap/commit/6a9a5d05) in v3.1.11

fixes https://github.com/rust-lang/cargo/issues/10591