### PR TITLE
test: Verify auto-traits for core types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ trycmd = { version = "0.13", default-features = false, features = ["color-auto",
 humantime = "2"
 snapbox = "0.2.9"
 shlex = "1.1.0"
+static_assertions = "1.1.0"
 
 [[example]]
 name = "demo"

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -5107,3 +5107,8 @@ where
         _ => None,
     }
 }
+
+#[test]
+fn check_auto_traits() {
+    static_assertions::assert_impl_all!(Command: Send, Sync, Unpin);
+}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1147,12 +1147,7 @@ impl Display for Backtrace {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    /// Check `clap::Error` impls Send and Sync.
-    mod clap_error_impl_send_sync {
-        use crate::Error;
-        trait Foo: std::error::Error + Send + Sync + 'static {}
-        impl Foo for Error {}
-    }
+#[test]
+fn check_auto_traits() {
+    static_assertions::assert_impl_all!(Error: Send, Sync, Unpin);
 }

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -54,3 +54,14 @@ impl std::fmt::Display for MatchesError {
         }
     }
 }
+
+#[test]
+fn check_auto_traits() {
+    static_assertions::assert_impl_all!(
+        MatchesError: Send,
+        Sync,
+        std::panic::RefUnwindSafe,
+        std::panic::UnwindSafe,
+        Unpin
+    );
+}

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -1742,6 +1742,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn check_auto_traits() {
+        static_assertions::assert_impl_all!(ArgMatches: Send, Sync, Unpin);
+    }
+
+    #[test]
     fn test_default_values() {
         #![allow(deprecated)]
         let mut values: Values = Values::default();

--- a/tests/derive_ui/next/tuple_struct.stderr
+++ b/tests/derive_ui/next/tuple_struct.stderr
@@ -17,5 +17,5 @@ error[E0599]: no function or associated item named `parse` found for struct `Opt
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `parse`, perhaps you need to implement one of them:
-           candidate #1: `StructOpt`
+           candidate #1: `Parser`
            candidate #2: `TypedValueParser`


### PR DESCRIPTION
By checking these types, we'll get some other types for free, like
`Command` verifying `Arg`.

This was inspired by #3876

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
