### PR TITLE
feat(derive): Allow users to opt-in to `ValueParser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// Name of the person to greet
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     name: String,
 
     /// Number of times to greet
-    #[clap(short, long, default_value_t = 1)]
+    #[clap(short, long, value_parser, default_value_t = 1)]
     count: u8,
 }
 

--- a/clap_complete/src/generator/utils.rs
+++ b/clap_complete/src/generator/utils.rs
@@ -128,7 +128,9 @@ pub fn flags<'help>(p: &Command<'help>) -> Vec<Arg<'help>> {
 
 /// Get the possible values for completion
 pub fn possible_values<'help>(a: &Arg<'help>) -> Option<Vec<clap::PossibleValue<'help>>> {
-    if let Some(pvs) = a.get_possible_values() {
+    if !a.is_takes_value_set() {
+        None
+    } else if let Some(pvs) = a.get_possible_values() {
         // Check old first in case the user explicitly set possible values and the derive inferred
         // a `ValueParser` with some.
         Some(pvs.to_vec())

--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -42,6 +42,7 @@ pub struct Attrs {
     ty: Option<Type>,
     doc_comment: Vec<Method>,
     methods: Vec<Method>,
+    value_parser: Option<Method>,
     parser: Sp<Parser>,
     verbatim_doc_comment: Option<Ident>,
     next_display_order: Option<Method>,
@@ -64,6 +65,12 @@ impl Attrs {
         res.push_attrs(attrs);
         res.push_doc_comment(attrs, "about");
 
+        if let Some(parser) = res.value_parser.as_ref() {
+            abort!(
+                parser.span(),
+                "`value_parse` attribute is only allowed on fields"
+            );
+        }
         if res.has_custom_parser {
             abort!(
                 res.parser.span(),
@@ -101,6 +108,12 @@ impl Attrs {
 
         match &*res.kind {
             Kind::Flatten => {
+                if let Some(parser) = res.value_parser.as_ref() {
+                    abort!(
+                        parser.span(),
+                        "`value_parse` attribute is only allowed flattened entry"
+                    );
+                }
                 if res.has_custom_parser {
                     abort!(
                         res.parser.span(),
@@ -121,6 +134,12 @@ impl Attrs {
             Kind::ExternalSubcommand => (),
 
             Kind::Subcommand(_) => {
+                if let Some(parser) = res.value_parser.as_ref() {
+                    abort!(
+                        parser.span(),
+                        "`value_parse` attribute is only allowed for subcommand"
+                    );
+                }
                 if res.has_custom_parser {
                     abort!(
                         res.parser.span(),
@@ -189,6 +208,12 @@ impl Attrs {
         res.push_attrs(&variant.attrs);
         res.push_doc_comment(&variant.attrs, "help");
 
+        if let Some(parser) = res.value_parser.as_ref() {
+            abort!(
+                parser.span(),
+                "`value_parse` attribute is only allowed on fields"
+            );
+        }
         if res.has_custom_parser {
             abort!(
                 res.parser.span(),
@@ -226,6 +251,12 @@ impl Attrs {
 
         match &*res.kind {
             Kind::Flatten => {
+                if let Some(parser) = res.value_parser.as_ref() {
+                    abort!(
+                        parser.span(),
+                        "`value_parse` attribute is not allowed for flattened entry"
+                    );
+                }
                 if res.has_custom_parser {
                     abort!(
                         res.parser.span(),
@@ -250,6 +281,12 @@ impl Attrs {
             }
 
             Kind::Subcommand(_) => {
+                if let Some(parser) = res.value_parser.as_ref() {
+                    abort!(
+                        parser.span(),
+                        "`value_parse` attribute is not allowed for subcommand"
+                    );
+                }
                 if res.has_custom_parser {
                     abort!(
                         res.parser.span(),
@@ -297,6 +334,12 @@ impl Attrs {
             Kind::Arg(orig_ty) => {
                 let mut ty = Ty::from_syn_ty(&field.ty);
                 if res.has_custom_parser {
+                    if let Some(parser) = res.value_parser.as_ref() {
+                        abort!(
+                            parser.name.span(),
+                            "`value_parse` attribute conflicts with `parse` attribute"
+                        );
+                    }
                     match *ty {
                         Ty::Option | Ty::Vec | Ty::OptionVec => (),
                         _ => ty = Sp::new(Ty::Other, ty.span()),
@@ -369,6 +412,7 @@ impl Attrs {
             env_casing,
             doc_comment: vec![],
             methods: vec![],
+            value_parser: None,
             parser: Parser::default_spanned(default_span),
             verbatim_doc_comment: None,
             next_display_order: None,
@@ -383,6 +427,8 @@ impl Attrs {
     fn push_method(&mut self, name: Ident, arg: impl ToTokens) {
         if name == "name" {
             self.name = Name::Assigned(quote!(#arg));
+        } else if name == "value_parser" {
+            self.value_parser = Some(Method::new(name, quote!(#arg)));
         } else {
             self.methods.push(Method::new(name, quote!(#arg)));
         }
@@ -689,6 +735,16 @@ impl Attrs {
         self.name.clone().translate(CasingStyle::ScreamingSnake)
     }
 
+    pub fn value_parser(&self) -> Method {
+        self.value_parser
+            .clone()
+            .unwrap_or_else(|| self.parser.value_parser())
+    }
+
+    pub fn custom_value_parser(&self) -> bool {
+        self.value_parser.is_some()
+    }
+
     pub fn parser(&self) -> &Sp<Parser> {
         &self.parser
     }
@@ -865,9 +921,23 @@ impl Parser {
         let parser = Parser { kind, func };
         Sp::new(parser, parse_ident.span())
     }
+
+    fn value_parser(&self) -> Method {
+        let func = Ident::new("value_parser", self.kind.span());
+        match *self.kind {
+            ParserKind::FromStr | ParserKind::TryFromStr => {
+                Method::new(func, quote!(clap::builder::ValueParser::string()))
+            }
+            ParserKind::FromOsStr | ParserKind::TryFromOsStr => {
+                Method::new(func, quote!(clap::builder::ValueParser::os_string()))
+            }
+            ParserKind::FromOccurrences => Method::new(func, quote!(clap::value_parser!(usize))),
+            ParserKind::FromFlag => Method::new(func, quote!(clap::ValueParser::bool())),
+        }
+    }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ParserKind {
     FromStr,
     TryFromStr,

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -542,8 +542,8 @@ fn gen_parsers(
         _ if attrs.custom_value_parser() => (
             quote_spanned!(span=> remove_one::<#convert_type>),
             quote_spanned!(span=> remove_many::<#convert_type>),
-            quote!(|s| s),
-            quote_spanned!(func.span()=> |s| ::std::result::Result::Ok::<_, clap::Error>(::std::sync::Arc::try_unwrap(s).unwrap_or_else(|arc| (*arc).clone()))),
+            quote!(|s| ::std::sync::Arc::try_unwrap(s).unwrap_or_else(|arc| (*arc).clone())),
+            quote_spanned!(func.span()=> |s| ::std::result::Result::Ok::<_, clap::Error>(s)),
         ),
         FromStr => (
             quote_spanned!(span=> get_one::<String>),

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -540,10 +540,10 @@ fn gen_parsers(
             func.clone(),
         ),
         _ if attrs.custom_value_parser() => (
-            quote_spanned!(span=> get_one::<#convert_type>),
-            quote_spanned!(span=> get_many::<#convert_type>),
+            quote_spanned!(span=> remove_one::<#convert_type>),
+            quote_spanned!(span=> remove_many::<#convert_type>),
             quote!(|s| s),
-            quote_spanned!(func.span()=> |s| ::std::result::Result::Ok::<_, clap::Error>(s.clone())),
+            quote_spanned!(func.span()=> |s| ::std::result::Result::Ok::<_, clap::Error>(::std::sync::Arc::try_unwrap(s).unwrap_or_else(|arc| (*arc).clone()))),
         ),
         FromStr => (
             quote_spanned!(span=> get_one::<String>),

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -246,7 +246,7 @@ pub fn gen_augment(
                 let occurrences = *attrs.parser().kind == ParserKind::FromOccurrences;
                 let flag = *attrs.parser().kind == ParserKind::FromFlag;
 
-                let value_parser = attrs.value_parser();
+                let value_parser = attrs.value_parser().resolve(convert_type);
                 let parser = attrs.parser();
                 let func = &parser.func;
 

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -604,7 +604,7 @@ fn gen_update_from_arg_matches(
                         quote!((ref mut __clap_arg)),
                         quote!(clap::FromArgMatches::update_from_arg_matches(
                             __clap_arg,
-                            __clap_sub_arg_matches
+                            __clap_arg_matches
                         )?),
                     )
                 } else {
@@ -615,7 +615,7 @@ fn gen_update_from_arg_matches(
 
         quote! {
             #name :: #variant_name #pattern if #sub_name == __clap_name => {
-                let __clap_arg_matches = __clap_sub_arg_matches;
+                let (_, __clap_arg_matches) = __clap_arg_matches.subcommand().unwrap();
                 #updater
             }
         }
@@ -647,7 +647,7 @@ fn gen_update_from_arg_matches(
             &mut self,
             __clap_arg_matches: &clap::ArgMatches,
         ) -> ::std::result::Result<(), clap::Error> {
-            if let Some((__clap_name, __clap_sub_arg_matches)) = __clap_arg_matches.subcommand() {
+            if let Some(__clap_name) = __clap_arg_matches.subcommand_name() {
                 match self {
                     #( #subcommands ),*
                     s => {

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -400,7 +400,7 @@ fn gen_from_arg_matches(
     let mut ext_subcmd = None;
 
     let subcommand_name_var = format_ident!("__clap_name");
-    let sub_arg_matches_var = format_ident!("__clap_sub_arg_matches");
+    let sub_arg_matches_var = format_ident!("__clap_arg_matches");
     let (flatten_variants, variants): (Vec<_>, Vec<_>) = variants
         .iter()
         .filter_map(|variant| {
@@ -538,10 +538,7 @@ fn gen_from_arg_matches(
             #( #child_subcommands )else*
 
             if let Some((#subcommand_name_var, #sub_arg_matches_var)) = __clap_arg_matches.subcommand() {
-                {
-                    let __clap_arg_matches = #sub_arg_matches_var;
-                    #( #subcommands )*
-                }
+                #( #subcommands )*
 
                 #wildcard
             } else {

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -122,7 +122,15 @@ fn gen_from_arg_matches_for_enum(
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #name #ty_generics #where_clause {
+            fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
+                Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())
+            }
+
             #from_arg_matches
+
+            fn update_from_arg_matches(&mut self, __clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<(), clap::Error> {
+                self.update_from_arg_matches_mut(&mut __clap_arg_matches.clone())
+            }
             #update_from_arg_matches
         }
     }
@@ -471,7 +479,7 @@ fn gen_from_arg_matches(
             Unit => quote!(),
             Unnamed(ref fields) if fields.unnamed.len() == 1 => {
                 let ty = &fields.unnamed[0];
-                quote!( ( <#ty as clap::FromArgMatches>::from_arg_matches(__clap_arg_matches)? ) )
+                quote!( ( <#ty as clap::FromArgMatches>::from_arg_matches_mut(__clap_arg_matches)? ) )
             }
             Unnamed(..) => abort_call_site!("{}: tuple enums are not supported", variant.ident),
         };
@@ -501,7 +509,7 @@ fn gen_from_arg_matches(
                         .map(|__clap_name| <#ty as clap::Subcommand>::has_subcommand(__clap_name))
                         .unwrap_or_default()
                     {
-                        let __clap_res = <#ty as clap::FromArgMatches>::from_arg_matches(__clap_arg_matches)?;
+                        let __clap_res = <#ty as clap::FromArgMatches>::from_arg_matches_mut(__clap_arg_matches)?;
                         return ::std::result::Result::Ok(#name :: #variant_name (__clap_res));
                     }
                 }
@@ -534,10 +542,11 @@ fn gen_from_arg_matches(
     };
 
     quote! {
-        fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
+        fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
             #( #child_subcommands )else*
 
-            if let Some((#subcommand_name_var, #sub_arg_matches_var)) = __clap_arg_matches.subcommand() {
+            if let Some((#subcommand_name_var, mut __clap_arg_sub_matches)) = __clap_arg_matches.remove_subcommand() {
+                let #sub_arg_matches_var = &mut __clap_arg_sub_matches;
                 #( #subcommands )*
 
                 #wildcard
@@ -565,7 +574,7 @@ fn gen_update_from_arg_matches(
             );
 
             match &*attrs.kind() {
-                // Fallback to `from_arg_matches`
+                // Fallback to `from_arg_matches_mut`
                 Kind::ExternalSubcommand => None,
                 _ => Some((variant, attrs)),
             }
@@ -603,7 +612,7 @@ fn gen_update_from_arg_matches(
                 if fields.unnamed.len() == 1 {
                     (
                         quote!((ref mut __clap_arg)),
-                        quote!(clap::FromArgMatches::update_from_arg_matches(
+                        quote!(clap::FromArgMatches::update_from_arg_matches_mut(
                             __clap_arg,
                             __clap_arg_matches
                         )?),
@@ -616,7 +625,8 @@ fn gen_update_from_arg_matches(
 
         quote! {
             #name :: #variant_name #pattern if #sub_name == __clap_name => {
-                let (_, __clap_arg_matches) = __clap_arg_matches.subcommand().unwrap();
+                let (_, mut __clap_arg_sub_matches) = __clap_arg_matches.remove_subcommand().unwrap();
+                let __clap_arg_matches = &mut __clap_arg_sub_matches;
                 #updater
             }
         }
@@ -630,7 +640,7 @@ fn gen_update_from_arg_matches(
                 quote! {
                     if <#ty as clap::Subcommand>::has_subcommand(__clap_name) {
                         if let #name :: #variant_name (child) = s {
-                            <#ty as clap::FromArgMatches>::update_from_arg_matches(child, __clap_arg_matches)?;
+                            <#ty as clap::FromArgMatches>::update_from_arg_matches_mut(child, __clap_arg_matches)?;
                             return ::std::result::Result::Ok(());
                         }
                     }
@@ -644,16 +654,16 @@ fn gen_update_from_arg_matches(
     });
 
     quote! {
-        fn update_from_arg_matches<'b>(
+        fn update_from_arg_matches_mut<'b>(
             &mut self,
-            __clap_arg_matches: &clap::ArgMatches,
+            __clap_arg_matches: &mut clap::ArgMatches,
         ) -> ::std::result::Result<(), clap::Error> {
             if let Some(__clap_name) = __clap_arg_matches.subcommand_name() {
                 match self {
                     #( #subcommands ),*
                     s => {
                         #( #child_subcommands )*
-                        *s = <Self as clap::FromArgMatches>::from_arg_matches(__clap_arg_matches)?;
+                        *s = <Self as clap::FromArgMatches>::from_arg_matches_mut(__clap_arg_matches)?;
                     }
                 }
             }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -527,9 +527,10 @@ fn gen_from_arg_matches(
                     ::std::iter::once(#str_ty::from(#subcommand_name_var))
                     .chain(
                         #sub_arg_matches_var
-                            .get_many::<#str_ty>("")
+                            .remove_many::<#str_ty>("")
                             .expect("unexpected type")
                             .into_iter().flatten()  // `""` isn't present, bug in `unstable-v4`
+                            .map(|f| ::std::sync::Arc::try_unwrap(f).unwrap_or_else(|arc| (*arc).clone()))
                             .map(#str_ty::from)
                     )
                     .collect::<::std::vec::Vec<_>>()

--- a/clap_derive/src/parse.rs
+++ b/clap_derive/src/parse.rs
@@ -26,6 +26,7 @@ pub enum ClapAttr {
     // single-identifier attributes
     Short(Ident),
     Long(Ident),
+    ValueParser(Ident),
     Env(Ident),
     Flatten(Ident),
     ArgEnum(Ident),
@@ -182,6 +183,7 @@ impl Parse for ClapAttr {
             match name_str.as_ref() {
                 "long" => Ok(Long(name)),
                 "short" => Ok(Short(name)),
+                "value_parser" => Ok(ValueParser(name)),
                 "env" => Ok(Env(name)),
                 "flatten" => Ok(Flatten(name)),
                 "arg_enum" => Ok(ArgEnum(name)),

--- a/examples/cargo-example-derive.rs
+++ b/examples/cargo-example-derive.rs
@@ -12,7 +12,7 @@ enum Cargo {
 #[derive(clap::Args)]
 #[clap(author, version, about, long_about = None)]
 struct ExampleDerive {
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<std::path::PathBuf>,
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,11 +7,11 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// Name of the person to greet
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     name: String,
 
     /// Number of times to greet
-    #[clap(short, long, default_value_t = 1)]
+    #[clap(short, long, value_parser, default_value_t = 1)]
     count: u8,
 }
 

--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -173,6 +173,8 @@ These correspond to a `clap::Arg`.
 **Magic attributes**:
 - `name = <expr>`: `clap::Arg::new`
   - When not present: case-converted field name is used
+- `value_parser [= <expr>]`: `clap::Arg::value_parser`
+  - When not present: will auto-select an implementation based on the field type
 - `help = <expr>`: `clap::Arg::help`
   - When not present: [Doc comment summary](#doc-comments)
 - `long_help = <expr>`: `clap::Arg::long_help`
@@ -198,6 +200,7 @@ These correspond to a `clap::Arg`.
   - When `Option<T>`, the subcommand becomes optional
 - `from_global`: Read a `clap::Arg::global` argument (raw attribute), regardless of what subcommand you are in
 - `parse(<kind> [= <function>])`: `clap::Arg::validator` and `clap::ArgMatches::values_of_t`
+  - **Deprecated:** See `value_parser`
   - Default: `try_from_str`
   - Warning: for `Path` / `OsString`, be sure to use `try_from_os_str`
   - See [Arg Types](#arg-types) for more details

--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -200,7 +200,7 @@ These correspond to a `clap::Arg`.
   - When `Option<T>`, the subcommand becomes optional
 - `from_global`: Read a `clap::Arg::global` argument (raw attribute), regardless of what subcommand you are in
 - `parse(<kind> [= <function>])`: `clap::Arg::validator` and `clap::ArgMatches::values_of_t`
-  - **Deprecated:** See `value_parser`
+  - **Deprecated:** except for `from_flag` or `from_occurrences`, instead use `value_parser`
   - Default: `try_from_str`
   - Warning: for `Path` / `OsString`, be sure to use `try_from_os_str`
   - See [Arg Types](#arg-types) for more details

--- a/examples/derive_ref/hand_subcommand.rs
+++ b/examples/derive_ref/hand_subcommand.rs
@@ -3,12 +3,14 @@ use clap::{ArgMatches, Args as _, Command, FromArgMatches, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 struct AddArgs {
+    #[clap(value_parser)]
     name: Vec<String>,
 }
 #[derive(Parser, Debug)]
 struct RemoveArgs {
     #[clap(short, long)]
     force: bool,
+    #[clap(value_parser)]
     name: Vec<String>,
 }
 

--- a/examples/escaped-positional-derive.rs
+++ b/examples/escaped-positional-derive.rs
@@ -8,10 +8,10 @@ struct Cli {
     #[clap(short = 'f')]
     eff: bool,
 
-    #[clap(short = 'p', value_name = "PEAR")]
+    #[clap(short = 'p', value_name = "PEAR", value_parser)]
     pea: Option<String>,
 
-    #[clap(last = true)]
+    #[clap(last = true, value_parser)]
     slop: Vec<String>,
 }
 

--- a/examples/git-derive.rs
+++ b/examples/git-derive.rs
@@ -20,19 +20,21 @@ enum Commands {
     #[clap(arg_required_else_help = true)]
     Clone {
         /// The remote to clone
+        #[clap(value_parser)]
         remote: String,
     },
     /// pushes things
     #[clap(arg_required_else_help = true)]
     Push {
         /// The remote to target
+        #[clap(value_parser)]
         remote: String,
     },
     /// adds things
     #[clap(arg_required_else_help = true)]
     Add {
         /// Stuff to add
-        #[clap(required = true, parse(from_os_str))]
+        #[clap(required = true, value_parser)]
         path: Vec<PathBuf>,
     },
     Stash(Stash),
@@ -53,13 +55,19 @@ struct Stash {
 #[derive(Debug, Subcommand)]
 enum StashCommands {
     Push(StashPush),
-    Pop { stash: Option<String> },
-    Apply { stash: Option<String> },
+    Pop {
+        #[clap(value_parser)]
+        stash: Option<String>,
+    },
+    Apply {
+        #[clap(value_parser)]
+        stash: Option<String>,
+    },
 }
 
 #[derive(Debug, Args)]
 struct StashPush {
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     message: Option<String>,
 }
 

--- a/examples/tutorial_derive/01_quick.rs
+++ b/examples/tutorial_derive/01_quick.rs
@@ -6,10 +6,11 @@ use clap::{Parser, Subcommand};
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Optional name to operate on
+    #[clap(value_parser)]
     name: Option<String>,
 
     /// Sets a custom config file
-    #[clap(short, long, parse(from_os_str), value_name = "FILE")]
+    #[clap(short, long, value_parser, value_name = "FILE")]
     config: Option<PathBuf>,
 
     /// Turn debugging information on
@@ -25,7 +26,7 @@ enum Commands {
     /// does testing things
     Test {
         /// lists test values
-        #[clap(short, long)]
+        #[clap(short, long, value_parser)]
         list: bool,
     },
 }

--- a/examples/tutorial_derive/02_app_settings.rs
+++ b/examples/tutorial_derive/02_app_settings.rs
@@ -6,9 +6,9 @@ use clap::{AppSettings, Parser};
 #[clap(allow_negative_numbers = true)]
 #[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Cli {
-    #[clap(long)]
+    #[clap(long, value_parser)]
     two: String,
-    #[clap(long)]
+    #[clap(long, value_parser)]
     one: String,
 }
 

--- a/examples/tutorial_derive/02_apps.rs
+++ b/examples/tutorial_derive/02_apps.rs
@@ -6,9 +6,9 @@ use clap::Parser;
 #[clap(version = "1.0")]
 #[clap(about = "Does awesome things", long_about = None)]
 struct Cli {
-    #[clap(long)]
+    #[clap(long, value_parser)]
     two: String,
-    #[clap(long)]
+    #[clap(long, value_parser)]
     one: String,
 }
 

--- a/examples/tutorial_derive/02_crate.rs
+++ b/examples/tutorial_derive/02_crate.rs
@@ -3,9 +3,9 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(long)]
+    #[clap(long, value_parser)]
     two: String,
-    #[clap(long)]
+    #[clap(long, value_parser)]
     one: String,
 }
 

--- a/examples/tutorial_derive/03_01_flag_bool.rs
+++ b/examples/tutorial_derive/03_01_flag_bool.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     verbose: bool,
 }
 

--- a/examples/tutorial_derive/03_02_option.rs
+++ b/examples/tutorial_derive/03_02_option.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long)]
+    #[clap(short, long, value_parser)]
     name: Option<String>,
 }
 

--- a/examples/tutorial_derive/03_03_positional.rs
+++ b/examples/tutorial_derive/03_03_positional.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
+    #[clap(value_parser)]
     name: Option<String>,
 }
 

--- a/examples/tutorial_derive/03_04_subcommands.rs
+++ b/examples/tutorial_derive/03_04_subcommands.rs
@@ -11,7 +11,10 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Adds files to myapp
-    Add { name: Option<String> },
+    Add {
+        #[clap(value_parser)]
+        name: Option<String>,
+    },
 }
 
 fn main() {

--- a/examples/tutorial_derive/03_04_subcommands_alt.rs
+++ b/examples/tutorial_derive/03_04_subcommands_alt.rs
@@ -16,6 +16,7 @@ enum Commands {
 
 #[derive(Args)]
 struct Add {
+    #[clap(value_parser)]
     name: Option<String>,
 }
 

--- a/examples/tutorial_derive/03_05_default_values.rs
+++ b/examples/tutorial_derive/03_05_default_values.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(default_value_t = String::from("alice"))]
+    #[clap(default_value_t = String::from("alice"), value_parser)]
     name: String,
 }
 

--- a/examples/tutorial_derive/04_01_enum.rs
+++ b/examples/tutorial_derive/04_01_enum.rs
@@ -4,7 +4,7 @@ use clap::{ArgEnum, Parser};
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// What mode to run the program in
-    #[clap(arg_enum)]
+    #[clap(arg_enum, value_parser)]
     mode: Mode,
 }
 

--- a/examples/tutorial_derive/04_02_parse.rs
+++ b/examples/tutorial_derive/04_02_parse.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Network port to use
-    #[clap(parse(try_from_str))]
-    port: usize,
+    #[clap(value_parser = clap::value_parser!(u16).range(1..))]
+    port: u16,
 }
 
 fn main() {

--- a/examples/tutorial_derive/04_02_validate.rs
+++ b/examples/tutorial_derive/04_02_validate.rs
@@ -6,8 +6,8 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Network port to use
-    #[clap(parse(try_from_str=port_in_range))]
-    port: usize,
+    #[clap(value_parser = port_in_range)]
+    port: u16,
 }
 
 fn main() {
@@ -18,12 +18,12 @@ fn main() {
 
 const PORT_RANGE: RangeInclusive<usize> = 1..=65535;
 
-fn port_in_range(s: &str) -> Result<usize, String> {
+fn port_in_range(s: &str) -> Result<u16, String> {
     let port: usize = s
         .parse()
         .map_err(|_| format!("`{}` isn't a port number", s))?;
     if PORT_RANGE.contains(&port) {
-        Ok(port)
+        Ok(port as u16)
     } else {
         Err(format!(
             "Port not in range {}-{}",

--- a/examples/tutorial_derive/04_03_relations.rs
+++ b/examples/tutorial_derive/04_03_relations.rs
@@ -9,7 +9,7 @@ use clap::{ArgGroup, Parser};
         ))]
 struct Cli {
     /// set version manually
-    #[clap(long, value_name = "VER")]
+    #[clap(long, value_name = "VER", value_parser)]
     set_ver: Option<String>,
 
     /// auto inc major
@@ -25,14 +25,14 @@ struct Cli {
     patch: bool,
 
     /// some regular input
-    #[clap(group = "input")]
+    #[clap(group = "input", value_parser)]
     input_file: Option<String>,
 
     /// some special input argument
-    #[clap(long, group = "input")]
+    #[clap(long, group = "input", value_parser)]
     spec_in: Option<String>,
 
-    #[clap(short, requires = "input")]
+    #[clap(short, requires = "input", value_parser)]
     config: Option<String>,
 }
 

--- a/examples/tutorial_derive/04_04_custom.rs
+++ b/examples/tutorial_derive/04_04_custom.rs
@@ -4,7 +4,7 @@ use clap::{CommandFactory, ErrorKind, Parser};
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// set version manually
-    #[clap(long, value_name = "VER")]
+    #[clap(long, value_name = "VER", value_parser)]
     set_ver: Option<String>,
 
     /// auto inc major
@@ -20,13 +20,14 @@ struct Cli {
     patch: bool,
 
     /// some regular input
+    #[clap(value_parser)]
     input_file: Option<String>,
 
     /// some special input argument
-    #[clap(long)]
+    #[clap(long, value_parser)]
     spec_in: Option<String>,
 
-    #[clap(short)]
+    #[clap(short, value_parser)]
     config: Option<String>,
 }
 

--- a/examples/tutorial_derive/05_01_assert.rs
+++ b/examples/tutorial_derive/05_01_assert.rs
@@ -4,8 +4,8 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Network port to use
-    #[clap(parse(try_from_str))]
-    port: usize,
+    #[clap(value_parser)]
+    port: u16,
 }
 
 fn main() {

--- a/examples/tutorial_derive/README.md
+++ b/examples/tutorial_derive/README.md
@@ -453,6 +453,12 @@ error: Invalid value "foobar" for '<PORT>': invalid digit found in string
 
 For more information try --help
 
+$ 04_02_parse_derive 0
+? failed
+error: Invalid value "0" for '<PORT>': 0 is not in 1..=65535
+
+For more information try --help
+
 ```
 
 A custom parser can be used to improve the error messages or provide additional validation:

