### PR TITLE
feat: Add method to get non-visible arg aliases

### DIFF
--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -4316,6 +4316,16 @@ impl<'help> Arg<'help> {
         }
     }
 
+    /// Get *all* short aliases for this argument, if any, both visible and hidden.
+    #[inline]
+    pub fn get_all_short_aliases(&self) -> Option<Vec<char>> {
+        if self.short_aliases.is_empty() {
+            None
+        } else {
+            Some(self.short_aliases.iter().map(|(s, _)| s).copied().collect())
+        }
+    }
+
     /// Get the short option name and its visible aliases, if any
     #[inline]
     pub fn get_short_and_visible_aliases(&self) -> Option<Vec<char>> {
@@ -4348,6 +4358,16 @@ impl<'help> Arg<'help> {
                     .copied()
                     .collect(),
             )
+        }
+    }
+
+    /// Get *all* aliases for this argument, if any, both visible and hidden.
+    #[inline]
+    pub fn get_all_aliases(&self) -> Option<Vec<&'help str>> {
+        if self.aliases.is_empty() {
+            None
+        } else {
+            Some(self.aliases.iter().map(|(s, _)| s).copied().collect())
         }
     }
 

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -112,6 +112,37 @@ fn multiple_aliases_of_option() {
 }
 
 #[test]
+fn get_aliases() {
+    let a = Arg::new("aliases")
+        .long("aliases")
+        .takes_value(true)
+        .help("multiple aliases")
+        .aliases(&["alias1", "alias2", "alias3"])
+        .short_aliases(&['a', 'b', 'c'])
+        .visible_aliases(&["alias4", "alias5", "alias6"])
+        .visible_short_aliases(&['d', 'e', 'f']);
+
+    assert!(a.get_short_and_visible_aliases().is_none());
+    assert_eq!(
+        a.get_long_and_visible_aliases().unwrap(),
+        &["aliases", "alias4", "alias5", "alias6"]
+    );
+    assert_eq!(
+        a.get_visible_aliases().unwrap(),
+        &["alias4", "alias5", "alias6"]
+    );
+    assert_eq!(
+        a.get_all_aliases().unwrap(),
+        &["alias1", "alias2", "alias3", "alias4", "alias5", "alias6"]
+    );
+    assert_eq!(a.get_visible_short_aliases().unwrap(), vec!['d', 'e', 'f']);
+    assert_eq!(
+        a.get_all_short_aliases().unwrap(),
+        vec!['a', 'b', 'c', 'd', 'e', 'f']
+    );
+}
+
+#[test]
 fn single_alias_of_flag() {
     let a = Command::new("test")
         .arg(


### PR DESCRIPTION
there currently appears to be no way to get non-visible arg aliases, so add a method to expose those, matching what `Command` offers with: https://docs.rs/clap/latest/clap/builder/struct.App.html#method.get_all_long_flag_aliases
