### PR TITLE
fix(parser): Add value_source as a replacement for occurrences_of

### DIFF
--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -604,13 +604,13 @@ impl ArgMatches {
         value.and_then(MatchedArg::source)
     }
 
-    /// Deprecated, replaced with  [`ArgAction::Count`][crate::ArgAction] or
-    /// [`ArgMatches::get_many`]`.len()`.
+    /// Deprecated, replaced with  [`ArgAction::Count`][crate::ArgAction],
+    /// [`ArgMatches::get_many`]`.len()`, or [`ArgMatches::value_source`].
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.2.0",
-            note = "Replaced with either `ArgAction::Count` or `ArgMatches::get_many(...).len()`"
+            note = "Replaced with either `ArgAction::Count`, `ArgMatches::get_many(...).len()`, or `ArgMatches::value_source`"
         )
     )]
     #[cfg_attr(debug_assertions, track_caller)]


### PR DESCRIPTION
This was an oversight when listing out the options as identified when
looking at oxidecomputer/humility#161.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
