### PR TITLE
Improve error for `args_conflicts_with_subcommands`

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -651,24 +651,24 @@ impl Error {
                                 c.warning(&**v);
                             }
                             true
-                        },
+                        }
                         (Some(ContextValue::String(value)), _) => {
                             c.none(" '");
                             c.warning(value);
                             c.none("'");
                             true
-                        },
+                        }
                         (_, Some(ContextValue::String(value))) => {
                             c.none(" subcommand '");
                             c.warning(value);
                             c.none("'");
                             true
-                        },
+                        }
                         (Some(_), _) | (_, Some(_)) => {
                             c.none(" one or more of the other specified arguments");
                             true
-                        },
-                        (None, None) => false
+                        }
+                        (None, None) => false,
                     }
                 } else {
                     false

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -78,7 +78,7 @@ OPTIONS:
 
 SUBCOMMANDS:
     help    Print this message or the help of the given subcommand(s)
-    info    
+    info
 ";
 
 #[test]
@@ -746,14 +746,24 @@ fn args_negate_subcommands_two_levels() {
 
 #[test]
 fn args_conflict_subcommands_error() {
-    let res = Command::new("todo")
+    let app = Command::new("todo")
         .args_conflicts_with_subcommands(true)
         .arg(arg!(--flag))
-        .subcommand(Command::new("sub1"))
-        .try_get_matches_from(vec!["", "--flag", "sub1"]);
+        .subcommand(Command::new("sub1"));
 
-    assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+    utils::assert_output(
+        app,
+        " --flag sub1",
+        "\
+error: The argument '--flag' cannot be used with subcommand 'sub1'
+
+USAGE:
+    todo [OPTIONS]
+    todo <SUBCOMMAND>
+
+For more information try --help\n",
+        true,
+    );
 }
 
 #[test]

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -745,6 +745,18 @@ fn args_negate_subcommands_two_levels() {
 }
 
 #[test]
+fn args_conflict_subcommands_error() {
+    let res = Command::new("todo")
+        .args_conflicts_with_subcommands(true)
+        .arg(arg!(--flag))
+        .subcommand(Command::new("sub1"))
+        .try_get_matches_from(vec!["", "--flag", "sub1"]);
+
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn propagate_vals_down() {
     let m = Command::new("myprog")
         .arg(arg!([cmd] "command to run").global(true))


### PR DESCRIPTION
Before this patch when running into errors due to
`args_conflicts_with_subcommands`, you'd get an output looking like
this:

```
error: The subcommand 'auth' wasn't recognized

	Did you mean 'auth'?
```

This is highly confusing and leaves the user without any information on
what actually went wrong.

This patch addresses this problem by introducing a new error message
dedicated for this scenario which will inform the user that the specific
combination of argument and subcommand used is not valid.