### PR TITLE
feat(builder): Set/Append Actions

### DIFF
--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -35,6 +35,53 @@ pub enum ArgAction {
     ///     .arg(
     ///         Arg::new("flag")
     ///             .long("flag")
+    ///             .action(clap::builder::ArgAction::Set)
+    ///     );
+    ///
+    /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "value"]).unwrap();
+    /// assert!(matches.is_present("flag"));
+    /// assert_eq!(matches.occurrences_of("flag"), 0);
+    /// assert_eq!(
+    ///     matches.get_many::<String>("flag").unwrap_or_default().map(|v| v.as_str()).collect::<Vec<_>>(),
+    ///     vec!["value"]
+    /// );
+    /// ```
+    Set,
+    /// When encountered, store the associated value(s) in [`ArgMatches`][crate::ArgMatches]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .multiple_occurrences(true)
+    ///             .action(clap::builder::ArgAction::Append)
+    ///     );
+    ///
+    /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "value1", "--flag", "value2"]).unwrap();
+    /// assert!(matches.is_present("flag"));
+    /// assert_eq!(matches.occurrences_of("flag"), 0);
+    /// assert_eq!(
+    ///     matches.get_many::<String>("flag").unwrap_or_default().map(|v| v.as_str()).collect::<Vec<_>>(),
+    ///     vec!["value1", "value2"]
+    /// );
+    /// ```
+    Append,
+    /// When encountered, store the associated value(s) in [`ArgMatches`][crate::ArgMatches]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
     ///             .action(clap::builder::ArgAction::StoreValue)
     ///     );
     ///
@@ -201,6 +248,8 @@ pub enum ArgAction {
 impl ArgAction {
     pub(crate) fn takes_value(&self) -> bool {
         match self {
+            Self::Set => true,
+            Self::Append => true,
             Self::StoreValue => true,
             Self::IncOccurrence => false,
             Self::SetTrue => false,
@@ -213,6 +262,8 @@ impl ArgAction {
 
     pub(crate) fn default_value_parser(&self) -> Option<super::ValueParser> {
         match self {
+            Self::Set => None,
+            Self::Append => None,
             Self::StoreValue => None,
             Self::IncOccurrence => None,
             Self::SetTrue => Some(super::ValueParser::bool()),
@@ -228,6 +279,8 @@ impl ArgAction {
         use crate::parser::AnyValueId;
 
         match self {
+            Self::Set => None,
+            Self::Append => None,
             Self::StoreValue => None,
             Self::IncOccurrence => None,
             Self::SetTrue => Some(AnyValueId::of::<bool>()),

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -5,6 +5,77 @@ use clap::Arg;
 use clap::Command;
 
 #[test]
+fn set() {
+    let cmd = Command::new("test").arg(Arg::new("mammal").long("mammal").action(ArgAction::Set));
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(matches.get_one::<String>("mammal"), None);
+    assert_eq!(matches.is_present("mammal"), false);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), None);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal", "dog"])
+        .unwrap();
+    assert_eq!(matches.get_one::<String>("mammal").unwrap(), "dog");
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(2));
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal", "dog", "--mammal", "cat"])
+        .unwrap();
+    assert_eq!(matches.get_one::<String>("mammal").unwrap(), "cat");
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), Some(4));
+}
+
+#[test]
+fn append() {
+    let cmd = Command::new("test").arg(Arg::new("mammal").long("mammal").action(ArgAction::Append));
+
+    let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
+    assert_eq!(matches.get_one::<String>("mammal"), None);
+    assert_eq!(matches.is_present("mammal"), false);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(matches.index_of("mammal"), None);
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal", "dog"])
+        .unwrap();
+    assert_eq!(matches.get_one::<String>("mammal").unwrap(), "dog");
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(
+        matches.indices_of("mammal").unwrap().collect::<Vec<_>>(),
+        vec![2]
+    );
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--mammal", "dog", "--mammal", "cat"])
+        .unwrap();
+    assert_eq!(
+        matches
+            .get_many::<String>("mammal")
+            .unwrap()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>(),
+        vec!["dog", "cat"]
+    );
+    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.occurrences_of("mammal"), 0);
+    assert_eq!(
+        matches.indices_of("mammal").unwrap().collect::<Vec<_>>(),
+        vec![2, 4]
+    );
+}
+
+#[test]
 fn set_true() {
     let cmd =
         Command::new("test").arg(Arg::new("mammal").long("mammal").action(ArgAction::SetTrue));


### PR DESCRIPTION
This round out the new style actions and allow us to start deprecating
occurrences.

As part of an effort to unify code paths, this does change flag parsing
to do splits.  This will only be a problem if the user enables splits
but we'll at least not crash.  Once we also address #3776, we'll be able
to have envs all work the same.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
