### PR TITLE
Fix #3648

### DIFF
--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -69,8 +69,8 @@ impl Colorizer {
         };
 
         let writer = match self.stream {
-            Stream::Stdout => BufferWriter::stderr(color_when),
-            Stream::Stderr => BufferWriter::stdout(color_when),
+            Stream::Stdout => BufferWriter::stdout(color_when),
+            Stream::Stderr => BufferWriter::stderr(color_when),
         };
 
         let mut buffer = writer.buffer();


### PR DESCRIPTION
This commit fixes mixing up the stdout/stderr streams in claps output
module

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
