### PR TITLE
fix(error):! Merge EmptyValue into InvalidValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 _gated behind `unstable-v4`_
 
+### Breaking Changes
+
+- `Error::EmptyValue` replaced with `Error::InvalidValue`
+
 ### Features
 
 - *(help)* Show `PossibleValue::help` in long help (`--help`) (#3312)

--- a/src/error/kind.rs
+++ b/src/error/kind.rs
@@ -83,24 +83,6 @@ pub enum ErrorKind {
     /// [`UnknownArgument`]: ErrorKind::UnknownArgument
     UnrecognizedSubcommand,
 
-    /// Occurs when the user provides an empty value for an option that does not allow empty
-    /// values.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{Command, Arg, ErrorKind};
-    /// let res = Command::new("prog")
-    ///     .arg(Arg::new("color")
-    ///          .takes_value(true)
-    ///          .value_parser(clap::builder::NonEmptyStringValueParser::new())
-    ///          .long("color"))
-    ///     .try_get_matches_from(vec!["prog", "--color="]);
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::EmptyValue);
-    /// ```
-    EmptyValue,
-
     /// Occurs when the user doesn't use equals for an option that requires equal
     /// sign to provide values.
     ///
@@ -380,7 +362,6 @@ impl ErrorKind {
             }
             Self::InvalidSubcommand => Some("A subcommand wasn't recognized"),
             Self::UnrecognizedSubcommand => Some("A subcommand wasn't recognized"),
-            Self::EmptyValue => Some("An argument requires a value but none was supplied"),
             Self::NoEquals => Some("Equal is needed when assigning values to one of the arguments"),
             Self::ValueValidation => Some("Invalid value for one of the arguments"),
             Self::TooManyValues => Some("An argument received an unexpected value"),

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -48,7 +48,7 @@ fn opt_without_value_fail() {
         .try_get_matches_from(vec!["", "-o"]);
     assert!(r.is_err());
     let err = r.unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::EmptyValue);
+    assert_eq!(err.kind(), ErrorKind::InvalidValue);
     assert!(err
         .to_string()
         .contains("The argument '-o <opt>' requires a value but none was supplied"));

--- a/tests/builder/empty_values.rs
+++ b/tests/builder/empty_values.rs
@@ -37,7 +37,7 @@ fn no_empty_values() {
         )
         .try_get_matches_from(&["config", "--config", ""]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 
     let m = Command::new("config")
         .arg(
@@ -48,7 +48,7 @@ fn no_empty_values() {
         )
         .try_get_matches_from(&["config", "-c", ""]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue)
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue)
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn no_empty_values_with_equals() {
         )
         .try_get_matches_from(&["config", "--config="]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 
     let m = Command::new("config")
         .arg(
@@ -73,7 +73,7 @@ fn no_empty_values_with_equals() {
         )
         .try_get_matches_from(&["config", "-c="]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn no_empty_values_without_equals() {
         )
         .try_get_matches_from(&["config", "--config"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue);
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue);
 
     let m = Command::new("config")
         .arg(
@@ -98,7 +98,7 @@ fn no_empty_values_without_equals() {
         )
         .try_get_matches_from(&["config", "-c"]);
     assert!(m.is_err());
-    assert_eq!(m.unwrap_err().kind(), ErrorKind::EmptyValue)
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::InvalidValue)
 }
 
 #[test]

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -112,7 +112,7 @@ fn require_equals_no_empty_values_fail() {
         .arg(Arg::new("some"))
         .try_get_matches_from(vec!["prog", "--config=", "file.conf"]);
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().kind(), ErrorKind::EmptyValue);
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -541,7 +541,7 @@ fn issue_1105_setup(argv: Vec<&'static str>) -> Result<ArgMatches, clap::Error> 
 fn issue_1105_empty_value_long_fail() {
     let r = issue_1105_setup(vec!["cmd", "--option", "--flag"]);
     assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind(), ErrorKind::EmptyValue);
+    assert_eq!(r.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]
@@ -564,7 +564,7 @@ fn issue_1105_empty_value_long_equals() {
 fn issue_1105_empty_value_short_fail() {
     let r = issue_1105_setup(vec!["cmd", "-o", "--flag"]);
     assert!(r.is_err());
-    assert_eq!(r.unwrap_err().kind(), ErrorKind::EmptyValue);
+    assert_eq!(r.unwrap_err().kind(), ErrorKind::InvalidValue);
 }
 
 #[test]


### PR DESCRIPTION
There isn't a reason to programmatically differentiate them so this
merges them simplify programamtic cases and to hopefully reduce binary
size.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