--- a/examples/typed-derive.rs
+++ b/examples/typed-derive.rs
@@ -6,23 +6,23 @@ use std::error::Error;
 #[derive(Parser, Debug)]
 struct Args {
     /// Implicitly using `std::str::FromStr`
-    #[clap(short = 'O')]
+    #[clap(short = 'O', value_parser)]
     optimization: Option<usize>,
 
     /// Allow invalid UTF-8 paths
-    #[clap(short = 'I', parse(from_os_str), value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
+    #[clap(short = 'I', value_parser, value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
     include: Option<std::path::PathBuf>,
 
     /// Handle IP addresses
-    #[clap(long)]
+    #[clap(long, value_parser)]
     bind: Option<std::net::IpAddr>,
 
     /// Allow human-readable durations
-    #[clap(long)]
+    #[clap(long, value_parser)]
     sleep: Option<humantime::Duration>,
 
     /// Hand-written parser for tuples
-    #[clap(short = 'D', parse(try_from_str = parse_key_val), multiple_occurrences(true))]
+    #[clap(short = 'D', value_parser = parse_key_val::<String, i32>, multiple_occurrences(true))]
     defines: Vec<(String, i32)>,
 }
 

--- a/src/builder/value_parser.rs
+++ b/src/builder/value_parser.rs
@@ -1125,7 +1125,7 @@ impl<T: std::convert::TryFrom<i64>> RangedI64ValueParser<T> {
             std::ops::Bound::Unbounded => i64::MIN.to_string(),
         };
         result.push_str("..");
