### PR TITLE
docs(tutorial): Link the derive API to the builder API

### DIFF
--- a/examples/tutorial_builder/README.md
+++ b/examples/tutorial_builder/README.md
@@ -5,9 +5,9 @@
 1. [Quick Start](#quick-start)
 2. [Configuring the Parser](#configuring-the-parser)
 3. [Adding Arguments](#adding-arguments)
-    1. [Flags](#flags)
+    1. [Positionals](#positionals)
     2. [Options](#options)
-    3. [Positionals](#positionals)
+    3. [Flags](#flags)
     4. [Subcommands](#subcommands)
     5. [Defaults](#defaults)
 4. Validation
@@ -134,9 +134,78 @@ one: "-3"
 
 ## Adding Arguments
 
+### Positionals
+
+You can have users specify values by their position on the command-line:
+
+[Example:](03_03_positional.rs)
+```console
+$ 03_03_positional --help
+clap [..]
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+USAGE:
+    03_03_positional[EXE] [NAME]
+
+ARGS:
+    <NAME>    
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+$ 03_03_positional
+NAME: None
+
+$ 03_03_positional bob
+NAME: Some("bob")
+
+```
+
+### Options
+
+You can name your arguments with a flag:
+- Order doesn't matter
+- They can be optional
+- Intent is clearer
+
+[Example:](03_02_option.rs)
+```console
+$ 03_02_option --help
+clap [..]
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+USAGE:
+    03_02_option[EXE] [OPTIONS]
+
+OPTIONS:
+    -h, --help           Print help information
+    -n, --name <NAME>    
+    -V, --version        Print version information
+
+$ 03_02_option
+name: None
+
+$ 03_02_option --name bob
+name: Some("bob")
+
+$ 03_02_option --name=bob
+name: Some("bob")
+
+$ 03_02_option -n bob
+name: Some("bob")
+
+$ 03_02_option -n=bob
+name: Some("bob")
+
+$ 03_02_option -nbob
+name: Some("bob")
+
+```
+
 ### Flags
 
-Flags are switches that can be on/off:
+Flags can also be switches that can be on/off:
 
 [Example:](03_01_flag_bool.rs)
 ```console
@@ -193,72 +262,6 @@ verbose: 1
 
 $ 03_01_flag_count --verbose --verbose
 verbose: 2
-
-```
-
-### Options
-
-Flags can also accept a value.
-
-[Example:](03_02_option.rs)
-```console
-$ 03_02_option --help
-clap [..]
-A simple to use, efficient, and full-featured Command Line Argument Parser
-
-USAGE:
-    03_02_option[EXE] [OPTIONS]
-
-OPTIONS:
-    -h, --help           Print help information
-    -n, --name <NAME>    
-    -V, --version        Print version information
-
-$ 03_02_option
-name: None
-
-$ 03_02_option --name bob
-name: Some("bob")
-
-$ 03_02_option --name=bob
-name: Some("bob")
-
-$ 03_02_option -n bob
-name: Some("bob")
-
-$ 03_02_option -n=bob
-name: Some("bob")
-
-$ 03_02_option -nbob
-name: Some("bob")
-
-```
-
-### Positionals
-
-Or you can have users specify values by their position on the command-line:
-
-[Example:](03_03_positional.rs)
-```console
-$ 03_03_positional --help
-clap [..]
-A simple to use, efficient, and full-featured Command Line Argument Parser
-
-USAGE:
-    03_03_positional[EXE] [NAME]
-
-ARGS:
-    <NAME>    
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-$ 03_03_positional
-NAME: None
-
-$ 03_03_positional bob
-NAME: Some("bob")
 
 ```
 

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -266,7 +266,7 @@ name: Some("bob")
 
 ### Subcommands
 
-Subcommands are derived with `Subcommand` that get added via `#[clap(subcommand)]` attribute. Each
+Subcommands are derived with `#[derive(Subcommand)]` and be added via `#[clap(subcommand)]` attribute. Each
 instance of a Subcommand can have its own version, author(s), Args, and even its own
 subcommands.
 

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -111,7 +111,7 @@ clap [..]
 
 ```
 
-You can use derive attributes to change the application level behavior of clap.
+You can use attributes to change the application level behavior of clap.  Any `Command` builder function can be used as an attribute.
 
 [Example:](02_app_settings.rs)
 ```console

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -171,6 +171,10 @@ You can name your arguments with a flag:
 - They can be optional
 - Intent is clearer
 
+The `#[clap(short = 'c')]` and `#[clap(long = "name")]` attributes that define
+the flags are `Arg` methods that are derived from the field name when no value
+is specified (`#[clap(short)]` and `#[clap(long)]`).
+
 [Example:](03_02_option.rs)
 ```console
 $ 03_02_option_derive --help
@@ -207,7 +211,9 @@ name: Some("bob")
 
 ### Flags
 
-Flags can also be switches that can be on/off:
+Flags can also be switches that can be on/off.  This is enabled via the
+`#[clap(parse(from_flag)]` attribute though this is implied when the field is a
+`bool`.
 
 [Example:](03_01_flag_bool.rs)
 ```console
@@ -240,7 +246,7 @@ For more information try --help
 
 ```
 
-Or counted.
+Or counted with `#[clap(parse(from_occurrences))]`:
 
 [Example:](03_01_flag_count.rs)
 ```console

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -5,9 +5,9 @@
 1. [Quick Start](#quick-start)
 2. [Configuring the Parser](#configuring-the-parser)
 3. [Adding Arguments](#adding-arguments)
-    1. [Flags](#flags)
+    1. [Positionals](#positionals)
     2. [Options](#options)
-    3. [Positionals](#positionals)
+    3. [Flags](#flags)
     4. [Subcommands](#subcommands)
     5. [Defaults](#defaults)
 4. Validation
@@ -136,9 +136,78 @@ one: "-3"
 
 ## Adding Arguments
 
+### Positionals
+
+You can have users specify values by their position on the command-line:
+
+[Example:](03_03_positional.rs)
+```console
+$ 03_03_positional_derive --help
+clap [..]
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+USAGE:
+    03_03_positional_derive[EXE] [NAME]
+
+ARGS:
+    <NAME>    
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+$ 03_03_positional_derive
+name: None
+
+$ 03_03_positional_derive bob
+name: Some("bob")
+
+```
+
+### Options
+
+You can name your arguments with a flag:
+- Order doesn't matter
+- They can be optional
+- Intent is clearer
+
+[Example:](03_02_option.rs)
+```console
+$ 03_02_option_derive --help
+clap [..]
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+USAGE:
+    03_02_option_derive[EXE] [OPTIONS]
+
+OPTIONS:
+    -h, --help           Print help information
+    -n, --name <NAME>    
+    -V, --version        Print version information
+
+$ 03_02_option_derive
+name: None
+
+$ 03_02_option_derive --name bob
+name: Some("bob")
+
+$ 03_02_option_derive --name=bob
+name: Some("bob")
+
+$ 03_02_option_derive -n bob
+name: Some("bob")
+
+$ 03_02_option_derive -n=bob
+name: Some("bob")
+
+$ 03_02_option_derive -nbob
+name: Some("bob")
+
+```
+
 ### Flags
 
-Flags are switches that can be on/off:
+Flags can also be switches that can be on/off:
 
 [Example:](03_01_flag_bool.rs)
 ```console
@@ -195,72 +264,6 @@ verbose: 1
 
 $ 03_01_flag_count_derive --verbose --verbose
 verbose: 2
-
-```
-
-### Options
-
-Flags can also accept a value.
-
-[Example:](03_02_option.rs)
-```console
-$ 03_02_option_derive --help
-clap [..]
-A simple to use, efficient, and full-featured Command Line Argument Parser
-
-USAGE:
-    03_02_option_derive[EXE] [OPTIONS]
-
-OPTIONS:
-    -h, --help           Print help information
-    -n, --name <NAME>    
-    -V, --version        Print version information
-
-$ 03_02_option_derive
-name: None
-
-$ 03_02_option_derive --name bob
-name: Some("bob")
-
-$ 03_02_option_derive --name=bob
-name: Some("bob")
-
-$ 03_02_option_derive -n bob
-name: Some("bob")
-
-$ 03_02_option_derive -n=bob
-name: Some("bob")
-
-$ 03_02_option_derive -nbob
-name: Some("bob")
-
-```
-
-### Positionals
-
-Or you can have users specify values by their position on the command-line:
-
-[Example:](03_03_positional.rs)
-```console
-$ 03_03_positional_derive --help
-clap [..]
-A simple to use, efficient, and full-featured Command Line Argument Parser
-
-USAGE:
-    03_03_positional_derive[EXE] [NAME]
-
-ARGS:
-    <NAME>    
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-$ 03_03_positional_derive
-name: None
-
-$ 03_03_positional_derive bob
-name: Some("bob")
 
 ```
 


### PR DESCRIPTION
When evaluating the documentation for #3681, I realized the tutorial doesn't link the APIs.  Right now, its fairly subtle but this is hopefully a good starting point.