### PR TITLE
fix(validator): Ignore defaults for requireds

### DIFF
--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -88,12 +88,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
         Ok(())
     }
 
-    fn validate_arg_values(
-        &self,
-        arg: &Arg,
-        ma: &MatchedArg,
-        matcher: &ArgMatcher,
-    ) -> ClapResult<()> {
+    fn validate_arg_values(&self, arg: &Arg, ma: &MatchedArg) -> ClapResult<()> {
         debug!("Validator::validate_arg_values: arg={:?}", arg.name);
         for val in ma.raw_vals_flatten() {
             if !arg.possible_vals.is_empty() {
@@ -121,7 +116,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
             }
             {
                 #![allow(deprecated)]
-                if arg.is_forbid_empty_values_set() && val.is_empty() && matcher.contains(&arg.id) {
+                if arg.is_forbid_empty_values_set() && val.is_empty() {
                     debug!("Validator::validate_arg_values: illegal empty val found");
                     return Err(Error::empty_value(
                         self.cmd,
@@ -327,7 +322,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
             );
             if let Some(arg) = self.cmd.find(name) {
                 self.validate_arg_num_vals(arg, ma)?;
-                self.validate_arg_values(arg, ma, matcher)?;
+                self.validate_arg_values(arg, ma)?;
                 self.validate_arg_num_occurs(arg, ma)?;
             }
             Ok(())

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -202,9 +202,9 @@ fn set_true_with_required_if_eq() {
     assert_eq!(*matches.get_one::<bool>("dog").unwrap(), false);
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
 
-    let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
-    assert_eq!(*matches.get_one::<bool>("dog").unwrap(), true);
-    assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
+    cmd.clone()
+        .try_get_matches_from(["test", "--dog"])
+        .unwrap_err();
 
     let matches = cmd
         .clone()


### PR DESCRIPTION
This is a follow up to https://github.com/clap-rs/clap/pull/3420.  Its easy to overlook this because it is only
useful for the conditionals (we actually prevent applying unconditional
defaults to unconditional requireds).  This became apparent with the
increased use of defaults with `SetTrue`.

As always, there is the question of when is a bug fix a breaking change.
I'm going to consider this safe since we prevent some instances of this
from even happening and we already did https://github.com/clap-rs/clap/pull/3420 and this is in line with
those.