### PR TITLE
fix(multicall): Polish user messages

### DIFF
--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -66,7 +66,6 @@ fn cli() -> Command<'static> {
     Command::new("repl")
         .multicall(true)
         .arg_required_else_help(true)
-        .disable_help_flag(true)
         .subcommand_required(true)
         .subcommand_value_name("APPLET")
         .subcommand_help_heading("APPLETS")

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -4027,7 +4027,7 @@ impl<'help> App<'help> {
 
             #[cfg(feature = "unstable-multicall")]
             {
-                if self.is_set(AppSettings::Multicall) {
+                if self.is_multicall_set() {
                     self.settings.insert(AppSettings::SubcommandRequired.into());
                     self.settings.insert(AppSettings::DisableHelpFlag.into());
                     self.settings.insert(AppSettings::DisableVersionFlag.into());

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -4025,6 +4025,14 @@ impl<'help> App<'help> {
             // Make sure all the globally set flags apply to us as well
             self.settings = self.settings | self.g_settings;
 
+            #[cfg(feature = "unstable-multicall")]
+            {
+                if self.is_set(AppSettings::Multicall) {
+                    self.settings.insert(AppSettings::DisableHelpFlag.into());
+                    self.settings.insert(AppSettings::DisableVersionFlag.into());
+                }
+            }
+
             self._propagate();
             self._check_help_and_version();
             self._propagate_global_args();

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -4028,6 +4028,7 @@ impl<'help> App<'help> {
             #[cfg(feature = "unstable-multicall")]
             {
                 if self.is_set(AppSettings::Multicall) {
+                    self.settings.insert(AppSettings::SubcommandRequired.into());
                     self.settings.insert(AppSettings::DisableHelpFlag.into());
                     self.settings.insert(AppSettings::DisableVersionFlag.into());
                 }

--- a/src/build/debug_asserts.rs
+++ b/src/build/debug_asserts.rs
@@ -56,6 +56,16 @@ pub(crate) fn assert_app(cmd: &Command) {
     for arg in cmd.get_arguments() {
         assert_arg(arg);
 
+        #[cfg(feature = "unstable-multicall")]
+        {
+            assert!(
+                !cmd.is_multicall_set(),
+                "Command {}: Arguments like {} cannot be set on a multicall command",
+                cmd.get_name(),
+                arg.name
+            );
+        }
+
         if let Some(s) = arg.short.as_ref() {
             short_flags.push(Flag::Arg(format!("-{}", s), &*arg.name));
         }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -386,9 +386,8 @@ impl Error {
             ])
     }
 
-    pub(crate) fn unrecognized_subcommand(cmd: &Command, subcmd: String, name: String) -> Self {
+    pub(crate) fn unrecognized_subcommand(cmd: &Command, subcmd: String, usage: String) -> Self {
         let info = vec![subcmd.clone()];
-        let usage = format!("USAGE:\n    {} <subcommands>", name);
         Self::new(ErrorKind::UnrecognizedSubcommand)
             .with_cmd(cmd)
             .set_info(info)

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -154,7 +154,7 @@ impl<'help, 'cmd> Usage<'help, 'cmd> {
                 usage.push(']');
             }
         }
-        usage.shrink_to_fit();
+        let usage = usage.trim().to_owned();
         debug!("Usage::create_help_usage: usage={}", usage);
         usage
     }

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -529,10 +529,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             return ClapError::unrecognized_subcommand(
                 self.cmd,
                 arg_os.display().to_string(),
-                self.cmd
-                    .get_bin_name()
-                    .unwrap_or_else(|| self.cmd.get_name())
-                    .to_owned(),
+                Usage::new(self.cmd).create_usage_with_title(&[]),
             );
         }
         ClapError::unknown_argument(
@@ -626,9 +623,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     return Err(ClapError::unrecognized_subcommand(
                         sc,
                         cmd.to_string_lossy().into_owned(),
-                        sc.get_bin_name()
-                            .unwrap_or_else(|| sc.get_name())
-                            .to_owned(),
+                        Usage::new(sc).create_usage_with_title(&[]),
                     ));
                 };
             }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -683,7 +683,7 @@ fn help_multi_subcommand_error() {
     static EXPECTED: &str = "error: The subcommand 'foo' wasn't recognized
 
 USAGE:
-    ctest subcmd multi <subcommands>
+    ctest subcmd multi [OPTIONS]
 
 For more information try --help
 ";

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -616,3 +616,81 @@ fn cant_have_args_with_multicall() {
         .arg(Arg::new("oh-no"));
     cmd.build();
 }
+
+#[cfg(feature = "unstable-multicall")]
+#[test]
+fn multicall_help_flag() {
+    static EXPECTED: &str = "\
+foo-bar 1.0.0
+
+USAGE:
+    foo bar [value]
+
+ARGS:
+    <value>    
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+    let cmd = Command::new("repl")
+        .version("1.0.0")
+        .propagate_version(true)
+        .multicall(true)
+        .subcommand(Command::new("foo").subcommand(Command::new("bar").arg(Arg::new("value"))));
+    utils::assert_output(cmd, "foo bar --help", EXPECTED, false);
+}
+
+#[cfg(feature = "unstable-multicall")]
+#[test]
+fn multicall_help_subcommand() {
+    static EXPECTED: &str = "\
+foo-bar 1.0.0
+
+USAGE:
+    foo bar [value]
+
+ARGS:
+    <value>    
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+    let cmd = Command::new("repl")
+        .version("1.0.0")
+        .propagate_version(true)
+        .multicall(true)
+        .subcommand(Command::new("foo").subcommand(Command::new("bar").arg(Arg::new("value"))));
+    utils::assert_output(cmd, "help foo bar", EXPECTED, false);
+}
+
+#[cfg(feature = "unstable-multicall")]
+#[test]
+fn multicall_render_help() {
+    static EXPECTED: &str = "\
+foo-bar 1.0.0
+
+USAGE:
+    foo bar [value]
+
+ARGS:
+    <value>    
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+    let mut cmd = Command::new("repl")
+        .version("1.0.0")
+        .propagate_version(true)
+        .multicall(true)
+        .subcommand(Command::new("foo").subcommand(Command::new("bar").arg(Arg::new("value"))));
+    cmd.build();
+    let subcmd = cmd.find_subcommand_mut("foo").unwrap();
+    let subcmd = subcmd.find_subcommand_mut("bar").unwrap();
+
+    let mut buf = Vec::new();
+    subcmd.write_help(&mut buf).unwrap();
+    utils::assert_eq(EXPECTED, String::from_utf8(buf).unwrap());
+}

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -602,3 +602,17 @@ For more information try help
         .unwrap_err();
     assert_eq!(err.kind(), ErrorKind::DisplayVersion);
 }
+
+#[cfg(feature = "unstable-multicall")]
+#[test]
+#[should_panic = "Command repl: Arguments like oh-no cannot be set on a multicall command"]
+fn cant_have_args_with_multicall() {
+    let mut cmd = Command::new("repl")
+        .version("1.0.0")
+        .propagate_version(true)
+        .multicall(true)
+        .subcommand(Command::new("foo"))
+        .subcommand(Command::new("bar"))
+        .arg(Arg::new("oh-no"));
+    cmd.build();
+}

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -582,7 +582,7 @@ error: The subcommand 'baz' wasn't recognized
 If you believe you received this message in error, try re-running with ' -- baz'
 
 USAGE:
-     [SUBCOMMAND]
+     <SUBCOMMAND>
 
 For more information try help
 ";

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -566,7 +566,7 @@ fn bad_multicall_command_error() {
 error: The subcommand 'world' wasn't recognized
 
 USAGE:
-     <SUBCOMMAND>
+    <SUBCOMMAND>
 
 For more information try help
 ";
@@ -582,7 +582,7 @@ error: The subcommand 'baz' wasn't recognized
 If you believe you received this message in error, try re-running with ' -- baz'
 
 USAGE:
-     <SUBCOMMAND>
+    <SUBCOMMAND>
 
 For more information try help
 ";

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -486,7 +486,7 @@ fn subcommand_not_recognized() {
         "error: The subcommand 'help' wasn't recognized
 
 USAGE:
-    fake <subcommands>
+    fake [SUBCOMMAND]
 
 For more information try --help
 ",
@@ -566,7 +566,7 @@ fn bad_multicall_command_error() {
 error: The subcommand 'world' wasn't recognized
 
 USAGE:
-     <subcommands>
+     <SUBCOMMAND>
 
 For more information try help
 ";


### PR DESCRIPTION
This goes a long way towards resolving #2862 and in general polishing multicall for becoming stable.

The only thing that isn't ideal is that the error message refers to it as a subcommand when in some cases its a command.