### PR TITLE
fix(docs): Update deprecations to latest target

### DIFF
--- a/src/builder/app_settings.rs
+++ b/src/builder/app_settings.rs
@@ -400,23 +400,20 @@ pub enum AppSettings {
     )]
     NoAutoVersion,
 
-    /// Deprecated, replaced with [`AppSettings::AllowHyphenValues`]
+    /// Deprecated, replaced with [`Command::allow_hyphen_values`]
     #[cfg_attr(
         feature = "deprecated",
-        deprecated(
-            since = "3.0.0",
-            note = "Replaced with `AppSettings::AllowHyphenValues`"
-        )
+        deprecated(since = "3.0.0", note = "Replaced with `Command::allow_hyphen_values`")
     )]
     #[doc(hidden)]
     AllowLeadingHyphen,
 
-    /// Deprecated, this is now the default, see [`AppSettings::AllowInvalidUtf8ForExternalSubcommands`] and [`ArgSettings::AllowInvalidUtf8`][crate::ArgSettings::AllowInvalidUtf8] for the opposite.
+    /// Deprecated, replaced with [`Command::allow_invalid_utf8_for_external_subcommands`] and [`Command::is_allow_invalid_utf8_for_external_subcommands_set`]
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.0.0",
-            note = "This is now the default see `AppSettings::AllowInvalidUtf8ForExternalSubcommands` and `ArgSettings::AllowInvalidUtf8` for the opposite."
+            note = "Replaced with `Command::allow_invalid_utf8_for_external_subcommands` and `Command::is_allow_invalid_utf8_for_external_subcommands_set`"
         )
     )]
     #[doc(hidden)]
@@ -462,42 +459,47 @@ pub enum AppSettings {
     #[doc(hidden)]
     ColorNever,
 
-    /// Deprecated, replaced with [`AppSettings::DisableHelpFlag`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.0.0", note = "Replaced with `AppSettings::DisableHelpFlag`")
-    )]
-    #[doc(hidden)]
-    DisableHelpFlags,
-
-    /// Deprecated, replaced with [`AppSettings::DisableVersionFlag`]
+    /// Deprecated, replaced with [`Command::disable_help_flag`] and [`Command::is_disable_help_flag_set`]
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.0.0",
-            note = "Replaced with `AppSettings::DisableVersionFlag`"
+            note = "Replaced with `Command::disable_help_flag` and `Command::is_disable_help_flag_set`"
+        )
+    )]
+    #[doc(hidden)]
+    DisableHelpFlags,
+
+    /// Deprecated, replaced with [`Command::disable_version_flag`] and
+    /// [`Command::is_disable_version_flag_set`]
+    #[cfg_attr(
+        feature = "deprecated",
+        deprecated(
+            since = "3.0.0",
+            note = "Replaced with `Command::disable_version_flag` and `Command::is_disable_version_flag_set`"
         )
     )]
     #[doc(hidden)]
     DisableVersion,
 
-    /// Deprecated, replaced with [`AppSettings::PropagateVersion`]
+    /// Deprecated, replaced with [`Command::propagate_version`] and [`Command::is_propagate_version_set`]
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.0.0",
-            note = "Replaced with `AppSettings::PropagateVersion`"
+            note = "Replaced with `Command::propagate_version` and `Command::is_propagate_version_set`"
         )
     )]
     #[doc(hidden)]
     GlobalVersion,
 
-    /// Deprecated, replaced with [`AppSettings::HidePossibleValues`]
+    /// Deprecated, replaced with [`Command::hide_possible_values`] and
+    /// [`Arg::is_hide_possible_values_set`]
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.0.0",
-            note = "Replaced with AppSettings::HidePossibleValues"
+            note = "Replaced with `Command::hide_possible_values` and `Arg::is_hide_possible_values_set`"
         )
     )]
     #[doc(hidden)]

--- a/src/builder/arg_settings.rs
+++ b/src/builder/arg_settings.rs
@@ -50,14 +50,10 @@ pub enum ArgSettings {
         )
     )]
     MultipleValues,
