### PR TITLE
feat(parser): Provide updated version of 'is_present' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Replaced
 - `ArgMatches::{values_of, values_of_os, values_of_os_lossy, values_of_t}` with `ArgMatches::{get_many,remove_many}` (#3753)
 - `ArgMatches::is_valid_arg` with `ArgMatches::{try_get_one,try_get_many}` (#3753)
 - `ArgMatches::occurrences_of` with `ArgMatches::value_source` or `ArgAction::Count` (#3797)
+- `ArgMatches::is_present` with `ArgMatches::contains_id` or `ArgAction::SetTrue` (#3797)
 - `ArgAction::StoreValue` with `ArgAction::Set` or `ArgAction::Append` (#3797)
 - `ArgAction::IncOccurrences` with `ArgAction::SetTrue` or `ArgAction::Count` (#3797)
 - *(derive)* `#[clap(parse(from_flag))]` replaced with `#[clap(action = ArgAction::SetTrue)]` (#3794)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ _gated behind `unstable-v4`_
   - Default `ValueParser` is determined by `value_parser!` (#3199, #3496)
   - Default `ArgAction` is determine by a hard-coded lookup on the type (#3794)
 - `Command::multicall` is now stable for busybox-like programs and REPLs (#2861, #3684)
+- `ArgMatches::{try_,}contains_id` for checking if there are values for an argument that mirrors the new `get_{one,many}` API
 
 ### Fixes
 

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -663,7 +663,7 @@ fn gen_parsers(
         }
 
         Ty::OptionOption => quote_spanned! { ty.span()=>
-            if #arg_matches.is_present(#id) {
+            if #arg_matches.contains_id(#id) {
                 Some(
                     #arg_matches.#get_one(#id)
                         .map(#deref)
@@ -675,7 +675,7 @@ fn gen_parsers(
         },
 
         Ty::OptionVec => quote_spanned! { ty.span()=>
-            if #arg_matches.is_present(#id) {
+            if #arg_matches.contains_id(#id) {
                 Some(#arg_matches.#get_many(#id)
                     .map(|v| v.map(#deref).map::<::std::result::Result<#convert_type, clap::Error>, _>(#parse).collect::<::std::result::Result<Vec<_>, clap::Error>>())
                     .transpose()?
@@ -724,7 +724,7 @@ fn gen_parsers(
 
     if let Some(access) = update {
         quote_spanned! { field.span()=>
-            if #arg_matches.is_present(#id) {
+            if #arg_matches.contains_id(#id) {
                 #access
                 *#field_name = #field_value
             }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -486,7 +486,7 @@ fn gen_from_arg_matches(
 
         if cfg!(feature = "unstable-v4") {
             quote! {
-                if #sub_name == #subcommand_name_var && !#sub_arg_matches_var.is_present("") {
+                if #sub_name == #subcommand_name_var && !#sub_arg_matches_var.contains_id("") {
                     return ::std::result::Result::Ok(#name :: #variant_name #constructor_block)
                 }
             }

--- a/examples/derive_ref/flatten_hand_args.rs
+++ b/examples/derive_ref/flatten_hand_args.rs
@@ -1,5 +1,5 @@
 use clap::error::Error;
-use clap::{Arg, ArgMatches, Args, Command, FromArgMatches, Parser};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches, Parser};
 
 #[derive(Debug)]
 struct CliArgs {
@@ -15,8 +15,8 @@ impl FromArgMatches for CliArgs {
     }
     fn from_arg_matches_mut(matches: &mut ArgMatches) -> Result<Self, Error> {
         Ok(Self {
-            foo: matches.is_present("foo"),
-            bar: matches.is_present("bar"),
+            foo: *matches.get_one::<bool>("foo").expect("defaulted by clap"),
+            bar: *matches.get_one::<bool>("bar").expect("defaulted by clap"),
             quuz: matches.remove_one::<String>("quuz"),
         })
     }
@@ -25,8 +25,8 @@ impl FromArgMatches for CliArgs {
         self.update_from_arg_matches_mut(&mut matches)
     }
     fn update_from_arg_matches_mut(&mut self, matches: &mut ArgMatches) -> Result<(), Error> {
-        self.foo |= matches.is_present("foo");
-        self.bar |= matches.is_present("bar");
+        self.foo |= *matches.get_one::<bool>("foo").expect("defaulted by clap");
+        self.bar |= *matches.get_one::<bool>("bar").expect("defaulted by clap");
         if let Some(quuz) = matches.remove_one::<String>("quuz") {
             self.quuz = Some(quuz);
         }
@@ -36,20 +36,40 @@ impl FromArgMatches for CliArgs {
 
 impl Args for CliArgs {
     fn augment_args(cmd: Command<'_>) -> Command<'_> {
-        cmd.arg(Arg::new("foo").short('f').long("foo"))
-            .arg(Arg::new("bar").short('b').long("bar"))
-            .arg(Arg::new("quuz").short('q').long("quuz").takes_value(true))
+        cmd.arg(
+            Arg::new("foo")
+                .short('f')
+                .long("foo")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("bar")
+                .short('b')
+                .long("bar")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(Arg::new("quuz").short('q').long("quuz").takes_value(true))
     }
     fn augment_args_for_update(cmd: Command<'_>) -> Command<'_> {
-        cmd.arg(Arg::new("foo").short('f').long("foo"))
-            .arg(Arg::new("bar").short('b').long("bar"))
-            .arg(Arg::new("quuz").short('q').long("quuz").takes_value(true))
+        cmd.arg(
+            Arg::new("foo")
+                .short('f')
+                .long("foo")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("bar")
+                .short('b')
+                .long("bar")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(Arg::new("quuz").short('q').long("quuz").takes_value(true))
     }
 }
 
 #[derive(Parser, Debug)]
 struct Cli {
-    #[clap(short, long)]
+    #[clap(short, long, action)]
     top_level: bool,
     #[clap(flatten)]
     more_args: CliArgs,

--- a/examples/escaped-positional.rs
+++ b/examples/escaped-positional.rs
@@ -1,10 +1,10 @@
 // Note: this requires the `cargo` feature
 
-use clap::{arg, command, value_parser};
+use clap::{arg, command, value_parser, ArgAction};
 
 fn main() {
     let matches = command!()
-        .arg(arg!(eff: -f))
+        .arg(arg!(eff: -f).action(ArgAction::SetTrue))
         .arg(
             arg!(pea: -p <PEAR>)
                 .required(false)
@@ -22,7 +22,10 @@ fn main() {
     // This is what will happen with `myprog -f -p=bob -- sloppy slop slop`...
 
     // -f used: true
-    println!("-f used: {:?}", matches.is_present("eff"));
+    println!(
+        "-f used: {:?}",
+        *matches.get_one::<bool>("eff").expect("defaulted by clap")
+    );
     // -p's value: Some("bob")
     println!("-p's value: {:?}", matches.get_one::<String>("pea"));
     // 'slops' values: Some(["sloppy", "slop", "slop"])

--- a/examples/multicall-busybox.rs
+++ b/examples/multicall-busybox.rs
@@ -35,7 +35,7 @@ fn main() {
     let matches = cmd.get_matches();
     let mut subcommand = matches.subcommand();
     if let Some(("busybox", cmd)) = subcommand {
-        if cmd.is_present("install") {
+        if cmd.contains_id("install") {
             unimplemented!("Make hardlinks to the executable here");
         }
         subcommand = cmd.subcommand();

--- a/examples/pacman.rs
+++ b/examples/pacman.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 
 fn main() {
     let matches = Command::new("pacman")
@@ -56,6 +56,7 @@ fn main() {
                         .long("info")
                         .conflicts_with("search")
                         .short('i')
+                        .action(ArgAction::SetTrue)
                         .help("view package information"),
                 )
                 .arg(
@@ -70,10 +71,10 @@ fn main() {
 
     match matches.subcommand() {
         Some(("sync", sync_matches)) => {
-            if sync_matches.is_present("search") {
+            if sync_matches.contains_id("search") {
                 let packages: Vec<_> = sync_matches
                     .get_many::<String>("search")
-                    .expect("is present")
+                    .expect("contains_id")
                     .map(|s| s.as_str())
                     .collect();
                 let values = packages.join(", ");
@@ -88,7 +89,10 @@ fn main() {
                 .collect();
             let values = packages.join(", ");
 
-            if sync_matches.is_present("info") {
+            if *sync_matches
+                .get_one::<bool>("info")
+                .expect("defaulted by clap")
+            {
                 println!("Retrieving info for {}...", values);
             } else {
                 println!("Installing {}...", values);

--- a/examples/tutorial_builder/01_quick.rs
+++ b/examples/tutorial_builder/01_quick.rs
@@ -24,7 +24,7 @@ fn main() {
         .subcommand(
             Command::new("test")
                 .about("does testing things")
-                .arg(arg!(-l --list "lists test values")),
+                .arg(arg!(-l --list "lists test values").action(ArgAction::SetTrue)),
         )
         .get_matches();
 
@@ -53,7 +53,7 @@ fn main() {
     // matches just as you would the top level cmd
     if let Some(matches) = matches.subcommand_matches("test") {
         // "$ myapp test" was run
-        if matches.is_present("list") {
+        if *matches.get_one::<bool>("list").expect("defaulted by clap") {
             // "$ myapp test -l" was run
             println!("Printing testing lists...");
         } else {

--- a/examples/tutorial_builder/03_01_flag_bool.rs
+++ b/examples/tutorial_builder/03_01_flag_bool.rs
@@ -1,9 +1,21 @@
 // Note: this requires the `cargo` feature
 
-use clap::{arg, command};
+use clap::{command, Arg, ArgAction};
 
 fn main() {
-    let matches = command!().arg(arg!(-v - -verbose)).get_matches();
+    let matches = command!()
+        .arg(
+            Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .action(ArgAction::SetTrue),
+        )
+        .get_matches();
 
-    println!("verbose: {:?}", matches.is_present("verbose"));
+    println!(
+        "verbose: {:?}",
+        *matches
+            .get_one::<bool>("verbose")
+            .expect("defaulted by clap")
+    );
 }

--- a/examples/tutorial_builder/04_03_relations.rs
+++ b/examples/tutorial_builder/04_03_relations.rs
@@ -2,16 +2,16 @@
 
 use std::path::PathBuf;
 
-use clap::{arg, command, value_parser, ArgGroup};
+use clap::{arg, command, value_parser, ArgAction, ArgGroup};
 
 fn main() {
     // Create application like normal
     let matches = command!()
         // Add the version arguments
         .arg(arg!(--"set-ver" <VER> "set version manually").required(false))
-        .arg(arg!(--major         "auto inc major"))
-        .arg(arg!(--minor         "auto inc minor"))
-        .arg(arg!(--patch         "auto inc patch"))
+        .arg(arg!(--major         "auto inc major").action(ArgAction::SetTrue))
+        .arg(arg!(--minor         "auto inc minor").action(ArgAction::SetTrue))
+        .arg(arg!(--patch         "auto inc patch").action(ArgAction::SetTrue))
         // Create a group, make it required, and add the above arguments
         .group(
             ArgGroup::new("vers")
@@ -52,9 +52,9 @@ fn main() {
     } else {
         // Increment the one requested (in a real program, we'd reset the lower numbers)
         let (maj, min, pat) = (
-            matches.is_present("major"),
-            matches.is_present("minor"),
-            matches.is_present("patch"),
+            *matches.get_one::<bool>("major").expect("defaulted by clap"),
+            *matches.get_one::<bool>("minor").expect("defaulted by clap"),
+            *matches.get_one::<bool>("patch").expect("defaulted by clap"),
         );
         match (maj, min, pat) {
             (true, _, _) => major += 1,
@@ -68,7 +68,7 @@ fn main() {
     println!("Version: {}", version);
 
     // Check for usage of -c
-    if matches.is_present("config") {
+    if matches.contains_id("config") {
         let input = matches
             .get_one::<PathBuf>("INPUT_FILE")
             .unwrap_or_else(|| matches.get_one::<PathBuf>("spec-in").unwrap())

--- a/examples/tutorial_builder/README.md
+++ b/examples/tutorial_builder/README.md
@@ -228,13 +228,7 @@ $ 03_01_flag_bool --verbose
 verbose: true
 
 $ 03_01_flag_bool --verbose --verbose
-? failed
-error: The argument '--verbose' was provided more than once, but cannot be used multiple times
-
-USAGE:
-    03_01_flag_bool[EXE] [OPTIONS]
-
-For more information try --help
+verbose: true
 
 ```
 

--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -39,7 +39,7 @@ pub enum ArgAction {
     ///     );
     ///
     /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "value"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_many::<String>("flag").unwrap_or_default().map(|v| v.as_str()).collect::<Vec<_>>(),
@@ -62,7 +62,7 @@ pub enum ArgAction {
     ///     );
     ///
     /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "value1", "--flag", "value2"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_many::<String>("flag").unwrap_or_default().map(|v| v.as_str()).collect::<Vec<_>>(),
@@ -101,7 +101,7 @@ pub enum ArgAction {
     ///     );
     ///
     /// let matches = cmd.clone().try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_one::<bool>("flag").copied(),
@@ -109,7 +109,7 @@ pub enum ArgAction {
     /// );
     ///
     /// let matches = cmd.try_get_matches_from(["mycmd"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_one::<bool>("flag").copied(),
@@ -136,7 +136,7 @@ pub enum ArgAction {
     ///     );
     ///
     /// let matches = cmd.clone().try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_one::<bool>("flag").copied(),
@@ -144,7 +144,7 @@ pub enum ArgAction {
     /// );
     ///
     /// let matches = cmd.try_get_matches_from(["mycmd"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_one::<bool>("flag").copied(),
@@ -171,7 +171,7 @@ pub enum ArgAction {
     ///     );
     ///
     /// let matches = cmd.clone().try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_one::<u8>("flag").copied(),
@@ -179,7 +179,7 @@ pub enum ArgAction {
     /// );
     ///
     /// let matches = cmd.try_get_matches_from(["mycmd"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_one::<u8>("flag").copied(),

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -156,12 +156,13 @@ impl<'help> Arg<'help> {
     /// # use clap::{Command, Arg};
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("config")
-    ///         .short('c'))
+    ///         .short('c')
+    ///         .takes_value(true))
     ///     .get_matches_from(vec![
-    ///         "prog", "-c"
+    ///         "prog", "-c", "file.toml"
     ///     ]);
     ///
-    /// assert!(m.is_present("config"));
+    /// assert_eq!(m.get_one::<String>("config").map(String::as_str), Some("file.toml"));
     /// ```
     #[inline]
     #[must_use]
@@ -193,12 +194,13 @@ impl<'help> Arg<'help> {
     /// # use clap::{Command, Arg};
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("cfg")
-    ///         .long("config"))
+    ///         .long("config")
+    ///         .takes_value(true))
     ///     .get_matches_from(vec![
-    ///         "prog", "--config"
+    ///         "prog", "--config", "file.toml"
     ///     ]);
     ///
-    /// assert!(m.is_present("cfg"));
+    /// assert_eq!(m.get_one::<String>("cfg").map(String::as_str), Some("file.toml"));
     /// ```
     #[inline]
     #[must_use]
@@ -231,7 +233,7 @@ impl<'help> Arg<'help> {
     ///        .get_matches_from(vec![
     ///             "prog", "--alias", "cool"
     ///         ]);
-    /// assert!(m.is_present("test"));
+    /// assert!(m.contains_id("test"));
     /// assert_eq!(m.value_of("test"), Some("cool"));
     /// ```
     #[must_use]
@@ -257,7 +259,7 @@ impl<'help> Arg<'help> {
     ///        .get_matches_from(vec![
     ///             "prog", "-e", "cool"
     ///         ]);
-    /// assert!(m.is_present("test"));
+    /// assert!(m.contains_id("test"));
     /// assert_eq!(m.value_of("test"), Some("cool"));
     /// ```
     #[must_use]
@@ -276,17 +278,18 @@ impl<'help> Arg<'help> {
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let m = Command::new("prog")
     ///             .arg(Arg::new("test")
     ///                     .long("test")
     ///                     .aliases(&["do-stuff", "do-tests", "tests"])
+    ///                     .action(ArgAction::SetTrue)
     ///                     .help("the file to add")
     ///                     .required(false))
     ///             .get_matches_from(vec![
     ///                 "prog", "--do-tests"
     ///             ]);
-    /// assert!(m.is_present("test"));
+    /// assert_eq!(*m.get_one::<bool>("test").expect("defaulted by clap"), true);
     /// ```
     #[must_use]
     pub fn aliases(mut self, names: &[&'help str]) -> Self {
@@ -302,17 +305,18 @@ impl<'help> Arg<'help> {
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let m = Command::new("prog")
     ///             .arg(Arg::new("test")
     ///                     .short('t')
     ///                     .short_aliases(&['e', 's'])
+    ///                     .action(ArgAction::SetTrue)
     ///                     .help("the file to add")
     ///                     .required(false))
     ///             .get_matches_from(vec![
     ///                 "prog", "-s"
     ///             ]);
-    /// assert!(m.is_present("test"));
+    /// assert_eq!(*m.get_one::<bool>("test").expect("defaulted by clap"), true);
     /// ```
     #[must_use]
     pub fn short_aliases(mut self, names: &[char]) -> Self {
@@ -339,7 +343,7 @@ impl<'help> Arg<'help> {
     ///        .get_matches_from(vec![
     ///             "prog", "--something-awesome", "coffee"
     ///         ]);
-    /// assert!(m.is_present("test"));
+    /// assert!(m.contains_id("test"));
     /// assert_eq!(m.value_of("test"), Some("coffee"));
     /// ```
     /// [`Command::alias`]: Arg::alias()
@@ -365,7 +369,7 @@ impl<'help> Arg<'help> {
     ///        .get_matches_from(vec![
     ///             "prog", "-t", "coffee"
     ///         ]);
-    /// assert!(m.is_present("test"));
+    /// assert!(m.contains_id("test"));
     /// assert_eq!(m.value_of("test"), Some("coffee"));
     /// ```
     #[must_use]
@@ -383,15 +387,16 @@ impl<'help> Arg<'help> {
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let m = Command::new("prog")
     ///             .arg(Arg::new("test")
     ///                 .long("test")
+    ///                 .action(ArgAction::SetTrue)
     ///                 .visible_aliases(&["something", "awesome", "cool"]))
     ///        .get_matches_from(vec![
     ///             "prog", "--awesome"
     ///         ]);
-    /// assert!(m.is_present("test"));
+    /// assert_eq!(*m.get_one::<bool>("test").expect("defaulted by clap"), true);
     /// ```
     /// [`Command::aliases`]: Arg::aliases()
     #[must_use]
@@ -407,15 +412,16 @@ impl<'help> Arg<'help> {
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let m = Command::new("prog")
     ///             .arg(Arg::new("test")
     ///                 .long("test")
+    ///                 .action(ArgAction::SetTrue)
     ///                 .visible_short_aliases(&['t', 'e']))
     ///        .get_matches_from(vec![
     ///             "prog", "-t"
     ///         ]);
-    /// assert!(m.is_present("test"));
+    /// assert_eq!(*m.get_one::<bool>("test").expect("defaulted by clap"), true);
     /// ```
     #[must_use]
     pub fn visible_short_aliases(mut self, names: &[char]) -> Self {
@@ -467,7 +473,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "--debug", "fast"
     ///     ]);
     ///
-    /// assert!(m.is_present("mode"));
+    /// assert!(m.contains_id("mode"));
     /// assert_eq!(m.value_of("mode"), Some("fast")); // notice index(1) means "first positional"
     ///                                               // *not* first argument
     /// ```
@@ -747,11 +753,12 @@ impl<'help> Arg<'help> {
     /// want to clutter the source with three duplicate [`Arg`] definitions.
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("verb")
     ///         .long("verbose")
     ///         .short('v')
+    ///         .action(ArgAction::SetTrue)
     ///         .global(true))
     ///     .subcommand(Command::new("test"))
     ///     .subcommand(Command::new("do-stuff"))
@@ -761,11 +768,10 @@ impl<'help> Arg<'help> {
     ///
     /// assert_eq!(m.subcommand_name(), Some("do-stuff"));
     /// let sub_m = m.subcommand_matches("do-stuff").unwrap();
-    /// assert!(sub_m.is_present("verb"));
+    /// assert_eq!(*sub_m.get_one::<bool>("verb").expect("defaulted by clap"), true);
     /// ```
     ///
     /// [`Subcommand`]: crate::Subcommand
-    /// [`ArgMatches::is_present("flag")`]: ArgMatches::is_present()
     #[inline]
     #[must_use]
     pub fn global(self, yes: bool) -> Self {
@@ -901,7 +907,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "--mode", "fast"
     ///     ]);
     ///
-    /// assert!(m.is_present("mode"));
+    /// assert!(m.contains_id("mode"));
     /// assert_eq!(m.value_of("mode"), Some("fast"));
     /// ```
     /// [`Arg::value_delimiter(char)`]: Arg::value_delimiter()
@@ -931,7 +937,7 @@ impl<'help> Arg<'help> {
     ///     );
     ///
     /// let matches = cmd.try_get_matches_from(["mycmd", "--flag", "value"]).unwrap();
-    /// assert!(matches.is_present("flag"));
+    /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
     ///     matches.get_many::<String>("flag").unwrap_or_default().map(|v| v.as_str()).collect::<Vec<_>>(),
@@ -1070,7 +1076,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "-F", "file1", "file2", "file3"
     ///     ]);
     ///
-    /// assert!(m.is_present("file"));
+    /// assert!(m.contains_id("file"));
     /// let files: Vec<_> = m.values_of("file").unwrap().collect();
     /// assert_eq!(files, ["file1", "file2", "file3"]);
     /// ```
@@ -1107,10 +1113,10 @@ impl<'help> Arg<'help> {
     ///         "prog", "-F", "file1", "file2", "file3", "word"
     ///     ]);
     ///
-    /// assert!(m.is_present("file"));
+    /// assert!(m.contains_id("file"));
     /// let files: Vec<_> = m.values_of("file").unwrap().collect();
     /// assert_eq!(files, ["file1", "file2", "file3", "word"]); // wait...what?!
-    /// assert!(!m.is_present("word")); // but we clearly used word!
+    /// assert!(!m.contains_id("word")); // but we clearly used word!
     /// ```
     ///
     /// The problem is `clap` doesn't know when to stop parsing values for "files". This is further
@@ -1132,10 +1138,10 @@ impl<'help> Arg<'help> {
     ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3", "word"
     ///     ]);
     ///
-    /// assert!(m.is_present("file"));
+    /// assert!(m.contains_id("file"));
     /// let files: Vec<_> = m.values_of("file").unwrap().collect();
     /// assert_eq!(files, ["file1", "file2", "file3"]);
-    /// assert!(m.is_present("word"));
+    /// assert!(m.contains_id("word"));
     /// assert_eq!(m.value_of("word"), Some("word"));
     /// ```
     ///
@@ -1809,7 +1815,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "--option=val1,val2,val3",
     ///     ]);
     ///
-    /// assert!(delims.is_present("option"));
+    /// assert!(delims.contains_id("option"));
     /// assert_eq!(delims.values_of("option").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
     /// ```
     /// The next example shows the difference when turning delimiters off. This is the default
@@ -1825,7 +1831,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "--option=val1,val2,val3",
     ///     ]);
     ///
-    /// assert!(nodelims.is_present("option"));
+    /// assert!(nodelims.contains_id("option"));
     /// assert_eq!(nodelims.value_of("option").unwrap(), "val1,val2,val3");
     /// ```
     /// [`Arg::value_delimiter`]: Arg::value_delimiter()
@@ -1914,7 +1920,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "-o", "val1,val2,val3",
     ///     ]);
     ///
-    /// assert!(delims.is_present("opt"));
+    /// assert!(delims.contains_id("opt"));
     /// assert_eq!(delims.values_of("opt").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
     /// ```
     ///
@@ -1955,7 +1961,7 @@ impl<'help> Arg<'help> {
     ///         "prog", "-o", "val1", "val2", "val3",
     ///     ]);
     ///
-    /// assert!(delims.is_present("opt"));
+    /// assert!(delims.contains_id("opt"));
     /// assert_eq!(delims.values_of("opt").unwrap().collect::<Vec<_>>(), ["val1", "val2", "val3"]);
     /// ```
     #[inline]
@@ -2068,7 +2074,7 @@ impl<'help> Arg<'help> {
     /// **NOTE:** If the user *does not* use this argument at runtime, [`ArgMatches::occurrences_of`]
     /// will return `0` even though the [`ArgMatches::value_of`] will return the default specified.
     ///
-    /// **NOTE:** If the user *does not* use this argument at runtime [`ArgMatches::is_present`] will
+    /// **NOTE:** If the user *does not* use this argument at runtime [`ArgMatches::contains_id`] will
     /// still return `true`. If you wish to determine whether the argument was used at runtime or
     /// not, consider [`ArgMatches::value_source`][crate::ArgMatches::value_source].
     ///
@@ -2097,7 +2103,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert_eq!(m.value_of("opt"), Some("myval"));
-    /// assert!(m.is_present("opt"));
+    /// assert!(m.contains_id("opt"));
     /// assert_eq!(m.value_source("opt"), Some(ValueSource::DefaultValue));
     /// ```
     ///
@@ -2114,13 +2120,13 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert_eq!(m.value_of("opt"), Some("non_default"));
-    /// assert!(m.is_present("opt"));
+    /// assert!(m.contains_id("opt"));
     /// assert_eq!(m.value_source("opt"), Some(ValueSource::CommandLine));
     /// ```
     /// [`ArgMatches::occurrences_of`]: crate::ArgMatches::occurrences_of()
     /// [`ArgMatches::value_of`]: crate::ArgMatches::value_of()
     /// [`Arg::takes_value(true)`]: Arg::takes_value()
-    /// [`ArgMatches::is_present`]: crate::ArgMatches::is_present()
+    /// [`ArgMatches::contains_id`]: crate::ArgMatches::contains_id()
     /// [`Arg::default_value_if`]: Arg::default_value_if()
     #[inline]
     #[must_use]
@@ -2208,7 +2214,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert_eq!(m.value_of("color"), Some("auto"));
-    /// assert!(m.is_present("color"));
+    /// assert!(m.contains_id("color"));
     /// assert_eq!(m.value_source("color"), Some(ValueSource::DefaultValue));
     ///
     /// // next, we'll provide a runtime value to override the default (as usually done).
@@ -2218,7 +2224,7 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert_eq!(m.value_of("color"), Some("never"));
-    /// assert!(m.is_present("color"));
+    /// assert!(m.contains_id("color"));
     /// assert_eq!(m.value_source("color"), Some(ValueSource::CommandLine));
     ///
     /// // finally, we will use the shortcut and only provide the argument without a value.
@@ -2228,12 +2234,11 @@ impl<'help> Arg<'help> {
     ///     ]);
     ///
     /// assert_eq!(m.value_of("color"), Some("always"));
-    /// assert!(m.is_present("color"));
+    /// assert!(m.contains_id("color"));
     /// assert_eq!(m.value_source("color"), Some(ValueSource::CommandLine));
     /// ```
     /// [`ArgMatches::value_of`]: ArgMatches::value_of()
     /// [`Arg::takes_value(true)`]: Arg::takes_value()
-    /// [`ArgMatches::is_present`]: ArgMatches::is_present()
     /// [`Arg::default_value`]: Arg::default_value()
     #[inline]
     #[must_use]
@@ -2412,7 +2417,6 @@ impl<'help> Arg<'help> {
     /// assert_eq!(m.values_of("flag").unwrap().collect::<Vec<_>>(), vec!["env1", "env2"]);
     /// ```
     /// [`ArgMatches::value_of`]: crate::ArgMatches::value_of()
-    /// [`ArgMatches::is_present`]: ArgMatches::is_present()
     /// [`Arg::takes_value(true)`]: Arg::takes_value()
     /// [`Arg::use_value_delimiter(true)`]: Arg::use_value_delimiter()
     #[cfg(feature = "env")]
@@ -3020,7 +3024,7 @@ impl<'help> Arg<'help> {
     ///     .get_matches_from(vec![
     ///         "prog", "--debug"
     ///     ]);
-    /// assert!(m.is_present("mode"));
+    /// assert!(m.contains_id("mode"));
     /// ```
     ///
     /// [`ArgGroup`]: crate::ArgGroup
@@ -3057,8 +3061,8 @@ impl<'help> Arg<'help> {
     ///     .get_matches_from(vec![
     ///         "prog", "--debug"
     ///     ]);
-    /// assert!(m.is_present("mode"));
-    /// assert!(m.is_present("verbosity"));
+    /// assert!(m.contains_id("mode"));
+    /// assert!(m.contains_id("verbosity"));
     /// ```
     ///
     /// [`ArgGroup`]: crate::ArgGroup
@@ -4059,7 +4063,7 @@ impl<'help> Arg<'help> {
     ///
     /// # Examples
     ///
-    /// ```rust # use clap::{Command, Arg};
+    /// ```rust
     /// # use clap::{Command, arg};
     /// let m = Command::new("prog")
     ///     .arg(arg!(-f --flag "some flag")

--- a/src/builder/arg_group.rs
+++ b/src/builder/arg_group.rs
@@ -68,7 +68,7 @@ use yaml_rust::Yaml;
 /// assert!(result.is_ok());
 /// let matches = result.unwrap();
 /// // We may not know which of the args was used, so we can test for the group...
-/// assert!(matches.is_present("vers"));
+/// assert!(matches.contains_id("vers"));
 /// // we could also alternatively check each arg individually (not shown here)
 /// ```
 /// [`ArgGroup::multiple(true)`]: ArgGroup::multiple()
@@ -150,9 +150,9 @@ impl<'help> ArgGroup<'help> {
     ///         .arg("color"))
     ///     .get_matches_from(vec!["myprog", "-f"]);
     /// // maybe we don't know which of the two flags was used...
-    /// assert!(m.is_present("req_flags"));
+    /// assert!(m.contains_id("req_flags"));
     /// // but we can also check individually if needed
-    /// assert!(m.is_present("flag"));
+    /// assert!(m.contains_id("flag"));
     /// ```
     /// [argument]: crate::Arg
     #[must_use]
@@ -176,9 +176,9 @@ impl<'help> ArgGroup<'help> {
     ///         .args(&["flag", "color"]))
     ///     .get_matches_from(vec!["myprog", "-f"]);
     /// // maybe we don't know which of the two flags was used...
-    /// assert!(m.is_present("req_flags"));
+    /// assert!(m.contains_id("req_flags"));
     /// // but we can also check individually if needed
-    /// assert!(m.is_present("flag"));
+    /// assert!(m.contains_id("flag"));
     /// ```
     /// [arguments]: crate::Arg
     #[must_use]
@@ -208,7 +208,7 @@ impl<'help> ArgGroup<'help> {
     ///         .multiple(true))
     ///     .get_matches_from(vec!["myprog", "-f", "-c"]);
     /// // maybe we don't know which of the two flags was used...
-    /// assert!(m.is_present("req_flags"));
+    /// assert!(m.contains_id("req_flags"));
     /// ```
     /// In this next example, we show the default behavior (i.e. `multiple(false)) which will throw
     /// an error if more than one of the args in the group was used.

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -409,11 +409,12 @@ impl<'help> App<'help> {
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// fn cmd() -> Command<'static> {
     ///     Command::new("foo")
-    ///         .arg(Arg::new("bar").short('b')
-    ///     )
+    ///         .arg(
+    ///             Arg::new("bar").short('b').action(ArgAction::SetTrue)
+    ///         )
     /// }
     ///
     /// #[test]
@@ -423,7 +424,7 @@ impl<'help> App<'help> {
     ///
     /// fn main() {
     ///     let m = cmd().get_matches_from(vec!["foo", "-b"]);
-    ///     println!("{}", m.is_present("bar"));
+    ///     println!("{}", *m.get_one::<bool>("bar").expect("defaulted by clap"));
     /// }
     /// ```
     pub fn debug_assert(mut self) {
@@ -1910,17 +1911,19 @@ impl<'help> App<'help> {
     /// need to change!
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let m = Command::new("cmd")
     ///     .arg(Arg::new("save-context")
-    ///         .long("save-context"))
+    ///         .long("save-context")
+    ///         .action(ArgAction::SetTrue))
     ///     .arg(Arg::new("save-runtime")
-    ///         .long("save-runtime"))
+    ///         .long("save-runtime")
+    ///         .action(ArgAction::SetTrue))
     ///     .replace("--save-all", &["--save-context", "--save-runtime"])
     ///     .get_matches_from(vec!["cmd", "--save-all"]);
     ///
-    /// assert!(m.is_present("save-context"));
-    /// assert!(m.is_present("save-runtime"));
+    /// assert!(*m.get_one::<bool>("save-context").expect("defaulted by clap"));
+    /// assert!(*m.get_one::<bool>("save-runtime").expect("defaulted by clap"));
     /// ```
     ///
     /// This can also be used with options, for example if our application with
@@ -1930,12 +1933,14 @@ impl<'help> App<'help> {
     /// above to enforce this:
     ///
     /// ```rust
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let m = Command::new("cmd")
     ///     .arg(Arg::new("save-context")
-    ///         .long("save-context"))
+    ///         .long("save-context")
+    ///         .action(ArgAction::SetTrue))
     ///     .arg(Arg::new("save-runtime")
-    ///         .long("save-runtime"))
+    ///         .long("save-runtime")
+    ///         .action(ArgAction::SetTrue))
     ///     .arg(Arg::new("format")
     ///         .long("format")
     ///         .takes_value(true)
@@ -1943,8 +1948,8 @@ impl<'help> App<'help> {
     ///     .replace("--save-all", &["--save-context", "--save-runtime", "--format=json"])
     ///     .get_matches_from(vec!["cmd", "--save-all"]);
     ///
-    /// assert!(m.is_present("save-context"));
-    /// assert!(m.is_present("save-runtime"));
+    /// assert!(*m.get_one::<bool>("save-context").expect("defaulted by clap"));
+    /// assert!(*m.get_one::<bool>("save-runtime").expect("defaulted by clap"));
     /// assert_eq!(m.value_of("format"), Some("json"));
     /// ```
     ///
@@ -2197,13 +2202,14 @@ impl<'help> App<'help> {
     /// # Examples
     ///
     /// ```
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let matches = Command::new("pacman")
     ///     .subcommand(
     ///         Command::new("sync").short_flag('S').arg(
     ///             Arg::new("search")
     ///                 .short('s')
     ///                 .long("search")
+    ///                 .action(ArgAction::SetTrue)
     ///                 .help("search remote repositories for matching strings"),
     ///         ),
     ///     )
@@ -2211,7 +2217,7 @@ impl<'help> App<'help> {
     ///
     /// assert_eq!(matches.subcommand_name().unwrap(), "sync");
     /// let sync_matches = matches.subcommand_matches("sync").unwrap();
-    /// assert!(sync_matches.is_present("search"));
+    /// assert!(*sync_matches.get_one::<bool>("search").expect("defaulted by clap"));
     /// ```
     /// [`Arg::short`]: Arg::short()
     #[must_use]
@@ -2233,13 +2239,14 @@ impl<'help> App<'help> {
     /// will *not* be stripped (i.e. `sync-file` is allowed).
     ///
     /// ```
-    /// # use clap::{Command, Arg};
+    /// # use clap::{Command, Arg, ArgAction};
     /// let matches = Command::new("pacman")
     ///     .subcommand(
     ///         Command::new("sync").long_flag("sync").arg(
     ///             Arg::new("search")
     ///                 .short('s')
     ///                 .long("search")
+    ///                 .action(ArgAction::SetTrue)
     ///                 .help("search remote repositories for matching strings"),
     ///         ),
     ///     )
@@ -2247,7 +2254,7 @@ impl<'help> App<'help> {
     ///
     /// assert_eq!(matches.subcommand_name().unwrap(), "sync");
     /// let sync_matches = matches.subcommand_matches("sync").unwrap();
-    /// assert!(sync_matches.is_present("search"));
+    /// assert!(*sync_matches.get_one::<bool>("search").expect("defaulted by clap"));
     /// ```
     ///
     /// [`Arg::long`]: Arg::long()

--- a/src/builder/debug_asserts.rs
+++ b/src/builder/debug_asserts.rs
@@ -317,19 +317,6 @@ pub(crate) fn assert_app(cmd: &Command) {
                 arg
             );
         }
-
-        // Required groups should have at least one arg without default values
-        if group.required && !group.args.is_empty() {
-            assert!(
-                group.args.iter().any(|arg| {
-                    cmd.get_arguments()
-                        .any(|x| x.id == *arg && x.default_vals.is_empty())
-                }),
-                "Command {}: Argument group '{}' is required but all of it's arguments have a default value.",
-                    cmd.get_name(),
-                group.name
-            )
-        }
     }
 
     // Conflicts between flags and subcommands
@@ -697,14 +684,6 @@ fn assert_arg(arg: &Arg) {
         assert!(
             arg.is_takes_value_set(),
             "Argument '{}` is positional, it must take a value",
-            arg.name
-        );
-    }
-
-    if arg.is_required_set() {
-        assert!(
-            arg.default_vals.is_empty(),
-            "Argument '{}' is required and can't have a default value",
             arg.name
         );
     }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -49,11 +49,12 @@ use std::ffi::OsString;
 /// The equivalent [`Command`] struct + `From` implementation:
 ///
 /// ```rust
-/// # use clap::{Command, Arg, ArgMatches};
+/// # use clap::{Command, Arg, ArgMatches, ArgAction};
 /// Command::new("demo")
 ///     .about("My super CLI")
 ///     .arg(Arg::new("verbose")
 ///         .long("verbose")
+///         .action(ArgAction::SetTrue)
 ///         .help("More verbose output"))
 ///     .arg(Arg::new("name")
 ///         .long("name")
@@ -69,8 +70,8 @@ use std::ffi::OsString;
 /// impl From<ArgMatches> for Context {
 ///     fn from(m: ArgMatches) -> Self {
 ///         Context {
-///             verbose: m.is_present("verbose"),
-///             name: m.get_one::<String>("name").map(|n| n.clone()),
+///             verbose: *m.get_one::<bool>("verbose").expect("defaulted_by_clap"),
+///             name: m.get_one::<String>("name").cloned(),
 ///         }
 ///     }
 /// }
@@ -287,7 +288,7 @@ pub trait FromArgMatches: Sized {
     ///    fn from(m: ArgMatches) -> Self {
     ///        Context {
     ///            name: m.get_one::<String>("name").unwrap().clone(),
-    ///            debug: m.is_present("debug"),
+    ///            debug: *m.get_one::<bool>("debug").expect("defaulted by clap"),
     ///        }
     ///    }
     /// }
@@ -321,7 +322,7 @@ pub trait FromArgMatches: Sized {
     ///    fn from(m: ArgMatches) -> Self {
     ///        Context {
     ///            name: m.get_one::<String>("name").unwrap().to_string(),
-    ///            debug: m.is_present("debug"),
+    ///            debug: *m.get_one::<bool>("debug").expect("defaulted by clap"),
     ///        }
     ///    }
     /// }

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -114,9 +114,9 @@ impl ArgMatches {
     /// [positional]: crate::Arg::index()
     /// [`default_value`]: crate::Arg::default_value()
     #[track_caller]
-    pub fn get_one<T: Any + Clone + Send + Sync + 'static>(&self, name: &str) -> Option<&T> {
-        let id = Id::from(name);
-        MatchesError::unwrap(&id, self.try_get_one(name))
+    pub fn get_one<T: Any + Clone + Send + Sync + 'static>(&self, id: &str) -> Option<&T> {
+        let internal_id = Id::from(id);
+        MatchesError::unwrap(&internal_id, self.try_get_one(id))
     }
 
     /// Iterate over values of a specific option or positional argument.
@@ -155,10 +155,10 @@ impl ArgMatches {
     #[track_caller]
     pub fn get_many<T: Any + Clone + Send + Sync + 'static>(
         &self,
-        name: &str,
+        id: &str,
     ) -> Option<ValuesRef<T>> {
-        let id = Id::from(name);
-        MatchesError::unwrap(&id, self.try_get_many(name))
+        let internal_id = Id::from(id);
+        MatchesError::unwrap(&internal_id, self.try_get_many(id))
     }
 
     /// Iterate over the original argument values.
@@ -203,9 +203,9 @@ impl ArgMatches {
     /// [values]: OsValues
     /// [`String`]: std::string::String
     #[track_caller]
-    pub fn get_raw(&self, name: &str) -> Option<RawValues<'_>> {
-        let id = Id::from(name);
-        MatchesError::unwrap(&id, self.try_get_raw(name))
+    pub fn get_raw(&self, id: &str) -> Option<RawValues<'_>> {
+        let internal_id = Id::from(id);
+        MatchesError::unwrap(&internal_id, self.try_get_raw(id))
     }
 
     /// Returns the value of a specific option or positional argument.
@@ -243,9 +243,9 @@ impl ArgMatches {
     /// [positional]: crate::Arg::index()
     /// [`default_value`]: crate::Arg::default_value()
     #[track_caller]
-    pub fn remove_one<T: Any + Clone + Send + Sync + 'static>(&mut self, name: &str) -> Option<T> {
-        let id = Id::from(name);
-        MatchesError::unwrap(&id, self.try_remove_one(name))
+    pub fn remove_one<T: Any + Clone + Send + Sync + 'static>(&mut self, id: &str) -> Option<T> {
+        let internal_id = Id::from(id);
+        MatchesError::unwrap(&internal_id, self.try_remove_one(id))
     }
 
     /// Return values of a specific option or positional argument.
@@ -282,10 +282,10 @@ impl ArgMatches {
     #[track_caller]
     pub fn remove_many<T: Any + Clone + Send + Sync + 'static>(
         &mut self,
-        name: &str,
+        id: &str,
     ) -> Option<Values2<T>> {
-        let id = Id::from(name);
-        MatchesError::unwrap(&id, self.try_remove_many(name))
+        let internal_id = Id::from(id);
+        MatchesError::unwrap(&internal_id, self.try_remove_many(id))
     }
 
     /// Check if any args were present on the command line
@@ -371,7 +371,7 @@ impl ArgMatches {
     ///
     /// If the value is invalid UTF-8.
     ///
-    /// If `id` is not a valid argument or group name.
+    /// If `id` is not a valid argument or group id.
     ///
     /// # Examples
     /// ```rust
@@ -528,7 +528,7 @@ impl ArgMatches {
     ///
     /// # Panics
     ///
-    /// If `id` is is not a valid argument or group name.
+    /// If `id` is is not a valid argument or group id.
     ///
     /// # Examples
     ///
@@ -585,7 +585,7 @@ impl ArgMatches {
     ///
     /// # Panics
     ///
-    /// If `id` is is not a valid argument or group name.
+    /// If `id` is is not a valid argument or group id.
     ///
     /// # Examples
     ///
@@ -719,7 +719,7 @@ impl ArgMatches {
     ///
     /// # Panics
     ///
-    /// If `id` is is not a valid argument or group name.
+    /// If `id` is is not a valid argument or group id.
     ///
     /// # Examples
     ///
@@ -1014,9 +1014,9 @@ impl ArgMatches {
     /// Non-panicking version of [`ArgMatches::get_one`]
     pub fn try_get_one<T: Any + Clone + Send + Sync + 'static>(
         &self,
-        name: &str,
+        id: &str,
     ) -> Result<Option<&T>, MatchesError> {
-        let id = Id::from(name);
+        let id = Id::from(id);
         let arg = self.try_get_arg_t::<T>(&id)?;
         let value = match arg.and_then(|a| a.first()) {
             Some(value) => value,
@@ -1033,9 +1033,9 @@ impl ArgMatches {
     /// Non-panicking version of [`ArgMatches::get_many`]
     pub fn try_get_many<T: Any + Clone + Send + Sync + 'static>(
         &self,
-        name: &str,
+        id: &str,
     ) -> Result<Option<ValuesRef<T>>, MatchesError> {
-        let id = Id::from(name);
+        let id = Id::from(id);
         let arg = match self.try_get_arg_t::<T>(&id)? {
             Some(arg) => arg,
             None => return Ok(None),
@@ -1051,8 +1051,8 @@ impl ArgMatches {
     }
 
     /// Non-panicking version of [`ArgMatches::get_raw`]
-    pub fn try_get_raw(&self, name: &str) -> Result<Option<RawValues<'_>>, MatchesError> {
-        let id = Id::from(name);
+    pub fn try_get_raw(&self, id: &str) -> Result<Option<RawValues<'_>>, MatchesError> {
+        let id = Id::from(id);
         let arg = match self.try_get_arg(&id)? {
             Some(arg) => arg,
             None => return Ok(None),
@@ -1069,9 +1069,9 @@ impl ArgMatches {
     /// Non-panicking version of [`ArgMatches::remove_one`]
     pub fn try_remove_one<T: Any + Clone + Send + Sync + 'static>(
         &mut self,
-        name: &str,
+        id: &str,
     ) -> Result<Option<T>, MatchesError> {
-        let id = Id::from(name);
+        let id = Id::from(id);
         match self.try_remove_arg_t::<T>(&id)? {
             Some(values) => Ok(values
                 .into_vals_flatten()
@@ -1085,9 +1085,9 @@ impl ArgMatches {
     /// Non-panicking version of [`ArgMatches::remove_many`]
     pub fn try_remove_many<T: Any + Clone + Send + Sync + 'static>(
         &mut self,
-        name: &str,
+        id: &str,
     ) -> Result<Option<Values2<T>>, MatchesError> {
-        let id = Id::from(name);
+        let id = Id::from(id);
         let arg = match self.try_remove_arg_t::<T>(&id)? {
             Some(arg) => arg,
             None => return Ok(None),

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -288,6 +288,36 @@ impl ArgMatches {
         MatchesError::unwrap(&internal_id, self.try_remove_many(id))
     }
 
+    /// Check if values are present for the argument or group id
+    ///
+    /// *NOTE:* This will always return `true` if [`default_value`] has been set.
+    /// [`ArgMatches::value_source`] can be used to check if a value is present at runtime.
+    ///
+    /// # Panics
+    ///
+    /// If `id` is is not a valid argument or group name.  To handle this case programmatically, see
+    /// [`ArgMatches::try_contains_id`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::{Command, Arg};
+    /// let m = Command::new("myprog")
+    ///     .arg(Arg::new("debug")
+    ///         .short('d'))
+    ///     .get_matches_from(vec![
+    ///         "myprog", "-d"
+    ///     ]);
+    ///
+    /// assert!(m.contains_id("debug"));
+    /// ```
+    ///
+    /// [`default_value`]: crate::Arg::default_value()
+    pub fn contains_id(&self, id: &str) -> bool {
+        let internal_id = Id::from(id);
+        MatchesError::unwrap(&internal_id, self.try_contains_id(id))
+    }
+
     /// Check if any args were present on the command line
     ///
     /// # Examples
@@ -1100,6 +1130,16 @@ impl ArgMatches {
             len,
         };
         Ok(Some(values))
+    }
+
+    /// Non-panicking version of [`ArgMatches::contains_id`]
+    pub fn try_contains_id(&self, id: &str) -> Result<bool, MatchesError> {
+        let id = Id::from(id);
+
+        self.verify_arg(&id)?;
+
+        let presence = self.args.contains_key(&id);
+        Ok(presence)
     }
 }
 

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -53,10 +53,10 @@ use crate::INTERNAL_ERROR_MSG;
 /// // used at runtime.
 /// println!("Value for --output: {}", matches.get_one::<String>("out").unwrap());
 ///
-/// // You can check the presence of an argument
-/// if matches.is_present("out") {
+/// // You can check the presence of an argument's values
+/// if matches.contains_id("out") {
 ///     // However, if you want to know where the value came from
-///     if matches.value_source("out").expect("checked is_present") == ValueSource::CommandLine {
+///     if matches.value_source("out").expect("checked contains_id") == ValueSource::CommandLine {
 ///         println!("`out` set by user");
 ///     } else {
 ///         println!("`out` is defaulted");
@@ -521,30 +521,12 @@ impl ArgMatches {
         self.values_of_t(name).unwrap_or_else(|e| e.exit())
     }
 
-    /// Check if an argument was present at runtime.
-    ///
-    /// *NOTE:* This will always return `true` if [`default_value`] has been set.
-    /// [`ArgMatches::value_source`] can be used to check if a value is present at runtime.
-    ///
-    /// # Panics
-    ///
-    /// If `id` is is not a valid argument or group name.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{Command, Arg};
-    /// let m = Command::new("myprog")
-    ///     .arg(Arg::new("debug")
-    ///         .short('d'))
-    ///     .get_matches_from(vec![
-    ///         "myprog", "-d"
-    ///     ]);
-    ///
-    /// assert!(m.is_present("debug"));
-    /// ```
-    ///
-    /// [`default_value`]: crate::Arg::default_value()
+    /// Deprecated, replaced with [`ArgMatches::contains_id`] or
+    /// [`ArgAction::SetTrue`][crate::ArgAction].
+    #[deprecated(
+        since = "3.2.0",
+        note = "Replaced with either `ArgMatches::contains_id(...)` or `ArgAction::SetTrue`"
+    )]
     pub fn is_present<T: Key>(&self, id: T) -> bool {
         let id = Id::from(id);
 
@@ -963,10 +945,12 @@ impl ArgMatches {
     /// # Examples
     ///
     /// ```rust
-    /// # use clap::{Command, Arg, };
+    /// # use clap::{Command, Arg, ArgAction};
     /// let app_m = Command::new("myprog")
     ///     .arg(Arg::new("debug")
-    ///         .short('d'))
+    ///         .short('d')
+    ///         .action(ArgAction::SetTrue)
+    ///     )
     ///     .subcommand(Command::new("test")
     ///         .arg(Arg::new("opt")
     ///             .long("option")
@@ -976,7 +960,7 @@ impl ArgMatches {
     ///     ]);
     ///
     /// // Both parent commands, and child subcommands can have arguments present at the same times
-    /// assert!(app_m.is_present("debug"));
+    /// assert!(*app_m.get_one::<bool>("debug").expect("defaulted by clap"));
     ///
     /// // Get the subcommand's ArgMatches instance
     /// if let Some(sub_m) = app_m.subcommand_matches("test") {

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -10,7 +10,7 @@ fn set() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(matches.get_one::<String>("mammal"), None);
-    assert_eq!(matches.is_present("mammal"), false);
+    assert_eq!(matches.contains_id("mammal"), false);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -22,7 +22,7 @@ fn set() {
         .try_get_matches_from(["test", "--mammal", "dog"])
         .unwrap();
     assert_eq!(matches.get_one::<String>("mammal").unwrap(), "dog");
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -34,7 +34,7 @@ fn set() {
         .try_get_matches_from(["test", "--mammal", "dog", "--mammal", "cat"])
         .unwrap();
     assert_eq!(matches.get_one::<String>("mammal").unwrap(), "cat");
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -48,7 +48,7 @@ fn append() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(matches.get_one::<String>("mammal"), None);
-    assert_eq!(matches.is_present("mammal"), false);
+    assert_eq!(matches.contains_id("mammal"), false);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -60,7 +60,7 @@ fn append() {
         .try_get_matches_from(["test", "--mammal", "dog"])
         .unwrap();
     assert_eq!(matches.get_one::<String>("mammal").unwrap(), "dog");
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -82,7 +82,7 @@ fn append() {
             .collect::<Vec<_>>(),
         vec!["dog", "cat"]
     );
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -100,7 +100,7 @@ fn set_true() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -112,7 +112,7 @@ fn set_true() {
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -124,7 +124,7 @@ fn set_true() {
         .try_get_matches_from(["test", "--mammal", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -146,7 +146,7 @@ fn set_true_with_explicit_default_value() {
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -155,7 +155,7 @@ fn set_true_with_explicit_default_value() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -257,7 +257,7 @@ fn set_false() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -269,7 +269,7 @@ fn set_false() {
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -281,7 +281,7 @@ fn set_false() {
         .try_get_matches_from(["test", "--mammal", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -303,7 +303,7 @@ fn set_false_with_explicit_default_value() {
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), false);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -312,7 +312,7 @@ fn set_false_with_explicit_default_value() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(*matches.get_one::<bool>("mammal").unwrap(), true);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -380,7 +380,7 @@ fn count() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 0);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -392,7 +392,7 @@ fn count() {
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -404,7 +404,7 @@ fn count() {
         .try_get_matches_from(["test", "--mammal", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 2);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -426,7 +426,7 @@ fn count_with_explicit_default_value() {
         .try_get_matches_from(["test", "--mammal"])
         .unwrap();
     assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 1);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);
@@ -435,7 +435,7 @@ fn count_with_explicit_default_value() {
 
     let matches = cmd.clone().try_get_matches_from(["test"]).unwrap();
     assert_eq!(*matches.get_one::<u8>("mammal").unwrap(), 10);
-    assert_eq!(matches.is_present("mammal"), true);
+    assert_eq!(matches.contains_id("mammal"), true);
     #[allow(deprecated)]
     {
         assert_eq!(matches.occurrences_of("mammal"), 0);

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, Arg, Command};
+use clap::{arg, Arg, ArgAction, Command};
 
 static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
@@ -41,7 +41,7 @@ fn single_alias_of_option() {
         .try_get_matches_from(vec!["", "--new-opt", "cool"]);
     assert!(a.is_ok(), "{}", a.unwrap_err());
     let a = a.unwrap();
-    assert!(a.is_present("alias"));
+    assert!(a.contains_id("alias"));
     assert_eq!(
         a.get_one::<String>("alias").map(|v| v.as_str()).unwrap(),
         "cool"
@@ -81,10 +81,10 @@ fn multiple_aliases_of_option() {
     assert!(als3.is_ok(), "{}", als3.unwrap_err());
     let als3 = als3.unwrap();
 
-    assert!(long.is_present("aliases"));
-    assert!(als1.is_present("aliases"));
-    assert!(als2.is_present("aliases"));
-    assert!(als3.is_present("aliases"));
+    assert!(long.contains_id("aliases"));
+    assert!(als1.contains_id("aliases"));
+    assert!(als2.contains_id("aliases"));
+    assert!(als3.contains_id("aliases"));
     assert_eq!(
         long.get_one::<String>("aliases")
             .map(|v| v.as_str())
@@ -114,22 +114,26 @@ fn multiple_aliases_of_option() {
 #[test]
 fn single_alias_of_flag() {
     let a = Command::new("test")
-        .arg(Arg::new("flag").long("flag").alias("alias"))
+        .arg(
+            Arg::new("flag")
+                .long("flag")
+                .alias("alias")
+                .action(ArgAction::SetTrue),
+        )
         .try_get_matches_from(vec!["", "--alias"]);
     assert!(a.is_ok(), "{}", a.unwrap_err());
     let a = a.unwrap();
-    assert!(a.is_present("flag"));
+    assert!(*a.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
 fn multiple_aliases_of_flag() {
-    let a = Command::new("test").arg(Arg::new("flag").long("flag").aliases(&[
-        "invisible",
-        "set",
-        "of",
-        "cool",
-        "aliases",
-    ]));
+    let a = Command::new("test").arg(
+        Arg::new("flag")
+            .long("flag")
+            .aliases(&["invisible", "set", "of", "cool", "aliases"])
+            .action(ArgAction::SetTrue),
+    );
 
     let flag = a.clone().try_get_matches_from(vec!["", "--flag"]);
     assert!(flag.is_ok(), "{}", flag.unwrap_err());
@@ -147,10 +151,10 @@ fn multiple_aliases_of_flag() {
     assert!(als.is_ok(), "{}", als.unwrap_err());
     let als = als.unwrap();
 
-    assert!(flag.is_present("flag"));
-    assert!(inv.is_present("flag"));
-    assert!(cool.is_present("flag"));
-    assert!(als.is_present("flag"));
+    assert!(*flag.get_one::<bool>("flag").expect("defaulted by clap"));
+    assert!(*inv.get_one::<bool>("flag").expect("defaulted by clap"));
+    assert!(*cool.get_one::<bool>("flag").expect("defaulted by clap"));
+    assert!(*als.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
@@ -172,7 +176,7 @@ fn alias_on_a_subcommand_option() {
 
     assert!(m.subcommand_matches("some").is_some());
     let sub_m = m.subcommand_matches("some").unwrap();
-    assert!(sub_m.is_present("test"));
+    assert!(sub_m.contains_id("test"));
     assert_eq!(
         sub_m.get_one::<String>("test").map(|v| v.as_str()).unwrap(),
         "awesome"

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, Arg, Command};
+use clap::{arg, Arg, ArgAction, Command};
 
 static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
@@ -41,7 +41,7 @@ fn single_short_alias_of_option() {
         .try_get_matches_from(vec!["", "-a", "cool"]);
     assert!(a.is_ok(), "{}", a.unwrap_err());
     let a = a.unwrap();
-    assert!(a.is_present("alias"));
+    assert!(a.contains_id("alias"));
     assert_eq!(
         a.get_one::<String>("alias").map(|v| v.as_str()).unwrap(),
         "cool"
@@ -75,10 +75,10 @@ fn multiple_short_aliases_of_option() {
     assert!(als3.is_ok(), "{}", als3.unwrap_err());
     let als3 = als3.unwrap();
 
-    assert!(long.is_present("aliases"));
-    assert!(als1.is_present("aliases"));
-    assert!(als2.is_present("aliases"));
-    assert!(als3.is_present("aliases"));
+    assert!(long.contains_id("aliases"));
+    assert!(als1.contains_id("aliases"));
+    assert!(als2.contains_id("aliases"));
+    assert!(als3.contains_id("aliases"));
     assert_eq!(
         long.get_one::<String>("aliases")
             .map(|v| v.as_str())
@@ -108,11 +108,16 @@ fn multiple_short_aliases_of_option() {
 #[test]
 fn single_short_alias_of_flag() {
     let a = Command::new("test")
-        .arg(Arg::new("flag").long("flag").short_alias('f'))
+        .arg(
+            Arg::new("flag")
+                .long("flag")
+                .short_alias('f')
+                .action(ArgAction::SetTrue),
+        )
         .try_get_matches_from(vec!["", "-f"]);
     assert!(a.is_ok(), "{}", a.unwrap_err());
     let a = a.unwrap();
-    assert!(a.is_present("flag"));
+    assert!(*a.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
@@ -120,7 +125,8 @@ fn multiple_short_aliases_of_flag() {
     let a = Command::new("test").arg(
         Arg::new("flag")
             .long("flag")
-            .short_aliases(&['a', 'b', 'c', 'd', 'e']),
+            .short_aliases(&['a', 'b', 'c', 'd', 'e'])
+            .action(ArgAction::SetTrue),
     );
 
     let flag = a.clone().try_get_matches_from(vec!["", "--flag"]);
@@ -139,10 +145,10 @@ fn multiple_short_aliases_of_flag() {
     assert!(als3.is_ok(), "{}", als3.unwrap_err());
     let als3 = als3.unwrap();
 
-    assert!(flag.is_present("flag"));
-    assert!(als1.is_present("flag"));
-    assert!(als2.is_present("flag"));
-    assert!(als3.is_present("flag"));
+    assert!(*flag.get_one::<bool>("flag").expect("defaulted by clap"));
+    assert!(*als1.get_one::<bool>("flag").expect("defaulted by clap"));
+    assert!(*als2.get_one::<bool>("flag").expect("defaulted by clap"));
+    assert!(*als3.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
@@ -168,7 +174,7 @@ fn short_alias_on_a_subcommand_option() {
 
     assert!(m.subcommand_matches("some").is_some());
     let sub_m = m.subcommand_matches("some").unwrap();
-    assert!(sub_m.is_present("test"));
+    assert!(sub_m.contains_id("test"));
     assert_eq!(
         sub_m.get_one::<String>("test").map(|v| v.as_str()).unwrap(),
         "awesome"

--- a/tests/builder/arg_matcher_assertions.rs
+++ b/tests/builder/arg_matcher_assertions.rs
@@ -1,17 +1,17 @@
 #[cfg(debug_assertions)]
-use clap::{Arg, Command};
+use clap::{Arg, ArgAction, Command};
 
 #[test]
 #[cfg(debug_assertions)]
-#[should_panic = "`f` is not a name of an argument or a group."]
+#[should_panic = "Unknown argument or group id.  Make sure you are using the argument id and not the short or long flags"]
 fn arg_matches_if_present_wrong_arg() {
     let m = Command::new("test")
-        .arg(Arg::new("flag").short('f'))
+        .arg(Arg::new("flag").short('f').action(ArgAction::SetTrue))
         .try_get_matches_from(&["test", "-f"])
         .unwrap();
 
-    assert!(m.is_present("flag"));
-    m.is_present("f");
+    assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
+    m.contains_id("f");
 }
 
 #[test]

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, error::ErrorKind, Arg, ArgGroup, Command};
+use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgGroup, Command};
 
 static CONFLICT_ERR: &str = "error: The argument '--flag' cannot be used with '-F'
 
@@ -443,7 +443,11 @@ fn conflict_with_unused_default() {
                 .required(false)
                 .default_value("default"),
         )
-        .arg(arg!(-f --flag "some flag").conflicts_with("opt"))
+        .arg(
+            arg!(-f --flag "some flag")
+                .conflicts_with("opt")
+                .action(ArgAction::SetTrue),
+        )
         .try_get_matches_from(vec!["myprog", "-f"]);
 
     assert!(result.is_ok(), "{}", result.unwrap_err());
@@ -453,7 +457,7 @@ fn conflict_with_unused_default() {
         m.get_one::<String>("opt").map(|v| v.as_str()),
         Some("default")
     );
-    assert!(m.is_present("flag"));
+    assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
@@ -465,7 +469,7 @@ fn conflicts_with_alongside_default() {
                 .required(false)
                 .conflicts_with("flag"),
         )
-        .arg(arg!(-f --flag "some flag"))
+        .arg(arg!(-f --flag "some flag").action(ArgAction::SetTrue))
         .try_get_matches_from(vec!["myprog", "-f"]);
 
     assert!(
@@ -479,7 +483,7 @@ fn conflicts_with_alongside_default() {
         m.get_one::<String>("opt").map(|v| v.as_str()),
         Some("default")
     );
-    assert!(m.is_present("flag"));
+    assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
@@ -491,7 +495,12 @@ fn group_in_conflicts_with() {
                 .default_value("default")
                 .group("one"),
         )
-        .arg(Arg::new("flag").long("flag").conflicts_with("one"))
+        .arg(
+            Arg::new("flag")
+                .long("flag")
+                .conflicts_with("one")
+                .action(ArgAction::SetTrue),
+        )
         .try_get_matches_from(vec!["myprog", "--flag"]);
 
     assert!(
@@ -505,7 +514,7 @@ fn group_in_conflicts_with() {
         m.get_one::<String>("opt").map(|v| v.as_str()),
         Some("default")
     );
-    assert!(m.is_present("flag"));
+    assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
@@ -517,7 +526,12 @@ fn group_conflicts_with_default_value() {
                 .default_value("default")
                 .group("one"),
         )
-        .arg(Arg::new("flag").long("flag").group("one"))
+        .arg(
+            Arg::new("flag")
+                .long("flag")
+                .group("one")
+                .action(ArgAction::SetTrue),
+        )
         .try_get_matches_from(vec!["myprog", "--flag"]);
 
     assert!(
@@ -531,14 +545,19 @@ fn group_conflicts_with_default_value() {
         m.get_one::<String>("opt").map(|v| v.as_str()),
         Some("default")
     );
-    assert!(m.is_present("flag"));
+    assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]
 fn group_conflicts_with_default_arg() {
     let result = Command::new("conflict")
         .arg(Arg::new("opt").long("opt").default_value("default"))
-        .arg(Arg::new("flag").long("flag").group("one"))
+        .arg(
+            Arg::new("flag")
+                .long("flag")
+                .group("one")
+                .action(ArgAction::SetTrue),
+        )
         .group(ArgGroup::new("one").conflicts_with("opt"))
         .try_get_matches_from(vec!["myprog", "--flag"]);
 
@@ -553,7 +572,7 @@ fn group_conflicts_with_default_arg() {
         m.get_one::<String>("opt").map(|v| v.as_str()),
         Some("default")
     );
-    assert!(m.is_present("flag"));
+    assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]

--- a/tests/builder/default_missing_vals.rs
+++ b/tests/builder/default_missing_vals.rs
@@ -14,15 +14,11 @@ fn opt_missing() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "auto"
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("color"), 0);
-    }
     assert_eq!(
         m.value_source("color").unwrap(),
         clap::ValueSource::DefaultValue
@@ -44,15 +40,11 @@ fn opt_present_with_missing_value() {
         .try_get_matches_from(vec!["", "--color"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "always"
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("color"), 1);
-    }
     assert_eq!(
         m.value_source("color").unwrap(),
         clap::ValueSource::CommandLine
@@ -74,15 +66,11 @@ fn opt_present_with_value() {
         .try_get_matches_from(vec!["", "--color=never"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "never"
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("color"), 1);
-    }
     assert_eq!(
         m.value_source("color").unwrap(),
         clap::ValueSource::CommandLine
@@ -103,15 +91,11 @@ fn opt_present_with_empty_value() {
         .try_get_matches_from(vec!["", "--color="]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         ""
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("color"), 1);
-    }
     assert_eq!(
         m.value_source("color").unwrap(),
         clap::ValueSource::CommandLine
@@ -133,7 +117,7 @@ fn opt_default() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_one::<String>("o").map(|v| v.as_str()).unwrap(),
         "default"
@@ -152,7 +136,7 @@ fn opt_default_user_override() {
         .try_get_matches_from(vec!["", "-o=value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_one::<String>("o").map(|v| v.as_str()).unwrap(),
         "value"
@@ -171,15 +155,11 @@ fn default_missing_value_flag_value() {
     );
 
     let m = cmd.clone().try_get_matches_from(&["test"]).unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()),
         Some("false")
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("flag"), 0);
-    }
     assert_eq!(
         m.value_source("flag").unwrap(),
         clap::ValueSource::DefaultValue
@@ -189,15 +169,11 @@ fn default_missing_value_flag_value() {
         .clone()
         .try_get_matches_from(&["test", "--flag"])
         .unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()),
         Some("true")
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("flag"), 1);
-    }
     assert_eq!(
         m.value_source("flag").unwrap(),
         clap::ValueSource::CommandLine
@@ -207,30 +183,22 @@ fn default_missing_value_flag_value() {
         .clone()
         .try_get_matches_from(&["test", "--flag=true"])
         .unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()),
         Some("true")
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("flag"), 1);
-    }
     assert_eq!(
         m.value_source("flag").unwrap(),
         clap::ValueSource::CommandLine
     );
 
     let m = cmd.try_get_matches_from(&["test", "--flag=false"]).unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()),
         Some("false")
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("flag"), 1);
-    }
     assert_eq!(
         m.value_source("flag").unwrap(),
         clap::ValueSource::CommandLine
@@ -257,10 +225,6 @@ fn delimited_missing_value() {
             .collect::<Vec<_>>(),
         vec!["one", "two"]
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("flag"), 0);
-    }
 
     let m = cmd.try_get_matches_from(["test", "--flag"]).unwrap();
     assert_eq!(
@@ -270,10 +234,6 @@ fn delimited_missing_value() {
             .collect::<Vec<_>>(),
         vec!["three", "four"]
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("flag"), 1);
-    }
 }
 
 #[cfg(debug_assertions)]
@@ -320,15 +280,11 @@ fn valid_index() {
         .arg(Arg::new("sync").long("sync"))
         .try_get_matches_from(vec!["df", "--color", "--sync"])
         .unwrap();
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "always"
     );
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("color"), 1);
-    }
     assert_eq!(
         m.value_source("color").unwrap(),
         clap::ValueSource::CommandLine

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -12,7 +12,7 @@ fn opts() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_one::<String>("o").map(|v| v.as_str()).unwrap(),
         "default"
@@ -62,7 +62,7 @@ fn opt_user_override() {
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("opt"));
+    assert!(m.contains_id("opt"));
     assert_eq!(
         m.get_one::<String>("opt").map(|v| v.as_str()).unwrap(),
         "value"
@@ -76,7 +76,7 @@ fn positionals() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "default"
@@ -90,7 +90,7 @@ fn positional_user_override() {
         .try_get_matches_from(vec!["", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "value"
@@ -113,7 +113,7 @@ fn osstr_opts() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_one::<String>("o").map(|v| v.as_str()).unwrap(),
         expected
@@ -134,7 +134,7 @@ fn osstr_opt_user_override() {
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("opt"));
+    assert!(m.contains_id("opt"));
     assert_eq!(
         m.get_one::<String>("opt").map(|v| v.as_str()).unwrap(),
         "value"
@@ -151,7 +151,7 @@ fn osstr_positionals() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         expected
@@ -168,7 +168,7 @@ fn osstr_positional_user_override() {
         .try_get_matches_from(vec!["", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "value"
@@ -185,7 +185,7 @@ fn default_if_arg_present_no_default() {
         .try_get_matches_from(vec!["", "--opt", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "default"
@@ -200,7 +200,7 @@ fn default_if_arg_present_no_default_user_override() {
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -219,7 +219,7 @@ fn default_if_arg_present_no_arg_with_default() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "first"
@@ -238,7 +238,7 @@ fn default_if_arg_present_with_default() {
         .try_get_matches_from(vec!["", "--opt", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "default"
@@ -257,7 +257,7 @@ fn default_if_arg_present_with_default_user_override() {
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -276,7 +276,7 @@ fn default_if_arg_present_no_arg_with_default_user_override() {
         .try_get_matches_from(vec!["", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -293,7 +293,7 @@ fn default_if_arg_present_with_value_no_default() {
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "default"
@@ -308,7 +308,7 @@ fn default_if_arg_present_with_value_no_default_fail() {
         .try_get_matches_from(vec!["", "--opt", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(!m.is_present("arg"));
+    assert!(!m.contains_id("arg"));
     assert!(m.get_one::<String>("arg").map(|v| v.as_str()).is_none());
 }
 
@@ -320,7 +320,7 @@ fn default_if_arg_present_with_value_no_default_user_override() {
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -339,7 +339,7 @@ fn default_if_arg_present_with_value_no_arg_with_default() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "first"
@@ -358,7 +358,7 @@ fn default_if_arg_present_with_value_no_arg_with_default_fail() {
         .try_get_matches_from(vec!["", "--opt", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "first"
@@ -377,7 +377,7 @@ fn default_if_arg_present_with_value_with_default() {
         .try_get_matches_from(vec!["", "--opt", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "default"
@@ -396,7 +396,7 @@ fn default_if_arg_present_with_value_with_default_user_override() {
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -415,7 +415,7 @@ fn default_if_arg_present_no_arg_with_value_with_default_user_override() {
         .try_get_matches_from(vec!["", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -434,7 +434,7 @@ fn default_if_arg_present_no_arg_with_value_with_default_user_override_fail() {
         .try_get_matches_from(vec!["", "--opt", "value", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -451,7 +451,7 @@ fn no_default_if_arg_present_with_value_no_default() {
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(!m.is_present("arg"));
+    assert!(!m.contains_id("arg"));
 }
 
 #[test]
@@ -466,7 +466,7 @@ fn no_default_if_arg_present_with_value_with_default() {
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(!m.is_present("arg"));
+    assert!(!m.contains_id("arg"));
     assert!(m.get_one::<String>("arg").map(|v| v.as_str()).is_none());
 }
 
@@ -482,7 +482,7 @@ fn no_default_if_arg_present_with_value_with_default_user_override() {
         .try_get_matches_from(vec!["", "--opt", "value", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "other"
@@ -501,7 +501,7 @@ fn no_default_if_arg_present_no_arg_with_value_with_default() {
         .try_get_matches_from(vec!["", "--opt", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "default"
@@ -526,7 +526,7 @@ fn default_ifs_arg_present() {
         .try_get_matches_from(vec!["", "--flag"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "flg"
@@ -546,7 +546,7 @@ fn no_default_ifs_arg_present() {
         .try_get_matches_from(vec!["", "--flag"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(!m.is_present("arg"));
+    assert!(!m.contains_id("arg"));
     assert!(m.get_one::<String>("arg").map(|v| v.as_str()).is_none());
 }
 
@@ -566,7 +566,7 @@ fn default_ifs_arg_present_user_override() {
         .try_get_matches_from(vec!["", "--flag", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "value"
@@ -589,7 +589,7 @@ fn default_ifs_arg_present_order() {
         .try_get_matches_from(vec!["", "--opt=some", "--flag"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "default"
@@ -645,7 +645,7 @@ fn multiple_defaults() {
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("files"));
+    assert!(m.contains_id("files"));
     assert_eq!(
         m.get_many::<String>("files").unwrap().collect::<Vec<_>>(),
         vec!["old", "new"]
@@ -664,7 +664,7 @@ fn multiple_defaults_override() {
         .try_get_matches_from(vec!["", "--files", "other", "mine"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("files"));
+    assert!(m.contains_id("files"));
     assert_eq!(
         m.get_many::<String>("files").unwrap().collect::<Vec<_>>(),
         vec!["other", "mine"]

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -716,27 +716,37 @@ fn issue_1050_num_vals_and_defaults() {
     );
 }
 
-#[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Argument group 'group' is required but all of it's arguments have a default value."]
 fn required_groups_with_default_values() {
     use clap::{Arg, ArgGroup, Command};
 
-    let _ = Command::new("test")
+    let cmd = Command::new("test")
         .arg(Arg::new("arg").default_value("value"))
-        .group(ArgGroup::new("group").args(&["arg"]).required(true))
-        .try_get_matches();
+        .group(ArgGroup::new("group").args(&["arg"]).required(true));
+
+    let result = cmd.clone().try_get_matches_from(&["test"]);
+    assert!(result.is_err());
+
+    let result = cmd.clone().try_get_matches_from(&["test", "value"]);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+    let m = result.unwrap();
+    assert!(m.contains_id("arg"));
+    assert!(m.contains_id("group"));
 }
 
-#[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Argument 'arg' is required and can't have a default value"]
 fn required_args_with_default_values() {
     use clap::{Arg, Command};
 
-    let _ = Command::new("test")
-        .arg(Arg::new("arg").required(true).default_value("value"))
-        .try_get_matches();
+    let cmd = Command::new("test").arg(Arg::new("arg").required(true).default_value("value"));
+
+    let result = cmd.clone().try_get_matches_from(&["test"]);
+    assert!(result.is_err());
+
+    let result = cmd.clone().try_get_matches_from(&["test", "value"]);
+    assert!(result.is_ok(), "{}", result.unwrap_err());
+    let m = result.unwrap();
+    assert!(m.contains_id("arg"));
 }
 
 #[cfg(debug_assertions)]

--- a/tests/builder/delimiters.rs
+++ b/tests/builder/delimiters.rs
@@ -9,11 +9,7 @@ fn opt_default_no_delim() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("option"), 1);
-    }
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -29,11 +25,7 @@ fn opt_eq_no_delim() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("option"), 1);
-    }
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -49,11 +41,7 @@ fn opt_s_eq_no_delim() {
     assert!(m.is_ok(), "{:?}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("option"), 1);
-    }
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -69,11 +57,7 @@ fn opt_s_default_no_delim() {
     assert!(m.is_ok(), "{:?}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("option"), 1);
-    }
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -89,11 +73,7 @@ fn opt_s_no_space_no_delim() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("option"), 1);
-    }
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -114,11 +94,7 @@ fn opt_s_no_space_mult_no_delim() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("option"), 1);
-    }
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -140,11 +116,7 @@ fn opt_eq_mult_def_delim() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("option"), 1);
-    }
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()

--- a/tests/builder/env.rs
+++ b/tests/builder/env.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::ffi::OsStr;
 
-use clap::{arg, Arg, Command};
+use clap::{arg, builder::FalseyValueParser, Arg, ArgAction, Command};
 
 #[test]
 fn env() {
@@ -15,11 +15,7 @@ fn env() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "env"
@@ -32,21 +28,34 @@ fn env_bool_literal() {
     env::set_var("CLP_TEST_FLAG_FALSE", "nO");
 
     let r = Command::new("df")
-        .arg(Arg::new("present").short('p').env("CLP_TEST_FLAG_TRUE"))
-        .arg(Arg::new("negated").short('n').env("CLP_TEST_FLAG_FALSE"))
-        .arg(Arg::new("absent").short('a').env("CLP_TEST_FLAG_ABSENT"))
+        .arg(
+            Arg::new("present")
+                .short('p')
+                .env("CLP_TEST_FLAG_TRUE")
+                .action(ArgAction::SetTrue)
+                .value_parser(FalseyValueParser::new()),
+        )
+        .arg(
+            Arg::new("negated")
+                .short('n')
+                .env("CLP_TEST_FLAG_FALSE")
+                .action(ArgAction::SetTrue)
+                .value_parser(FalseyValueParser::new()),
+        )
+        .arg(
+            Arg::new("absent")
+                .short('a')
+                .env("CLP_TEST_FLAG_ABSENT")
+                .action(ArgAction::SetTrue)
+                .value_parser(FalseyValueParser::new()),
+        )
         .try_get_matches_from(vec![""]);
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("present"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("present"), 0);
-    }
-    assert_eq!(m.get_one::<String>("present").map(|v| v.as_str()), None);
-    assert!(!m.is_present("negated"));
-    assert!(!m.is_present("absent"));
+    assert!(*m.get_one::<bool>("present").expect("defaulted by clap"));
+    assert!(!*m.get_one::<bool>("negated").expect("defaulted by clap"));
+    assert!(!*m.get_one::<bool>("absent").expect("defaulted by clap"));
 }
 
 #[test]
@@ -63,11 +72,7 @@ fn env_os() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "env"
@@ -90,11 +95,7 @@ fn no_env() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(!m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(!m.contains_id("arg"));
     assert_eq!(m.get_one::<String>("arg").map(|v| v.as_str()), None);
 }
 
@@ -110,11 +111,7 @@ fn no_env_no_takes_value() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(!m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(!m.contains_id("arg"));
     assert_eq!(m.get_one::<String>("arg").map(|v| v.as_str()), None);
 }
 
@@ -133,11 +130,7 @@ fn with_default() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "env"
@@ -158,11 +151,7 @@ fn opt_user_override() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 1);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "opt"
@@ -191,11 +180,7 @@ fn positionals() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "env"
@@ -216,11 +201,7 @@ fn positionals_user_override() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 1);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "opt"
@@ -251,11 +232,7 @@ fn multiple_one() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_many::<String>("arg")
             .unwrap()
@@ -281,11 +258,7 @@ fn multiple_three() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_many::<String>("arg")
             .unwrap()
@@ -310,11 +283,7 @@ fn multiple_no_delimiter() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_many::<String>("arg")
             .unwrap()
@@ -339,11 +308,7 @@ fn possible_value() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "env"
@@ -387,11 +352,7 @@ fn value_parser() {
 
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("arg"), 0);
-    }
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_one::<String>("arg").map(|v| v.as_str()).unwrap(),
         "env"

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, error::ErrorKind, Arg, Command};
+use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 
 #[test]
 fn flag_subcommand_normal() {
@@ -10,14 +10,17 @@ fn flag_subcommand_normal() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .help("testing testing"),
+                    .help("testing testing")
+                    .action(ArgAction::SetTrue),
             ),
         )
         .try_get_matches_from(vec!["myprog", "some", "--test"])
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -31,7 +34,8 @@ fn flag_subcommand_normal_with_alias() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .help("testing testing"),
+                        .help("testing testing")
+                        .action(ArgAction::SetTrue),
                 )
                 .alias("result"),
         )
@@ -39,7 +43,9 @@ fn flag_subcommand_normal_with_alias() {
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -50,14 +56,17 @@ fn flag_subcommand_short() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .help("testing testing"),
+                    .help("testing testing")
+                    .action(ArgAction::SetTrue),
             ),
         )
         .try_get_matches_from(vec!["myprog", "-S", "--test"])
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -68,14 +77,17 @@ fn flag_subcommand_short_with_args() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .help("testing testing"),
+                    .help("testing testing")
+                    .action(ArgAction::SetTrue),
             ),
         )
         .try_get_matches_from(vec!["myprog", "-St"])
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -88,7 +100,8 @@ fn flag_subcommand_short_with_alias() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .help("testing testing"),
+                        .help("testing testing")
+                        .action(ArgAction::SetTrue),
                 )
                 .short_flag_alias('M')
                 .short_flag_alias('B'),
@@ -97,7 +110,9 @@ fn flag_subcommand_short_with_alias() {
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -159,7 +174,8 @@ fn flag_subcommand_short_with_aliases() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .help("testing testing"),
+                        .help("testing testing")
+                        .action(ArgAction::SetTrue),
                 )
                 .short_flag_aliases(&['M', 'B']),
         )
@@ -167,7 +183,9 @@ fn flag_subcommand_short_with_aliases() {
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -214,7 +232,7 @@ fn flag_subcommand_short_after_long_arg() {
         .subcommand(
             Command::new("sync")
                 .short_flag('S')
-                .arg(Arg::new("clean").short('c')),
+                .arg(Arg::new("clean").short('c').action(ArgAction::SetTrue)),
         )
         .arg(Arg::new("arg").long("arg").takes_value(true))
         .try_get_matches_from(vec!["pacman", "--arg", "foo", "-Sc"])
@@ -222,7 +240,7 @@ fn flag_subcommand_short_after_long_arg() {
     let subm = m.subcommand_matches("sync");
     assert!(subm.is_some());
     let subm = subm.unwrap();
-    assert!(subm.is_present("clean"));
+    assert!(*subm.get_one::<bool>("clean").expect("defaulted by clap"));
 }
 
 #[test]
@@ -233,14 +251,17 @@ fn flag_subcommand_long() {
                 Arg::new("test")
                     .short('t')
                     .long("test")
-                    .help("testing testing"),
+                    .help("testing testing")
+                    .action(ArgAction::SetTrue),
             ),
         )
         .try_get_matches_from(vec!["myprog", "--some", "--test"])
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -253,7 +274,8 @@ fn flag_subcommand_long_with_alias() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .help("testing testing"),
+                        .help("testing testing")
+                        .action(ArgAction::SetTrue),
                 )
                 .long_flag_alias("result"),
         )
@@ -261,7 +283,9 @@ fn flag_subcommand_long_with_alias() {
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -274,7 +298,8 @@ fn flag_subcommand_long_with_aliases() {
                     Arg::new("test")
                         .short('t')
                         .long("test")
-                        .help("testing testing"),
+                        .help("testing testing")
+                        .action(ArgAction::SetTrue),
                 )
                 .long_flag_aliases(&["result", "someall"]),
         )
@@ -282,7 +307,9 @@ fn flag_subcommand_long_with_aliases() {
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("test"));
+    assert!(*sub_matches
+        .get_one::<bool>("test")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -292,26 +319,34 @@ fn flag_subcommand_multiple() {
             Command::new("some")
                 .short_flag('S')
                 .long_flag("some")
-                .arg(arg!(-f --flag "some flag"))
-                .arg(arg!(-p --print "print something"))
+                .arg(arg!(-f --flag "some flag").action(ArgAction::SetTrue))
+                .arg(arg!(-p --print "print something").action(ArgAction::SetTrue))
                 .subcommand(
                     Command::new("result")
                         .short_flag('R')
                         .long_flag("result")
-                        .arg(arg!(-f --flag "some flag"))
-                        .arg(arg!(-p --print "print something")),
+                        .arg(arg!(-f --flag "some flag").action(ArgAction::SetTrue))
+                        .arg(arg!(-p --print "print something").action(ArgAction::SetTrue)),
                 ),
         )
         .try_get_matches_from(vec!["myprog", "-SfpRfp"])
         .unwrap();
     assert_eq!(matches.subcommand_name().unwrap(), "some");
     let sub_matches = matches.subcommand_matches("some").unwrap();
-    assert!(sub_matches.is_present("flag"));
-    assert!(sub_matches.is_present("print"));
+    assert!(*sub_matches
+        .get_one::<bool>("flag")
+        .expect("defaulted by clap"));
+    assert!(*sub_matches
+        .get_one::<bool>("print")
+        .expect("defaulted by clap"));
     assert_eq!(sub_matches.subcommand_name().unwrap(), "result");
     let result_matches = sub_matches.subcommand_matches("result").unwrap();
-    assert!(result_matches.is_present("flag"));
-    assert!(result_matches.is_present("print"));
+    assert!(*result_matches
+        .get_one::<bool>("flag")
+        .expect("defaulted by clap"));
+    assert!(*result_matches
+        .get_one::<bool>("print")
+        .expect("defaulted by clap"));
 }
 
 #[cfg(debug_assertions)]

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1688,9 +1688,21 @@ fn escaped_whitespace_values() {
 fn issue_1112_setup() -> Command<'static> {
     Command::new("test")
         .version("1.3")
-        .arg(Arg::new("help1").long("help").short('h').help("some help"))
+        .arg(
+            Arg::new("help1")
+                .long("help")
+                .short('h')
+                .help("some help")
+                .action(ArgAction::SetTrue),
+        )
         .subcommand(
-            Command::new("foo").arg(Arg::new("help1").long("help").short('h').help("some help")),
+            Command::new("foo").arg(
+                Arg::new("help1")
+                    .long("help")
+                    .short('h')
+                    .help("some help")
+                    .action(ArgAction::SetTrue),
+            ),
         )
 }
 
@@ -1699,7 +1711,8 @@ fn prefer_user_help_long_1112() {
     let m = issue_1112_setup().try_get_matches_from(vec!["test", "--help"]);
 
     assert!(m.is_ok(), "{}", m.unwrap_err());
-    assert!(m.unwrap().is_present("help1"));
+    let m = m.unwrap();
+    assert!(*m.get_one::<bool>("help1").expect("defaulted by clap"));
 }
 
 #[test]
@@ -1707,7 +1720,8 @@ fn prefer_user_help_short_1112() {
     let m = issue_1112_setup().try_get_matches_from(vec!["test", "-h"]);
 
     assert!(m.is_ok(), "{}", m.unwrap_err());
-    assert!(m.unwrap().is_present("help1"));
+    let m = m.unwrap();
+    assert!(*m.get_one::<bool>("help1").expect("defaulted by clap"));
 }
 
 #[test]
@@ -1715,11 +1729,12 @@ fn prefer_user_subcmd_help_long_1112() {
     let m = issue_1112_setup().try_get_matches_from(vec!["test", "foo", "--help"]);
 
     assert!(m.is_ok(), "{}", m.unwrap_err());
-    assert!(m
-        .unwrap()
+    let m = m.unwrap();
+    assert!(*m
         .subcommand_matches("foo")
         .unwrap()
-        .is_present("help1"));
+        .get_one::<bool>("help1")
+        .expect("defaulted by clap"));
 }
 
 #[test]
@@ -1727,11 +1742,12 @@ fn prefer_user_subcmd_help_short_1112() {
     let m = issue_1112_setup().try_get_matches_from(vec!["test", "foo", "-h"]);
 
     assert!(m.is_ok(), "{}", m.unwrap_err());
+    let m = m.unwrap();
     assert!(m
-        .unwrap()
         .subcommand_matches("foo")
         .unwrap()
-        .is_present("help1"));
+        .get_one::<bool>("help1")
+        .expect("defaulted by clap"));
 }
 
 #[test]

--- a/tests/builder/ignore_errors.rs
+++ b/tests/builder/ignore_errors.rs
@@ -1,4 +1,4 @@
-use clap::{arg, Arg, Command};
+use clap::{arg, Arg, ArgAction, Command};
 
 #[test]
 fn single_short_arg_without_value() {
@@ -10,7 +10,7 @@ fn single_short_arg_without_value() {
 
     assert!(r.is_ok(), "unexpected error: {:?}", r);
     let m = r.unwrap();
-    assert!(m.is_present("config"));
+    assert!(m.contains_id("config"));
 }
 
 #[test]
@@ -23,7 +23,7 @@ fn single_long_arg_without_value() {
 
     assert!(r.is_ok(), "unexpected error: {:?}", r);
     let m = r.unwrap();
-    assert!(m.is_present("config"));
+    assert!(m.contains_id("config"));
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn multiple_args_and_final_arg_without_value() {
         .arg(arg!(
             -x --stuff [FILE] "Sets a custom stuff file"
         ))
-        .arg(arg!(f: -f "Flag"));
+        .arg(arg!(f: -f "Flag").action(ArgAction::SetTrue));
 
     let r = cmd.try_get_matches_from(vec![
         "cmd", "-c", "file", "-f", "-x", /* missing: , "some stuff" */
@@ -48,7 +48,7 @@ fn multiple_args_and_final_arg_without_value() {
         m.get_one::<String>("config").map(|v| v.as_str()),
         Some("file")
     );
-    assert!(m.is_present("f"));
+    assert!(*m.get_one::<bool>("f").expect("defaulted by clap"));
     assert_eq!(m.get_one::<String>("stuff").map(|v| v.as_str()), None);
 }
 
@@ -62,7 +62,7 @@ fn multiple_args_and_intermittent_arg_without_value() {
         .arg(arg!(
             -x --stuff[FILE] "Sets a custom stuff file"
         ))
-        .arg(arg!(f: -f "Flag"));
+        .arg(arg!(f: -f "Flag").action(ArgAction::SetTrue));
 
     let r = cmd.try_get_matches_from(vec![
         "cmd", "-x", /* missing: ,"some stuff" */
@@ -75,7 +75,7 @@ fn multiple_args_and_intermittent_arg_without_value() {
         m.get_one::<String>("config").map(|v| v.as_str()),
         Some("file")
     );
-    assert!(m.is_present("f"));
+    assert!(*m.get_one::<bool>("f").expect("defaulted by clap"));
     assert_eq!(m.get_one::<String>("stuff").map(|v| v.as_str()), None);
 }
 
@@ -115,7 +115,7 @@ fn subcommand() {
     assert_eq!(m.subcommand_name().unwrap(), "some");
     let sub_m = m.subcommand_matches("some").unwrap();
     assert!(
-        sub_m.is_present("test"),
+        sub_m.contains_id("test"),
         "expected subcommand to be present due to partial parsing"
     );
     assert_eq!(sub_m.get_one::<String>("test").map(|v| v.as_str()), None);

--- a/tests/builder/legacy/default_vals.rs
+++ b/tests/builder/legacy/default_vals.rs
@@ -610,29 +610,6 @@ fn issue_1050_num_vals_and_defaults() {
 
 #[cfg(debug_assertions)]
 #[test]
-#[should_panic = "Argument group 'group' is required but all of it's arguments have a default value."]
-fn required_groups_with_default_values() {
-    use clap::{Arg, ArgGroup, Command};
-
-    let _ = Command::new("test")
-        .arg(Arg::new("arg").default_value("value"))
-        .group(ArgGroup::new("group").args(&["arg"]).required(true))
-        .try_get_matches();
-}
-
-#[cfg(debug_assertions)]
-#[test]
-#[should_panic = "Argument 'arg' is required and can't have a default value"]
-fn required_args_with_default_values() {
-    use clap::{Arg, Command};
-
-    let _ = Command::new("test")
-        .arg(Arg::new("arg").required(true).default_value("value"))
-        .try_get_matches();
-}
-
-#[cfg(debug_assertions)]
-#[test]
 #[should_panic = "Argument `arg`'s default_value=value doesn't match possible values"]
 fn default_values_are_possible_values() {
     use clap::{Arg, Command};

--- a/tests/builder/main.rs
+++ b/tests/builder/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::bool_assert_comparison)]
+
 mod action;
 mod app_from_crate;
 mod app_settings;

--- a/tests/builder/multiple_occurrences.rs
+++ b/tests/builder/multiple_occurrences.rs
@@ -7,9 +7,9 @@ fn multiple_occurrences_of_flags_long() {
         .arg(arg!(--flag "disallowed multiple flag").action(ArgAction::SetTrue))
         .try_get_matches_from(vec!["", "--multflag", "--flag", "--multflag"])
         .unwrap();
-    assert!(m.is_present("multflag"));
+    assert!(m.contains_id("multflag"));
     assert_eq!(m.get_one::<bool>("multflag").copied(), Some(true));
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(m.get_one::<bool>("flag").copied(), Some(true));
 }
 
@@ -20,9 +20,9 @@ fn multiple_occurrences_of_flags_short() {
         .arg(arg!(-f --flag "disallowed multiple flag").action(ArgAction::SetTrue))
         .try_get_matches_from(vec!["", "-m", "-f", "-m"])
         .unwrap();
-    assert!(m.is_present("multflag"));
+    assert!(m.contains_id("multflag"));
     assert_eq!(m.get_one::<bool>("multflag").copied(), Some(true));
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(m.get_one::<bool>("flag").copied(), Some(true));
 }
 
@@ -38,14 +38,14 @@ fn multiple_occurrences_of_positional() {
         .clone()
         .try_get_matches_from(&["test"])
         .expect("zero occurrences work");
-    assert!(!m.is_present("multi"));
+    assert!(!m.contains_id("multi"));
     assert!(m.get_many::<String>("multi").is_none());
 
     let m = cmd
         .clone()
         .try_get_matches_from(&["test", "one"])
         .expect("single occurrence work");
-    assert!(m.is_present("multi"));
+    assert!(m.contains_id("multi"));
     assert_eq!(
         m.get_many::<String>("multi")
             .unwrap()
@@ -58,7 +58,7 @@ fn multiple_occurrences_of_positional() {
         .clone()
         .try_get_matches_from(&["test", "one", "two", "three", "four"])
         .expect("many occurrences work");
-    assert!(m.is_present("multi"));
+    assert!(m.contains_id("multi"));
     assert_eq!(
         m.get_many::<String>("multi")
             .unwrap()
@@ -78,7 +78,7 @@ fn multiple_occurrences_of_flags_large_quantity() {
         .chain(vec!["-m"; 200].into_iter())
         .collect();
     let m = cmd.clone().try_get_matches_from(args).unwrap();
-    assert!(m.is_present("multflag"));
+    assert!(m.contains_id("multflag"));
     assert_eq!(m.get_one::<u8>("multflag").copied(), Some(200));
 
     let args: Vec<&str> = vec![""]
@@ -86,7 +86,7 @@ fn multiple_occurrences_of_flags_large_quantity() {
         .chain(vec!["-m"; 500].into_iter())
         .collect();
     let m = cmd.try_get_matches_from(args).unwrap();
-    assert!(m.is_present("multflag"));
+    assert!(m.contains_id("multflag"));
     assert_eq!(m.get_one::<u8>("multflag").copied(), Some(u8::MAX));
 }
 

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -18,7 +18,7 @@ fn option_long() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -44,7 +44,7 @@ fn option_short() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -73,7 +73,7 @@ fn option_mixed() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -98,7 +98,7 @@ fn option_exact_exact() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -122,7 +122,7 @@ fn option_exact_exact_not_mult() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -149,7 +149,7 @@ fn option_exact_exact_mult() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -208,7 +208,7 @@ fn option_min_exact() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -252,8 +252,8 @@ fn option_short_min_more_mult_occurs() {
     assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
     let m = res.unwrap();
 
-    assert!(m.is_present("option"));
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("option"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -279,8 +279,8 @@ fn option_short_min_more_single_occur() {
     assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
     let m = res.unwrap();
 
-    assert!(m.is_present("option"));
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("option"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -306,7 +306,7 @@ fn option_max_exact() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -331,7 +331,7 @@ fn option_max_less() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -373,7 +373,7 @@ fn positional() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("pos"));
+    assert!(m.contains_id("pos"));
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -396,7 +396,7 @@ fn positional_exact_exact() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("pos"));
+    assert!(m.contains_id("pos"));
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -443,7 +443,7 @@ fn positional_min_exact() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("pos"));
+    assert!(m.contains_id("pos"));
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -472,7 +472,7 @@ fn positional_min_more() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("pos"));
+    assert!(m.contains_id("pos"));
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -491,7 +491,7 @@ fn positional_max_exact() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("pos"));
+    assert!(m.contains_id("pos"));
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -510,7 +510,7 @@ fn positional_max_less() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("pos"));
+    assert!(m.contains_id("pos"));
     assert_eq!(
         m.get_many::<String>("pos")
             .unwrap()
@@ -544,7 +544,7 @@ fn sep_long_equals() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -568,7 +568,7 @@ fn sep_long_space() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -592,7 +592,7 @@ fn sep_short_equals() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -616,7 +616,7 @@ fn sep_short_space() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -640,7 +640,7 @@ fn sep_short_no_space() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -663,7 +663,7 @@ fn sep_positional() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -687,7 +687,7 @@ fn different_sep() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -710,7 +710,7 @@ fn different_sep_positional() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -735,7 +735,7 @@ fn no_sep() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -756,7 +756,7 @@ fn no_sep_positional() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()).unwrap(),
         "val1,val2,val3"
@@ -784,7 +784,7 @@ fn req_delimiter_long() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -822,7 +822,7 @@ fn req_delimiter_long_with_equal() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -860,7 +860,7 @@ fn req_delimiter_short_with_space() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -898,7 +898,7 @@ fn req_delimiter_short_with_no_space() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -936,7 +936,7 @@ fn req_delimiter_short_with_equal() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -1003,7 +1003,7 @@ fn req_delimiter_complex() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()
@@ -1105,7 +1105,7 @@ fn low_index_positional() {
     assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
-    assert!(m.is_present("files"));
+    assert!(m.contains_id("files"));
     assert_eq!(
         m.get_many::<String>("files")
             .unwrap()
@@ -1113,7 +1113,7 @@ fn low_index_positional() {
             .collect::<Vec<_>>(),
         ["file1", "file2", "file3"]
     );
-    assert!(m.is_present("target"));
+    assert!(m.contains_id("target"));
     assert_eq!(
         m.get_one::<String>("target").map(|v| v.as_str()).unwrap(),
         "target"
@@ -1140,7 +1140,7 @@ fn low_index_positional_in_subcmd() {
     let m = m.unwrap();
     let sm = m.subcommand_matches("test").unwrap();
 
-    assert!(sm.is_present("files"));
+    assert!(sm.contains_id("files"));
     assert_eq!(
         sm.get_many::<String>("files")
             .unwrap()
@@ -1148,7 +1148,7 @@ fn low_index_positional_in_subcmd() {
             .collect::<Vec<_>>(),
         ["file1", "file2", "file3"]
     );
-    assert!(sm.is_present("target"));
+    assert!(sm.contains_id("target"));
     assert_eq!(
         sm.get_one::<String>("target").map(|v| v.as_str()).unwrap(),
         "target"
@@ -1174,7 +1174,7 @@ fn low_index_positional_with_option() {
     assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
-    assert!(m.is_present("files"));
+    assert!(m.contains_id("files"));
     assert_eq!(
         m.get_many::<String>("files")
             .unwrap()
@@ -1182,7 +1182,7 @@ fn low_index_positional_with_option() {
             .collect::<Vec<_>>(),
         ["file1", "file2", "file3"]
     );
-    assert!(m.is_present("target"));
+    assert!(m.contains_id("target"));
     assert_eq!(
         m.get_one::<String>("target").map(|v| v.as_str()).unwrap(),
         "target"
@@ -1204,13 +1204,13 @@ fn low_index_positional_with_flag() {
                 .multiple_values(true),
         )
         .arg(Arg::new("target").index(2).required(true))
-        .arg(Arg::new("flg").long("flag"))
+        .arg(Arg::new("flg").long("flag").action(ArgAction::SetTrue))
         .try_get_matches_from(vec!["lip", "file1", "file2", "file3", "target", "--flag"]);
 
     assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
-    assert!(m.is_present("files"));
+    assert!(m.contains_id("files"));
     assert_eq!(
         m.get_many::<String>("files")
             .unwrap()
@@ -1218,12 +1218,12 @@ fn low_index_positional_with_flag() {
             .collect::<Vec<_>>(),
         ["file1", "file2", "file3"]
     );
-    assert!(m.is_present("target"));
+    assert!(m.contains_id("target"));
     assert_eq!(
         m.get_one::<String>("target").map(|v| v.as_str()).unwrap(),
         "target"
     );
-    assert!(m.is_present("flg"));
+    assert!(*m.get_one::<bool>("flg").expect("defaulted by clap"));
 }
 
 #[test]
@@ -1242,8 +1242,8 @@ fn multiple_value_terminator_option() {
     assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
-    assert!(m.is_present("other"));
-    assert!(m.is_present("files"));
+    assert!(m.contains_id("other"));
+    assert!(m.contains_id("files"));
     assert_eq!(
         m.get_many::<String>("files")
             .unwrap()
@@ -1268,14 +1268,14 @@ fn multiple_value_terminator_option_other_arg() {
                 .multiple_values(true),
         )
         .arg(Arg::new("other"))
-        .arg(Arg::new("flag").short('F'))
+        .arg(Arg::new("flag").short('F').action(ArgAction::SetTrue))
         .try_get_matches_from(vec!["lip", "-f", "val1", "val2", "-F", "otherval"]);
 
     assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
     let m = m.unwrap();
 
-    assert!(m.is_present("other"));
-    assert!(m.is_present("files"));
+    assert!(m.contains_id("other"));
+    assert!(m.contains_id("files"));
     assert_eq!(
         m.get_many::<String>("files")
             .unwrap()
@@ -1287,7 +1287,7 @@ fn multiple_value_terminator_option_other_arg() {
         m.get_one::<String>("other").map(|v| v.as_str()),
         Some("otherval")
     );
-    assert!(m.is_present("flag"));
+    assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
 }
 
 #[test]

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, error::ErrorKind, Arg, ArgMatches, Command};
+use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgMatches, Command};
 
 #[cfg(feature = "suggestions")]
 static DYM: &str =
@@ -78,7 +78,7 @@ fn require_equals_min_values_zero() {
         .try_get_matches_from(vec!["prog", "--config", "cmd"]);
     assert!(res.is_ok(), "{}", res.unwrap_err());
     let m = res.unwrap();
-    assert!(m.is_present("cfg"));
+    assert!(m.contains_id("cfg"));
     assert_eq!(m.get_one::<String>("cmd").map(|v| v.as_str()), Some("cmd"));
 }
 
@@ -148,7 +148,7 @@ fn stdin_char() {
         .try_get_matches_from(vec!["", "-f", "-"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("f"));
+    assert!(m.contains_id("f"));
     assert_eq!(m.get_one::<String>("f").map(|v| v.as_str()).unwrap(), "-");
 }
 
@@ -162,12 +162,12 @@ fn opts_using_short() {
         .try_get_matches_from(vec!["", "-f", "some", "-c", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("f"));
+    assert!(m.contains_id("f"));
     assert_eq!(
         m.get_one::<String>("f").map(|v| v.as_str()).unwrap(),
         "some"
     );
-    assert!(m.is_present("c"));
+    assert!(m.contains_id("c"));
     assert_eq!(
         m.get_one::<String>("c").map(|v| v.as_str()).unwrap(),
         "other"
@@ -210,7 +210,7 @@ fn lots_o_vals() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(m.get_many::<String>("o").unwrap().count(), 297); // i.e. more than u8
 }
 
@@ -224,12 +224,12 @@ fn opts_using_long_space() {
         .try_get_matches_from(vec!["", "--flag", "some", "--color", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()).unwrap(),
         "some"
     );
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "other"
@@ -246,12 +246,12 @@ fn opts_using_long_equals() {
         .try_get_matches_from(vec!["", "--flag=some", "--color=other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()).unwrap(),
         "some"
     );
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "other"
@@ -268,12 +268,12 @@ fn opts_using_mixed() {
         .try_get_matches_from(vec!["", "-f", "some", "--color", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()).unwrap(),
         "some"
     );
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "other"
@@ -290,12 +290,12 @@ fn opts_using_mixed2() {
         .try_get_matches_from(vec!["", "--flag=some", "-c", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("flag"));
+    assert!(m.contains_id("flag"));
     assert_eq!(
         m.get_one::<String>("flag").map(|v| v.as_str()).unwrap(),
         "some"
     );
-    assert!(m.is_present("color"));
+    assert!(m.contains_id("color"));
     assert_eq!(
         m.get_one::<String>("color").map(|v| v.as_str()).unwrap(),
         "other"
@@ -309,7 +309,7 @@ fn default_values_user_value() {
         .try_get_matches_from(vec!["", "-o", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_one::<String>("o").map(|v| v.as_str()).unwrap(),
         "value"
@@ -324,9 +324,9 @@ fn multiple_vals_pos_arg_equals() {
         .try_get_matches_from(vec!["", "-o=1", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(m.get_one::<String>("o").map(|v| v.as_str()).unwrap(), "1");
-    assert!(m.is_present("file"));
+    assert!(m.contains_id("file"));
     assert_eq!(
         m.get_one::<String>("file").map(|v| v.as_str()).unwrap(),
         "some"
@@ -345,7 +345,7 @@ fn multiple_vals_pos_arg_delim() {
         .try_get_matches_from(vec!["", "-o", "1,2", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_many::<String>("o")
             .unwrap()
@@ -353,7 +353,7 @@ fn multiple_vals_pos_arg_delim() {
             .collect::<Vec<_>>(),
         &["1", "2"]
     );
-    assert!(m.is_present("file"));
+    assert!(m.contains_id("file"));
     assert_eq!(
         m.get_one::<String>("file").map(|v| v.as_str()).unwrap(),
         "some"
@@ -388,7 +388,7 @@ fn require_delims() {
         .try_get_matches_from(vec!["", "-o", "1,2", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_many::<String>("o")
             .unwrap()
@@ -396,7 +396,7 @@ fn require_delims() {
             .collect::<Vec<_>>(),
         &["1", "2"]
     );
-    assert!(m.is_present("file"));
+    assert!(m.contains_id("file"));
     assert_eq!(
         m.get_one::<String>("file").map(|v| v.as_str()).unwrap(),
         "some"
@@ -414,7 +414,7 @@ fn leading_hyphen_pass() {
         .try_get_matches_from(vec!["", "-o", "-2", "3"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_many::<String>("o")
             .unwrap()
@@ -442,11 +442,11 @@ fn leading_hyphen_with_flag_after() {
                 .multiple_values(true)
                 .allow_hyphen_values(true),
         )
-        .arg(arg!(f: -f "some flag"))
+        .arg(arg!(f: -f "some flag").action(ArgAction::SetTrue))
         .try_get_matches_from(vec!["", "-o", "-2", "-f"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_many::<String>("o")
             .unwrap()
@@ -454,18 +454,18 @@ fn leading_hyphen_with_flag_after() {
             .collect::<Vec<_>>(),
         &["-2", "-f"]
     );
-    assert!(!m.is_present("f"));
+    assert!(!*m.get_one::<bool>("f").expect("defaulted by clap"));
 }
 
 #[test]
 fn leading_hyphen_with_flag_before() {
     let r = Command::new("mvae")
         .arg(arg!(o: -o [opt] ... "some opt").allow_hyphen_values(true))
-        .arg(arg!(f: -f "some flag"))
+        .arg(arg!(f: -f "some flag").action(ArgAction::SetTrue))
         .try_get_matches_from(vec!["", "-f", "-o", "-2"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_many::<String>("o")
             .unwrap()
@@ -473,7 +473,7 @@ fn leading_hyphen_with_flag_before() {
             .collect::<Vec<_>>(),
         &["-2"]
     );
-    assert!(m.is_present("f"));
+    assert!(*m.get_one::<bool>("f").expect("defaulted by clap"));
 }
 
 #[test]
@@ -489,7 +489,7 @@ fn leading_hyphen_with_only_pos_follows() {
         .try_get_matches_from(vec!["", "-o", "-2", "--", "val"]);
     assert!(r.is_ok(), "{:?}", r);
     let m = r.unwrap();
-    assert!(m.is_present("o"));
+    assert!(m.contains_id("o"));
     assert_eq!(
         m.get_many::<String>("o")
             .unwrap()
@@ -695,14 +695,21 @@ fn issue_2279() {
 fn infer_long_arg() {
     let cmd = Command::new("test")
         .infer_long_args(true)
-        .arg(Arg::new("racetrack").long("racetrack").alias("autobahn"))
+        .arg(
+            Arg::new("racetrack")
+                .long("racetrack")
+                .alias("autobahn")
+                .action(ArgAction::SetTrue),
+        )
         .arg(Arg::new("racecar").long("racecar").takes_value(true));
 
     let matches = cmd
         .clone()
         .try_get_matches_from(&["test", "--racec=hello"])
         .unwrap();
-    assert!(!matches.is_present("racetrack"));
+    assert!(!*matches
+        .get_one::<bool>("racetrack")
+        .expect("defaulted by clap"));
     assert_eq!(
         matches.get_one::<String>("racecar").map(|v| v.as_str()),
         Some("hello")
@@ -712,7 +719,9 @@ fn infer_long_arg() {
         .clone()
         .try_get_matches_from(&["test", "--racet"])
         .unwrap();
-    assert!(matches.is_present("racetrack"));
+    assert!(*matches
+        .get_one::<bool>("racetrack")
+        .expect("defaulted by clap"));
     assert_eq!(
         matches.get_one::<String>("racecar").map(|v| v.as_str()),
         None
@@ -722,7 +731,9 @@ fn infer_long_arg() {
         .clone()
         .try_get_matches_from(&["test", "--auto"])
         .unwrap();
-    assert!(matches.is_present("racetrack"));
+    assert!(*matches
+        .get_one::<bool>("racetrack")
+        .expect("defaulted by clap"));
     assert_eq!(
         matches.get_one::<String>("racecar").map(|v| v.as_str()),
         None
@@ -730,11 +741,11 @@ fn infer_long_arg() {
 
     let cmd = Command::new("test")
         .infer_long_args(true)
-        .arg(Arg::new("arg").long("arg"));
+        .arg(Arg::new("arg").long("arg").action(ArgAction::SetTrue));
 
     let matches = cmd.clone().try_get_matches_from(&["test", "--"]).unwrap();
-    assert!(!matches.is_present("arg"));
+    assert!(!*matches.get_one::<bool>("arg").expect("defaulted by clap"));
 
     let matches = cmd.clone().try_get_matches_from(&["test", "--a"]).unwrap();
-    assert!(matches.is_present("arg"));
+    assert!(*matches.get_one::<bool>("arg").expect("defaulted by clap"));
 }

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -43,7 +43,7 @@ fn possible_values_of_positional() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("positional"));
+    assert!(m.contains_id("positional"));
     assert_eq!(
         m.get_one::<String>("positional").map(|v| v.as_str()),
         Some("test123")
@@ -65,7 +65,7 @@ fn possible_value_arg_value() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("arg_value"));
+    assert!(m.contains_id("arg_value"));
     assert_eq!(
         m.get_one::<String>("arg_value").map(|v| v.as_str()),
         Some("test123")
@@ -97,7 +97,7 @@ fn possible_values_of_positional_multiple() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("positional"));
+    assert!(m.contains_id("positional"));
     assert_eq!(
         m.get_many::<String>("positional")
             .unwrap()
@@ -138,7 +138,7 @@ fn possible_values_of_option() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_one::<String>("option").map(|v| v.as_str()),
         Some("test123")
@@ -177,7 +177,7 @@ fn possible_values_of_option_multiple() {
     assert!(m.is_ok(), "{}", m.unwrap_err());
     let m = m.unwrap();
 
-    assert!(m.is_present("option"));
+    assert!(m.contains_id("option"));
     assert_eq!(
         m.get_many::<String>("option")
             .unwrap()

--- a/tests/builder/propagate_globals.rs
+++ b/tests/builder/propagate_globals.rs
@@ -55,19 +55,19 @@ fn outer_can_access_arg<T: Into<Option<&'static str>>>(m: &ArgMatches, val: T) -
 }
 
 fn top_can_access_flag(m: &ArgMatches, present: bool, occurrences: u8) -> bool {
-    (m.is_present("GLOBAL_FLAG") == present)
+    (m.contains_id("GLOBAL_FLAG") == present)
         && (m.get_one::<u8>("GLOBAL_FLAG").copied() == Some(occurrences))
 }
 
 fn inner_can_access_flag(m: &ArgMatches, present: bool, occurrences: u8) -> bool {
     let m = get_inner_matches(m);
-    (m.is_present("GLOBAL_FLAG") == present)
+    (m.contains_id("GLOBAL_FLAG") == present)
         && (m.get_one::<u8>("GLOBAL_FLAG").copied() == Some(occurrences))
 }
 
 fn outer_can_access_flag(m: &ArgMatches, present: bool, occurrences: u8) -> bool {
     let m = get_outer_matches(m);
-    (m.is_present("GLOBAL_FLAG") == present)
+    (m.contains_id("GLOBAL_FLAG") == present)
         && (m.get_one::<u8>("GLOBAL_FLAG").copied() == Some(occurrences))
 }
 

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, error::ErrorKind, Arg, Command};
+use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 
 static VISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 
@@ -115,7 +115,7 @@ fn subcommand() {
 
     assert_eq!(m.subcommand_name().unwrap(), "some");
     let sub_m = m.subcommand_matches("some").unwrap();
-    assert!(sub_m.is_present("test"));
+    assert!(sub_m.contains_id("test"));
     assert_eq!(
         sub_m.get_one::<String>("test").map(|v| v.as_str()).unwrap(),
         "testing"
@@ -162,7 +162,7 @@ fn subcommand_multiple() {
     assert!(m.subcommand_matches("add").is_none());
     assert_eq!(m.subcommand_name().unwrap(), "some");
     let sub_m = m.subcommand_matches("some").unwrap();
-    assert!(sub_m.is_present("test"));
+    assert!(sub_m.contains_id("test"));
     assert_eq!(
         sub_m.get_one::<String>("test").map(|v| v.as_str()).unwrap(),
         "testing"
@@ -475,7 +475,7 @@ fn subcommand_after_argument_looks_like_help() {
 #[test]
 fn issue_2494_subcommand_is_present() {
     let cmd = Command::new("opt")
-        .arg(Arg::new("global").long("global"))
+        .arg(Arg::new("global").long("global").action(ArgAction::SetTrue))
         .subcommand(Command::new("global"));
 
     let m = cmd
@@ -483,18 +483,18 @@ fn issue_2494_subcommand_is_present() {
         .try_get_matches_from(&["opt", "--global", "global"])
         .unwrap();
     assert_eq!(m.subcommand_name().unwrap(), "global");
-    assert!(m.is_present("global"));
+    assert!(*m.get_one::<bool>("global").expect("defaulted by clap"));
 
     let m = cmd
         .clone()
         .try_get_matches_from(&["opt", "--global"])
         .unwrap();
     assert!(m.subcommand_name().is_none());
-    assert!(m.is_present("global"));
+    assert!(*m.get_one::<bool>("global").expect("defaulted by clap"));
 
     let m = cmd.try_get_matches_from(&["opt", "global"]).unwrap();
     assert_eq!(m.subcommand_name().unwrap(), "global");
-    assert!(!m.is_present("global"));
+    assert!(!*m.get_one::<bool>("global").expect("defaulted by clap"));
 }
 
 #[test]

--- a/tests/builder/tests.rs
+++ b/tests/builder/tests.rs
@@ -100,7 +100,7 @@ pub fn check_complex_output(args: &str, out: &str) {
         }
     }
 
-    if matches.is_present("option") {
+    if matches.contains_id("option") {
         if let Some(v) = matches.get_one::<String>("option").map(|v| v.as_str()) {
             writeln!(w, "option present with value: {}", v).unwrap();
         }
@@ -119,7 +119,7 @@ pub fn check_complex_output(args: &str, out: &str) {
         writeln!(w, "positional NOT present").unwrap();
     }
 
-    if matches.is_present("flag2") {
+    if *matches.get_one::<bool>("flag2").expect("defaulted by clap") {
         writeln!(w, "flag2 present").unwrap();
         writeln!(
             w,
@@ -181,7 +181,7 @@ pub fn check_complex_output(args: &str, out: &str) {
         _ => writeln!(w, "positional3 NOT present"),
     };
 
-    if matches.is_present("option") {
+    if matches.contains_id("option") {
         if let Some(v) = matches.get_one::<String>("option").map(|v| v.as_str()) {
             writeln!(w, "option present with value: {}", v).unwrap();
         }
@@ -211,7 +211,7 @@ pub fn check_complex_output(args: &str, out: &str) {
                 }
             }
 
-            if matches.is_present("option") {
+            if matches.contains_id("option") {
                 if let Some(v) = matches.get_one::<String>("option").map(|v| v.as_str()) {
                     writeln!(w, "scoption present with value: {}", v).unwrap();
                 }

--- a/tests/builder/utf16.rs
+++ b/tests/builder/utf16.rs
@@ -4,7 +4,7 @@
 
 #![cfg(windows)]
 
-use clap::{arg, Command};
+use clap::{arg, value_parser, Command};
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 
@@ -21,94 +21,20 @@ fn bad_osstring(ascii: &[u8]) -> OsString {
 }
 
 #[test]
-fn invalid_utf16_lossy_positional() {
-    let r = Command::new("bad_utf16")
-        .arg(arg!(<arg> "some arg").allow_invalid_utf8(true))
-        .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"")]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf16_lossy_option_short_space() {
-    let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
-        .try_get_matches_from(vec![
-            OsString::from(""),
-            OsString::from("-a"),
-            bad_osstring(b""),
-        ]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf16_lossy_option_short_equals() {
-    let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
-        .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"-a=")]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf16_lossy_option_short_no_space() {
-    let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
-        .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"-a")]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf16_lossy_option_long_space() {
-    let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
-        .try_get_matches_from(vec![
-            OsString::from(""),
-            OsString::from("--arg"),
-            bad_osstring(b""),
-        ]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf16_lossy_option_long_equals() {
-    let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
-        .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"--arg=")]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
 fn invalid_utf16_positional() {
     let r = Command::new("bad_utf16")
-        .arg(arg!(<arg> "some arg").allow_invalid_utf8(true))
+        .arg(arg!(<arg> "some arg").value_parser(value_parser!(OsString)))
         .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"")]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_os("arg").unwrap(), &*bad_osstring(b""));
+    assert!(m.contains_id("arg"));
+    assert_eq!(&*m.get_one::<OsString>("arg").unwrap(), &*bad_osstring(b""));
 }
 
 #[test]
 fn invalid_utf16_option_short_space() {
     let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
+        .arg(arg!(-a --arg <arg> "some arg").value_parser(value_parser!(OsString)))
         .try_get_matches_from(vec![
             OsString::from(""),
             OsString::from("-a"),
@@ -116,36 +42,36 @@ fn invalid_utf16_option_short_space() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_os("arg").unwrap(), &*bad_osstring(b""));
+    assert!(m.contains_id("arg"));
+    assert_eq!(&*m.get_one::<OsString>("arg").unwrap(), &*bad_osstring(b""));
 }
 
 #[test]
 fn invalid_utf16_option_short_equals() {
     let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
+        .arg(arg!(-a --arg <arg> "some arg").value_parser(value_parser!(OsString)))
         .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"-a=")]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_os("arg").unwrap(), &*bad_osstring(b""));
+    assert!(m.contains_id("arg"));
+    assert_eq!(&*m.get_one::<OsString>("arg").unwrap(), &*bad_osstring(b""));
 }
 
 #[test]
 fn invalid_utf16_option_short_no_space() {
     let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
+        .arg(arg!(-a --arg <arg> "some arg").value_parser(value_parser!(OsString)))
         .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"-a")]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_os("arg").unwrap(), &*bad_osstring(b""));
+    assert!(m.contains_id("arg"));
+    assert_eq!(&*m.get_one::<OsString>("arg").unwrap(), &*bad_osstring(b""));
 }
 
 #[test]
 fn invalid_utf16_option_long_space() {
     let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
+        .arg(arg!(-a --arg <arg> "some arg").value_parser(value_parser!(OsString)))
         .try_get_matches_from(vec![
             OsString::from(""),
             OsString::from("--arg"),
@@ -153,17 +79,17 @@ fn invalid_utf16_option_long_space() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_os("arg").unwrap(), &*bad_osstring(b""));
+    assert!(m.contains_id("arg"));
+    assert_eq!(&*m.get_one::<OsString>("arg").unwrap(), &*bad_osstring(b""));
 }
 
 #[test]
 fn invalid_utf16_option_long_equals() {
     let r = Command::new("bad_utf16")
-        .arg(arg!(-a --arg <arg> "some arg").allow_invalid_utf8(true))
+        .arg(arg!(-a --arg <arg> "some arg").value_parser(value_parser!(OsString)))
         .try_get_matches_from(vec![OsString::from(""), bad_osstring(b"--arg=")]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_os("arg").unwrap(), &*bad_osstring(b""));
+    assert!(m.contains_id("arg"));
+    assert_eq!(&*m.get_one::<OsString>("arg").unwrap(), &*bad_osstring(b""));
 }

--- a/tests/builder/utf8.rs
+++ b/tests/builder/utf8.rs
@@ -76,132 +76,13 @@ fn invalid_utf8_strict_option_long_equals() {
 }
 
 #[test]
-fn invalid_utf8_lossy_positional() {
-    #![allow(deprecated)]
-    let r = Command::new("bad_utf8")
-        .arg(Arg::new("arg").allow_invalid_utf8(true))
-        .try_get_matches_from(vec![OsString::from(""), OsString::from_vec(vec![0xe9])]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf8_lossy_option_short_space() {
-    #![allow(deprecated)]
-    let r = Command::new("bad_utf8")
-        .arg(
-            Arg::new("arg")
-                .short('a')
-                .long("arg")
-                .takes_value(true)
-                .allow_invalid_utf8(true),
-        )
-        .try_get_matches_from(vec![
-            OsString::from(""),
-            OsString::from("-a"),
-            OsString::from_vec(vec![0xe9]),
-        ]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf8_lossy_option_short_equals() {
-    #![allow(deprecated)]
-    let r = Command::new("bad_utf8")
-        .arg(
-            Arg::new("arg")
-                .short('a')
-                .long("arg")
-                .takes_value(true)
-                .allow_invalid_utf8(true),
-        )
-        .try_get_matches_from(vec![
-            OsString::from(""),
-            OsString::from_vec(vec![0x2d, 0x61, 0x3d, 0xe9]),
-        ]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf8_lossy_option_short_no_space() {
-    #![allow(deprecated)]
-    let r = Command::new("bad_utf8")
-        .arg(
-            Arg::new("arg")
-                .short('a')
-                .long("arg")
-                .takes_value(true)
-                .allow_invalid_utf8(true),
-        )
-        .try_get_matches_from(vec![
-            OsString::from(""),
-            OsString::from_vec(vec![0x2d, 0x61, 0xe9]),
-        ]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf8_lossy_option_long_space() {
-    #![allow(deprecated)]
-    let r = Command::new("bad_utf8")
-        .arg(
-            Arg::new("arg")
-                .short('a')
-                .long("arg")
-                .takes_value(true)
-                .allow_invalid_utf8(true),
-        )
-        .try_get_matches_from(vec![
-            OsString::from(""),
-            OsString::from("--arg"),
-            OsString::from_vec(vec![0xe9]),
-        ]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
-fn invalid_utf8_lossy_option_long_equals() {
-    #![allow(deprecated)]
-    let r = Command::new("bad_utf8")
-        .arg(
-            Arg::new("arg")
-                .short('a')
-                .long("arg")
-                .takes_value(true)
-                .allow_invalid_utf8(true),
-        )
-        .try_get_matches_from(vec![
-            OsString::from(""),
-            OsString::from_vec(vec![0x2d, 0x2d, 0x61, 0x72, 0x67, 0x3d, 0xe9]),
-        ]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.is_present("arg"));
-    assert_eq!(&*m.value_of_lossy("arg").unwrap(), "\u{FFFD}");
-}
-
-#[test]
 fn invalid_utf8_positional() {
     let r = Command::new("bad_utf8")
         .arg(Arg::new("arg").value_parser(value_parser!(OsString)))
         .try_get_matches_from(vec![OsString::from(""), OsString::from_vec(vec![0xe9])]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         &*m.get_one::<OsString>("arg").unwrap(),
         &*OsString::from_vec(vec![0xe9])
@@ -225,7 +106,7 @@ fn invalid_utf8_option_short_space() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         &*m.get_one::<OsString>("arg").unwrap(),
         &*OsString::from_vec(vec![0xe9])
@@ -248,7 +129,7 @@ fn invalid_utf8_option_short_equals() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         &*m.get_one::<OsString>("arg").unwrap(),
         &*OsString::from_vec(vec![0xe9])
@@ -271,7 +152,7 @@ fn invalid_utf8_option_short_no_space() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         &*m.get_one::<OsString>("arg").unwrap(),
         &*OsString::from_vec(vec![0xe9])
@@ -295,7 +176,7 @@ fn invalid_utf8_option_long_space() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         &*m.get_one::<OsString>("arg").unwrap(),
         &*OsString::from_vec(vec![0xe9])
@@ -318,7 +199,7 @@ fn invalid_utf8_option_long_equals() {
         ]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
-    assert!(m.is_present("arg"));
+    assert!(m.contains_id("arg"));
     assert_eq!(
         &*m.get_one::<OsString>("arg").unwrap(),
         &*OsString::from_vec(vec![0xe9])

--- a/tests/builder/utils.rs
+++ b/tests/builder/utils.rs
@@ -63,7 +63,8 @@ pub fn complex_app() -> Command<'static> {
         .args(&[
             arg!(flag2: -F "tests flags with exclusions")
                 .conflicts_with("flag")
-                .requires("long-option-2"),
+                .requires("long-option-2")
+                .action(ArgAction::SetTrue),
             arg!(--"long-option-2" <option2> "tests long options with exclusions")
                 .required(false)
                 .conflicts_with("option")

--- a/tests/builder/version.rs
+++ b/tests/builder/version.rs
@@ -81,12 +81,12 @@ fn version_flag_from_long_version_long() {
 #[test]
 fn override_version_long_with_user_flag() {
     let res = with_version()
-        .arg(Arg::new("ver").long("version"))
+        .arg(Arg::new("ver").long("version").action(ArgAction::SetTrue))
         .try_get_matches_from("foo --version".split(' '));
 
     assert!(res.is_ok(), "{}", res.unwrap_err());
     let m = res.unwrap();
-    assert!(m.is_present("ver"));
+    assert!(*m.get_one::<bool>("ver").expect("defaulted by clap"));
 }
 
 #[test]
@@ -103,12 +103,12 @@ fn override_version_long_with_user_flag_no_version_flag() {
 #[test]
 fn override_version_short_with_user_flag() {
     let res = with_version()
-        .arg(Arg::new("ver").short('V'))
+        .arg(Arg::new("ver").short('V').action(ArgAction::SetTrue))
         .try_get_matches_from("foo -V".split(' '));
 
     assert!(res.is_ok(), "{}", res.unwrap_err());
     let m = res.unwrap();
-    assert!(m.is_present("ver"));
+    assert!(*m.get_one::<bool>("ver").expect("defaulted by clap"));
 }
 
 #[test]

--- a/tests/derive/naming.rs
+++ b/tests/derive/naming.rs
@@ -33,7 +33,7 @@ fn test_custom_long_overwrites_default_name() {
 fn test_standalone_long_uses_previous_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(name = "foo", long)]
+        #[clap(name = "foo", long, action)]
         foo_option: bool,
     }
 
@@ -47,7 +47,7 @@ fn test_standalone_long_uses_previous_defined_custom_name() {
 fn test_standalone_long_ignores_afterwards_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(long, name = "foo")]
+        #[clap(long, name = "foo", action)]
         foo_option: bool,
     }
 
@@ -62,7 +62,7 @@ fn test_standalone_short_generates_kebab_case() {
     #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
-        #[clap(short)]
+        #[clap(short, action)]
         FOO_OPTION: bool,
     }
 
@@ -76,7 +76,7 @@ fn test_standalone_short_generates_kebab_case() {
 fn test_custom_short_overwrites_default_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short = 'o')]
+        #[clap(short = 'o', action)]
         foo_option: bool,
     }
 
@@ -90,7 +90,7 @@ fn test_custom_short_overwrites_default_name() {
 fn test_standalone_short_uses_previous_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(name = "option", short)]
+        #[clap(name = "option", short, action)]
         foo_option: bool,
     }
 
@@ -104,7 +104,7 @@ fn test_standalone_short_uses_previous_defined_custom_name() {
 fn test_standalone_short_ignores_afterwards_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short, name = "option")]
+        #[clap(short, name = "option", action)]
         foo_option: bool,
     }
 
@@ -118,7 +118,7 @@ fn test_standalone_short_ignores_afterwards_defined_custom_name() {
 fn test_standalone_long_uses_previous_defined_casing() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "screaming_snake", long)]
+        #[clap(rename_all = "screaming_snake", long, action)]
         foo_option: bool,
     }
 
@@ -132,7 +132,7 @@ fn test_standalone_long_uses_previous_defined_casing() {
 fn test_standalone_short_uses_previous_defined_casing() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "screaming_snake", short)]
+        #[clap(rename_all = "screaming_snake", short, action)]
         foo_option: bool,
     }
 
@@ -147,7 +147,7 @@ fn test_standalone_long_works_with_verbatim_casing() {
     #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
-        #[clap(rename_all = "verbatim", long)]
+        #[clap(rename_all = "verbatim", long, action)]
         _fOO_oPtiON: bool,
     }
 
@@ -161,7 +161,7 @@ fn test_standalone_long_works_with_verbatim_casing() {
 fn test_standalone_short_works_with_verbatim_casing() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "verbatim", short)]
+        #[clap(rename_all = "verbatim", short, action)]
         _foo: bool,
     }
 
@@ -176,7 +176,7 @@ fn test_rename_all_is_propagated_from_struct_to_fields() {
     #[derive(Parser, Debug, PartialEq)]
     #[clap(rename_all = "screaming_snake")]
     struct Opt {
-        #[clap(long)]
+        #[clap(long, action)]
         foo: bool,
     }
 
@@ -197,7 +197,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
 
     #[derive(Parser, Debug, PartialEq)]
     struct Foo {
-        #[clap(long)]
+        #[clap(long, action)]
         foo: bool,
     }
 
@@ -213,7 +213,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
 fn test_lower_is_renamed() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "lower", long)]
+        #[clap(rename_all = "lower", long, action)]
         foo_option: bool,
     }
 
@@ -227,7 +227,7 @@ fn test_lower_is_renamed() {
 fn test_upper_is_renamed() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "upper", long)]
+        #[clap(rename_all = "upper", long, action)]
         foo_option: bool,
     }
 
@@ -281,7 +281,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_subcommand() {
     #[derive(Parser, Debug, PartialEq)]
     enum Foo {
         Command {
-            #[clap(long)]
+            #[clap(long, action)]
             foo: bool,
         },
     }
@@ -339,11 +339,11 @@ fn test_rename_all_is_propagation_can_be_overridden() {
     enum Opt {
         #[clap(rename_all = "kebab_case")]
         FirstVariant {
-            #[clap(long)]
+            #[clap(long, action)]
             foo_option: bool,
         },
         SecondVariant {
-            #[clap(rename_all = "kebab_case", long)]
+            #[clap(rename_all = "kebab_case", long, action)]
             foo_option: bool,
         },
     }

--- a/tests/derive_ui/next/bool_value_enum.stderr
+++ b/tests/derive_ui/next/bool_value_enum.stderr
@@ -35,6 +35,12 @@ help: `bool` is a unit variant, you need to write it without the parenthesis
 7 |     opts: bool,
   |           ~~~~
 
+warning: use of deprecated associated function `clap::ArgMatches::is_present`: Replaced with either `ArgMatches::contains_id(...)` or `ArgAction::SetTrue`
+ --> tests/derive_ui/next/bool_value_enum.rs:7:11
+  |
+7 |     opts: bool,
+  |           ^^^^
+
 warning: use of deprecated associated function `clap::Arg::<'help>::possible_values`: Replaced with `Arg::value_parser(PossibleValuesParser::new(...)).takes_value(true)`
  --> tests/derive_ui/next/bool_value_enum.rs:7:11
   |

--- a/tests/derive_ui/non_existent_attr.stderr
+++ b/tests/derive_ui/non_existent_attr.stderr
@@ -1,5 +1,19 @@
+warning: use of deprecated associated function `clap::ArgMatches::is_present`: Replaced with either `ArgMatches::contains_id(...)` or `ArgAction::SetTrue`
+  --> tests/derive_ui/non_existent_attr.rs:15:12
+   |
+15 |     debug: bool,
+   |            ^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+warning: use of deprecated associated function `clap::ArgMatches::is_present`: Replaced with either `ArgMatches::contains_id(...)` or `ArgAction::SetTrue`
+  --> tests/derive_ui/non_existent_attr.rs:15:12
+   |
+15 |     debug: bool,
+   |            ^^^^
+
 error[E0599]: no method named `non_existing_attribute` found for struct `Arg` in the current scope
-  --> $DIR/non_existent_attr.rs:14:19
+  --> tests/derive_ui/non_existent_attr.rs:14:19
    |
 14 |     #[clap(short, non_existing_attribute = 1)]
    |                   ^^^^^^^^^^^^^^^^^^^^^^ method not found in `Arg<'_>`

--- a/tests/derive_ui/stable/bool_value_enum.stderr
+++ b/tests/derive_ui/stable/bool_value_enum.stderr
@@ -35,6 +35,12 @@ help: `bool` is a unit variant, you need to write it without the parenthesis
 7 |     opts: bool,
   |           ~~~~
 
+warning: use of deprecated associated function `clap::ArgMatches::is_present`: Replaced with either `ArgMatches::contains_id(...)` or `ArgAction::SetTrue`
+ --> tests/derive_ui/stable/bool_value_enum.rs:7:11
+  |
+7 |     opts: bool,
+  |           ^^^^
+
 warning: use of deprecated associated function `clap::Arg::<'help>::possible_values`: Replaced with `Arg::value_parser(PossibleValuesParser::new(...)).takes_value(true)`
  --> tests/derive_ui/stable/bool_value_enum.rs:7:11
   |

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -114,7 +114,10 @@ fn quoted_arg_long_name() {
     let matches = cmd
         .try_get_matches_from(vec!["bin_name", "value1", "value2", "--long-option-2"])
         .expect("Expected to successfully match the given args.");
-    assert!(matches.is_present("option2"));
+    #[allow(deprecated)]
+    {
+        assert!(matches.is_present("option2"));
+    }
 }
 
 #[test]
@@ -522,7 +525,10 @@ mod arg_impl {
             .arg(arg)
             .try_get_matches_from(vec!["", "some-val"])
             .unwrap();
-        assert!(m.is_present("some-arg"));
+        #[allow(deprecated)]
+        {
+            assert!(m.is_present("some-arg"));
+        }
         assert_eq!(m.get_one::<String>("some-arg").unwrap(), "some-val");
     }
 
@@ -543,7 +549,10 @@ mod arg_impl {
             .arg(arg)
             .try_get_matches_from(vec!["", "-a", "val"])
             .unwrap();
-        assert!(m.is_present("some-val"));
+        #[allow(deprecated)]
+        {
+            assert!(m.is_present("some-val"));
+        }
         assert_eq!(m.get_one::<String>("some-val").unwrap(), "val");
     }
 
@@ -564,7 +573,10 @@ mod arg_impl {
             .arg(arg)
             .try_get_matches_from(vec!["", "--arg", "some-val"])
             .unwrap();
-        assert!(m.is_present("arg"));
+        #[allow(deprecated)]
+        {
+            assert!(m.is_present("arg"));
+        }
         assert_eq!(m.get_one::<String>("arg").unwrap(), "some-val");
     }
 }


### PR DESCRIPTION
- This matches the more container-like naming we are aiming for
- This provides an opportunity to warn people about moving away from
  `ArgAction::IncOcccurrences` for flags, like the deprecation for
  `ArgMatches::occurrences_of` to help people migrate in preparation for
  clap 4 (rather than having the behavior change subtly in a way only
  caught by thorough tests)

In addition, I feel `contains_id` has less ambiguous meaning than
`is_present`.