### PR TITLE
test(complete): Ensure we infer path completions from value_parser

### DIFF
--- a/clap_complete/tests/general.rs
+++ b/clap_complete/tests/general.rs
@@ -1,0 +1,11 @@
+#[test]
+fn infer_value_hint_for_path_buf() {
+    let mut cmd = clap::Command::new("completer")
+        .arg(clap::Arg::new("input").value_parser(clap::value_parser!(std::path::PathBuf)));
+    cmd.build();
+    let input = cmd
+        .get_arguments()
+        .find(|arg| arg.get_id() == "input")
+        .unwrap();
+    assert_eq!(input.get_value_hint(), clap::builder::ValueHint::AnyPath);
+}


### PR DESCRIPTION
Looks like I forgot to add a test case for this.

I put this in `clap_complete` because I expect `ValueHint` to move here
as we move towards a plugin system.

Fixes #3840

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
