### PR TITLE
feat(clap_complete_fig): Switch to using `ArgAction`

### DIFF
--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -216,8 +216,9 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
             }
 
-            #[allow(deprecated)]
-            if option.is_multiple_occurrences_set() {
+            if let ArgAction::Set | ArgAction::Append | ArgAction::Count =
+                option.get_action()
+            {
                 buffer.push_str(&format!(
                     "{:indent$}isRepeatable: true,\n",
                     "",
@@ -304,8 +305,9 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
             }
 
-            #[allow(deprecated)]
-            if flag.is_multiple_occurrences_set() {
+            if let ArgAction::Set | ArgAction::Append | ArgAction::Count =
+                flag.get_action()
+            {
                 buffer.push_str(&format!(
                     "{:indent$}isRepeatable: true,\n",
                     "",

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -216,9 +216,7 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
             }
 
-            if let ArgAction::Set | ArgAction::Append | ArgAction::Count =
-                option.get_action()
-            {
+            if let ArgAction::Set | ArgAction::Append | ArgAction::Count = option.get_action() {
                 buffer.push_str(&format!(
                     "{:indent$}isRepeatable: true,\n",
                     "",
@@ -305,9 +303,7 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
             }
 
-            if let ArgAction::Set | ArgAction::Append | ArgAction::Count =
-                flag.get_action()
-            {
+            if let ArgAction::Set | ArgAction::Append | ArgAction::Count = flag.get_action() {
                 buffer.push_str(&format!(
                     "{:indent$}isRepeatable: true,\n",
                     "",

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -216,6 +216,19 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
             }
 
+            #[allow(deprecated)]
+            if matches!(
+                option.get_action(),
+                ArgAction::StoreValue | ArgAction::IncOccurrence
+            ) && option.is_multiple_occurrences_set()
+            {
+                buffer.push_str(&format!(
+                    "{:indent$}isRepeatable: true,\n",
+                    "",
+                    indent = indent + 4
+                ));
+            }
+
             if let ArgAction::Set | ArgAction::Append | ArgAction::Count = option.get_action() {
                 buffer.push_str(&format!(
                     "{:indent$}isRepeatable: true,\n",
@@ -301,6 +314,19 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 }
 
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
+            }
+
+            #[allow(deprecated)]
+            if matches!(
+                flag.get_action(),
+                ArgAction::StoreValue | ArgAction::IncOccurrence
+            ) && flag.is_multiple_occurrences_set()
+            {
+                buffer.push_str(&format!(
+                    "{:indent$}isRepeatable: true,\n",
+                    "",
+                    indent = indent + 4
+                ));
             }
 
             if let ArgAction::Set | ArgAction::Append | ArgAction::Count = flag.get_action() {


### PR DESCRIPTION
This removes the deprecated `is_multiple_occurrences_set` and uses `ArgAction` instead