### PR TITLE
Add comment about requiring the derive feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ Create your command-line parser, with all of the bells and whistles, declarative
 
 ### Example
 
-This uses our
+Add `clap` as a dependency with the `derive` feature enabled:
+```console
+cargo add clap -F derive
+```
+
+This allows using the
 [Derive API](https://github.com/clap-rs/clap/blob/v3.2.8/examples/tutorial_derive/README.md)
 which provides access to the [Builder API](https://github.com/clap-rs/clap/blob/v3.2.8/examples/tutorial_builder/README.md) as attributes on a `struct`:
 
@@ -60,11 +65,7 @@ fn main() {
     }
 }
 ```
-Add this to `Cargo.toml`:
-```toml
-[dependencies]
-clap = { version = "3.2.8", features = ["derive"] }
-```
+
 ```bash
 $ demo --help
 clap [..]


### PR DESCRIPTION
This example is the first example on the [main documentation page](https://docs.rs/clap/latest/clap/). However, by default, copy pasting just the example doesn't work since it requires enabling the `derive` feature first. The necessity of this is described after the example, which makes it easy to miss. By adding this comment to the top of the example it is more likely to be noticed by devs eager to get their command line handling going.

It's a minor thing, I missed it, got a compile failure and only then scrolled down far enough to see the note about the feature. I expect I'm not the only one who has done that, so maybe this prevents others from running into this. Feel free to close if not deemed important enough.