### PR TITLE
feat(parser): SetTrue/SetFalse/Count Actions

### DIFF
--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -1,5 +1,3 @@
-use crate::parser::AnyValueId;
-
 /// Behavior of arguments when they are encountered while parsing
 ///
 /// # Examples
@@ -225,7 +223,10 @@ impl ArgAction {
         }
     }
 
-    pub(crate) fn value_type_id(&self) -> Option<AnyValueId> {
+    #[cfg(debug_assertions)]
+    pub(crate) fn value_type_id(&self) -> Option<crate::parser::AnyValueId> {
+        use crate::parser::AnyValueId;
+
         match self {
             Self::StoreValue => None,
             Self::IncOccurrence => None,

--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -1,3 +1,5 @@
+use crate::parser::AnyValueId;
+
 /// Behavior of arguments when they are encountered while parsing
 ///
 /// # Examples
@@ -70,6 +72,81 @@ pub enum ArgAction {
     /// assert_eq!(matches.get_many::<String>("flag").unwrap_or_default().count(), 0);
     /// ```
     IncOccurrence,
+    /// When encountered, act as if `"true"` was encountered on the command-line
+    ///
+    /// No value is allowed
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .action(clap::builder::ArgAction::SetTrue)
+    ///     );
+    ///
+    /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
+    /// assert!(matches.is_present("flag"));
+    /// assert_eq!(matches.occurrences_of("flag"), 0);
+    /// assert_eq!(
+    ///     matches.get_one::<bool>("flag").copied(),
+    ///     Some(true)
+    /// );
+    /// ```
+    SetTrue,
+    /// When encountered, act as if `"false"` was encountered on the command-line
+    ///
+    /// No value is allowed
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .action(clap::builder::ArgAction::SetFalse)
+    ///     );
+    ///
+    /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
+    /// assert!(matches.is_present("flag"));
+    /// assert_eq!(matches.occurrences_of("flag"), 0);
+    /// assert_eq!(
+    ///     matches.get_one::<bool>("flag").copied(),
+    ///     Some(false)
+    /// );
+    /// ```
+    SetFalse,
+    /// When encountered, increment a counter
+    ///
+    /// No value is allowed
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .action(clap::builder::ArgAction::Count)
+    ///     );
+    ///
+    /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
+    /// assert!(matches.is_present("flag"));
+    /// assert_eq!(matches.occurrences_of("flag"), 0);
+    /// assert_eq!(
+    ///     matches.get_one::<u64>("flag").copied(),
+    ///     Some(2)
+    /// );
+    /// ```
+    Count,
     /// When encountered, display [`Command::print_help`][super::App::print_help]
     ///
     /// Depending on the flag, [`Command::print_long_help`][super::App::print_long_help] may be shown
@@ -128,8 +205,37 @@ impl ArgAction {
         match self {
             Self::StoreValue => true,
             Self::IncOccurrence => false,
+            Self::SetTrue => false,
+            Self::SetFalse => false,
+            Self::Count => false,
             Self::Help => false,
             Self::Version => false,
         }
     }
+
+    pub(crate) fn default_value_parser(&self) -> Option<super::ValueParser> {
+        match self {
+            Self::StoreValue => None,
+            Self::IncOccurrence => None,
+            Self::SetTrue => Some(super::ValueParser::bool()),
+            Self::SetFalse => Some(super::ValueParser::bool()),
+            Self::Count => Some(crate::value_parser!(u64)),
+            Self::Help => None,
+            Self::Version => None,
+        }
+    }
+
+    pub(crate) fn value_type_id(&self) -> Option<AnyValueId> {
+        match self {
+            Self::StoreValue => None,
+            Self::IncOccurrence => None,
+            Self::SetTrue => Some(AnyValueId::of::<bool>()),
+            Self::SetFalse => Some(AnyValueId::of::<bool>()),
+            Self::Count => Some(AnyValueId::of::<CountType>()),
+            Self::Help => None,
+            Self::Version => None,
+        }
+    }
 }
+
+pub(crate) type CountType = u64;

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -4900,7 +4900,9 @@ impl<'help> Arg<'help> {
         }
 
         if self.value_parser.is_none() {
-            if self.is_allow_invalid_utf8_set() {
+            if let Some(default) = self.action.as_ref().and_then(|a| a.default_value_parser()) {
+                self.value_parser = Some(default);
+            } else if self.is_allow_invalid_utf8_set() {
                 self.value_parser = Some(super::ValueParser::os_string());
             } else {
                 self.value_parser = Some(super::ValueParser::string());

--- a/src/builder/debug_asserts.rs
+++ b/src/builder/debug_asserts.rs
@@ -649,6 +649,16 @@ fn assert_arg(arg: &Arg) {
         arg.name,
         arg.get_action()
     );
+    if let Some(action_type_id) = arg.get_action().value_type_id() {
+        assert_eq!(
+            action_type_id,
+            arg.get_value_parser().type_id(),
+            "Argument `{}`'s selected action {:?} contradicts `value_parser` ({:?})",
+            arg.name,
+            arg.get_action(),
+            arg.get_value_parser()
+        );
+    }
 
     if arg.get_value_hint() != ValueHint::Unknown {
         assert!(

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -55,6 +55,7 @@ pub use command::App;
 #[cfg(feature = "regex")]
 pub use self::regex::RegexRef;
 
+pub(crate) use action::CountType;
 pub(crate) use arg::display_arg_val;
 pub(crate) use arg_predicate::ArgPredicate;
 pub(crate) use value_parser::ValueParserInner;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1385,12 +1385,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
     fn add_defaults(&self, matcher: &mut ArgMatcher) -> ClapResult<()> {
         debug!("Parser::add_defaults");
 
-        for arg in self.cmd.get_opts() {
-            debug!("Parser::add_defaults:iter:{}:", arg.name);
-            self.add_default_value(arg, matcher)?;
-        }
-
-        for arg in self.cmd.get_positionals() {
+        for arg in self.cmd.get_arguments() {
             debug!("Parser::add_defaults:iter:{}:", arg.name);
             self.add_default_value(arg, matcher)?;
         }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1183,13 +1183,6 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 Ok(ParseResult::ValuesDone)
             }
             ArgAction::SetTrue => {
-                if source == ValueSource::CommandLine
-                    && matches!(ident, Some(Identifier::Short) | Some(Identifier::Long))
-                {
-                    // Record flag's index
-                    self.cur_idx.set(self.cur_idx.get() + 1);
-                    debug!("Parser::react: cur_idx:={}", self.cur_idx.get());
-                }
                 let raw_vals = match raw_vals.len() {
                     0 => {
                         vec![OsString::from("true")]
@@ -1209,13 +1202,6 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 Ok(ParseResult::ValuesDone)
             }
             ArgAction::SetFalse => {
-                if source == ValueSource::CommandLine
-                    && matches!(ident, Some(Identifier::Short) | Some(Identifier::Long))
-                {
-                    // Record flag's index
-                    self.cur_idx.set(self.cur_idx.get() + 1);
-                    debug!("Parser::react: cur_idx:={}", self.cur_idx.get());
-                }
                 let raw_vals = match raw_vals.len() {
                     0 => {
                         vec![OsString::from("false")]
@@ -1235,13 +1221,6 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 Ok(ParseResult::ValuesDone)
             }
             ArgAction::Count => {
-                if source == ValueSource::CommandLine
-                    && matches!(ident, Some(Identifier::Short) | Some(Identifier::Long))
-                {
-                    // Record flag's index
-                    self.cur_idx.set(self.cur_idx.get() + 1);
-                    debug!("Parser::react: cur_idx:={}", self.cur_idx.get());
-                }
                 let raw_vals = match raw_vals.len() {
                     0 => {
                         let existing_value = *matcher

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -104,6 +104,36 @@ fn set_true_with_default_value_if_value() {
 }
 
 #[test]
+fn set_true_with_required_if_eq() {
+    let cmd = Command::new("test")
+        .arg(
+            Arg::new("mammal")
+                .long("mammal")
+                .action(ArgAction::SetTrue)
+                .required_if_eq("dog", "true"),
+        )
+        .arg(Arg::new("dog").long("dog").action(ArgAction::SetTrue));
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(matches.get_one::<u64>("dog"), None);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+
+    cmd.clone()
+        .try_get_matches_from(["test", "--dog"])
+        .unwrap_err();
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--dog", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<bool>("dog").unwrap(), true);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+}
+
+#[test]
 fn set_false() {
     let cmd = Command::new("test").arg(
         Arg::new("mammal")

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::bool_assert_comparison)]
+
 use clap::builder::ArgAction;
 use clap::Arg;
 use clap::Command;

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -1,0 +1,49 @@
+use clap::builder::ArgAction;
+use clap::Arg;
+use clap::Command;
+
+#[test]
+fn set_true_with_default_value_if_present() {
+    let cmd = Command::new("test")
+        .arg(
+            Arg::new("mammal")
+                .long("mammal")
+                .action(ArgAction::SetTrue)
+                .default_value_if("dog", None, Some("true")),
+        )
+        .arg(Arg::new("dog").long("dog").action(ArgAction::SetTrue));
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
+    assert_eq!(*matches.get_one::<bool>("dog").unwrap(), true);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(matches.get_one::<bool>("dog"), None);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+}
+
+#[test]
+fn set_true_with_default_value_if_value() {
+    let cmd = Command::new("test")
+        .arg(
+            Arg::new("mammal")
+                .long("mammal")
+                .action(ArgAction::SetTrue)
+                .default_value_if("dog", Some("true"), Some("true")),
+        )
+        .arg(Arg::new("dog").long("dog").action(ArgAction::SetTrue));
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
+    assert_eq!(*matches.get_one::<bool>("dog").unwrap(), true);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(matches.get_one::<bool>("dog"), None);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+}

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -3,6 +3,61 @@ use clap::Arg;
 use clap::Command;
 
 #[test]
+fn set_true() {
+    let cmd =
+        Command::new("test").arg(Arg::new("mammal").long("mammal").action(ArgAction::SetTrue));
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(matches.get_one::<bool>("mammal"), None);
+    assert_eq!(matches.is_present("mammal"), false);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), None);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(2));
+}
+
+#[test]
+fn set_true_with_default_value() {
+    let cmd = Command::new("test").arg(
+        Arg::new("mammal")
+            .long("mammal")
+            .action(ArgAction::SetTrue)
+            .default_value("false"),
+    );
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+}
+
+#[test]
 fn set_true_with_default_value_if_present() {
     let cmd = Command::new("test")
         .arg(
@@ -46,4 +101,215 @@ fn set_true_with_default_value_if_value() {
         .unwrap();
     assert_eq!(matches.get_one::<bool>("dog"), None);
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+}
+
+#[test]
+fn set_false() {
+    let cmd = Command::new("test").arg(
+        Arg::new("mammal")
+            .long("mammal")
+            .action(ArgAction::SetFalse),
+    );
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(matches.get_one::<bool>("mammal"), None);
+    assert_eq!(matches.is_present("mammal"), false);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), None);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(2));
+}
+
+#[test]
+fn set_false_with_default_value() {
+    let cmd = Command::new("test").arg(
+        Arg::new("mammal")
+            .long("mammal")
+            .action(ArgAction::SetFalse)
+            .default_value("true"),
+    );
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+}
+
+#[test]
+fn set_false_with_default_value_if_present() {
+    let cmd = Command::new("test")
+        .arg(
+            Arg::new("mammal")
+                .long("mammal")
+                .action(ArgAction::SetFalse)
+                .default_value_if("dog", None, Some("false")),
+        )
+        .arg(Arg::new("dog").long("dog").action(ArgAction::SetFalse));
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
+    assert_eq!(*matches.get_one::<bool>("dog").unwrap(), false);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(matches.get_one::<bool>("dog"), None);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+}
+
+#[test]
+fn set_false_with_default_value_if_value() {
+    let cmd = Command::new("test")
+        .arg(
+            Arg::new("mammal")
+                .long("mammal")
+                .action(ArgAction::SetFalse)
+                .default_value_if("dog", Some("false"), Some("false")),
+        )
+        .arg(Arg::new("dog").long("dog").action(ArgAction::SetFalse));
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
+    assert_eq!(*matches.get_one::<bool>("dog").unwrap(), false);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(matches.get_one::<bool>("dog"), None);
+    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+}
+
+#[test]
+fn count() {
+    let cmd = Command::new("test").arg(Arg::new("mammal").long("mammal").action(ArgAction::Count));
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(matches.get_one::<u64>("mammal"), None);
+    assert_eq!(matches.is_present("mammal"), false);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), None);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 2);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(2));
+}
+
+#[test]
+fn count_with_default_value() {
+    let cmd = Command::new("test").arg(
+        Arg::new("mammal")
+            .long("mammal")
+            .action(ArgAction::Count)
+            .default_value("10"),
+    );
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(1));
+}
+
+#[test]
+fn count_with_default_value_if_present() {
+    let cmd = Command::new("test")
+        .arg(
+            Arg::new("mammal")
+                .long("mammal")
+                .action(ArgAction::Count)
+                .default_value_if("dog", None, Some("10")),
+        )
+        .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
+    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(matches.get_one::<u64>("dog"), None);
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+}
+
+#[test]
+fn count_with_default_value_if_value() {
+    let cmd = Command::new("test")
+        .arg(
+            Arg::new("mammal")
+                .long("mammal")
+                .action(ArgAction::Count)
+                .default_value_if("dog", Some("2"), Some("10")),
+        )
+        .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
+    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 1);
+    assert_eq!(matches.get_one::<u64>("mammal"), None);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--dog", "--dog"])
+        .unwrap();
+    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 2);
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal"])
+        .unwrap();
+    assert_eq!(matches.get_one::<u64>("dog"), None);
+    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
 }

--- a/tests/builder/main.rs
+++ b/tests/builder/main.rs
@@ -1,3 +1,4 @@
+mod action;
 mod app_from_crate;
 mod app_settings;
 mod arg_aliases;


### PR DESCRIPTION
This is the minimum set of actions for the derive to move off of
`parse`.  These are inspired by Python's native actions.

These new actions have a "unified" behavior with defaults/envs.  This
mostly means that occurrences aren't tracked.  Occurrences were used as
a substitute for `ValueSource` or for counting values.  Both cases
shouldn't be needed anymore but we can re-evaluate this later if needed.

There is room for performance improvements where we reuse allocations but we can worry about that as a profiler says its a case to care about.

Now that we can store constants for flags, we can apply defaults for
flags too.

Fixes #3294