### PR TITLE
chore: documentation field defaults to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ name = "clap"
 version = "3.2.5"
 description = "A simple to use, efficient, and full-featured Command Line Argument Parser"
 repository = "https://github.com/clap-rs/clap"
-documentation = "https://docs.rs/clap/"
 categories = ["command-line-interface"]
 keywords = [
   "argument",


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html?#the-documentation-field

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
