### PR TITLE
chore: Bump MSRV from 1.56.0 to 1.56.1

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.56.0"  # MSRV
+msrv = "1.56.1"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         build: [msrv, wasm, wasm-wasi, debug, release]
         include:
           - build: msrv
-            rust: 1.56.0  # MSRV
+            rust: 1.56.1  # MSRV
             target: x86_64-unknown-linux-gnu
             features: full
           - build: wasm
@@ -122,7 +122,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56.0  # MSRV
+        toolchain: 1.56.1  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v1
@@ -172,7 +172,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56.0  # MSRV
+        toolchain: 1.56.1  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -92,9 +92,9 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.56.0  # MSRV
+        - 1.56.1  # MSRV
         - stable
-    continue-on-error: ${{ matrix.rust != '1.56.0' }}  # MSRV
+    continue-on-error: ${{ matrix.rust != '1.56.1' }}  # MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.56.1"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq (${TOOLCHAIN_TARGET},)
   ARGS+=--target ${TOOLCHAIN_TARGET}
 endif
 
-MSRV?=1.56.0
+MSRV?=1.56.1
 
 _FEATURES = minimal default wasm full debug release
 _FEATURES_minimal = --no-default-features --features "std"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ OPTIONS:
   - Leverage feature flags to keep to one active branch
   - Being under [WG-CLI](https://github.com/rust-cli/team/) to increase the bus factor
 - We follow semver and will wait about 6-9 months between major breaking changes
-- We will support the last two minor Rust releases (MSRV, currently 1.56.0)
+- We will support the last two minor Rust releases (MSRV, currently 1.56.1)
 
 While these aspirations can be at odds with fast build times and low binary
 size, we will still strive to keep these reasonable for the flexibility you

--- a/clap_bench/Cargo.toml
+++ b/clap_bench/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Benchmarks for clap"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.56.1"  # MSRV
 publish = false
 
 [package.metadata.release]

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.56.1"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_complete_fig/Cargo.toml
+++ b/clap_complete_fig/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.56.1"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.56.1"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_lex/Cargo.toml
+++ b/clap_lex/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.56.1"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.56.0"  # MSRV
+rust-version = "1.56.1"  # MSRV
 include = [
   "build.rs",
   "src/**/*",


### PR DESCRIPTION
Being a patch release, I'm fine doing this outside of a minor release.
This avoids us having to deal with indexmap having a higher MSRV.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
