### PR TITLE
fix(derive): Provide derive-friendly deprecation messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,8 @@ color = ["atty", "termcolor"]
 suggestions = ["strsim"]
 
 # Optional
-deprecated = [] # Guided experience to prepare for next breaking release (at different stages of development, this may become default)
+# note: this will always enable clap_derive, change this to `clap_derive?/unstable-v4` when MSRV is bigger than 1.60
+deprecated = ["clap_derive/deprecated"] # Guided experience to prepare for next breaking release (at different stages of development, this may become default)
 derive = ["clap_derive", "once_cell"]
 cargo = ["once_cell"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
 wrap_help = ["terminal_size", "textwrap/terminal_size"]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -51,4 +51,6 @@ proc-macro-error = "1"
 [features]
 default = []
 debug = []
-unstable-v4 = []
+unstable-v4 = ["deprecated"]
+deprecated = []
+raw-deprecated = ["deprecated"]

--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -825,6 +825,10 @@ impl Attrs {
         self.value_parser.is_some() || self.action.is_some()
     }
 
+    pub fn explicit_parser(&self) -> bool {
+        self.parser.is_some()
+    }
+
     pub fn parser(&self, field_type: &Type) -> Sp<Parser> {
         self.parser
             .clone()

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -136,6 +136,7 @@ pub fn gen_from_arg_matches_for_struct(
             }
 
             fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
+                #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Args`
                 let v = #struct_name #constructor;
                 ::std::result::Result::Ok(v)
             }
@@ -145,6 +146,7 @@ pub fn gen_from_arg_matches_for_struct(
             }
 
             fn update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<(), clap::Error> {
+                #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Args`
                 #updater
                 ::std::result::Result::Ok(())
             }

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -406,11 +406,13 @@ pub fn gen_augment(
                 let explicit_methods = attrs.field_methods(true);
 
                 Some(quote_spanned! { field.span()=>
-                    let #app_var = #app_var.arg(
-                        clap::Arg::new(#id)
-                            #implicit_methods
-                            #explicit_methods
-                    );
+                    let #app_var = #app_var.arg({
+                        let arg = clap::Arg::new(#id)
+                            #implicit_methods;
+                        let arg = arg
+                            #explicit_methods;
+                        arg
+                    });
                 })
             }
         }

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -282,7 +282,7 @@ pub fn gen_augment(
                     quote!()
                 };
 
-                let modifier = match **ty {
+                let implicit_methods = match **ty {
                     Ty::Option => {
                         quote_spanned! { ty.span()=>
                             .takes_value(true)
@@ -403,13 +403,13 @@ pub fn gen_augment(
                 };
 
                 let id = attrs.id();
-                let methods = attrs.field_methods(true);
+                let explicit_methods = attrs.field_methods(true);
 
                 Some(quote_spanned! { field.span()=>
                     let #app_var = #app_var.arg(
                         clap::Arg::new(#id)
-                            #modifier
-                            #methods
+                            #implicit_methods
+                            #explicit_methods
                     );
                 })
             }

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -113,6 +113,7 @@ pub fn gen_from_arg_matches_for_struct(
 
     let constructor = gen_constructor(fields, &attrs);
     let updater = gen_updater(fields, &attrs, true);
+    let raw_deprecated = raw_deprecated();
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
@@ -136,7 +137,7 @@ pub fn gen_from_arg_matches_for_struct(
             }
 
             fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
-                #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Args`
+                #raw_deprecated
                 let v = #struct_name #constructor;
                 ::std::result::Result::Ok(v)
             }
@@ -146,7 +147,7 @@ pub fn gen_from_arg_matches_for_struct(
             }
 
             fn update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<(), clap::Error> {
-                #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Args`
+                #raw_deprecated
                 #updater
                 ::std::result::Result::Ok(())
             }
@@ -735,5 +736,18 @@ fn gen_parsers(
         }
     } else {
         quote_spanned!(field.span()=> #field_name: #field_value )
+    }
+}
+
+#[cfg(feature = "raw-deprecated")]
+pub fn raw_deprecated() -> TokenStream {
+    quote! {}
+}
+
+#[cfg(not(feature = "raw-deprecated"))]
+pub fn raw_deprecated() -> TokenStream {
+    quote! {
+        #![allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Args`
+
     }
 }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -540,9 +540,10 @@ fn gen_from_arg_matches(
         },
     };
 
+    let raw_deprecated = args::raw_deprecated();
     quote! {
         fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
-            #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Subcommand`
+            #raw_deprecated
 
             #( #child_subcommands )else*
 
@@ -654,12 +655,13 @@ fn gen_update_from_arg_matches(
         }
     });
 
