### PR TITLE
fix(help): Offer a html_template variable for display name

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -953,6 +953,22 @@ impl<'help, 'cmd, 'writer> Help<'help, 'cmd, 'writer> {
     }
 
     /// Writes binary name of a Parser Object to the wrapped stream.
+    fn write_display_name(&mut self) -> io::Result<()> {
+        debug!("Help::write_display_name");
+
+        let display_name = text_wrapper(
+            &self
+                .cmd
+                .get_display_name()
+                .unwrap_or_else(|| self.cmd.get_name())
+                .replace("{n}", "\n"),
+            self.term_w,
+        );
+        self.good(&display_name)?;
+        Ok(())
+    }
+
+    /// Writes binary name of a Parser Object to the wrapped stream.
     fn write_bin_name(&mut self) -> io::Result<()> {
         debug!("Help::write_bin_name");
 
@@ -1019,6 +1035,9 @@ impl<'help, 'cmd, 'writer> Help<'help, 'cmd, 'writer> {
         for part in parts {
             tags! {
                 match part {
+                    "name" => {
+                        self.write_display_name()?;
+                    }
                     "bin" => {
                         self.write_bin_name()?;
                     }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2737,3 +2737,43 @@ OPTIONS:
     subcmd.write_help(&mut buf).unwrap();
     utils::assert_eq(EXPECTED, String::from_utf8(buf).unwrap());
 }
+
+#[test]
+fn display_name_default() {
+    let mut cmd = Command::new("app").bin_name("app.exe");
+    cmd.build();
+    assert_eq!(cmd.get_display_name(), None);
+}
+
+#[test]
+fn display_name_explicit() {
+    let mut cmd = Command::new("app")
+        .bin_name("app.exe")
+        .display_name("app.display");
+    cmd.build();
+    assert_eq!(cmd.get_display_name(), Some("app.display"));
+}
+
+#[test]
+fn display_name_subcommand_default() {
+    let mut cmd = Command::new("parent").subcommand(Command::new("child").bin_name("child.exe"));
+    cmd.build();
+    assert_eq!(
+        cmd.find_subcommand("child").unwrap().get_display_name(),
+        Some("parent-child")
+    );
+}
+
+#[test]
+fn display_name_subcommand_explicit() {
+    let mut cmd = Command::new("parent").subcommand(
+        Command::new("child")
+            .bin_name("child.exe")
+            .display_name("child.display"),
+    );
+    cmd.build();
+    assert_eq!(
+        cmd.find_subcommand("child").unwrap().get_display_name(),
+        Some("child.display")
+    );
+}


### PR DESCRIPTION
This is a step towards #992.  When help renders the application name, it
uses the `bin` template variable which is just the `bin` name with
spaces converted to ` `.  While having `app.exe sub` makes sense,
`app.exe-sub` does not.

To get around needing this for usage, we've created a `display_name`
field that is fairly similar but
- The root name is the `name` and not `bin_name`
- We always join with `-`

This means that the derived `bin_name` will only show up in usage.

For now, the default template has not been updated as that is a minor
compatibility change and should be in a minor release, at least.  I was
worried this would be a full breaking change.  The main case I was
worried about was cargo subcommands but our tests show they should just
work.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