-        match self.bounds.0 {
+        match self.bounds.1 {
             std::ops::Bound::Included(i) => {
                 result.push('=');
                 result.push_str(&i.to_string());

--- a/tests/derive/options.rs
+++ b/tests/derive/options.rs
@@ -471,3 +471,16 @@ fn two_option_vec_types() {
         Opt::try_parse_from(&["test"]).unwrap()
     );
 }
+
+#[test]
+fn explicit_value_parser() {
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[clap(long, value_parser = clap::value_parser!(i32))]
+        arg: i32,
+    }
+    assert_eq!(
+        Opt { arg: 42 },
+        Opt::try_parse_from(&["test", "--arg", "42"]).unwrap()
+    );
+}

--- a/tests/derive/options.rs
+++ b/tests/derive/options.rs
@@ -484,3 +484,16 @@ fn explicit_value_parser() {
         Opt::try_parse_from(&["test", "--arg", "42"]).unwrap()
     );
 }
+
+#[test]
+fn implicit_value_parser() {
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[clap(long, value_parser)]
+        arg: i32,
+    }
+    assert_eq!(
+        Opt { arg: 42 },
+        Opt::try_parse_from(&["test", "--arg", "42"]).unwrap()
+    );
+}

--- a/tests/derive_ui/parse_with_value_parser.rs
+++ b/tests/derive_ui/parse_with_value_parser.rs
@@ -1,0 +1,21 @@
+// Copyright 2018 Guillaume Pinot (@TeXitoi) <texitoi@texitoi.eu>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(name = "basic")]
+struct Opt {
+    #[clap(parse(from_str), value_parser = clap::value_parser!(String))]
+    s: String,
+}
+
+fn main() {
+    let opt = Opt::parse();
+    println!("{:?}", opt);
+}

--- a/tests/derive_ui/parse_with_value_parser.stderr
+++ b/tests/derive_ui/parse_with_value_parser.stderr
@@ -1,0 +1,5 @@
+error: `value_parse` attribute conflicts with `parse` attribute
+  --> tests/derive_ui/parse_with_value_parser.rs:14:29
+   |
+14 |     #[clap(parse(from_str), value_parser = clap::value_parser!(String))]
+   |                             ^^^^^^^^^^^^


### PR DESCRIPTION
For clap 3, its opt-in as a precaution against breaking
compatibility in some weird cases.  We made this easy by just specifying `#[clap(value_parser)]` which will default to `value_parser(value_parser!(T))`.

This does require the types to implement `Clone` since the `Arc` might have copies made.

In doing this, some bugs / inccompleteness of `value_parser` was observed and fixed
- Not showing possible values from value parser in help
- Range errors didn't show the correct range

Deprecations were deferred out of this to keep it smaller.

Fixes #3731
Fixes #3496
Fixes #3589