### PR TITLE
chore: Bump `terminal_size` version to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ strsim = { version = "0.10",  optional = true }
 yaml-rust = { version = "0.4.1",  optional = true }
 atty = { version = "0.2",  optional = true }
 termcolor = { version = "1.1.1", optional = true }
-terminal_size = { version = "0.1.12", optional = true }
+terminal_size = { version = "0.2.1", optional = true }
 regex = { version = "1.0", optional = true }
 backtrace = { version = "0.3", optional = true }
 once_cell = { version = "1.12.0", optional = true }


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