+    let raw_deprecated = args::raw_deprecated();
     quote! {
         fn update_from_arg_matches_mut<'b>(
             &mut self,
             __clap_arg_matches: &mut clap::ArgMatches,
         ) -> ::std::result::Result<(), clap::Error> {
-            #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Subcommand`
+            #raw_deprecated
 
             if let Some(__clap_name) = __clap_arg_matches.subcommand_name() {
                 match self {

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -542,6 +542,8 @@ fn gen_from_arg_matches(
 
     quote! {
         fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
+            #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Subcommand`
+
             #( #child_subcommands )else*
 
             if let Some((#subcommand_name_var, mut __clap_arg_sub_matches)) = __clap_arg_matches.remove_subcommand() {
@@ -657,6 +659,8 @@ fn gen_update_from_arg_matches(
             &mut self,
             __clap_arg_matches: &mut clap::ArgMatches,
         ) -> ::std::result::Result<(), clap::Error> {
+            #[allow(deprecated)]  // Assuming any deprecation in here will be related to a deprecation in `Subcommand`
+
             if let Some(__clap_name) = __clap_arg_matches.subcommand_name() {
                 match self {
                     #( #subcommands ),*


### PR DESCRIPTION
This is a step towards #3822.  I'd say this fixes it but I'd want some
user acceptance before doing so.

To do this, we
- Mask all `ArgMatches` deprecation messages with assumption being that any message from these has its roots in an `augment_args` deprecation.  You can see the raw deprecations with `clap_derive/raw-deprecation`
- Create call generated functions with a targeted deprecation message that we call for each `parse` case. 
- Mask all deprecation messages for implicit `Arg` methods, delegating to the messages for the generated functions

We intentionally do not provide a deprecation message for implicit `parse` attributes since resolving that is just busywork that most likely won't help users in migrating to clap 4.

I had originally assumed this would be difficult to be precise in our `allow` and deprecations but I found place to split up the calls.  Its not completely precise but it should be good enough in the short term.

Example messages
```
warning: use of deprecated function `<legacy::custom_string_parsers::DefaultedOpt as clap::Args>::augment_args::parse_from_str`: Replaced with `#[clap(value_parser = ...)]`
   --> tests/derive/legacy/custom_string_parsers.rs:167:25
    |
167 |     #[clap(short, parse(from_str))]
    |                         ^^^^^^^^

warning: use of deprecated function `<legacy::custom_string_parsers::DefaultedOpt as clap::Args>::augment_args_for_update::parse_try_from_str`: Replaced with `#[clap(value_parser = ...)]`
   --> tests/derive/legacy/custom_string_parsers.rs:170:25
    |
170 |     #[clap(short, parse(try_from_str))]
    |                         ^^^^^^^^^^^^


warning: use of deprecated function `<legacy::custom_string_parsers::PathOpt as clap::Args>::augment_args::parse_from_os_str`: Replaced with `#[clap(value_parser)]` for `PathBuf` or `#[clap(value_parser = ...)]` with a custom `TypedValueParser`
  --> tests/derive/legacy/custom_string_parsers.rs:23:31
   |
23 |     #[clap(short, long, parse(from_os_str))]
   |                               ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `<legacy::custom_string_parsers::PathOpt as clap::Args>::augment_args::parse_from_os_str`: Replaced with `#[clap(value_parser)]` for `PathBuf` or `#[clap(value_parser = ...)]` with a custom `TypedValueParser`
  --> tests/derive/legacy/custom_string_parsers.rs:23:31
   |
23 |     #[clap(short, long, parse(from_os_str))]
   |                               ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated function `<legacy::custom_string_parsers::Occurrences as clap::Args>::augment_args::parse_from_occurrences`: Replaced with `#[clap(action = ArgAction::Count)]` with a field type of `u8`
   --> tests/derive/legacy/custom_string_parsers.rs:207:31
    |
207 |     #[clap(short, long, parse(from_occurrences))]
    |                               ^^^^^^^^^^^^^^^^

warning: use of deprecated function `<legacy::custom_string_parsers::Occurrences as clap::Args>::augment_args::parse_from_occurrences`: Replaced with `#[clap(action = ArgAction::Count)]` with a field type of `u8`
   --> tests/derive/legacy/custom_string_parsers.rs:219:50
    |
219 |     #[clap(short, long, parse(from_occurrences = foo))]
    |                                                  ^^^

warning: use of deprecated function `<legacy::flags::non_bool_type_flag::Opt as clap::Args>::augment_args_for_update::parse_from_flag`: Replaced with `#[clap(action = ArgAction::SetTrue)]`
  --> tests/derive/legacy/flags.rs:85:47
   |
85 |         #[clap(short, long, parse(from_flag = parse_from_flag))]
   |                                               ^^^^^^^^^^^^^^^

```
- We encourage busywork for users accepting a `PathBuf` and correctly set the `parse(from_os_str)`.  Correctly detecting this to not show it would add another level of work and we'd need to have some way to tell users when they upgrade to clap 4 what the correct replacement for `parse(from_os_str)` is (nothing).
- We're not providing much guidance when users that only specify `parse(from_str)`,. etc