### PR TITLE
docs(derive): Clarify `rename_all` takes a string literal

### DIFF
--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -153,11 +153,11 @@ when defining subcommands.
 - `next_help_heading`: `clap::Command::next_help_heading`
   - When `flatten`ing `Args`, this is scoped to just the args in this struct and any struct `flatten`ed into it
 - `rename_all = <expr>`: Override default field / variant name case conversion for `Command::name` / `Arg::name`
-  - When not present: `kebab-case`
-  - Available values: `camelCase`, `kebab-case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, `snake_case`, `lower`, `UPPER`, `verbatim`
+  - When not present: `"kebab-case"`
+  - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
 - `rename_all_env = <expr>`: Override default field name case conversion for env variables for  `clap::Arg::env`
-  - When not present: `SCREAMING_SNAKE_CASE`
-  - Available values: `camelCase`, `kebab-case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, `snake_case`, `lower`, `UPPER`, `verbatim`
+  - When not present: `"SCREAMING_SNAKE_CASE"`
+  - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
 
 And for `Subcommand` variants:
 - `skip`: Ignore this variant
@@ -229,8 +229,8 @@ These correspond to a `clap::Arg`.
 ### Arg Enum Attributes
 
 - `rename_all = <expr>`: Override default field / variant name case conversion for `PossibleValue::new`
-  - When not present: `kebab-case`
-  - Available values: `camelCase`, `kebab-case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, `snake_case`, `lower`, `UPPER`, `verbatim`
+  - When not present: `"kebab-case"`
+  - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
 
 ### Possible Value Attributes
 

--- a/examples/derive_ref/README.md
+++ b/examples/derive_ref/README.md
@@ -152,10 +152,10 @@ when defining subcommands.
 - `next_display_order`: `clap::Command::next_display_order`
 - `next_help_heading`: `clap::Command::next_help_heading`
   - When `flatten`ing `Args`, this is scoped to just the args in this struct and any struct `flatten`ed into it
-- `rename_all = <expr>`: Override default field / variant name case conversion for `Command::name` / `Arg::name`
+- `rename_all = <string_literal>`: Override default field / variant name case conversion for `Command::name` / `Arg::name`
   - When not present: `"kebab-case"`
   - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
-- `rename_all_env = <expr>`: Override default field name case conversion for env variables for  `clap::Arg::env`
+- `rename_all_env = <string_literal>`: Override default field name case conversion for env variables for  `clap::Arg::env`
   - When not present: `"SCREAMING_SNAKE_CASE"`
   - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
 
@@ -228,7 +228,7 @@ These correspond to a `clap::Arg`.
 
 ### Arg Enum Attributes
 
-- `rename_all = <expr>`: Override default field / variant name case conversion for `PossibleValue::new`
+- `rename_all = <string_literal>`: Override default field / variant name case conversion for `PossibleValue::new`
   - When not present: `"kebab-case"`
   - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
 


### PR DESCRIPTION
This makes it more clear that quotes are needed. When deriving `ValueEnum` (and possibly in other cases as well), the attribute is silently ignored if the user leaves off these quotes: see #3907.