### PR TITLE
fix(help): Don't wrap URLs

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -1127,7 +1127,9 @@ fn should_show_subcommand(subcommand: &Command) -> bool {
 }
 
 fn text_wrapper(help: &str, width: usize) -> String {
-    let wrapper = textwrap::Options::new(width).break_words(false);
+    let wrapper = textwrap::Options::new(width)
+        .break_words(false)
+        .word_splitter(textwrap::WordSplitter::NoHyphenation);
     help.lines()
         .map(|line| textwrap::fill(line, &wrapper))
         .collect::<Vec<String>>()

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1222,6 +1222,37 @@ fn wrapping_newline_variables() {
 }
 
 #[test]
+fn dont_wrap_urls() {
+    let cmd = Command::new("Example")
+        .term_width(30)
+        .subcommand(Command::new("update").arg(
+            Arg::new("force-non-host")
+                .help("Install toolchains that require an emulator. See https://github.com/rust-lang/rustup/wiki/Non-host-toolchains")
+                .long("force-non-host")
+                .takes_value(false))
+    );
+
+    const EXPECTED: &str = "\
+Example-update 
+
+USAGE:
+    Example update [OPTIONS]
+
+OPTIONS:
+        --force-non-host
+            Install toolchains
+            that require an
+            emulator. See
+            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+
+    -h, --help
+            Print help
+            information
+";
+    utils::assert_output(cmd, "Example update --help", EXPECTED, false);
+}
+
+#[test]
 fn old_newline_chars() {
     let cmd = Command::new("ctest").version("0.1").arg(
         Arg::new("mode")


### PR DESCRIPTION
Confusingly, there are two similar but slightly different settings in
`textwrap`.  We need both set.

Fixes #3222

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
