### PR TITLE
feat(mangen): clap/env is itself a feature of mangen

### DIFF
--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -36,15 +36,21 @@ bench = false
 
 [dependencies]
 roff = "0.2.1"
-clap = { path = "../", version = "3.1.10", default-features = false, features = ["std", "env"] }
+clap = { path = "../", version = "3.1.10", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 snapbox = { version = "0.2", features = ["diff"] }
 clap = { path = "../", version = "3.1.10", default-features = false, features = ["std"] }
 
 [features]
-default = []
+default = ["env"]
+
 debug = ["clap/debug"]
+env = ["clap/env"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[[example]]
+name = "man"
+required-features = ["env"]

--- a/clap_mangen/README.md
+++ b/clap_mangen/README.md
@@ -51,3 +51,10 @@ fn main() -> std::io::Result<()> {
 ```
 
 Tip: Consider a [cargo xtask](https://github.com/matklad/cargo-xtask) instead of a `build.rs` to reduce build costs.
+
+
+## Feature Flags
+
+#### Optional features
+
+* **env**: Enable Clap's `env` feature.

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -116,6 +116,7 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
         roff.text(header);
         roff.text(body);
 
+        #[cfg(feature = "env")]
         if let Some(env) = option_environment(opt) {
             roff.control("RS", []);
             roff.text(env);
@@ -147,6 +148,7 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
         roff.text(header);
         roff.text(body);
 
+        #[cfg(feature = "env")]
         if let Some(env) = option_environment(pos) {
             roff.control("RS", []);
             roff.text(env);
@@ -212,6 +214,7 @@ fn long_option(opt: &str) -> Inline {
     bold(&format!("--{}", opt))
 }
 
+#[cfg(feature = "env")]
 fn option_environment(opt: &clap::Arg) -> Option<Vec<Inline>> {
     if opt.is_hide_env_set() {
         return None;

--- a/clap_mangen/tests/common.rs
+++ b/clap_mangen/tests/common.rs
@@ -232,14 +232,21 @@ pub fn hidden_option_command(name: &'static str) -> clap::Command<'static> {
 }
 
 pub fn env_value_command(name: &'static str) -> clap::Command<'static> {
+    let arg = clap::Arg::new("config")
+        .short('c')
+        .long_help("Set configuration file path")
+        .required(false)
+        .takes_value(true)
+        .default_value("config.toml");
     clap::Command::new(name).arg(
-        clap::Arg::new("config")
-            .short('c')
-            .long_help("Set configuration file path")
-            .required(false)
-            .takes_value(true)
-            .default_value("config.toml")
-            .env("CONFIG_FILE"),
+        #[cfg(feature = "env")]
+        {
+            arg.env("CONFIG_FILE")
+        },
+        #[cfg(not(feature = "env"))]
+        {
+            arg
+        },
     )
 }
 

--- a/clap_mangen/tests/roff.rs
+++ b/clap_mangen/tests/roff.rs
@@ -56,6 +56,15 @@ fn hidden_options() {
     common::assert_matches_path("tests/snapshots/hidden_option.bash.roff", cmd);
 }
 
+#[cfg(not(feature = "env"))]
+#[test]
+fn value_no_env() {
+    let name = "my-app";
+    let cmd = common::env_value_command(name);
+    common::assert_matches_path("tests/snapshots/value_no_env.bash.roff", cmd);
+}
+
+#[cfg(feature = "env")]
 #[test]
 fn value_env() {
     let name = "my-app";

--- a/clap_mangen/tests/snapshots/value_no_env.bash.roff
+++ b/clap_mangen/tests/snapshots/value_no_env.bash.roff
@@ -1,0 +1,15 @@
+.ie /n(.g .ds Aq /(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my/-app
+.SH SYNOPSIS
+/fBmy/-app/fR [/fB/-h/fR|/fB/-/-help/fR] [/fB/-c /fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+/fB/-h/fR, /fB/-/-help/fR
+Print help information
+.TP
+/fB/-c/fR [default: config.toml]
+Set configuration file path


### PR DESCRIPTION
This adds `env` as a feature to `clap_mangen` and enables it by default to keep the default behaviour. I wish there was a way to make it automatically enable the feature if it detects the used library/binary uses `clap/env`, though I'm unsure of how to exactly do that. I found [this StackOverflow post](https://stackoverflow.com/questions/64546459/how-can-my-crate-check-the-selected-features-of-a-dependency), though it would be somewhat non-trivial and I would appreciate some input.

Fixes #3355.