### PR TITLE
fix(builder): Clean up after hiding `AnyValueParser`

### DIFF
--- a/src/builder/value_parser.rs
+++ b/src/builder/value_parser.rs
@@ -227,25 +227,13 @@ impl ValueParser {
     /// Parse into a `AnyValue`
     ///
     /// When `arg` is `None`, an external subcommand value is being parsed.
-    pub fn parse_ref(
+    pub(crate) fn parse_ref(
         &self,
         cmd: &crate::Command,
         arg: Option<&crate::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<AnyValue, crate::Error> {
         self.any_value_parser().parse_ref(cmd, arg, value)
-    }
-
-    /// Parse into a `AnyValue`
-    ///
-    /// When `arg` is `None`, an external subcommand value is being parsed.
-    pub fn parse(
-        &self,
-        cmd: &crate::Command,
-        arg: Option<&crate::Arg>,
-        value: std::ffi::OsString,
-    ) -> Result<AnyValue, crate::Error> {
-        self.any_value_parser().parse(cmd, arg, value)
     }
 
     /// Describes the content of `AnyValue`

--- a/src/parser/matches/any_value.rs
+++ b/src/parser/matches/any_value.rs
@@ -1,5 +1,5 @@
 #[derive(Clone)]
-pub struct AnyValue {
+pub(crate) struct AnyValue {
     inner: std::sync::Arc<dyn std::any::Any + Send + Sync + 'static>,
     // While we can extract `TypeId` from `inner`, the debug repr is of a number, so let's track
     // the type_name in debug builds.

--- a/src/parser/matches/mod.rs
+++ b/src/parser/matches/mod.rs
@@ -3,13 +3,13 @@ mod arg_matches;
 mod matched_arg;
 mod value_source;
 
+pub use any_value::AnyValueId;
 pub use arg_matches::RawValues;
 pub use arg_matches::ValuesRef;
 pub use arg_matches::{ArgMatches, Indices};
 pub use value_source::ValueSource;
 
 pub(crate) use any_value::AnyValue;
-pub(crate) use any_value::AnyValueId;
 pub(crate) use arg_matches::SubCommand;
 pub(crate) use matched_arg::MatchedArg;
 


### PR DESCRIPTION
Hiding `AnyValueParser` has given us a bit more flexibility to prepare for `any_vec` in the future.  Granted, `ArgGroup`s are still a blocker.