### PR TITLE
fix: default_value_os_t

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -594,7 +594,7 @@ impl Attrs {
                         quote_spanned!(ident.span()=> {
                             static DEFAULT_VALUE: clap::once_cell::sync::Lazy<::std::ffi::OsString> = clap::once_cell::sync::Lazy::new(|| {
                                 let val: #ty = #val;
-                                ::std::ffi::OsString = val.into()
+                                ::std::ffi::OsString::from(val)
                             });
                             &*DEFAULT_VALUE
                         })

--- a/tests/derive/default_value.rs
+++ b/tests/derive/default_value.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{CommandFactory, Parser};
 
 use crate::utils;
@@ -42,6 +44,30 @@ fn auto_default_value_t() {
 
     let help = utils::get_long_help::<Opt>();
     assert!(help.contains("[default: 0]"));
+}
+
+#[test]
+fn default_value_os_t() {
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[clap(value_parser, default_value_os_t = PathBuf::from("abc.def"))]
+        arg: PathBuf,
+    }
+    assert_eq!(
+        Opt {
+            arg: PathBuf::from("abc.def")
+        },
+        Opt::try_parse_from(&["test"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            arg: PathBuf::from("ghi")
+        },
+        Opt::try_parse_from(&["test", "ghi"]).unwrap()
+    );
+
+    let help = utils::get_long_help::<Opt>();
+    assert!(help.contains("[default: abc.def]"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes `default_value_os_t` which was broken in https://github.com/clap-rs/clap/pull/3829