### PR TITLE
fix(assert): Make sure group members exist before using them

### DIFF
--- a/src/build/debug_asserts.rs
+++ b/src/build/debug_asserts.rs
@@ -301,6 +301,17 @@ pub(crate) fn assert_app(cmd: &Command) {
             group.name,
         );
 
+        for arg in &group.args {
+            // Args listed inside groups should exist
+            assert!(
+                cmd.get_arguments().any(|x| x.id == *arg),
+                "Command {}: Argument group '{}' contains non-existent argument '{:?}'",
+                cmd.get_name(),
+                group.name,
+                arg
+            );
+        }
+
         // Required groups should have at least one arg without default values
         if group.required && !group.args.is_empty() {
             assert!(
@@ -312,17 +323,6 @@ pub(crate) fn assert_app(cmd: &Command) {
                     cmd.get_name(),
                 group.name
             )
-        }
-
-        for arg in &group.args {
-            // Args listed inside groups should exist
-            assert!(
-                cmd.get_arguments().any(|x| x.id == *arg),
-                "Command {}: Argument group '{}' contains non-existent argument '{:?}'",
-                cmd.get_name(),
-                group.name,
-                arg
-            );
         }
     }
 


### PR DESCRIPTION
In #3711, we had a confusing assert about no non-default members of a
required group when there were no defaults involved.  This is because
there were no valid args in the group but that check happens after.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
