### PR TITLE
fix(parser): Disambiguate whether built-in subcommands are escaped (unstable)

### DIFF
--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -484,9 +484,17 @@ fn gen_from_arg_matches(
             Unnamed(..) => abort_call_site!("{}: tuple enums are not supported", variant.ident),
         };
 
-        quote! {
-            if #sub_name == #subcommand_name_var {
-                return ::std::result::Result::Ok(#name :: #variant_name #constructor_block)
+        if cfg!(feature = "unstable-v4") {
+            quote! {
+                if #sub_name == #subcommand_name_var && !#sub_arg_matches_var.is_present("") {
+                    return ::std::result::Result::Ok(#name :: #variant_name #constructor_block)
+                }
+            }
+        } else {
+            quote! {
+                if #sub_name == #subcommand_name_var {
+                    return ::std::result::Result::Ok(#name :: #variant_name #constructor_block)
+                }
             }
         }
     });

--- a/src/build/command.rs
+++ b/src/build/command.rs
@@ -2709,10 +2709,15 @@ impl<'help> App<'help> {
 
     /// Assume unexpected positional arguments are a [`subcommand`].
     ///
+    /// Arguments will be stored in the `""` argument in the [`ArgMatches`]
+    ///
     /// **NOTE:** Use this setting with caution,
     /// as a truly unexpected argument (i.e. one that is *NOT* an external subcommand)
     /// will **not** cause an error and instead be treated as a potential subcommand.
     /// One should check for such cases manually and inform the user appropriately.
+    ///
+    /// **NOTE:** A built-in subcommand will be parsed as an external subcommand when escaped with
+    /// `--`.
     ///
     /// # Examples
     ///

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -30,7 +30,11 @@ impl ArgMatcher {
             //
             // See clap-rs/clap#3263
             #[cfg(debug_assertions)]
+            #[cfg(not(feature = "unstable-v4"))]
             disable_asserts: _cmd.is_allow_external_subcommands_set(),
+            #[cfg(debug_assertions)]
+            #[cfg(feature = "unstable-v4")]
+            disable_asserts: false,
             ..Default::default()
         })
     }

--- a/src/parse/arg_matcher.rs
+++ b/src/parse/arg_matcher.rs
@@ -85,6 +85,7 @@ impl ArgMatcher {
         }
     }
 
+    #[cfg(not(feature = "unstable-v4"))]
     pub(crate) fn get_mut(&mut self, arg: &Id) -> Option<&mut MatchedArg> {
         self.0.args.get_mut(arg)
     }
@@ -139,6 +140,19 @@ impl ArgMatcher {
         debug!("ArgMatcher::inc_occurrence_of_group: id={:?}", id);
         let ma = self.entry(id).or_insert(MatchedArg::new());
         ma.update_ty(ValueSource::CommandLine);
+        ma.inc_occurrences();
+    }
+
+    #[cfg(feature = "unstable-v4")]
+    pub(crate) fn inc_occurrence_of_external(&mut self, allow_invalid_utf8: bool) {
+        let id = &Id::empty_hash();
+        debug!(
+            "ArgMatcher::inc_occurrence_of_external: id={:?}, allow_invalid_utf8={}",
+            id, allow_invalid_utf8
+        );
+        let ma = self.entry(id).or_insert(MatchedArg::new());
+        ma.update_ty(ValueSource::CommandLine);
+        ma.invalid_utf8_allowed(allow_invalid_utf8);
         ma.inc_occurrences();
     }
 

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -931,6 +931,25 @@ fn external_subcommand_looks_like_built_in() {
 }
 
 #[test]
