### PR TITLE
fix(complete): Complete visible, rather than hidden, values

### DIFF
--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -178,7 +178,7 @@ fn vals_for(o: &Arg) -> String {
         format!(
             "$(compgen -W \"{}\" -- \"${{cur}}\")",
             vals.iter()
-                .filter(|pv| pv.is_hide_set())
+                .filter(|pv| !pv.is_hide_set())
                 .map(PossibleValue::get_name)
                 .collect::<Vec<_>>()
                 .join(" ")

--- a/clap_complete/tests/snapshots/sub_subcommands.bash
+++ b/clap_complete/tests/snapshots/sub_subcommands.bash
@@ -94,7 +94,7 @@ _my-app() {
             fi
             case "${prev}" in
                 --config)
-                    COMPREPLY=($(compgen -W "" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "Lest quotes aren't escaped." -- "${cur}"))
                     return 0
                     ;;
                 *)

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -26,7 +26,7 @@ _my-app() {
             fi
             case "${prev}" in
                 --choice)
-                    COMPREPLY=($(compgen -W "" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
                     return 0
                     ;;
                 --unknown)


### PR DESCRIPTION
In a refactor for #3503, one of the checks for `is_hide_set` got flipped
and we are completing hidden `PossibleValue`s rather than visible.

Fixes #3697

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
