### PR TITLE
chore: trim Cargo manifest fields whose values are defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ name = "clap"
 version = "3.2.5"
 description = "A simple to use, efficient, and full-featured Command Line Argument Parser"
 repository = "https://github.com/clap-rs/clap"
-documentation = "https://docs.rs/clap/"
 categories = ["command-line-interface"]
 keywords = [
   "argument",
@@ -23,7 +22,6 @@ keywords = [
   "parse"
 ]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 edition = "2021"
 rust-version = "1.56.0"  # MSRV
 include = [

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -3,7 +3,6 @@ name = "clap_complete"
 version = "3.2.1"
 description = "Generate shell completion scripts for your clap::Command"
 repository = "https://github.com/clap-rs/clap/tree/master/clap_complete"
-documentation = "https://docs.rs/clap_complete"
 categories = ["command-line-interface"]
 keywords = [
   "clap",
@@ -12,7 +11,6 @@ keywords = [
   "bash",
 ]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 edition = "2021"
 rust-version = "1.56.0"  # MSRV
 include = [

--- a/clap_complete_fig/Cargo.toml
+++ b/clap_complete_fig/Cargo.toml
@@ -3,7 +3,6 @@ name = "clap_complete_fig"
 version = "3.2.1"
 description = "A generator library used with clap for Fig completion scripts"
 repository = "https://github.com/clap-rs/clap/tree/master/clap_complete_fig"
-documentation = "https://docs.rs/clap_complete_fig"
 categories = ["command-line-interface"]
 keywords = [
   "clap",
@@ -12,7 +11,6 @@ keywords = [
   "fig",
 ]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 edition = "2021"
 rust-version = "1.56.0"  # MSRV
 include = [

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -3,7 +3,6 @@ name = "clap_derive"
 version = "3.2.5"
 description = "Parse command line argument by defining a struct, derive crate."
 repository = "https://github.com/clap-rs/clap/tree/master/clap_derive"
-documentation = "https://docs.rs/clap_derive"
 categories = ["command-line-interface", "development-tools::procedural-macro-helpers"]
 keywords = [
   "clap",
@@ -13,7 +12,6 @@ keywords = [
   "proc_macro"
 ]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 edition = "2021"
 rust-version = "1.56.0"  # MSRV
 include = [

--- a/clap_lex/Cargo.toml
+++ b/clap_lex/Cargo.toml
@@ -3,7 +3,6 @@ name = "clap_lex"
 version = "0.2.2"
 description = "Minimal, flexible command line parser"
 repository = "https://github.com/clap-rs/clap/tree/master/clap_lex"
-documentation = "https://docs.rs/clap_lex"
 categories = ["command-line-interface"]
 keywords = [
   "argument",
@@ -13,7 +12,6 @@ keywords = [
   "parse"
 ]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 edition = "2021"
 rust-version = "1.56.0"  # MSRV
 include = [

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -3,7 +3,6 @@ name = "clap_mangen"
 version = "0.1.8"
 description = "A manpage generator for clap"
 repository = "https://github.com/clap-rs/clap/tree/master/clap_mangen"
-documentation = "https://docs.rs/clap_mangen"
 categories = ["command-line-interface"]
 keywords = [
   "clap",
@@ -12,7 +11,6 @@ keywords = [
   "manpage",
 ]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 edition = "2021"
 rust-version = "1.56.0"  # MSRV
 include = [


### PR DESCRIPTION
See...
- https://doc.rust-lang.org/cargo/reference/manifest.html?#the-documentation-field
- https://doc.rust-lang.org/cargo/reference/manifest.html?#the-readme-field

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
