### PR TITLE
docs: update return signature for try_from_os_str

### DIFF
--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -268,7 +268,7 @@ You can then support your custom type with `#[clap(parse(<kind> [= <function>]))
 | `from_str`               | `fn(&str) -> T`                       | `::std::convert::From::from`    |
 | `try_from_str` (default) | `fn(&str) -> Result<T, E>`            | `::std::str::FromStr::from_str` |
 | `from_os_str`            | `fn(&OsStr) -> T`                     | `::std::convert::From::from`    |
-| `try_from_os_str`        | `fn(&OsStr) -> Result<T, String>`     | (no default function)           |
+| `try_from_os_str`        | `fn(&OsStr) -> Result<T, E>`          | (no default function)           |
 | `from_occurrences`       | `fn(u64) -> T`                        | `value as T`                    |
 | `from_flag`              | `fn(bool) -> T`                       | `::std::convert::From::from`    |
 

--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -268,7 +268,7 @@ You can then support your custom type with `#[clap(parse(<kind> [= <function>]))
 | `from_str`               | `fn(&str) -> T`                       | `::std::convert::From::from`    |
 | `try_from_str` (default) | `fn(&str) -> Result<T, E>`            | `::std::str::FromStr::from_str` |
 | `from_os_str`            | `fn(&OsStr) -> T`                     | `::std::convert::From::from`    |
-| `try_from_os_str`        | `fn(&OsStr) -> Result<T, OsString>`   | (no default function)           |
+| `try_from_os_str`        | `fn(&OsStr) -> Result<T, String>`     | (no default function)           |
 | `from_occurrences`       | `fn(u64) -> T`                        | `value as T`                    |
 | `from_flag`              | `fn(bool) -> T`                       | `::std::convert::From::from`    |
 


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Small documentation fix to update the documentedt expected signature of `try_from_os_str`. The error type of the return `Result` was stated as `OsString`, but it is actually `String`. This is confirmed by this test https://github.com/clap-rs/clap/blob/e8ad62b784b3430fbaf0f819c45330ab6c264d85/tests/derive/legacy/custom_string_parsers.rs#L109

When I was trying to use `OsString` I was unable to compile with the error ``error[E0277]: `OsString` doesn't implement `std::fmt::Display` ``. Changing the error type to `String` fixed this.