### PR TITLE
fix(complete): CommandWithArguments with previous positional args in zsh

### DIFF
--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -633,7 +633,7 @@ fn write_positionals_of(p: &Command) -> String {
         debug!("write_positionals_of:iter: arg={}", arg.get_id());
 
         let cardinality = if arg.is_multiple_values_set() || arg.is_multiple_occurrences_set() {
-            "*:"
+            "*::"
         } else if !arg.is_required_set() {
             ":"
         } else {

--- a/clap_complete/tests/common.rs
+++ b/clap_complete/tests/common.rs
@@ -202,6 +202,11 @@ pub fn value_hint_command(name: &'static str) -> clap::Command<'static> {
                 .value_hint(clap::ValueHint::CommandString),
         )
         .arg(
+            clap::Arg::new("positional")
+                .required(true)
+                .possible_values(["stable", "nightly"]),
+        )
+        .arg(
             clap::Arg::new("command_with_args")
                 .takes_value(true)
                 .multiple_values(true)

--- a/clap_complete/tests/snapshots/basic.zsh
+++ b/clap_complete/tests/snapshots/basic.zsh
@@ -39,7 +39,7 @@ _arguments "${_arguments_options[@]}" /
 (help)
 _arguments "${_arguments_options[@]}" /
 '-c[]' /
-'*::subcommand -- The subcommand whose help message to display:' /
+'*:::subcommand -- The subcommand whose help message to display:' /
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -45,7 +45,7 @@ _arguments "${_arguments_options[@]}" /
 ;;
 (help)
 _arguments "${_arguments_options[@]}" /
-'*::subcommand -- The subcommand whose help message to display:' /
+'*:::subcommand -- The subcommand whose help message to display:' /
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -72,7 +72,7 @@ _arguments "${_arguments_options[@]}" /
 ;;
 (help)
 _arguments "${_arguments_options[@]}" /
-'*::subcommand -- The subcommand whose help message to display:' /
+'*:::subcommand -- The subcommand whose help message to display:' /
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -50,7 +50,7 @@ _arguments "${_arguments_options[@]}" /
 '--help[Print help information]' /
 '-V[Print version information]' /
 '--version[Print version information]' /
-'*::path:' /
+'*:::path:' /
 && ret=0
 ;;
 (some-cmd-with-hyphens)
@@ -71,7 +71,7 @@ _arguments "${_arguments_options[@]}" /
 ;;
 (help)
 _arguments "${_arguments_options[@]}" /
-'*::subcommand -- The subcommand whose help message to display:' /
+'*:::subcommand -- The subcommand whose help message to display:' /
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -70,7 +70,7 @@ _arguments "${_arguments_options[@]}" /
 ;;
 (help)
 _arguments "${_arguments_options[@]}" /
-'*::subcommand -- The subcommand whose help message to display:' /
+'*:::subcommand -- The subcommand whose help message to display:' /
 && ret=0
 ;;
         esac
@@ -79,7 +79,7 @@ esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" /
-'*::subcommand -- The subcommand whose help message to display:' /
+'*:::subcommand -- The subcommand whose help message to display:' /
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -19,7 +19,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-p -f -d -e -c -u -h --help --choice --unknown --other --path --file --dir --exe --cmd-name --cmd --user --host --url --email <command_with_args>..."
+            opts="-p -f -d -e -c -u -h --help --choice --unknown --other --path --file --dir --exe --cmd-name --cmd --user --host --url --email stable nightly <command_with_args>..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/value_hint.zsh
+++ b/clap_complete/tests/snapshots/value_hint.zsh
@@ -36,7 +36,8 @@ _my-app() {
 '--url=[]: :_urls' /
 '--email=[]: :_email_addresses' /
 '--help[Print help information]' /
-'*::command_with_args:_cmdambivalent' /
+':positional:(stable nightly)' /
+'*:::command_with_args:_cmdambivalent' /
 && ret=0
 }
 


### PR DESCRIPTION
Iiuc the value hint CommandWithArgs for zsh was incorrect when in a positional argument after the first positional argument.

I updated the clap_complete/tests/common.rs:value_hint_command accordingly to generate a test case. The relevant part is
```
clap::Command::new(name)
    .trailing_var_arg(true)
    .arg(clap::Arg::new("positional")
        .required(true)
        .possible_values(["stable", "nightly"]),
    )
    .arg(clap::Arg::new("command_with_arg")
        .takes_value(true)
        .multiple_values(true)
        .value_hint(clap::ValueHint::CommandWithArguments),
    )
```

The resulting section of the completion function is then without my change to zsh.rs
```
_arguments \
':positional:(stable nightly)' \
'*::command_with_args:_cmdambivalent'
```

With this function, I don't get any completion past `my-app stable TAB`. From the zshcompsys man page https://github.com/zsh-users/zsh/blob/master/Doc/Zsh/compsys.yo#L3903=  (section on _arguments for the forms `*:message:action` with one, two, or three colons):
```
 *:message:action
 *::message:action
 *:::message:action
        This  describes  how  arguments (usually non-option
        arguments, those not beginning with - or +) are  to
        be  completed  when  neither of the first two forms
        was provided.  Any number of arguments can be  com‐
        pleted in this fashion.

        With  two colons before the message, the words spe‐
        cial array and the CURRENT  special  parameter  are
        modified to refer only to the normal arguments when
        the action is executed or  evaluated.   With  three
        colons  before the message they are modified to re‐
        fer only to the normal arguments  covered  by  this
        description.

```

I.e. the completion now tries to complete a command `stable …`.

With my change, the third colon gets added, such that `_cmdambivalent` only "sees" the arguments after the stable/nightly argument:
```
_arguments \
':positional:(stable nightly)' \
'*:::command_with_args:_cmdambivalent'
```

As cross check, I tried `my-app stable TAB` and got tons of suggestions, all seeming like valid commands I have installed. To try further I ran `my-app stable git cl<TAB>` and got `clean` and `clone` suggested.

NB 1: I only focussed on this one test case. The other changes to the test. I haven't looked long at the changes to `my-app help TAB` I'm questioning here if `my-app help TAB` should complete more than one subcommand? This is to me less a question about what the desired zsh completion code is but more about [this opt in to multiple occurences](https://github.com/clap-rs/clap/blob/master/src/build/command.rs#L4571=)

NB 2: Obviously my change alters the snapshots for other shells, I blindly updated the snapshot here.