-    /// Deprecated, replaced with [`Arg::multiple_occurrences`] and
-    /// [`Arg::is_multiple_occurrences_set`]
+    /// Deprecated, replaced with [`Arg::action`] ([Issue #3772](https://github.com/clap-rs/clap/issues/3772))
     #[cfg_attr(
         feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Arg::multiple_occurrences` and `Arg::is_multiple_occurrences_set`"
-        )
+        deprecated(since = "3.1.0", note = "Replaced with `Arg::action` (Issue #3772)")
     )]
     MultipleOccurrences,
     /// Deprecated, see [`ArgSettings::MultipleOccurrences`] (most likely what you want) and
@@ -66,18 +62,17 @@ pub enum ArgSettings {
         feature = "deprecated",
         deprecated(
             since = "3.0.0",
-            note = "Split into `ArgSettings::MultipleOccurrences` (most likely what you want)  and `ArgSettings::MultipleValues`"
+            note = "Split into `Arg::multiple_occurrences` (most likely what you want)  and `Arg::multiple_values`"
         )
     )]
     #[doc(hidden)]
     Multiple,
-    /// Deprecated, replaced with [`Arg::forbid_empty_values`] and
-    /// [`Arg::is_forbid_empty_values_set`]
+    /// Deprecated, replaced with [`Arg::value_parser(NonEmptyStringValueParser::new())`]
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.1.0",
-            note = "Replaced with `Arg::forbid_empty_values` and `Arg::is_forbid_empty_values_set`"
+            note = "Replaced with `Arg::value_parser(NonEmptyStringValueParser::new())`"
         )
     )]
     ForbidEmptyValues,
@@ -157,12 +152,13 @@ pub enum ArgSettings {
         )
     )]
     AllowHyphenValues,
-    /// Deprecated, replaced with [`ArgSettings::AllowHyphenValues`]
+    /// Deprecated, replaced with [`Arg::allow_hyphen_values`] and
+    /// [`Arg::is_allow_hyphen_values_set`]
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.0.0",
-            note = "Replaced with `ArgSettings::AllowHyphenValues`"
+            note = "Replaced with `Arg::allow_hyphen_values` and `Arg::is_allow_hyphen_values_set`"
         )
     )]
     #[doc(hidden)]
@@ -203,10 +199,13 @@ pub enum ArgSettings {
         )
     )]
     IgnoreCase,
-    /// Deprecated, replaced with [`ArgSettings::IgnoreCase`]
+    /// Deprecated, replaced with [`Arg::ignore_case`] and [`Arg::is_ignore_case_set`]
     #[cfg_attr(
         feature = "deprecated",
-        deprecated(since = "3.0.0", note = "Replaced with `ArgSettings::IgnoreCase`")
+        deprecated(
+            since = "3.0.0",
+            note = "Replaced with `Arg::ignore_case` and `Arg::is_ignore_case_set`"
+        )
     )]
     #[doc(hidden)]
     CaseInsensitive,

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -156,13 +156,13 @@ pub trait Parser: FromArgMatches + CommandFactory + Sized {
             .map_err(format_error::<Self>)
     }
 
-    /// Deprecated, `StructOpt::clap` replaced with [`IntoCommand::command`] (derive as part of
+    /// Deprecated, `StructOpt::clap` replaced with [`CommandFactory::command`] (derive as part of
     /// [`Parser`])
     #[cfg_attr(
         feature = "deprecated",
         deprecated(
             since = "3.0.0",
-            note = "`StructOpt::clap` is replaced with `IntoCommand::command` (derived as part of `Parser`)"
+            note = "`StructOpt::clap` is replaced with `CommandFactory::command` (derived as part of `Parser`)"
         )
     )]
     #[doc(hidden)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! load_yaml {
 #[macro_export]
 #[cfg_attr(
     feature = "deprecated",
-    deprecated(since = "3.0.0", note = "Replaced with `ArgMatches::value_of_t`")
+    deprecated(since = "3.0.0", note = "Replaced with `ArgMatches::get_one`")
 )]
 #[doc(hidden)]
 macro_rules! value_t {
@@ -36,10 +36,7 @@ macro_rules! value_t {
 #[macro_export]
 #[cfg_attr(
     feature = "deprecated",
-    deprecated(
-        since = "3.0.0",
-        note = "Replaced with `ArgMatches::value_of_t_or_exit`"
-    )
+    deprecated(since = "3.0.0", note = "Replaced with `ArgMatches::get_one`")
 )]
 #[doc(hidden)]
 macro_rules! value_t_or_exit {
@@ -55,7 +52,7 @@ macro_rules! value_t_or_exit {
 #[macro_export]
 #[cfg_attr(
     feature = "deprecated",
-    deprecated(since = "3.0.0", note = "Replaced with `ArgMatches::values_of_t`")
+    deprecated(since = "3.0.0", note = "Replaced with `ArgMatches::get_many`")
 )]
 #[doc(hidden)]
 macro_rules! values_t {
@@ -71,10 +68,7 @@ macro_rules! values_t {
 #[macro_export]
 #[cfg_attr(
     feature = "deprecated",
-    deprecated(
-        since = "3.0.0",
-        note = "Replaced with `ArgMatches::values_of_t_or_exit`"
-    )
+    deprecated(since = "3.0.0", note = "Replaced with `ArgMatches::get_many`")
 )]
 #[doc(hidden)]
 macro_rules! values_t_or_exit {
@@ -88,7 +82,7 @@ macro_rules! values_t_or_exit {
 
 #[cfg_attr(
     feature = "deprecated",
-    deprecated(since = "3.0.0", note = "Replaced with `ArgEnum`")
+    deprecated(since = "3.0.0", note = "Replaced with `ValueEnum`")
 )]
 #[doc(hidden)]
 #[macro_export]
@@ -101,7 +95,7 @@ macro_rules! _clap_count_exprs {
 /// Deprecated, replaced with [`ArgEnum`][crate::ArgEnum]
 #[cfg_attr(
     feature = "deprecated",
-    deprecated(since = "3.0.0", note = "Replaced with `ArgEnum`")
+    deprecated(since = "3.0.0", note = "Replaced with `ValueEnum`")
 )]
 #[doc(hidden)]
 #[macro_export]


### PR DESCRIPTION
Before, I was mixed on doing this as ideally people would upgrade
through the minor releases, going through the release notes.  This also
saves us havin to audit deprecations to make sure they are all pointing
to the latest.

First, this isn't practical for users.  Its annoying to pin your version (at least
its easier now that we pin `clap_derive` for users) and a lot of work to
go through them one step at a time.

On top of that, we've changed our deprecation policy to put the timing
of responding to deprecations into the user's hands with, with us
putting them behind the `deprecated` feature flag.  This means someone
might respond to deprecations every once in a while or might not do it
until right before the 4.0 release.  Our deprecation messages should be
updated to respond to that.

This supersedes #3616

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
