### PR TITLE
fix(derive): Align value parser's type with occurrences_of

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -971,7 +971,7 @@ impl Parser {
             ),
             ParserKind::FromOccurrences => Method::new(
                 func,
-                quote_spanned! { self.kind.span()=> clap::value_parser!(usize)},
+                quote_spanned! { self.kind.span()=> clap::value_parser!(u64)},
             ),
             ParserKind::FromFlag => Method::new(
                 func,


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
