### PR TITLE
fix(parser): Make behavior more consistent

### DIFF
--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -1,0 +1,8 @@
+/// Behavior of arguments when they are encountered while parsing
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Action {
+    StoreValue,
+    Flag,
+    Help,
+    Version,
+}

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -18,6 +18,7 @@ use yaml_rust::Yaml;
 
 // Internal
 use crate::builder::usage_parser::UsageParser;
+use crate::builder::Action;
 use crate::builder::ArgPredicate;
 use crate::util::{Id, Key};
 use crate::PossibleValue;
@@ -63,6 +64,7 @@ pub struct Arg<'help> {
     pub(crate) name: &'help str,
     pub(crate) help: Option<&'help str>,
     pub(crate) long_help: Option<&'help str>,
+    pub(crate) action: Option<Action>,
     pub(crate) value_parser: Option<super::ValueParser>,
     pub(crate) blacklist: Vec<Id>,
     pub(crate) settings: ArgFlags,
@@ -4526,6 +4528,12 @@ impl<'help> Arg<'help> {
     #[deprecated(since = "3.2.0", note = "Replaced with `Arg::get_value_parser()`")]
     pub fn is_allow_invalid_utf8_set(&self) -> bool {
         self.is_set(ArgSettings::AllowInvalidUtf8)
+    }
+
+    /// Behavior when parsing the argument
+    pub(crate) fn get_action(&self) -> &super::Action {
+        const DEFAULT: super::Action = super::Action::StoreValue;
+        self.action.as_ref().unwrap_or(&DEFAULT)
     }
 
     /// Configured parser for argument values

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 mod macros;
 
+mod action;
 mod app_settings;
 mod arg;
 mod arg_group;
@@ -53,6 +54,7 @@ pub use command::App;
 #[cfg(feature = "regex")]
 pub use self::regex::RegexRef;
 
+pub(crate) use action::Action;
 pub(crate) use arg::display_arg_val;
 pub(crate) use arg_predicate::ArgPredicate;
 pub(crate) use value_parser::ValueParserInner;

--- a/src/parser/matches/matched_arg.rs
+++ b/src/parser/matches/matched_arg.rs
@@ -87,11 +87,6 @@ impl MatchedArg {
         self.indices.push(index)
     }
 
-    #[cfg(test)]
-    pub(crate) fn raw_vals(&self) -> Iter<Vec<OsString>> {
-        self.raw_vals.iter()
-    }
-
     #[cfg(feature = "unstable-grouped")]
     pub(crate) fn vals(&self) -> Iter<Vec<AnyValue>> {
         self.vals.iter()
@@ -116,11 +111,6 @@ impl MatchedArg {
     #[cfg(test)]
     pub(crate) fn first_raw(&self) -> Option<&OsString> {
         self.raw_vals_flatten().next()
-    }
-
-    pub(crate) fn push_val(&mut self, val: AnyValue, raw_val: OsString) {
-        self.vals.push(vec![val]);
-        self.raw_vals.push(vec![raw_val]);
     }
 
     pub(crate) fn new_val_group(&mut self) {
@@ -149,10 +139,6 @@ impl MatchedArg {
 
     pub(crate) fn all_val_groups_empty(&self) -> bool {
         self.vals.iter().flatten().count() == 0
-    }
-
-    pub(crate) fn has_val_groups(&self) -> bool {
-        !self.vals.is_empty()
     }
 
     pub(crate) fn check_explicit(&self, predicate: ArgPredicate) -> bool {
@@ -243,39 +229,5 @@ mod tests {
         m.append_val(AnyValue::new(String::from("bbb")), "bbb".into());
         m.append_val(AnyValue::new(String::from("ccc")), "ccc".into());
         assert_eq!(m.first_raw(), Some(&OsString::from("bbb")));
-    }
-
-    #[test]
-    fn test_grouped_vals_push_and_append() {
-        let mut m = MatchedArg::new_group();
-        m.push_val(AnyValue::new(String::from("aaa")), "aaa".into());
-        m.new_val_group();
-        m.append_val(AnyValue::new(String::from("bbb")), "bbb".into());
-        m.append_val(AnyValue::new(String::from("ccc")), "ccc".into());
-        m.new_val_group();
-        m.append_val(AnyValue::new(String::from("ddd")), "ddd".into());
-        m.push_val(AnyValue::new(String::from("eee")), "eee".into());
-        m.new_val_group();
-        m.append_val(AnyValue::new(String::from("fff")), "fff".into());
-        m.append_val(AnyValue::new(String::from("ggg")), "ggg".into());
-        m.append_val(AnyValue::new(String::from("hhh")), "hhh".into());
-        m.append_val(AnyValue::new(String::from("iii")), "iii".into());
-
-        let vals: Vec<&Vec<OsString>> = m.raw_vals().collect();
-        assert_eq!(
-            vals,
-            vec![
-                &vec![OsString::from("aaa")],
-                &vec![OsString::from("bbb"), OsString::from("ccc"),],
-                &vec![OsString::from("ddd")],
-                &vec![OsString::from("eee")],
-                &vec![
-                    OsString::from("fff"),
-                    OsString::from("ggg"),
-                    OsString::from("hhh"),
-                    OsString::from("iii"),
-                ]
-            ]
-        )
     }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -419,8 +419,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 });
 
                 #[cfg(feature = "env")]
-                self.add_env(matcher, trailing_values)?;
-                self.add_defaults(matcher, trailing_values)?;
+                self.add_env(matcher)?;
+                self.add_defaults(matcher)?;
                 return Validator::new(self.cmd).validate(parse_state, matcher);
             } else {
                 // Start error processing
@@ -439,8 +439,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         }
 
         #[cfg(feature = "env")]
-        self.add_env(matcher, trailing_values)?;
-        self.add_defaults(matcher, trailing_values)?;
+        self.add_env(matcher)?;
+        self.add_defaults(matcher)?;
         Validator::new(self.cmd).validate(parse_state, matcher)
     }
 
@@ -1101,10 +1101,11 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
     }
 
     #[cfg(feature = "env")]
-    fn add_env(&mut self, matcher: &mut ArgMatcher, trailing_values: bool) -> ClapResult<()> {
+    fn add_env(&mut self, matcher: &mut ArgMatcher) -> ClapResult<()> {
         debug!("Parser::add_env");
         use crate::util::str_to_bool;
 
+        let trailing_values = false; // defaults are independent of the commandline
         for arg in self.cmd.get_arguments() {
             // Use env only if the arg was absent among command line args,
             // early return if this is not the case.
@@ -1154,28 +1155,25 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         Ok(())
     }
 
-    fn add_defaults(&mut self, matcher: &mut ArgMatcher, trailing_values: bool) -> ClapResult<()> {
+    fn add_defaults(&mut self, matcher: &mut ArgMatcher) -> ClapResult<()> {
         debug!("Parser::add_defaults");
 
         for o in self.cmd.get_opts() {
             debug!("Parser::add_defaults:iter:{}:", o.name);
-            self.add_default_value(o, matcher, trailing_values)?;
+            self.add_default_value(o, matcher)?;
         }
 
         for p in self.cmd.get_positionals() {
             debug!("Parser::add_defaults:iter:{}:", p.name);
-            self.add_default_value(p, matcher, trailing_values)?;
+            self.add_default_value(p, matcher)?;
         }
 
         Ok(())
     }
 
-    fn add_default_value(
-        &self,
-        arg: &Arg<'help>,
-        matcher: &mut ArgMatcher,
-        trailing_values: bool,
-    ) -> ClapResult<()> {
+    fn add_default_value(&self, arg: &Arg<'help>, matcher: &mut ArgMatcher) -> ClapResult<()> {
+        let trailing_values = false; // defaults are independent of the commandline
+
         if !arg.default_vals_ifs.is_empty() {
             debug!("Parser::add_default_value: has conditional defaults");
             if matcher.get(&arg.id).is_none() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -182,7 +182,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                             && !self.is_set(AS::NoAutoHelp)
                             && !self.cmd.is_disable_help_subcommand_set()
                         {
-                            self.parse_help_subcommand(raw_args.remaining(&mut args_cursor))?;
+                            let _ =
+                                self.parse_help_subcommand(raw_args.remaining(&mut args_cursor))?;
                         }
                         subcmd_name = Some(sc_name.to_owned());
                         break;
@@ -376,7 +377,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 if !p.is_multiple_values_set() || !matcher.contains(&p.id) {
                     self.start_occurrence_of_arg(matcher, p);
                 }
-                self.add_val_to_arg(p, arg_os.to_value_os(), matcher, trailing_values)?;
+                let _ = self.add_val_to_arg(p, arg_os.to_value_os(), matcher, trailing_values)?;
 
                 // Only increment the positional counter if it doesn't allow multiples
                 if !p.is_multiple() {
@@ -942,7 +943,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 if !opt.default_missing_vals.is_empty() {
                     debug!("Parser::parse_opt_value: has default_missing_vals");
                     for v in opt.default_missing_vals.iter() {
-                        self.add_val_to_arg(opt, &RawOsStr::new(v), matcher, trailing_values)?;
+                        let _ =
+                            self.add_val_to_arg(opt, &RawOsStr::new(v), matcher, trailing_values)?;
                     }
                 };
                 if attached_value.is_some() {
@@ -958,7 +960,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             }
         } else if let Some(v) = attached_value {
             self.start_occurrence_of_arg(matcher, opt);
-            self.add_val_to_arg(opt, v, matcher, trailing_values)?;
+            let _ = self.add_val_to_arg(opt, v, matcher, trailing_values)?;
             Ok(ParseResult::ValuesDone)
         } else {
             debug!("Parser::parse_opt_value: More arg vals required...");
@@ -1122,7 +1124,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                         val, trailing_values
                     );
                     self.start_custom_arg(matcher, arg, ValueSource::EnvVariable);
-                    self.add_val_to_arg(arg, &val, matcher, trailing_values)?;
+                    let _ = self.add_val_to_arg(arg, &val, matcher, trailing_values)?;
                 } else {
                     match arg.get_action() {
                         Action::StoreValue => unreachable!("{:?} is not a flag", arg.get_id()),
@@ -1183,7 +1185,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     // The flag occurred, we just want to add the val groups
                     self.start_custom_arg(matcher, arg, ValueSource::CommandLine);
                     for v in arg.default_missing_vals.iter() {
-                        self.add_val_to_arg(arg, &RawOsStr::new(v), matcher, trailing_values)?;
+                        let _ =
+                            self.add_val_to_arg(arg, &RawOsStr::new(v), matcher, trailing_values)?;
                     }
                 }
                 None => {
@@ -1224,7 +1227,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     if add {
                         if let Some(default) = default {
                             self.start_custom_arg(matcher, arg, ValueSource::DefaultValue);
-                            self.add_val_to_arg(
+                            let _ = self.add_val_to_arg(
                                 arg,
                                 &RawOsStr::new(default),
                                 matcher,
@@ -1252,7 +1255,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
 
                 self.start_custom_arg(matcher, arg, ValueSource::DefaultValue);
                 for v in arg.default_vals.iter() {
-                    self.add_val_to_arg(arg, &RawOsStr::new(v), matcher, trailing_values)?;
+                    let _ =
+                        self.add_val_to_arg(arg, &RawOsStr::new(v), matcher, trailing_values)?;
                 }
             }
         } else {
@@ -1373,6 +1377,7 @@ pub(crate) enum ParseState {
 
 /// Recoverable Parsing results.
 #[derive(Debug, PartialEq, Clone)]
+#[must_use]
 enum ParseResult {
     FlagSubCommand(String),
     Opt(Id),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -743,7 +743,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     long_arg, &long_value
                 );
                 let has_eq = long_value.is_some();
-                self.parse_opt(long_value, opt, matcher, trailing_values, has_eq)
+                self.parse_opt_value(long_value, opt, matcher, trailing_values, has_eq)
             } else if let Some(rest) = long_value {
                 let required = self.cmd.required_graph();
                 debug!(
@@ -890,7 +890,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 } else {
                     (val, false)
                 };
-                match self.parse_opt(val, opt, matcher, trailing_values, has_eq)? {
+                match self.parse_opt_value(val, opt, matcher, trailing_values, has_eq)? {
                     ParseResult::AttachedValueNotConsumed => continue,
                     x => return Ok(x),
                 }
@@ -918,7 +918,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         Ok(ret)
     }
 
-    fn parse_opt(
+    fn parse_opt_value(
         &self,
         attached_value: Option<&RawOsStr>,
         opt: &Arg<'help>,
@@ -927,12 +927,12 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         has_eq: bool,
     ) -> ClapResult<ParseResult> {
         debug!(
-            "Parser::parse_opt; opt={}, val={:?}, has_eq={:?}",
+            "Parser::parse_opt_value; opt={}, val={:?}, has_eq={:?}",
             opt.name, attached_value, has_eq
         );
-        debug!("Parser::parse_opt; opt.settings={:?}", opt.settings);
+        debug!("Parser::parse_opt_value; opt.settings={:?}", opt.settings);
 
-        debug!("Parser::parse_opt; Checking for val...");
+        debug!("Parser::parse_opt_value; Checking for val...");
         // require_equals is set, but no '=' is provided, try throwing error.
         if opt.is_require_equals_set() && !has_eq {
             if opt.min_vals == Some(0) {
@@ -940,7 +940,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 self.start_occurrence_of_arg(matcher, opt);
                 // We assume this case is valid: require equals, but min_vals == 0.
                 if !opt.default_missing_vals.is_empty() {
-                    debug!("Parser::parse_opt: has default_missing_vals");
+                    debug!("Parser::parse_opt_value: has default_missing_vals");
                     for v in opt.default_missing_vals.iter() {
                         self.add_val_to_arg(opt, &RawOsStr::new(v), matcher, trailing_values)?;
                     }
@@ -961,7 +961,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             self.add_val_to_arg(opt, v, matcher, trailing_values)?;
             Ok(ParseResult::ValuesDone)
         } else {
-            debug!("Parser::parse_opt: More arg vals required...");
+            debug!("Parser::parse_opt_value: More arg vals required...");
             self.start_occurrence_of_arg(matcher, opt);
             Ok(ParseResult::Opt(opt.id.clone()))
         }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -971,7 +971,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             self.start_occurrence_of_arg(matcher, opt);
             let mut val_result = self.add_val_to_arg(opt, v, matcher, trailing_values)?;
             if val_result != ParseResult::ValuesDone {
-                debug!("Parser::parse_opt_value: Overiding state {:?}; no values accepted after attached", val_result);
+                debug!("Parser::parse_opt_value: Overriding state {:?}; no values accepted after attached", val_result);
                 val_result = ParseResult::ValuesDone;
             }
             Ok(val_result)

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1174,6 +1174,43 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
     fn add_default_value(&self, arg: &Arg<'help>, matcher: &mut ArgMatcher) -> ClapResult<()> {
         let trailing_values = false; // defaults are independent of the commandline
 
+        if !arg.default_missing_vals.is_empty() {
+            debug!(
+                "Parser::add_default_value:iter:{}: has default missing vals",
+                arg.name
+            );
+            match matcher.get(&arg.id) {
+                Some(ma) if ma.all_val_groups_empty() => {
+                    debug!(
+                        "Parser::add_default_value:iter:{}: has no user defined vals",
+                        arg.name
+                    );
+                    // The flag occurred, we just want to add the val groups
+                    self.start_custom_arg(matcher, arg, ValueSource::CommandLine);
+                    for v in arg.default_missing_vals.iter() {
+                        self.add_val_to_arg(arg, &RawOsStr::new(v), matcher, trailing_values)?;
+                    }
+                }
+                None => {
+                    debug!("Parser::add_default_value:iter:{}: wasn't used", arg.name);
+                    // do nothing
+                }
+                _ => {
+                    debug!(
+                        "Parser::add_default_value:iter:{}: has user defined vals",
+                        arg.name
+                    );
+                    // do nothing
+                }
+            }
+        } else {
+            debug!(
+                "Parser::add_default_value:iter:{}: doesn't have default missing vals",
+                arg.name
+            );
+            // do nothing
+        }
+
         if !arg.default_vals_ifs.is_empty() {
             debug!("Parser::add_default_value: has conditional defaults");
             if matcher.get(&arg.id).is_none() {
@@ -1226,43 +1263,6 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         } else {
             debug!(
                 "Parser::add_default_value:iter:{}: doesn't have default vals",
-                arg.name
-            );
-
-            // do nothing
-        }
-
-        if !arg.default_missing_vals.is_empty() {
-            debug!(
-                "Parser::add_default_value:iter:{}: has default missing vals",
-                arg.name
-            );
-            match matcher.get(&arg.id) {
-                Some(ma) if ma.all_val_groups_empty() => {
-                    debug!(
-                        "Parser::add_default_value:iter:{}: has no user defined vals",
-                        arg.name
-                    );
-                    self.start_custom_arg(matcher, arg, ValueSource::DefaultValue);
-                    for v in arg.default_missing_vals.iter() {
-                        self.add_val_to_arg(arg, &RawOsStr::new(v), matcher, trailing_values)?;
-                    }
-                }
-                None => {
-                    debug!("Parser::add_default_value:iter:{}: wasn't used", arg.name);
-                    // do nothing
-                }
-                _ => {
-                    debug!(
-                        "Parser::add_default_value:iter:{}: has user defined vals",
-                        arg.name
-                    );
-                    // do nothing
-                }
-            }
-        } else {
-            debug!(
-                "Parser::add_default_value:iter:{}: doesn't have default missing vals",
                 arg.name
             );
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1119,10 +1119,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         for arg in self.cmd.get_arguments() {
             // Use env only if the arg was absent among command line args,
             // early return if this is not the case.
-            if matcher
-                .get(&arg.id)
-                .map_or(false, |arg| arg.get_occurrences() != 0)
-            {
+            if matcher.contains(&arg.id) {
                 debug!("Parser::add_env: Skipping existing arg `{}`", arg);
                 continue;
             }
@@ -1231,7 +1228,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
 
         if !arg.default_vals_ifs.is_empty() {
             debug!("Parser::add_default_value: has conditional defaults");
-            if matcher.get(&arg.id).is_none() {
+            if !matcher.contains(&arg.id) {
                 for (id, val, default) in arg.default_vals_ifs.iter() {
                     let add = if let Some(a) = matcher.get(id) {
                         match val {
@@ -1270,7 +1267,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 "Parser::add_default_value:iter:{}: has default vals",
                 arg.name
             );
-            if matcher.get(&arg.id).is_some() {
+            if matcher.contains(&arg.id) {
                 debug!("Parser::add_default_value:iter:{}: was used", arg.name);
             // do nothing
             } else {

--- a/tests/builder/default_missing_vals.rs
+++ b/tests/builder/default_missing_vals.rs
@@ -174,6 +174,39 @@ fn default_missing_value_flag_value() {
     );
 }
 
+#[test]
+fn delimited_missing_value() {
+    let cmd = Command::new("test").arg(
+        Arg::new("flag")
+            .long("flag")
+            .default_value("one,two")
+            .default_missing_value("three,four")
+            .min_values(0)
+            .value_delimiter(',')
+            .require_equals(true),
+    );
+
+    let m = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(
+        m.get_many::<String>("flag")
+            .unwrap()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>(),
+        vec!["one", "two"]
+    );
+    assert_eq!(m.occurrences_of("flag"), 0);
+
+    let m = cmd.try_get_matches_from(["test", "--flag"]).unwrap();
+    assert_eq!(
+        m.get_many::<String>("flag")
+            .unwrap()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>(),
+        vec!["three", "four"]
+    );
+    assert_eq!(m.occurrences_of("flag"), 1);
+}
+
 #[cfg(debug_assertions)]
 #[test]
 #[should_panic = "Argument `arg`'s default_missing_value=\"value\" failed validation: error: \"value\" isn't a valid value for '<arg>'"]

--- a/tests/builder/default_missing_vals.rs
+++ b/tests/builder/default_missing_vals.rs
@@ -1,4 +1,4 @@
-use clap::{arg, Arg, ArgMatches, Command};
+use clap::{arg, Arg, Command};
 
 #[test]
 fn opt_missing() {
@@ -20,6 +20,10 @@ fn opt_missing() {
         "auto"
     );
     assert_eq!(m.occurrences_of("color"), 0);
+    assert_eq!(
+        m.value_source("color").unwrap(),
+        clap::ValueSource::DefaultValue
+    );
 }
 
 #[test]
@@ -42,6 +46,10 @@ fn opt_present_with_missing_value() {
         "always"
     );
     assert_eq!(m.occurrences_of("color"), 1);
+    assert_eq!(
+        m.value_source("color").unwrap(),
+        clap::ValueSource::CommandLine
+    );
 }
 
 #[test]
@@ -64,6 +72,10 @@ fn opt_present_with_value() {
         "never"
     );
     assert_eq!(m.occurrences_of("color"), 1);
+    assert_eq!(
+        m.value_source("color").unwrap(),
+        clap::ValueSource::CommandLine
+    );
 }
 
 #[test]
@@ -85,6 +97,10 @@ fn opt_present_with_empty_value() {
         ""
     );
     assert_eq!(m.occurrences_of("color"), 1);
+    assert_eq!(
+        m.value_source("color").unwrap(),
+        clap::ValueSource::CommandLine
+    );
 }
 
 //## `default_value`/`default_missing_value` non-interaction checks
@@ -134,43 +150,62 @@ fn default_missing_value_flag_value() {
         Arg::new("flag")
             .long("flag")
             .takes_value(true)
+            .default_value("false")
             .default_missing_value("true"),
     );
 
-    fn flag_value(m: ArgMatches) -> bool {
-        match m.get_one::<String>("flag").map(|v| v.as_str()) {
-            None => false,
-            Some(x) => x.parse().expect("non boolean value"),
-        }
-    }
+    let m = cmd.clone().try_get_matches_from(&["test"]).unwrap();
+    assert!(m.is_present("flag"));
+    assert_eq!(
+        m.get_one::<String>("flag").map(|v| v.as_str()),
+        Some("false")
+    );
+    assert_eq!(m.occurrences_of("flag"), 0);
+    assert_eq!(
+        m.value_source("flag").unwrap(),
+        clap::ValueSource::DefaultValue
+    );
 
+    let m = cmd
+        .clone()
+        .try_get_matches_from(&["test", "--flag"])
+        .unwrap();
+    assert!(m.is_present("flag"));
     assert_eq!(
-        flag_value(cmd.clone().try_get_matches_from(&["test"]).unwrap()),
-        false
+        m.get_one::<String>("flag").map(|v| v.as_str()),
+        Some("true")
     );
+    assert_eq!(m.occurrences_of("flag"), 1);
     assert_eq!(
-        flag_value(
-            cmd.clone()
-                .try_get_matches_from(&["test", "--flag"])
-                .unwrap()
-        ),
-        true
+        m.value_source("flag").unwrap(),
+        clap::ValueSource::CommandLine
     );
+
+    let m = cmd
+        .clone()
+        .try_get_matches_from(&["test", "--flag=true"])
+        .unwrap();
+    assert!(m.is_present("flag"));
     assert_eq!(
-        flag_value(
-            cmd.clone()
-                .try_get_matches_from(&["test", "--flag=true"])
-                .unwrap()
-        ),
-        true
+        m.get_one::<String>("flag").map(|v| v.as_str()),
+        Some("true")
     );
+    assert_eq!(m.occurrences_of("flag"), 1);
     assert_eq!(
-        flag_value(
-            cmd.clone()
-                .try_get_matches_from(&["test", "--flag=false"])
-                .unwrap()
-        ),
-        false
+        m.value_source("flag").unwrap(),
+        clap::ValueSource::CommandLine
+    );
+
+    let m = cmd.try_get_matches_from(&["test", "--flag=false"]).unwrap();
+    assert!(m.is_present("flag"));
+    assert_eq!(
+        m.get_one::<String>("flag").map(|v| v.as_str()),
+        Some("false")
+    );
+    assert_eq!(m.occurrences_of("flag"), 1);
+    assert_eq!(
+        m.value_source("flag").unwrap(),
+        clap::ValueSource::CommandLine
     );
 }
 

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -831,3 +831,49 @@ fn missing_with_value_delimiter() {
         ["value1", "value2", "value3", "value4", "value5"]
     );
 }
+
+#[test]
+fn default_independent_of_trailing() {
+    let cmd = Command::new("test")
+        .dont_delimit_trailing_values(true)
+        .arg(Arg::new("pos").required(true))
+        .arg(
+            Arg::new("flag")
+                .long("flag")
+                .default_value("one,two")
+                .value_delimiter(','),
+        );
+
+    // Baseline behavior
+    let m = cmd
+        .clone()
+        .try_get_matches_from(vec!["program", "here"])
+        .unwrap();
+    assert_eq!(
+        m.get_one::<String>("pos").map(|v| v.as_str()).unwrap(),
+        "here"
+    );
+    assert_eq!(
+        m.get_many::<String>("flag")
+            .unwrap()
+            .map(|v| v.as_str())
+            .collect::<Vec<_>>(),
+        ["one", "two"]
+    );
+
+    // Trailing-values behavior should match the baseline
+    let m = cmd
+        .try_get_matches_from(vec!["program", "--", "here"])
+        .unwrap();
+    assert_eq!(
+        m.get_one::<String>("pos").map(|v| v.as_str()).unwrap(),
+        "here"
+    );
+    assert_eq!(
+        m.get_many::<String>("flag")
+            .unwrap()
+            .map(|v| v.as_str())
+            .collect::<Vec<_>>(),
+        ["one", "two"]
+    );
+}


### PR DESCRIPTION
Overall this is refactoring to slowly prepare the parser for customizable responses to arguments needed for #3405.  Some of these fixed bugs along the way while others just cleaned up the parser, making it easier to understand what is going on.

The line between a bug fix and a breaking change is awkward at times.  The part that seems most questionable to me is changing how we count occurrences for positional arguments.  This gets us closer to the documented behavior and makes the parser more consistent.  I'm trying to stop short of #3763 because I worry that resolving that would be too much of a change for the 3.x line since it ties into validation.