### PR TITLE
refactor(parser): Extract Actions from Parser

### DIFF
--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -1,6 +1,6 @@
 /// Behavior of arguments when they are encountered while parsing
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum Action {
+pub(crate) enum ArgAction {
     StoreValue,
     Flag,
     Help,

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -18,7 +18,7 @@ use yaml_rust::Yaml;
 
 // Internal
 use crate::builder::usage_parser::UsageParser;
-use crate::builder::Action;
+use crate::builder::ArgAction;
 use crate::builder::ArgPredicate;
 use crate::util::{Id, Key};
 use crate::PossibleValue;
@@ -64,7 +64,7 @@ pub struct Arg<'help> {
     pub(crate) name: &'help str,
     pub(crate) help: Option<&'help str>,
     pub(crate) long_help: Option<&'help str>,
-    pub(crate) action: Option<Action>,
+    pub(crate) action: Option<ArgAction>,
     pub(crate) value_parser: Option<super::ValueParser>,
     pub(crate) blacklist: Vec<Id>,
     pub(crate) settings: ArgFlags,
@@ -4531,8 +4531,8 @@ impl<'help> Arg<'help> {
     }
 
     /// Behavior when parsing the argument
-    pub(crate) fn get_action(&self) -> &super::Action {
-        const DEFAULT: super::Action = super::Action::StoreValue;
+    pub(crate) fn get_action(&self) -> &super::ArgAction {
+        const DEFAULT: super::ArgAction = super::ArgAction::StoreValue;
         self.action.as_ref().unwrap_or(&DEFAULT)
     }
 

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -4150,16 +4150,16 @@ impl<'help> App<'help> {
                 // compat, actions will reign supreme (default to `Store`)
                 if a.action.is_none() {
                     if a.get_id() == "help" && auto_help {
-                        let action = super::Action::Help;
+                        let action = super::ArgAction::Help;
                         a.action = Some(action);
                     } else if a.get_id() == "version" && auto_version {
-                        let action = super::Action::Version;
+                        let action = super::ArgAction::Version;
                         a.action = Some(action);
                     } else if a.is_takes_value_set() {
-                        let action = super::Action::StoreValue;
+                        let action = super::ArgAction::StoreValue;
                         a.action = Some(action);
                     } else {
-                        let action = super::Action::Flag;
+                        let action = super::ArgAction::Flag;
                         a.action = Some(action);
                     }
                 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -54,7 +54,7 @@ pub use command::App;
 #[cfg(feature = "regex")]
 pub use self::regex::RegexRef;
 
-pub(crate) use action::Action;
+pub(crate) use action::ArgAction;
 pub(crate) use arg::display_arg_val;
 pub(crate) use arg_predicate::ArgPredicate;
 pub(crate) use value_parser::ValueParserInner;

--- a/src/parser/matches/matched_arg.rs
+++ b/src/parser/matches/matched_arg.rs
@@ -71,6 +71,10 @@ impl MatchedArg {
         self.occurs += 1;
     }
 
+    pub(crate) fn set_occurrences(&mut self, occurs: u64) {
+        self.occurs = occurs
+    }
+
     pub(crate) fn get_occurrences(&self) -> u64 {
         self.occurs
     }

--- a/src/parser/matches/matched_arg.rs
+++ b/src/parser/matches/matched_arg.rs
@@ -132,7 +132,7 @@ impl MatchedArg {
     }
 
     pub(crate) fn num_vals(&self) -> usize {
-        self.vals.iter().flatten().count()
+        self.vals.iter().map(|v| v.len()).sum()
     }
 
     // Will be used later

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use self::arg_matcher::ArgMatcher;
 pub(crate) use self::matches::AnyValue;
 pub(crate) use self::matches::AnyValueId;
 pub(crate) use self::matches::{MatchedArg, SubCommand};
+pub(crate) use self::parser::Identifier;
+pub(crate) use self::parser::PendingArg;
 pub(crate) use self::parser::{ParseState, Parser};
 pub(crate) use self::validator::Validator;
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -967,11 +967,10 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         if arg.is_require_equals_set() && !has_eq {
             if arg.min_vals == Some(0) {
                 debug!("Requires equals, but min_vals == 0");
-                self.start_occurrence_of_arg(matcher, arg);
+                let mut arg_values = Vec::new();
                 // We assume this case is valid: require equals, but min_vals == 0.
                 if !arg.default_missing_vals.is_empty() {
                     debug!("Parser::parse_opt_value: has default_missing_vals");
-                    let mut arg_values = Vec::new();
                     for v in arg.default_missing_vals.iter() {
                         let _parse_result = self.push_arg_values(
                             arg,
@@ -985,8 +984,9 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                             }
                         }
                     }
-                    self.store_arg_values(arg, arg_values, matcher)?;
                 };
+                self.start_occurrence_of_arg(matcher, arg);
+                self.store_arg_values(arg, arg_values, matcher)?;
                 if attached_value.is_some() {
                     Ok(ParseResult::AttachedValueNotConsumed)
                 } else {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -985,8 +985,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                         }
                     }
                 };
-                self.start_occurrence_of_arg(matcher, arg);
-                self.store_arg_values(arg, arg_values, matcher)?;
+                let react_result = self.react(ident, arg, arg_values, matcher)?;
+                debug_assert_eq!(react_result, ParseResult::ValuesDone);
                 if attached_value.is_some() {
                     Ok(ParseResult::AttachedValueNotConsumed)
                 } else {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -345,7 +345,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     // Assume this is a value of a previous arg.
 
                     // get the option so we can check the settings
-                    let arg_values = matcher.pending_values_mut(&id, None);
+                    let arg_values = matcher.pending_values_mut(id, None);
                     let arg = &self.cmd[id];
                     let parse_result = self.push_arg_values(
                         arg,
@@ -1144,17 +1144,15 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     && matcher.contains(&arg.id)
                 {
                     // HACK: Reuse existing occurrence
-                } else {
-                    if source == ValueSource::CommandLine {
-                        if matches!(ident, Some(Identifier::Short) | Some(Identifier::Long)) {
-                            // Record flag's index
-                            self.cur_idx.set(self.cur_idx.get() + 1);
-                            debug!("Parser::react: cur_idx:={}", self.cur_idx.get());
-                        }
-                        self.start_occurrence_of_arg(matcher, arg);
-                    } else {
-                        self.start_custom_arg(matcher, arg, source);
+                } else if source == ValueSource::CommandLine {
+                    if matches!(ident, Some(Identifier::Short) | Some(Identifier::Long)) {
+                        // Record flag's index
+                        self.cur_idx.set(self.cur_idx.get() + 1);
+                        debug!("Parser::react: cur_idx:={}", self.cur_idx.get());
                     }
+                    self.start_occurrence_of_arg(matcher, arg);
+                } else {
+                    self.start_custom_arg(matcher, arg, source);
                 }
                 self.store_arg_values(arg, raw_vals, matcher)?;
                 if ident == Some(Identifier::Index) && arg.is_multiple_values_set() {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -762,8 +762,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             None
         };
 
-        if let Some((long_arg, arg)) = arg {
-            let ident = Identifier::Long(long_arg);
+        if let Some((_long_arg, arg)) = arg {
+            let ident = Identifier::Long;
             *valid_arg_found = true;
             if arg.is_takes_value_set() {
                 debug!(
@@ -886,7 +886,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             // Option: -o
             // Value: val
             if let Some(arg) = self.cmd.get_keymap().get(&c) {
-                let ident = Identifier::Short(c);
+                let ident = Identifier::Short;
                 debug!(
                     "Parser::parse_short_arg:iter:{}: Found valid opt or flag",
                     c
@@ -1152,8 +1152,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             Action::Help => {
                 debug_assert_eq!(raw_vals, Vec::<OsString>::new());
                 let use_long = match ident {
-                    Some(Identifier::Long(_)) => true,
-                    Some(Identifier::Short(_)) => false,
+                    Some(Identifier::Long) => true,
+                    Some(Identifier::Short) => false,
                     None => true,
                 };
                 debug!("Help: use_long={}", use_long);
@@ -1162,8 +1162,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             Action::Version => {
                 debug_assert_eq!(raw_vals, Vec::<OsString>::new());
                 let use_long = match ident {
-                    Some(Identifier::Long(_)) => true,
-                    Some(Identifier::Short(_)) => false,
+                    Some(Identifier::Long) => true,
+                    Some(Identifier::Short) => false,
                     None => true,
                 };
                 debug!("Version: use_long={}", use_long);
@@ -1542,7 +1542,7 @@ enum ParseResult {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum Identifier<'f> {
-    Short(char),
-    Long(&'f str),
+enum Identifier {
+    Short,
+    Long,
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1157,6 +1157,11 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     }
                 }
                 self.store_arg_values(arg, raw_vals, matcher)?;
+                if ident == Some(Identifier::Index) && arg.is_multiple_values_set() {
+                    // HACK: Maintain existing occurrence behavior
+                    let matched = matcher.get_mut(&arg.id).unwrap();
+                    matched.set_occurrences(matched.num_vals() as u64);
+                }
                 if cfg!(debug_assertions) && matcher.needs_more_vals(arg) {
                     debug!(
                         "Parser::react not enough values passed in, leaving it to the validator to complain",

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -8,8 +8,8 @@ use std::{
 use clap_lex::RawOsStr;
 
 // Internal
-use crate::builder::Action;
 use crate::builder::AppSettings as AS;
+use crate::builder::ArgAction;
 use crate::builder::{Arg, Command};
 use crate::error::Error as ClapError;
 use crate::error::Result as ClapResult;
@@ -1138,7 +1138,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
             source
         );
         match arg.get_action() {
-            Action::StoreValue => {
+            ArgAction::StoreValue => {
                 if ident == Some(Identifier::Index)
                     && arg.is_multiple_values_set()
                     && matcher.contains(&arg.id)
@@ -1164,7 +1164,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 }
                 Ok(ParseResult::ValuesDone)
             }
-            Action::Flag => {
+            ArgAction::Flag => {
                 debug_assert_eq!(raw_vals, Vec::<OsString>::new());
                 if source == ValueSource::CommandLine {
                     if matches!(ident, Some(Identifier::Short) | Some(Identifier::Long)) {
@@ -1179,7 +1179,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 matcher.add_index_to(&arg.id, self.cur_idx.get());
                 Ok(ParseResult::ValuesDone)
             }
-            Action::Help => {
+            ArgAction::Help => {
                 debug_assert_eq!(raw_vals, Vec::<OsString>::new());
                 let use_long = match ident {
                     Some(Identifier::Long) => true,
@@ -1190,7 +1190,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 debug!("Help: use_long={}", use_long);
                 Err(self.help_err(use_long, Stream::Stdout))
             }
-            Action::Version => {
+            ArgAction::Version => {
                 debug_assert_eq!(raw_vals, Vec::<OsString>::new());
                 let use_long = match ident {
                     Some(Identifier::Long) => true,
@@ -1260,8 +1260,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     }
                 } else {
                     match arg.get_action() {
-                        Action::StoreValue => unreachable!("{:?} is not a flag", arg.get_id()),
-                        Action::Flag => {
+                        ArgAction::StoreValue => unreachable!("{:?} is not a flag", arg.get_id()),
+                        ArgAction::Flag => {
                             debug!("Parser::add_env: Found a flag with value `{:?}`", val);
                             let predicate = str_to_bool(val.to_str_lossy());
                             debug!("Parser::add_env: Found boolean literal `{:?}`", predicate);
@@ -1276,7 +1276,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                             }
                         }
                         // Early return on `Help` or `Version`.
-                        Action::Help | Action::Version => {
+                        ArgAction::Help | ArgAction::Version => {
                             let _ =
                                 self.react(None, ValueSource::EnvVariable, arg, vec![], matcher)?;
                         }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -794,7 +794,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 })
             } else {
                 debug!("Parser::parse_long_arg({:?}): Presence validated", long_arg);
-                self.parse_flag(Identifier::Long(long_arg), arg, matcher)
+                self.react(Identifier::Long(long_arg), arg, matcher)
             }
         } else if let Some(sc_name) = self.possible_long_flag_subcommand(long_arg) {
             Ok(ParseResult::FlagSubCommand(sc_name.to_string()))
@@ -891,7 +891,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 );
                 *valid_arg_found = true;
                 if !arg.is_takes_value_set() {
-                    ret = self.parse_flag(Identifier::Short(c), arg, matcher)?;
+                    ret = self.react(Identifier::Short(c), arg, matcher)?;
                     continue;
                 }
 
@@ -1093,13 +1093,16 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         Ok(())
     }
 
-    fn parse_flag(
+    fn react(
         &self,
         ident: Identifier,
         arg: &Arg<'help>,
         matcher: &mut ArgMatcher,
     ) -> ClapResult<ParseResult> {
-        debug!("Parser::parse_flag");
+        debug!(
+            "Parser::react action={:?}, identifier={:?}",
+            arg.get_action, ident
+        );
         match arg.get_action() {
             Action::StoreValue => unreachable!("{:?} is not a flag", arg.get_id()),
             Action::Flag => {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1139,15 +1139,22 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         );
         match arg.get_action() {
             Action::StoreValue => {
-                if source == ValueSource::CommandLine {
-                    if matches!(ident, Some(Identifier::Short) | Some(Identifier::Long)) {
-                        // Record flag's index
-                        self.cur_idx.set(self.cur_idx.get() + 1);
-                        debug!("Parser::react: cur_idx:={}", self.cur_idx.get());
-                    }
-                    self.start_occurrence_of_arg(matcher, arg);
+                if ident == Some(Identifier::Index)
+                    && arg.is_multiple_values_set()
+                    && matcher.contains(&arg.id)
+                {
+                    // HACK: Reuse existing occurrence
                 } else {
-                    self.start_custom_arg(matcher, arg, source);
+                    if source == ValueSource::CommandLine {
+                        if matches!(ident, Some(Identifier::Short) | Some(Identifier::Long)) {
+                            // Record flag's index
+                            self.cur_idx.set(self.cur_idx.get() + 1);
+                            debug!("Parser::react: cur_idx:={}", self.cur_idx.get());
+                        }
+                        self.start_occurrence_of_arg(matcher, arg);
+                    } else {
+                        self.start_custom_arg(matcher, arg, source);
+                    }
                 }
                 self.store_arg_values(arg, raw_vals, matcher)?;
                 if cfg!(debug_assertions) && matcher.needs_more_vals(arg) {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -973,6 +973,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 if !arg.default_missing_vals.is_empty() {
                     debug!("Parser::parse_opt_value: has default_missing_vals");
                     for v in arg.default_missing_vals.iter() {
+                        let trailing_values = false; // CLI should not be affecting default_missing_values
                         let _parse_result = self.push_arg_values(
                             arg,
                             &RawOsStr::new(v),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1132,7 +1132,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         self.resolve_pending(matcher)?;
 
         debug!(
-            "Parser::react action={:?}, identifier={:?}, souce={:?}",
+            "Parser::react action={:?}, identifier={:?}, source={:?}",
             arg.get_action(),
             ident,
             source

--- a/tests/builder/grouped_values.rs
+++ b/tests/builder/grouped_values.rs
@@ -175,6 +175,52 @@ fn grouped_value_multiple_positional_arg_last_multiple() {
 }
 
 #[test]
+fn grouped_interleaved_positional_values() {
+    let cmd = clap::Command::new("foo")
+        .arg(clap::Arg::new("pos").multiple_values(true))
+        .arg(
+            clap::Arg::new("flag")
+                .short('f')
+                .long("flag")
+                .takes_value(true)
+                .multiple_occurrences(true),
+        );
+
+    let m = cmd
+        .try_get_matches_from(["foo", "1", "2", "-f", "a", "3", "-f", "b", "4"])
+        .unwrap();
+    let pos: Vec<_> = m.grouped_values_of("pos").unwrap().collect();
+    assert_eq!(pos, vec![vec!["1", "2", "3", "4"]]);
+    assert_eq!(m.occurrences_of("pos"), 1);
+    let flag: Vec<_> = m.grouped_values_of("flag").unwrap().collect();
+    assert_eq!(flag, vec![vec!["a"], vec!["b"]]);
+    assert_eq!(m.occurrences_of("flag"), 2);
+}
+
+#[test]
+fn grouped_interleaved_positional_occurrences() {
+    let cmd = clap::Command::new("foo")
+        .arg(clap::Arg::new("pos").multiple_occurrences(true))
+        .arg(
+            clap::Arg::new("flag")
+                .short('f')
+                .long("flag")
+                .takes_value(true)
+                .multiple_occurrences(true),
+        );
+
+    let m = cmd
+        .try_get_matches_from(["foo", "1", "2", "-f", "a", "3", "-f", "b", "4"])
+        .unwrap();
+    let pos: Vec<_> = m.grouped_values_of("pos").unwrap().collect();
+    assert_eq!(pos, vec![vec!["1"], vec!["2"], vec!["3"], vec!["4"]]);
+    assert_eq!(m.occurrences_of("pos"), 4);
+    let flag: Vec<_> = m.grouped_values_of("flag").unwrap().collect();
+    assert_eq!(flag, vec![vec!["a"], vec!["b"]]);
+    assert_eq!(m.occurrences_of("flag"), 2);
+}
+
+#[test]
 fn issue_1374() {
     let cmd = Command::new("MyApp").arg(
         Arg::new("input")

--- a/tests/builder/grouped_values.rs
+++ b/tests/builder/grouped_values.rs
@@ -190,8 +190,8 @@ fn grouped_interleaved_positional_values() {
         .try_get_matches_from(["foo", "1", "2", "-f", "a", "3", "-f", "b", "4"])
         .unwrap();
     let pos: Vec<_> = m.grouped_values_of("pos").unwrap().collect();
-    assert_eq!(pos, vec![vec!["1", "2", "3", "4"]]);
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(pos, vec![vec!["1", "2"], vec!["3"], vec!["4"]]);
+    assert_eq!(m.occurrences_of("pos"), 3);
     let flag: Vec<_> = m.grouped_values_of("flag").unwrap().collect();
     assert_eq!(flag, vec![vec!["a"], vec!["b"]]);
     assert_eq!(m.occurrences_of("flag"), 2);

--- a/tests/builder/grouped_values.rs
+++ b/tests/builder/grouped_values.rs
@@ -190,8 +190,8 @@ fn grouped_interleaved_positional_values() {
         .try_get_matches_from(["foo", "1", "2", "-f", "a", "3", "-f", "b", "4"])
         .unwrap();
     let pos: Vec<_> = m.grouped_values_of("pos").unwrap().collect();
-    assert_eq!(pos, vec![vec!["1", "2"], vec!["3"], vec!["4"]]);
-    assert_eq!(m.occurrences_of("pos"), 3);
+    assert_eq!(pos, vec![vec!["1", "2", "3", "4"]]);
+    assert_eq!(m.occurrences_of("pos"), 1);
     let flag: Vec<_> = m.grouped_values_of("flag").unwrap().collect();
     assert_eq!(flag, vec![vec!["a"], vec!["b"]]);
     assert_eq!(m.occurrences_of("flag"), 2);

--- a/tests/builder/grouped_values.rs
+++ b/tests/builder/grouped_values.rs
@@ -191,7 +191,7 @@ fn grouped_interleaved_positional_values() {
         .unwrap();
     let pos: Vec<_> = m.grouped_values_of("pos").unwrap().collect();
     assert_eq!(pos, vec![vec!["1", "2", "3", "4"]]);
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 4);
     let flag: Vec<_> = m.grouped_values_of("flag").unwrap().collect();
     assert_eq!(flag, vec![vec!["a"], vec!["b"]]);
     assert_eq!(m.occurrences_of("flag"), 2);

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -385,7 +385,7 @@ fn positional() {
     let m = m.unwrap();
 
     assert!(m.is_present("pos"));
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 3);
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -409,7 +409,7 @@ fn positional_exact_exact() {
     let m = m.unwrap();
 
     assert!(m.is_present("pos"));
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 3);
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -457,7 +457,7 @@ fn positional_min_exact() {
     let m = m.unwrap();
 
     assert!(m.is_present("pos"));
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 3);
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -487,7 +487,7 @@ fn positional_min_more() {
     let m = m.unwrap();
 
     assert!(m.is_present("pos"));
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 4);
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -507,7 +507,7 @@ fn positional_max_exact() {
     let m = m.unwrap();
 
     assert!(m.is_present("pos"));
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 3);
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -527,7 +527,7 @@ fn positional_max_less() {
     let m = m.unwrap();
 
     assert!(m.is_present("pos"));
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 2);
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -1139,7 +1139,7 @@ fn low_index_positional() {
     let m = m.unwrap();
 
     assert!(m.is_present("files"));
-    assert_eq!(m.occurrences_of("files"), 1);
+    assert_eq!(m.occurrences_of("files"), 3);
     assert!(m.is_present("target"));
     assert_eq!(m.occurrences_of("target"), 1);
     assert_eq!(
@@ -1176,7 +1176,7 @@ fn low_index_positional_in_subcmd() {
     let sm = m.subcommand_matches("test").unwrap();
 
     assert!(sm.is_present("files"));
-    assert_eq!(sm.occurrences_of("files"), 1);
+    assert_eq!(sm.occurrences_of("files"), 3);
     assert!(sm.is_present("target"));
     assert_eq!(sm.occurrences_of("target"), 1);
     assert_eq!(
@@ -1212,7 +1212,7 @@ fn low_index_positional_with_option() {
     let m = m.unwrap();
 
     assert!(m.is_present("files"));
-    assert_eq!(m.occurrences_of("files"), 1);
+    assert_eq!(m.occurrences_of("files"), 3);
     assert!(m.is_present("target"));
     assert_eq!(m.occurrences_of("target"), 1);
     assert_eq!(
@@ -1250,7 +1250,7 @@ fn low_index_positional_with_flag() {
     let m = m.unwrap();
 
     assert!(m.is_present("files"));
-    assert_eq!(m.occurrences_of("files"), 1);
+    assert_eq!(m.occurrences_of("files"), 3);
     assert!(m.is_present("target"));
     assert_eq!(m.occurrences_of("target"), 1);
     assert_eq!(
@@ -1537,7 +1537,7 @@ fn values_per_occurrence_positional() {
             .collect::<Vec<_>>(),
         ["val1", "val2"]
     );
-    assert_eq!(m.occurrences_of("pos"), 1);
+    assert_eq!(m.occurrences_of("pos"), 2);
 
     let m = a.try_get_matches_from_mut(vec!["myprog", "val1", "val2", "val3", "val4"]);
     let m = match m {


### PR DESCRIPTION
This is not publicly exposed yet and is a step towards #3405.  Nearly all storing of data into `ArgMatches` is extracted into a `react` function that is based on an `Action` enum associated with the `Arg`.  I said "nearly" because we can't quite do this for external subcommand values.

The parser iterates once per argv field.  This presented a problem for flags with values and multi-valued positionals.  We handle this by tracking "pending" values and resolving them before reacting to the current value.  This comes at some behavior changes for `ArgMatches::occurrences_of` that could be fine for future versions of the actions though we should reconsider this before release.