+fn built_in_subcommand_escaped() {
+    let res = Command::new("cargo")
+        .version("1.26.0")
+        .allow_external_subcommands(true)
+        .allow_invalid_utf8_for_external_subcommands(true)
+        .subcommand(Command::new("install"))
+        .try_get_matches_from(vec!["cargo", "--", "install", "foo"]);
+    assert!(res.is_ok(), "{}", res.unwrap_err());
+    let m = res.unwrap();
+    match m.subcommand() {
+        Some((name, args)) => {
+            assert_eq!(name, "install");
+            assert_eq!(args.values_of_lossy(""), Some(vec!["foo".to_string()]));
+        }
+        _ => panic!("external_subcommand didn't work"),
+    }
+}
+
+#[test]
 fn aaos_flags() {
     // flags
     let res = Command::new("posix")

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -852,6 +852,46 @@ fn issue_1093_allow_ext_sc() {
 }
 
 #[test]
+#[cfg(not(feature = "unstable-v4"))]
+fn allow_ext_sc_empty_args() {
+    let res = Command::new("clap-test")
+        .version("v1.4.8")
+        .allow_external_subcommands(true)
+        .allow_invalid_utf8_for_external_subcommands(true)
+        .try_get_matches_from(vec!["clap-test", "external-cmd"]);
+
+    assert!(res.is_ok(), "{}", res.unwrap_err());
+
+    match res.unwrap().subcommand() {
+        Some((name, args)) => {
+            assert_eq!(name, "external-cmd");
+            assert_eq!(args.values_of_lossy(""), None);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+#[cfg(feature = "unstable-v4")]
+fn allow_ext_sc_empty_args() {
+    let res = Command::new("clap-test")
+        .version("v1.4.8")
+        .allow_external_subcommands(true)
+        .allow_invalid_utf8_for_external_subcommands(true)
+        .try_get_matches_from(vec!["clap-test", "external-cmd"]);
+
+    assert!(res.is_ok(), "{}", res.unwrap_err());
+
+    match res.unwrap().subcommand() {
+        Some((name, args)) => {
+            assert_eq!(name, "external-cmd");
+            assert_eq!(args.values_of_lossy(""), Some(vec![]));
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn allow_ext_sc_when_sc_required() {
     let res = Command::new("clap-test")
         .version("v1.4.8")

--- a/tests/derive/subcommands.rs
+++ b/tests/derive/subcommands.rs
@@ -547,3 +547,59 @@ fn skip_subcommand() {
     let res = Opt::try_parse_from(&["test", "skip"]);
     assert_eq!(res.unwrap_err().kind(), clap::ErrorKind::UnknownArgument,);
 }
+
+#[test]
+#[cfg(feature = "unstable-v4")]
+fn built_in_subcommand_escaped() {
+    #[derive(Debug, PartialEq, Parser)]
+    enum Command {
+        Install {
+            arg: Option<String>,
+        },
+        #[clap(external_subcommand)]
+        Custom(Vec<String>),
+    }
+
+    assert_eq!(
+        Command::try_parse_from(&["test", "install", "arg"]).unwrap(),
+        Command::Install {
+            arg: Some(String::from("arg"))
+        }
+    );
+    assert_eq!(
+        Command::try_parse_from(&["test", "--", "install"]).unwrap(),
+        Command::Custom(vec![String::from("install")])
+    );
+    assert_eq!(
+        Command::try_parse_from(&["test", "--", "install", "arg"]).unwrap(),
+        Command::Custom(vec![String::from("install"), String::from("arg")])
+    );
+}
+
+#[test]
+#[cfg(not(feature = "unstable-v4"))]
+fn built_in_subcommand_escaped() {
+    #[derive(Debug, PartialEq, Parser)]
+    enum Command {
+        Install {
+            arg: Option<String>,
+        },
+        #[clap(external_subcommand)]
+        Custom(Vec<String>),
+    }
+
+    assert_eq!(
+        Command::try_parse_from(&["test", "install", "arg"]).unwrap(),
+        Command::Install {
+            arg: Some(String::from("arg"))
+        }
+    );
+    assert_eq!(
+        Command::try_parse_from(&["test", "--", "install"]).unwrap(),
+        Command::Install { arg: None }
+    );
+    assert_eq!(
+        Command::try_parse_from(&["test", "--", "install", "arg"]).unwrap(),
+        Command::Install { arg: None }
+    );
+}


### PR DESCRIPTION
When you escape subcommand (`cmd -- subcmd`), it always becomes an external subcommand even if a built-in one matches.  There wasn't a way to detect this.  Now, a user can check `matches.is_present("")` and that will signal its an external subcommand.

With this change, we've updated `clap_derive` to correctly populate external subcommands rather than the built-in version (and error if it didn't work out).

With all of that done, we can now remove the hack where we disable unknown argument assertions since users can correctly guard to prevent hitting it.

Because of compatibility concerns, this is all gated behind `unstable-v4`.

Fixes #3263 