### PR TITLE
Put once_cell reexport into __macro_refs

### DIFF
--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -552,7 +552,7 @@ impl Attrs {
                         })
                     } else {
                         quote_spanned!(ident.span()=> {
-                            static DEFAULT_VALUE: clap::once_cell::sync::Lazy<String> = clap::once_cell::sync::Lazy::new(|| {
+                            static DEFAULT_VALUE: clap::__macro_refs::once_cell::sync::Lazy<String> = clap::__macro_refs::once_cell::sync::Lazy::new(|| {
                                 let val: #ty = #val;
                                 ::std::string::ToString::to_string(&val)
                             });
@@ -592,7 +592,7 @@ impl Attrs {
                         })
                     } else {
                         quote_spanned!(ident.span()=> {
-                            static DEFAULT_VALUE: clap::once_cell::sync::Lazy<::std::ffi::OsString> = clap::once_cell::sync::Lazy::new(|| {
+                            static DEFAULT_VALUE: clap::__macro_refs::once_cell::sync::Lazy<::std::ffi::OsString> = clap::__macro_refs::once_cell::sync::Lazy::new(|| {
                                 let val: #ty = #val;
                                 ::std::ffi::OsString::from(val)
                             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,12 @@ pub use Parser as StructOpt;
 )]
 pub use ValueEnum as ArgEnum;
 
-#[cfg(any(feature = "derive", feature = "cargo"))]
 #[doc(hidden)]
-pub use once_cell;
+pub mod __macro_refs {
+    #[cfg(any(feature = "derive", feature = "cargo"))]
+    #[doc(hidden)]
+    pub use once_cell;
+}
 
 #[macro_use]
 #[allow(missing_docs)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -250,8 +250,10 @@ macro_rules! crate_version {
 #[macro_export]
 macro_rules! crate_authors {
     ($sep:expr) => {{
-        static CACHED: clap::once_cell::sync::Lazy<String> =
-            clap::once_cell::sync::Lazy::new(|| env!("CARGO_PKG_AUTHORS").replace(':', $sep));
+        static CACHED: clap::__macro_refs::once_cell::sync::Lazy<String> =
+            clap::__macro_refs::once_cell::sync::Lazy::new(|| {
+                env!("CARGO_PKG_AUTHORS").replace(':', $sep)
+            });
 
         let s: &'static str = &*CACHED;
         s

--- a/tests/derive_ui/next/bool_value_enum.stderr
+++ b/tests/derive_ui/next/bool_value_enum.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `bool: ValueEnum` is not satisfied
+error[E0277]: the trait bound `bool: ArgEnum` is not satisfied
    --> tests/derive_ui/next/bool_value_enum.rs:6:31
     |
 6   |     #[clap(short, value_enum, default_value_t)]
-    |                               ^^^^^^^^^^^^^^^ the trait `ValueEnum` is not implemented for `bool`
+    |                               ^^^^^^^^^^^^^^^ the trait `ArgEnum` is not implemented for `bool`
     |
 note: required by `to_possible_value`
    --> src/derive.rs


### PR DESCRIPTION
When upgrading our company projects from clap 3.1 to clap 3.2 I had
to fix several references to `clap::lazy_init`. People are not
supposed to do that, but that's hard to enforce.

Hope placing `once_cell` reexport into `__macro_refs` prevent at
least some of the such issues in the future.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
