### PR TITLE
test: Re-enable ui tests

### DIFF
--- a/tests/derive_ui.rs
+++ b/tests/derive_ui.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 
 #[cfg(feature = "derive")]
-#[rustversion::attr(any(not(stable), before(1.54), since(1.55)), ignore)]
+#[rustversion::attr(any(not(stable), before(1.56), since(1.57)), ignore)] // MSRV
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/derive_ui/enum_variant_not_args.stderr
+++ b/tests/derive_ui/enum_variant_not_args.stderr
@@ -1,15 +1,23 @@
 error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
- --> $DIR/enum_variant_not_args.rs:3:9
-  |
-3 |     Sub(SubCmd),
-  |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-  |
-  = note: required by `augment_args`
+   --> tests/derive_ui/enum_variant_not_args.rs:3:9
+    |
+3   |     Sub(SubCmd),
+    |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+    |
+note: required by `augment_args`
+   --> src/derive.rs
+    |
+    |     fn augment_args(cmd: Command<'_>) -> Command<'_>;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
- --> $DIR/enum_variant_not_args.rs:3:9
-  |
-3 |     Sub(SubCmd),
-  |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-  |
-  = note: required by `augment_args_for_update`
+   --> tests/derive_ui/enum_variant_not_args.rs:3:9
+    |
+3   |     Sub(SubCmd),
+    |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+    |
+note: required by `augment_args_for_update`
+   --> src/derive.rs
+    |
+    |     fn augment_args_for_update(cmd: Command<'_>) -> Command<'_>;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/derive_ui/flatten_enum_in_struct.stderr
+++ b/tests/derive_ui/flatten_enum_in_struct.stderr
@@ -1,15 +1,23 @@
 error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
- --> $DIR/flatten_enum_in_struct.rs:3:12
-  |
-3 |     #[clap(flatten)]
-  |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-  |
-  = note: required by `augment_args`
+   --> tests/derive_ui/flatten_enum_in_struct.rs:3:12
+    |
+3   |     #[clap(flatten)]
+    |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+    |
+note: required by `augment_args`
+   --> src/derive.rs
+    |
+    |     fn augment_args(cmd: Command<'_>) -> Command<'_>;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
- --> $DIR/flatten_enum_in_struct.rs:3:12
-  |
-3 |     #[clap(flatten)]
-  |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-  |
-  = note: required by `augment_args_for_update`
+   --> tests/derive_ui/flatten_enum_in_struct.rs:3:12
+    |
+3   |     #[clap(flatten)]
+    |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+    |
+note: required by `augment_args_for_update`
+   --> src/derive.rs
+    |
+    |     fn augment_args_for_update(cmd: Command<'_>) -> Command<'_>;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/derive_ui/flatten_struct_in_enum.stderr
+++ b/tests/derive_ui/flatten_struct_in_enum.stderr
@@ -1,26 +1,38 @@
 error[E0277]: the trait bound `SubCmd: Subcommand` is not satisfied
- --> $DIR/flatten_struct_in_enum.rs:1:10
-  |
-1 | #[derive(clap::Parser)]
-  |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
-  |
-  = note: required by `has_subcommand`
-  = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> tests/derive_ui/flatten_struct_in_enum.rs:1:10
+    |
+1   | #[derive(clap::Parser)]
+    |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
+    |
+note: required by `has_subcommand`
+   --> src/derive.rs
+    |
+    |     fn has_subcommand(name: &str) -> bool;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SubCmd: Subcommand` is not satisfied
- --> $DIR/flatten_struct_in_enum.rs:1:10
-  |
-1 | #[derive(clap::Parser)]
-  |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
-  |
-  = note: required by `augment_subcommands`
-  = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> tests/derive_ui/flatten_struct_in_enum.rs:1:10
+    |
+1   | #[derive(clap::Parser)]
+    |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
+    |
+note: required by `augment_subcommands`
+   --> src/derive.rs
+    |
+    |     fn augment_subcommands(cmd: Command<'_>) -> Command<'_>;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SubCmd: Subcommand` is not satisfied
- --> $DIR/flatten_struct_in_enum.rs:1:10
-  |
-1 | #[derive(clap::Parser)]
-  |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
-  |
-  = note: required by `augment_subcommands_for_update`
-  = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
+   --> tests/derive_ui/flatten_struct_in_enum.rs:1:10
+    |
+1   | #[derive(clap::Parser)]
+    |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
+    |
+note: required by `augment_subcommands_for_update`
+   --> src/derive.rs
+    |
+    |     fn augment_subcommands_for_update(cmd: Command<'_>) -> Command<'_>;
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_ui/next/tuple_struct.stderr
+++ b/tests/derive_ui/next/tuple_struct.stderr
@@ -16,5 +16,7 @@ error[E0599]: no function or associated item named `parse` found for struct `Opt
    |                    ^^^^^ function or associated item not found in `Opt`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `parse`, perhaps you need to implement it:
-           candidate #1: `Parser`
+   = note: the following traits define an item `parse`, perhaps you need to implement one of them:
+           candidate #1: `StructOpt`
+           candidate #2: `AnyValueParser`
+           candidate #3: `TypedValueParser`

--- a/tests/derive_ui/skip_without_default.stderr
+++ b/tests/derive_ui/skip_without_default.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `Kind: Default` is not satisfied
-  --> $DIR/skip_without_default.rs:22:12
-   |
-22 |     #[clap(skip)]
-   |            ^^^^ the trait `Default` is not implemented for `Kind`
-   |
-   = note: required by `std::default::Default::default`
+   --> tests/derive_ui/skip_without_default.rs:22:12
+    |
+22  |     #[clap(skip)]
+    |            ^^^^ the trait `Default` is not implemented for `Kind`
+    |
+note: required by `std::default::Default::default`

--- a/tests/derive_ui/stable/tuple_struct.stderr
+++ b/tests/derive_ui/stable/tuple_struct.stderr
@@ -1,5 +1,5 @@
 error: `#[derive(Parser)]` only supports non-tuple structs and enums
-  --> $DIR/tuple_struct.rs:11:10
+  --> tests/derive_ui/stable/tuple_struct.rs:11:10
    |
 11 | #[derive(Parser, Debug)]
    |          ^^^^^^
@@ -7,7 +7,7 @@ error: `#[derive(Parser)]` only supports non-tuple structs and enums
    = note: this error originates in the derive macro `Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no function or associated item named `parse` found for struct `Opt` in the current scope
-  --> $DIR/tuple_struct.rs:16:20
+  --> tests/derive_ui/stable/tuple_struct.rs:16:20
    |
 13 | struct Opt(u32);
    | ---------------- function or associated item `parse` not found for this
@@ -16,5 +16,7 @@ error[E0599]: no function or associated item named `parse` found for struct `Opt
    |                    ^^^^^ function or associated item not found in `Opt`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `parse`, perhaps you need to implement it:
+   = note: the following traits define an item `parse`, perhaps you need to implement one of them:
            candidate #1: `Parser`
+           candidate #2: `AnyValueParser`
+           candidate #3: `TypedValueParser`


### PR DESCRIPTION
`derive_ui.rs` did not have a marker for needing to be updated on MSRV
changes, so it got missed.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
