### PR TITLE
WIP: fix: Ensure 'ArgMatches' is unwind safe

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -5110,5 +5110,11 @@ where
 
 #[test]
 fn check_auto_traits() {
-    static_assertions::assert_impl_all!(Command: Send, Sync, Unpin);
+    static_assertions::assert_impl_all!(
+        Command: Send,
+        Sync,
+        std::panic::RefUnwindSafe,
+        std::panic::UnwindSafe,
+        Unpin
+    );
 }

--- a/src/builder/value_parser.rs
+++ b/src/builder/value_parser.rs
@@ -108,7 +108,7 @@ impl ValueParser {
     pub fn new<P>(other: P) -> Self
     where
         P: TypedValueParser,
-        P::Value: Send + Sync + Clone,
+        P::Value: Send + Sync + Clone + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
     {
         Self(ValueParserInner::Other(Box::new(other)))
     }
@@ -284,7 +284,7 @@ impl ValueParser {
 impl<P> From<P> for ValueParser
 where
     P: TypedValueParser + Send + Sync + 'static,
-    P::Value: Send + Sync + Clone,
+    P::Value: Send + Sync + Clone + std::panic::UnwindSafe + std::panic::RefUnwindSafe,
 {
     fn from(p: P) -> Self {
         Self::new(p)
@@ -563,7 +563,13 @@ trait AnyValueParser: Send + Sync + 'static {
 
 impl<T, P> AnyValueParser for P
 where
-    T: std::any::Any + Clone + Send + Sync + 'static,
+    T: std::any::Any
+        + Clone
+        + Send
+        + Sync
+        + std::panic::UnwindSafe
+        + std::panic::RefUnwindSafe
+        + 'static,
     P: TypedValueParser<Value = T>,
 {
     fn parse_ref(
@@ -1963,7 +1969,14 @@ pub mod via_prelude {
     }
     impl<FromStr> _ValueParserViaFromStr for _AutoValueParser<FromStr>
     where
-        FromStr: std::str::FromStr + std::any::Any + Clone + Send + Sync + 'static,
+        FromStr: std::str::FromStr
+            + std::any::Any
+            + Clone
+            + Send
+            + Sync
+            + std::panic::UnwindSafe
+            + std::panic::RefUnwindSafe
+            + 'static,
         <FromStr as std::str::FromStr>::Err:
             Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
     {

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -114,7 +114,12 @@ impl ArgMatches {
     /// [positional]: crate::Arg::index()
     /// [`default_value`]: crate::Arg::default_value()
     #[track_caller]
-    pub fn get_one<T: Any + Clone + Send + Sync + 'static>(&self, id: &str) -> Option<&T> {
+    pub fn get_one<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
+        &self,
+        id: &str,
+    ) -> Option<&T> {
         let internal_id = Id::from(id);
         MatchesError::unwrap(&internal_id, self.try_get_one(id))
     }
@@ -153,7 +158,9 @@ impl ArgMatches {
     /// assert_eq!(vals, [22, 80, 2020]);
     /// ```
     #[track_caller]
-    pub fn get_many<T: Any + Clone + Send + Sync + 'static>(
+    pub fn get_many<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
         &self,
         id: &str,
     ) -> Option<ValuesRef<T>> {
@@ -243,7 +250,12 @@ impl ArgMatches {
     /// [positional]: crate::Arg::index()
     /// [`default_value`]: crate::Arg::default_value()
     #[track_caller]
-    pub fn remove_one<T: Any + Clone + Send + Sync + 'static>(&mut self, id: &str) -> Option<T> {
+    pub fn remove_one<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
+        &mut self,
+        id: &str,
+    ) -> Option<T> {
         let internal_id = Id::from(id);
         MatchesError::unwrap(&internal_id, self.try_remove_one(id))
     }
@@ -280,7 +292,9 @@ impl ArgMatches {
     /// assert_eq!(vals, ["file1.txt", "file2.txt", "file3.txt", "file4.txt"]);
     /// ```
     #[track_caller]
-    pub fn remove_many<T: Any + Clone + Send + Sync + 'static>(
+    pub fn remove_many<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
         &mut self,
         id: &str,
     ) -> Option<Values2<T>> {
@@ -1074,7 +1088,9 @@ impl ArgMatches {
 /// # Advanced
 impl ArgMatches {
     /// Non-panicking version of [`ArgMatches::get_one`]
-    pub fn try_get_one<T: Any + Clone + Send + Sync + 'static>(
+    pub fn try_get_one<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
         &self,
         id: &str,
     ) -> Result<Option<&T>, MatchesError> {
@@ -1093,7 +1109,9 @@ impl ArgMatches {
     }
 
     /// Non-panicking version of [`ArgMatches::get_many`]
-    pub fn try_get_many<T: Any + Clone + Send + Sync + 'static>(
+    pub fn try_get_many<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
         &self,
         id: &str,
     ) -> Result<Option<ValuesRef<T>>, MatchesError> {
@@ -1129,7 +1147,9 @@ impl ArgMatches {
     }
 
     /// Non-panicking version of [`ArgMatches::remove_one`]
-    pub fn try_remove_one<T: Any + Clone + Send + Sync + 'static>(
+    pub fn try_remove_one<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
         &mut self,
         id: &str,
     ) -> Result<Option<T>, MatchesError> {
@@ -1145,7 +1165,9 @@ impl ArgMatches {
     }
 
     /// Non-panicking version of [`ArgMatches::remove_many`]
-    pub fn try_remove_many<T: Any + Clone + Send + Sync + 'static>(
+    pub fn try_remove_many<
+        T: Any + Clone + Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe + 'static,
+    >(
         &mut self,
         id: &str,
     ) -> Result<Option<Values2<T>>, MatchesError> {
@@ -1743,7 +1765,13 @@ mod tests {
 
     #[test]
     fn check_auto_traits() {
-        static_assertions::assert_impl_all!(ArgMatches: Send, Sync, Unpin);
+        static_assertions::assert_impl_all!(
+            ArgMatches: Send,
+            Sync,
+            std::panic::RefUnwindSafe,
+            std::panic::UnwindSafe,
+            Unpin
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3876

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
