### PR TITLE
fix(help): Use display name instead of bin name (unstable-v4)

### DIFF
--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -32,6 +32,15 @@ pub(crate) struct Help<'help, 'cmd, 'writer> {
 
 // Public Functions
 impl<'help, 'cmd, 'writer> Help<'help, 'cmd, 'writer> {
+    #[cfg(feature = "unstable-v4")]
+    const DEFAULT_TEMPLATE: &'static str = "\
+        {before-help}{name} {version}\n\
+        {author-with-newline}{about-with-newline}\n\
+        {usage-heading}\n    {usage}\n\
+        \n\
+        {all-args}{after-help}\
+    ";
+    #[cfg(not(feature = "unstable-v4"))]
     const DEFAULT_TEMPLATE: &'static str = "\
         {before-help}{bin} {version}\n\
         {author-with-newline}{about-with-newline}\n\
@@ -40,6 +49,13 @@ impl<'help, 'cmd, 'writer> Help<'help, 'cmd, 'writer> {
         {all-args}{after-help}\
     ";
 
+    #[cfg(feature = "unstable-v4")]
+    const DEFAULT_NO_ARGS_TEMPLATE: &'static str = "\
+        {before-help}{name} {version}\n\
+        {author-with-newline}{about-with-newline}\n\
+        {usage-heading}\n    {usage}{after-help}\
+    ";
+    #[cfg(not(feature = "unstable-v4"))]
     const DEFAULT_NO_ARGS_TEMPLATE: &'static str = "\
         {before-help}{bin} {version}\n\
         {author-with-newline}{about-with-newline}\n\

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2615,7 +2615,7 @@ fn override_help_flag_using_short() {
 fn subcommand_help_doesnt_have_useless_help_flag() {
     // The main care-about is that the docs and behavior match.  Since the `help` subcommand
     // currently ignores the `--help` flag, the output shouldn't have it.
-    let cmd = Command::new("test_app").subcommand(Command::new("test").about("Subcommand"));
+    let cmd = Command::new("example").subcommand(Command::new("test").about("Subcommand"));
 
     utils::assert_output(
         cmd,
@@ -2655,7 +2655,7 @@ fn disable_help_flag_affects_help_subcommand() {
 
 #[test]
 fn dont_propagate_version_to_help_subcommand() {
-    let cmd = clap::Command::new("test")
+    let cmd = clap::Command::new("example")
         .version("1.0")
         .propagate_version(true)
         .subcommand(clap::Command::new("subcommand"));


### PR DESCRIPTION
This will mean we won't have an awkard `.exe` in the middle on Windows

This means users can have a display name for their application rather
than it being dependent on the binary name it was run as

This means users can manually set it to use spaces instead of dashes for
separating things out.

Fixes #992
Fixes #1474
Fixes #1431

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
