### PR TITLE
Add support for ignoring errors on subcommands

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -671,7 +671,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
     ) -> ClapResult<()> {
         debug!("Parser::parse_subcommand");
 
-        let partial_parsing_enabled = self.cmd.is_ignore_errors_set();
+        let global_ignore_errors = self.cmd.is_ignore_errors_set();
 
         if let Some(sc) = self.cmd._build_subcommand(sc_name) {
             let mut sc_matcher = ArgMatcher::new(sc);
@@ -691,7 +691,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     p.flag_subcmd_skip = self.flag_subcmd_skip;
                 }
                 if let Err(error) = p.get_matches_with(&mut sc_matcher, raw_args, args_cursor) {
-                    if partial_parsing_enabled {
+                    if sc.is_ignore_errors_set() || global_ignore_errors {
                         debug!(
                             "Parser::parse_subcommand: ignored error in subcommand {}: {:?}",
                             sc_name, error


### PR DESCRIPTION
Currently when setting `ignore_errors(true)` anywhere but the top level,
it would not have any effect. As a result this means it's not possible
to ignore errors for a subcommand while still enforcing correctness on
the top level.

This patch makes it possible to set `ignore_errors(true)` anywhere in
the nested subcommand chain and all children will ignore errors without
affecting the parent elements.

This is particularly helpful for external subcommands that are still
documented on the top level, making it possible to generically forward
all parameters while still documenting the externals subcommand on the
top level.