### PR TITLE
perf(parser): Take up less memory with ArgAction::Count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Replaced
 - `Arg::validator_regex` with users providing their own `builder::TypedValueParser` (#3756)
 - `Arg::forbid_empty_values` with `builder::NonEmptyStringValueParser` / `builder::PathBufValueParser` (#3753)
 - `Arg::possible_values` with `Arg::value_parser([...])`, `builder::PossibleValuesParser`, or `builder::EnumValueParser` (#3753)
-- `Arg::max_occurrences` with `arg.action(ArgAction::Count).value_parser(value_parser!(u64).range(..N))` for flags (#3797)
+- `Arg::max_occurrences` with `arg.action(ArgAction::Count).value_parser(value_parser!(u8).range(..N))` for flags (#3797)
 - `Arg::multiple_occurrences` with `ArgAction::Append` or `ArgAction::Count` though positionals will need `Arg::multiple_values` (#3772, #3797)
 - `Command::args_override_self` with `ArgAction::Set` (#2627, #3797)
 - `AppSettings::NoAutoVersion` with `ArgAction` or `Command::disable_version_flag` (#3800)
@@ -99,7 +99,7 @@ Replaced
 - `ArgAction::StoreValue` with `ArgAction::Set` or `ArgAction::Append` (#3797)
 - `ArgAction::IncOccurrences` with `ArgAction::SetTrue` or `ArgAction::Count` (#3797)
 - *(derive)* `#[clap(parse(from_flag))]` replaced with `#[clap(action = ArgAction::SetTrue)]` (#3794)
-- *(derive)* `#[clap(parse(from_occurrences))]` replaced with `#[clap(action = ArgAction::Count)]` though the field's type must be `u64` (#3794)
+- *(derive)* `#[clap(parse(from_occurrences))]` replaced with `#[clap(action = ArgAction::Count)]` though the field's type must be `u8` (#3794)
 - *(derive)* `#[clap(parse(...))]` replaced with `#[clap(value_parser)]`  (#3589, #3794)
 
 ## [3.1.18] - 2022-05-10

--- a/examples/tutorial_builder/01_quick.rs
+++ b/examples/tutorial_builder/01_quick.rs
@@ -40,7 +40,7 @@ fn main() {
     // You can see how many times a particular flag or argument occurred
     // Note, only flags can have multiple occurrences
     match matches
-        .get_one::<u64>("debug")
+        .get_one::<u8>("debug")
         .expect("Count's are defaulted")
     {
         0 => println!("Debug mode is off"),

--- a/examples/tutorial_builder/03_01_flag_count.rs
+++ b/examples/tutorial_builder/03_01_flag_count.rs
@@ -10,7 +10,7 @@ fn main() {
     println!(
         "verbose: {:?}",
         matches
-            .get_one::<u64>("verbose")
+            .get_one::<u8>("verbose")
             .expect("Count always defaulted")
     );
 }

--- a/examples/tutorial_derive/01_quick.rs
+++ b/examples/tutorial_derive/01_quick.rs
@@ -15,7 +15,7 @@ struct Cli {
 
     /// Turn debugging information on
     #[clap(short, long, action = clap::ArgAction::Count)]
-    debug: u64,
+    debug: u8,
 
     #[clap(subcommand)]
     command: Option<Commands>,

--- a/examples/tutorial_derive/03_01_flag_count.rs
+++ b/examples/tutorial_derive/03_01_flag_count.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     #[clap(short, long, action = clap::ArgAction::Count)]
-    verbose: u64,
+    verbose: u8,
 }
 
 fn main() {

--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -152,7 +152,7 @@ pub enum ArgAction {
     /// );
     /// ```
     SetFalse,
-    /// When encountered, increment a `u64` counter
+    /// When encountered, increment a `u8` counter
     ///
     /// If no [`default_value`][super::Arg::default_value] is set, it will be `0`.
     ///
@@ -174,7 +174,7 @@ pub enum ArgAction {
     /// assert!(matches.is_present("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
-    ///     matches.get_one::<u64>("flag").copied(),
+    ///     matches.get_one::<u8>("flag").copied(),
     ///     Some(2)
     /// );
     ///
@@ -182,7 +182,7 @@ pub enum ArgAction {
     /// assert!(matches.is_present("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
-    ///     matches.get_one::<u64>("flag").copied(),
+    ///     matches.get_one::<u8>("flag").copied(),
     ///     Some(0)
     /// );
     /// ```
@@ -287,7 +287,7 @@ impl ArgAction {
             Self::IncOccurrence => None,
             Self::SetTrue => Some(super::ValueParser::bool()),
             Self::SetFalse => Some(super::ValueParser::bool()),
-            Self::Count => Some(crate::value_parser!(u64).into()),
+            Self::Count => Some(crate::value_parser!(u8).into()),
             Self::Help => None,
             Self::Version => None,
         }
@@ -313,4 +313,4 @@ impl ArgAction {
     }
 }
 
-pub(crate) type CountType = u64;
+pub(crate) type CountType = u8;

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -788,12 +788,12 @@ impl<'help> Arg<'help> {
         }
     }
 
-    /// Deprecated, for flags this is replaced with `action(ArgAction::Count).value_parser(value_parser!(u64).range(..max))`
+    /// Deprecated, for flags this is replaced with `action(ArgAction::Count).value_parser(value_parser!(u8).range(..max))`
     #[inline]
     #[must_use]
     #[deprecated(
         since = "3.2.0",
-        note = "For flags, replaced with `action(ArgAction::Count).value_parser(value_parser!(u64).range(..max))`"
+        note = "For flags, replaced with `action(ArgAction::Count).value_parser(value_parser!(u8).range(..max))`"
     )]
     pub fn max_occurrences(mut self, qty: usize) -> Self {
         self.max_occurs = Some(qty);

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1268,7 +1268,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                         let existing_value = *matcher
                             .get_one::<crate::builder::CountType>(arg.get_id())
                             .unwrap_or(&0);
-                        let next_value = existing_value + 1;
+                        let next_value = existing_value.saturating_add(1);
                         vec![OsString::from(next_value.to_string())]
                     }
                     1 => raw_vals,

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -379,7 +379,7 @@ fn count() {
     let cmd = Command::new("test").arg(Arg::new("mammal").long("mammal").action(ArgAction::Count));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -391,7 +391,7 @@ fn count() {
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -403,7 +403,7 @@ fn count() {
         .clone()
         .try_get_matches_from(["test", "--mammal", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 2);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 2);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -425,7 +425,7 @@ fn count_with_explicit_default_value() {
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -434,7 +434,7 @@ fn count_with_explicit_default_value() {
     assert_eq!(matches.index_of("mammal"), Some(1));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 10);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -455,19 +455,19 @@ fn count_with_default_value_if_present() {
         .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
 
     let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 1);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 10);
 
     let matches = cmd
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
 }
 
 #[test]
@@ -482,24 +482,24 @@ fn count_with_default_value_if_value() {
         .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
 
     let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 1);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
 
     let matches = cmd
         .clone()
         .try_get_matches_from(["test", "--dog", "--dog"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 2);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 2);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 10);
 
     let matches = cmd
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
 }

--- a/tests/builder/legacy/action.rs
+++ b/tests/builder/legacy/action.rs
@@ -379,7 +379,7 @@ fn count() {
     let cmd = Command::new("test").arg(Arg::new("mammal").long("mammal").action(ArgAction::Count));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -391,7 +391,7 @@ fn count() {
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -403,7 +403,7 @@ fn count() {
         .clone()
         .try_get_matches_from(["test", "--mammal", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 2);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 2);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -425,7 +425,7 @@ fn count_with_explicit_default_value() {
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -434,7 +434,7 @@ fn count_with_explicit_default_value() {
     assert_eq!(matches.index_of("mammal"), Some(1));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 10);
     assert_eq!(matches.is_present("mammal"), true);
     #[allow(deprecated)]
     {
@@ -455,19 +455,19 @@ fn count_with_default_value_if_present() {
         .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
 
     let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 1);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 10);
 
     let matches = cmd
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
 }
 
 #[test]
@@ -482,24 +482,24 @@ fn count_with_default_value_if_value() {
         .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
 
     let matches = cmd.clone().try_get_matches_from(["test", "--dog"]).unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 1);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
 
     let matches = cmd
         .clone()
         .try_get_matches_from(["test", "--dog", "--dog"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 2);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 10);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 2);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 10);
 
     let matches = cmd
         .clone()
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
-    assert_eq!(*matches.get_one::<u64>("dog").unwrap(), 0);
-    assert_eq!(*matches.get_one::<u64>("mammal").unwrap(), 1);
+    assert_eq!(*matches.get_one::<u8>("dog").unwrap(), 0);
+    assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
 }

--- a/tests/builder/multiple_occurrences.rs
+++ b/tests/builder/multiple_occurrences.rs
@@ -70,16 +70,24 @@ fn multiple_occurrences_of_positional() {
 
 #[test]
 fn multiple_occurrences_of_flags_large_quantity() {
+    let cmd = Command::new("mo_flags_large_qty")
+        .arg(arg!(-m --multflag "allowed multiple flag").action(ArgAction::Count));
+
     let args: Vec<&str> = vec![""]
         .into_iter()
-        .chain(vec!["-m"; 1024].into_iter())
+        .chain(vec!["-m"; 200].into_iter())
         .collect();
-    let m = Command::new("mo_flags_large_qty")
-        .arg(arg!(-m --multflag "allowed multiple flag").action(ArgAction::Count))
-        .try_get_matches_from(args)
-        .unwrap();
+    let m = cmd.clone().try_get_matches_from(args).unwrap();
     assert!(m.is_present("multflag"));
-    assert_eq!(m.get_one::<u64>("multflag").copied(), Some(1024));
+    assert_eq!(m.get_one::<u8>("multflag").copied(), Some(200));
+
+    let args: Vec<&str> = vec![""]
+        .into_iter()
+        .chain(vec!["-m"; 500].into_iter())
+        .collect();
+    let m = cmd.try_get_matches_from(args).unwrap();
+    assert!(m.is_present("multflag"));
+    assert_eq!(m.get_one::<u8>("multflag").copied(), Some(u8::MAX));
 }
 
 #[cfg(feature = "env")]
@@ -97,22 +105,22 @@ fn multiple_occurrences_of_before_env() {
     let m = cmd.clone().try_get_matches_from(vec![""]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(0));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(0));
 
     let m = cmd.clone().try_get_matches_from(vec!["", "-v"]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(1));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(1));
 
     let m = cmd.clone().try_get_matches_from(vec!["", "-vv"]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(2));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(2));
 
     let m = cmd.clone().try_get_matches_from(vec!["", "-vvv"]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(3));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(3));
 }
 
 #[cfg(feature = "env")]
@@ -130,20 +138,20 @@ fn multiple_occurrences_of_after_env() {
     let m = cmd.clone().try_get_matches_from(vec![""]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(0));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(0));
 
     let m = cmd.clone().try_get_matches_from(vec!["", "-v"]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(1));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(1));
 
     let m = cmd.clone().try_get_matches_from(vec!["", "-vv"]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(2));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(2));
 
     let m = cmd.clone().try_get_matches_from(vec!["", "-vvv"]);
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
-    assert_eq!(m.get_one::<u64>("verbose").copied(), Some(3));
+    assert_eq!(m.get_one::<u8>("verbose").copied(), Some(3));
 }

--- a/tests/builder/propagate_globals.rs
+++ b/tests/builder/propagate_globals.rs
@@ -54,21 +54,21 @@ fn outer_can_access_arg<T: Into<Option<&'static str>>>(m: &ArgMatches, val: T) -
         == val.into()
 }
 
-fn top_can_access_flag(m: &ArgMatches, present: bool, occurrences: u64) -> bool {
+fn top_can_access_flag(m: &ArgMatches, present: bool, occurrences: u8) -> bool {
     (m.is_present("GLOBAL_FLAG") == present)
-        && (m.get_one::<u64>("GLOBAL_FLAG").copied() == Some(occurrences))
+        && (m.get_one::<u8>("GLOBAL_FLAG").copied() == Some(occurrences))
 }
 
-fn inner_can_access_flag(m: &ArgMatches, present: bool, occurrences: u64) -> bool {
+fn inner_can_access_flag(m: &ArgMatches, present: bool, occurrences: u8) -> bool {
     let m = get_inner_matches(m);
     (m.is_present("GLOBAL_FLAG") == present)
-        && (m.get_one::<u64>("GLOBAL_FLAG").copied() == Some(occurrences))
+        && (m.get_one::<u8>("GLOBAL_FLAG").copied() == Some(occurrences))
 }
 
-fn outer_can_access_flag(m: &ArgMatches, present: bool, occurrences: u64) -> bool {
+fn outer_can_access_flag(m: &ArgMatches, present: bool, occurrences: u8) -> bool {
     let m = get_outer_matches(m);
     (m.is_present("GLOBAL_FLAG") == present)
-        && (m.get_one::<u64>("GLOBAL_FLAG").copied() == Some(occurrences))
+        && (m.get_one::<u8>("GLOBAL_FLAG").copied() == Some(occurrences))
 }
 
 #[test]

--- a/tests/builder/tests.rs
+++ b/tests/builder/tests.rs
@@ -91,7 +91,7 @@ pub fn check_complex_output(args: &str, out: &str) {
     let matches = utils::complex_app()
         .try_get_matches_from(args.split(' ').collect::<Vec<_>>())
         .unwrap();
-    match matches.get_one::<u64>("flag").unwrap() {
+    match matches.get_one::<u8>("flag").unwrap() {
         0 => {
             writeln!(w, "flag NOT present").unwrap();
         }
@@ -202,7 +202,7 @@ pub fn check_complex_output(args: &str, out: &str) {
     if let Some("subcmd") = matches.subcommand_name() {
         writeln!(w, "subcmd present").unwrap();
         if let Some(matches) = matches.subcommand_matches("subcmd") {
-            match matches.get_one::<u64>("flag").unwrap() {
+            match matches.get_one::<u8>("flag").unwrap() {
                 0 => {
                     writeln!(w, "flag NOT present").unwrap();
                 }

--- a/tests/derive/flags.rs
+++ b/tests/derive/flags.rs
@@ -49,9 +49,9 @@ fn count() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
         #[clap(short, long, action = clap::ArgAction::Count)]
-        alice: u64,
+        alice: u8,
         #[clap(short, long, action = clap::ArgAction::Count)]
-        bob: u64,
+        bob: u8,
     }
 
     assert_eq!(
@@ -116,7 +116,7 @@ fn mixed_type_flags() {
         #[clap(short, long, action)]
         alice: bool,
         #[clap(short, long, action = clap::ArgAction::Count)]
-        bob: u64,
+        bob: u8,
     }
 
     assert_eq!(

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -275,7 +275,7 @@ fn derive_generated_error_has_full_context() {
     enum SubCommands {
         Sub {
             #[clap(short, long, action = clap::ArgAction::Count)]
-            verbose: u64,
+            verbose: u8,
         },
     }
 

--- a/tests/derive/nested_subcommands.rs
+++ b/tests/derive/nested_subcommands.rs
@@ -19,7 +19,7 @@ struct Opt {
     #[clap(short, long, action)]
     force: bool,
     #[clap(short, long, action = clap::ArgAction::Count)]
-    verbose: u64,
+    verbose: u8,
     #[clap(subcommand)]
     cmd: Sub,
 }
@@ -35,7 +35,7 @@ struct Opt2 {
     #[clap(short, long, action)]
     force: bool,
     #[clap(short, long, action = clap::ArgAction::Count)]
-    verbose: u64,
+    verbose: u8,
     #[clap(subcommand)]
     cmd: Option<Sub>,
 }

--- a/tests/derive/options.rs
+++ b/tests/derive/options.rs
@@ -195,7 +195,7 @@ fn required_with_option_type() {
     enum SubCommands {
         ExSub {
             #[clap(short, long, action = clap::ArgAction::Count)]
-            verbose: u64,
+            verbose: u8,
         },
     }
 


### PR DESCRIPTION
Someone should not reasonably expect a coun flag to go up to billions,
millions, or even thousands.  255 should be sufficient for anyone,
right?

The original type was selected to be consistent with
`ArgMatches::occurrences_of` but that is also used for tracking how
many values appear which can be large with `xargs`.

I'm still conflicted on what the "right type" is an wish we could
support any numeric type.  When I did a search on github though, every
case was for debug/quiet flags and only supported 2-3 occurrences,
making a `u8` overkill.

This came out of a discussion on #3792