### PR TITLE
fix(parser): Switch to concrete iterators

### DIFF
--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -1582,6 +1582,7 @@ pub(crate) struct SubCommand {
 /// ```
 #[derive(Clone, Debug)]
 pub struct Values2<T> {
+    #[allow(clippy::type_complexity)]
     iter: Map<Flatten<std::vec::IntoIter<Vec<AnyValue>>>, fn(AnyValue) -> T>,
     len: usize,
 }
@@ -1640,6 +1641,7 @@ impl<T> Default for Values2<T> {
 /// ```
 #[derive(Clone, Debug)]
 pub struct ValuesRef<'a, T> {
+    #[allow(clippy::type_complexity)]
     iter: Map<Flatten<Iter<'a, Vec<AnyValue>>>, fn(&AnyValue) -> &T>,
     len: usize,
 }
@@ -1701,6 +1703,7 @@ impl<'a, T: 'a> Default for ValuesRef<'a, T> {
 /// ```
 #[derive(Clone, Debug)]
 pub struct RawValues<'a> {
+    #[allow(clippy::type_complexity)]
     iter: Map<Flatten<Iter<'a, Vec<OsString>>>, fn(&OsString) -> &OsStr>,
     len: usize,
 }

--- a/src/parser/matches/matched_arg.rs
+++ b/src/parser/matches/matched_arg.rs
@@ -101,7 +101,7 @@ impl MatchedArg {
         self.vals.iter().flatten()
     }
 
-    pub(crate) fn into_vals_flatten(self) -> impl Iterator<Item = AnyValue> {
+    pub(crate) fn into_vals_flatten(self) -> Flatten<std::vec::IntoIter<Vec<AnyValue>>> {
         self.vals.into_iter().flatten()
     }
 

--- a/src/parser/matches/mod.rs
+++ b/src/parser/matches/mod.rs
@@ -3,6 +3,7 @@ mod arg_matches;
 mod matched_arg;
 mod value_source;
 
+pub use arg_matches::RawValues;
 pub use arg_matches::{ArgMatches, Indices, OsValues, Values};
 pub use value_source::ValueSource;
 

--- a/src/parser/matches/mod.rs
+++ b/src/parser/matches/mod.rs
@@ -4,6 +4,7 @@ mod matched_arg;
 mod value_source;
 
 pub use arg_matches::RawValues;
+pub use arg_matches::ValuesRef;
 pub use arg_matches::{ArgMatches, Indices, OsValues, Values};
 pub use value_source::ValueSource;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,5 +17,6 @@ pub(crate) use self::parser::{ParseState, Parser};
 pub(crate) use self::validator::Validator;
 
 pub use self::matches::RawValues;
+pub use self::matches::ValuesRef;
 pub use self::matches::{ArgMatches, Indices, OsValues, ValueSource, Values};
 pub use error::MatchesError;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -16,5 +16,6 @@ pub(crate) use self::matches::{MatchedArg, SubCommand};
 pub(crate) use self::parser::{ParseState, Parser};
 pub(crate) use self::validator::Validator;
 
+pub use self::matches::RawValues;
 pub use self::matches::{ArgMatches, Indices, OsValues, ValueSource, Values};
 pub use error::MatchesError;


### PR DESCRIPTION
When I added the `get_many` and friends, I went the fast route of `impl Iterator<>`.  When handling deprecations, I found there were uses in the tests for `unwrap_or_default()` on the iterators.  This is nice and I'd like to preserve it, so I created named iterator types that implement more traits.