### PR TITLE
fix(help)!: Make DeriveDisplayOrder the default, removing it 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `ErrorKind::EmptyValue` replaced with `ErrorKind::InvalidValue`
 - `ErrorKind::UnrecognizedSubcommand` replaced with `ErrorKind::InvalidSubcommand`
 - `arg!` now sets `ArgAction::SetTrue`, `ArgAction::Count`, `ArgAction::Set`, or `ArgAction::Append` as appropriate
+- *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag
 - *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 
 - `ErrorKind::EmptyValue` replaced with `ErrorKind::InvalidValue`
-- `ErrorKind::UnrecognizedSubcommand` replaced with `ErrorKind::InvalidSubcommand`
-- `arg!` now sets `ArgAction::SetTrue`, `ArgAction::Count`, `ArgAction::Set`, or `ArgAction::Append` as appropriate
-- *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value
-- *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag
-- *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp`
+- `ErrorKind::UnrecognizedSubcommand` replaced with `ErrorKind::InvalidSubcommand` (#3676)
+- `arg!` now sets `ArgAction::SetTrue`, `ArgAction::Count`, `ArgAction::Set`, or `ArgAction::Append` as appropriate (#3795)
+- *(help)* Make `DeriveDisplayOrder` the default and removed the setting.  To sort help, set `next_display_order(None)` (#2808)
+- *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value (#2808)
+- *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)
+- *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp` (#3280)
 
 ### Features
 

--- a/clap_bench/benches/06_rustup.rs
+++ b/clap_bench/benches/06_rustup.rs
@@ -2,7 +2,7 @@
 //
 // CLI used is from rustup 408ed84f0e50511ed44a405dd91365e5da588790
 
-use clap::{AppSettings, Arg, ArgGroup, Command};
+use clap::{Arg, ArgGroup, Command};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 pub fn build_rustup(c: &mut Criterion) {
@@ -26,7 +26,6 @@ fn build_cli() -> Command<'static> {
         .version("0.9.0") // Simulating
         .about("The Rust toolchain installer")
         .after_help(RUSTUP_HELP)
-        .setting(AppSettings::DeriveDisplayOrder)
         .arg(
             Arg::new("verbose")
                 .help("Enable verbose output")
@@ -67,7 +66,6 @@ fn build_cli() -> Command<'static> {
             Command::new("toolchain")
                 .about("Modify or query the installed toolchains")
                 .after_help(TOOLCHAIN_HELP)
-                .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(Command::new("list").about("List installed toolchains"))
                 .subcommand(
                     Command::new("install")
@@ -104,7 +102,6 @@ fn build_cli() -> Command<'static> {
         .subcommand(
             Command::new("target")
                 .about("Modify a toolchain's supported targets")
-                .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(
                     Command::new("list")
                         .about("List installed and available targets")
@@ -138,7 +135,6 @@ fn build_cli() -> Command<'static> {
         .subcommand(
             Command::new("component")
                 .about("Modify a toolchain's installed components")
-                .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(
                     Command::new("list")
                         .about("List installed and available components")
@@ -163,7 +159,6 @@ fn build_cli() -> Command<'static> {
             Command::new("override")
                 .about("Modify directory toolchain overrides")
                 .after_help(OVERRIDE_HELP)
-                .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(Command::new("list").about("List directory toolchain overrides"))
                 .subcommand(
                     Command::new("set")
@@ -246,7 +241,6 @@ fn build_cli() -> Command<'static> {
         .subcommand(
             Command::new("self")
                 .about("Modify the rustup installation")
-                .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(Command::new("update").about("Download and install updates to rustup"))
                 .subcommand(
                     Command::new("uninstall")
@@ -261,7 +255,6 @@ fn build_cli() -> Command<'static> {
             Command::new("telemetry")
                 .about("rustup telemetry commands")
                 .hide(true)
-                .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(Command::new("enable").about("Enable rustup telemetry"))
                 .subcommand(Command::new("disable").about("Disable rustup telemetry"))
                 .subcommand(Command::new("analyze").about("Analyze stored telemetry")),

--- a/clap_complete/src/generator/utils.rs
+++ b/clap_complete/src/generator/utils.rs
@@ -62,7 +62,7 @@ pub fn subcommands(p: &Command) -> Vec<(String, String)> {
 }
 
 /// Gets all the short options, their visible aliases and flags of a [`clap::Command`].
-/// Includes `h` and `V` depending on the [`clap::AppSettings`].
+/// Includes `h` and `V` depending on the [`clap::Command`] settings.
 pub fn shorts_and_visible_aliases(p: &Command) -> Vec<char> {
     debug!("shorts: name={}", p.get_name());
 
@@ -87,7 +87,7 @@ pub fn shorts_and_visible_aliases(p: &Command) -> Vec<char> {
 }
 
 /// Gets all the long options, their visible aliases and flags of a [`clap::Command`].
-/// Includes `help` and `version` depending on the [`clap::AppSettings`].
+/// Includes `help` and `version` depending on the [`clap::Command`] settings.
 pub fn longs_and_visible_aliases(p: &Command) -> Vec<String> {
     debug!("longs: name={}", p.get_name());
 
@@ -117,7 +117,7 @@ pub fn longs_and_visible_aliases(p: &Command) -> Vec<String> {
 }
 
 /// Gets all the flags of a [`clap::Command`](Command).
-/// Includes `help` and `version` depending on the [`clap::AppSettings`].
+/// Includes `help` and `version` depending on the [`clap::Command`] settings.
 pub fn flags<'help>(p: &Command<'help>) -> Vec<Arg<'help>> {
     debug!("flags: name={}", p.get_name());
     p.get_arguments()

--- a/examples/cargo-example-derive.md
+++ b/examples/cargo-example-derive.md
@@ -26,8 +26,8 @@ USAGE:
     cargo example-derive [OPTIONS]
 
 OPTIONS:
-    -h, --help                             Print help information
         --manifest-path <MANIFEST_PATH>    
+    -h, --help                             Print help information
     -V, --version                          Print version information
 
 ```

--- a/examples/cargo-example.md
+++ b/examples/cargo-example.md
@@ -26,8 +26,8 @@ USAGE:
     cargo example [OPTIONS]
 
 OPTIONS:
-    -h, --help                    Print help information
         --manifest-path <PATH>    
+    -h, --help                    Print help information
     -V, --version                 Print version information
 
 ```

--- a/examples/demo.md
+++ b/examples/demo.md
@@ -7,9 +7,9 @@ USAGE:
     demo[EXE] [OPTIONS] --name <NAME>
 
 OPTIONS:
+    -n, --name <NAME>      Name of the person to greet
     -c, --count <COUNT>    Number of times to greet [default: 1]
     -h, --help             Print help information
-    -n, --name <NAME>      Name of the person to greet
     -V, --version          Print version information
 
 $ demo --name Me

--- a/examples/derive_ref/custom-bool.md
+++ b/examples/derive_ref/custom-bool.md
@@ -14,8 +14,8 @@ ARGS:
     <BOOM>    [possible values: true, false]
 
 OPTIONS:
-        --bar <BAR>    [default: false]
         --foo <FOO>    [possible values: true, false]
+        --bar <BAR>    [default: false]
     -h, --help         Print help information
     -V, --version      Print version information
 

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -107,8 +107,8 @@ USAGE:
     interop_hand_subcommand[EXE] [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
-    -h, --help         Print help information
     -t, --top-level    
+    -h, --help         Print help information
 
 SUBCOMMANDS:
     add       

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -112,8 +112,8 @@ OPTIONS:
 
 SUBCOMMANDS:
     add       
-    help      Print this message or the help of the given subcommand(s)
     remove    
+    help      Print this message or the help of the given subcommand(s)
 
 ```
 

--- a/examples/escaped-positional-derive.md
+++ b/examples/escaped-positional-derive.md
@@ -16,8 +16,8 @@ ARGS:
 
 OPTIONS:
     -f               
-    -h, --help       Print help information
     -p <PEAR>        
+    -h, --help       Print help information
     -V, --version    Print version information
 
 ```

--- a/examples/escaped-positional.md
+++ b/examples/escaped-positional.md
@@ -16,8 +16,8 @@ ARGS:
 
 OPTIONS:
     -f               
-    -h, --help       Print help information
     -p <PEAR>        
+    -h, --help       Print help information
     -V, --version    Print version information
 
 ```

--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -85,8 +85,8 @@ USAGE:
     git-derive[EXE] stash <SUBCOMMAND>
 
 OPTIONS:
-    -h, --help                 Print help information
     -m, --message <MESSAGE>    
+    -h, --help                 Print help information
 
 SUBCOMMANDS:
     push     
@@ -101,8 +101,8 @@ USAGE:
     git-derive[EXE] stash push [OPTIONS]
 
 OPTIONS:
-    -h, --help                 Print help information
     -m, --message <MESSAGE>    
+    -h, --help                 Print help information
 
 $ git-derive stash pop -h
 git-stash-pop 

--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -16,11 +16,11 @@ OPTIONS:
     -h, --help    Print help information
 
 SUBCOMMANDS:
-    add      adds things
     clone    Clones repos
-    help     Print this message or the help of the given subcommand(s)
     push     pushes things
+    add      adds things
     stash    
+    help     Print this message or the help of the given subcommand(s)
 
 $ git-derive help
 git 
@@ -33,11 +33,11 @@ OPTIONS:
     -h, --help    Print help information
 
 SUBCOMMANDS:
-    add      adds things
     clone    Clones repos
-    help     Print this message or the help of the given subcommand(s)
     push     pushes things
+    add      adds things
     stash    
+    help     Print this message or the help of the given subcommand(s)
 
 $ git-derive help add
 git-add 
@@ -89,10 +89,10 @@ OPTIONS:
     -m, --message <MESSAGE>    
 
 SUBCOMMANDS:
+    push     
+    pop      
     apply    
     help     Print this message or the help of the given subcommand(s)
-    pop      
-    push     
 
 $ git-derive stash push -h
 git-stash-push 

--- a/examples/git.md
+++ b/examples/git.md
@@ -14,11 +14,11 @@ OPTIONS:
     -h, --help    Print help information
 
 SUBCOMMANDS:
-    add      adds things
     clone    Clones repos
-    help     Print this message or the help of the given subcommand(s)
     push     pushes things
+    add      adds things
     stash    
+    help     Print this message or the help of the given subcommand(s)
 
 $ git help
 git 
@@ -31,11 +31,11 @@ OPTIONS:
     -h, --help    Print help information
 
 SUBCOMMANDS:
-    add      adds things
     clone    Clones repos
-    help     Print this message or the help of the given subcommand(s)
     push     pushes things
+    add      adds things
     stash    
+    help     Print this message or the help of the given subcommand(s)
 
 $ git help add
 git-add 
@@ -87,10 +87,10 @@ OPTIONS:
     -m, --message <MESSAGE>    
 
 SUBCOMMANDS:
+    push     
+    pop      
     apply    
     help     Print this message or the help of the given subcommand(s)
-    pop      
-    push     
 
 $ git stash push -h
 git-stash-push 

--- a/examples/git.md
+++ b/examples/git.md
@@ -83,8 +83,8 @@ USAGE:
     git[EXE] stash <SUBCOMMAND>
 
 OPTIONS:
-    -h, --help                 Print help information
     -m, --message <MESSAGE>    
+    -h, --help                 Print help information
 
 SUBCOMMANDS:
     push     
@@ -99,8 +99,8 @@ USAGE:
     git[EXE] stash push [OPTIONS]
 
 OPTIONS:
-    -h, --help                 Print help information
     -m, --message <MESSAGE>    
+    -h, --help                 Print help information
 
 $ git stash pop -h
 git-stash-pop 

--- a/examples/multicall-busybox.md
+++ b/examples/multicall-busybox.md
@@ -35,8 +35,8 @@ OPTIONS:
         --install <install>    Install hardlinks for all subcommands in path
 
 APPLETS:
+    true     does nothing successfully
     false    does nothing unsuccessfully
     help     Print this message or the help of the given subcommand(s)
-    true     does nothing successfully
 
 ```

--- a/examples/multicall-busybox.md
+++ b/examples/multicall-busybox.md
@@ -31,8 +31,8 @@ USAGE:
     busybox [OPTIONS] [APPLET]
 
 OPTIONS:
-    -h, --help                 Print help information
         --install <install>    Install hardlinks for all subcommands in path
+    -h, --help                 Print help information
 
 APPLETS:
     true     does nothing successfully

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -62,9 +62,9 @@ ARGS:
     <package>...    packages
 
 OPTIONS:
-    -h, --help                  Print help information
-    -i, --info                  view package information
     -s, --search <search>...    search remote repositories for matching strings
+    -i, --info                  view package information
+    -h, --help                  Print help information
 
 ```
 

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -47,9 +47,9 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    help                Print this message or the help of the given subcommand(s)
     query -Q --query    Query the package database.
     sync -S --sync      Synchronize packages.
+    help                Print this message or the help of the given subcommand(s)
 
 $ pacman -S -h
 pacman-sync 

--- a/examples/tutorial_builder/01_quick.md
+++ b/examples/tutorial_builder/01_quick.md
@@ -16,8 +16,8 @@ OPTIONS:
     -V, --version          Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    does testing things
+    help    Print this message or the help of the given subcommand(s)
 
 ```
 

--- a/examples/tutorial_builder/02_app_settings.rs
+++ b/examples/tutorial_builder/02_app_settings.rs
@@ -1,8 +1,7 @@
-use clap::{arg, command, AppSettings, ArgAction};
+use clap::{arg, command, ArgAction};
 
 fn main() {
     let matches = command!() // requires `cargo` feature
-        .global_setting(AppSettings::DeriveDisplayOrder)
         .allow_negative_numbers(true)
         .arg(arg!(--two <VALUE>).action(ArgAction::Set))
         .arg(arg!(--one <VALUE>).action(ArgAction::Set))

--- a/examples/tutorial_builder/02_apps.md
+++ b/examples/tutorial_builder/02_apps.md
@@ -8,9 +8,9 @@ USAGE:
     02_apps[EXE] --two <VALUE> --one <VALUE>
 
 OPTIONS:
-    -h, --help           Print help information
-        --one <VALUE>    
         --two <VALUE>    
+        --one <VALUE>    
+    -h, --help           Print help information
     -V, --version        Print version information
 
 $ 02_apps --version

--- a/examples/tutorial_builder/02_crate.md
+++ b/examples/tutorial_builder/02_crate.md
@@ -7,9 +7,9 @@ USAGE:
     02_crate[EXE] --two <VALUE> --one <VALUE>
 
 OPTIONS:
-    -h, --help           Print help information
-        --one <VALUE>    
         --two <VALUE>    
+        --one <VALUE>    
+    -h, --help           Print help information
     -V, --version        Print version information
 
 $ 02_crate --version

--- a/examples/tutorial_builder/03_01_flag_bool.md
+++ b/examples/tutorial_builder/03_01_flag_bool.md
@@ -7,8 +7,8 @@ USAGE:
     03_01_flag_bool[EXE] [OPTIONS]
 
 OPTIONS:
-    -h, --help       Print help information
     -v, --verbose    
+    -h, --help       Print help information
     -V, --version    Print version information
 
 $ 03_01_flag_bool

--- a/examples/tutorial_builder/03_01_flag_count.md
+++ b/examples/tutorial_builder/03_01_flag_count.md
@@ -7,8 +7,8 @@ USAGE:
     03_01_flag_count[EXE] [OPTIONS]
 
 OPTIONS:
-    -h, --help       Print help information
     -v, --verbose    
+    -h, --help       Print help information
     -V, --version    Print version information
 
 $ 03_01_flag_count

--- a/examples/tutorial_builder/03_02_option.md
+++ b/examples/tutorial_builder/03_02_option.md
@@ -7,8 +7,8 @@ USAGE:
     03_02_option[EXE] [OPTIONS]
 
 OPTIONS:
-    -h, --help           Print help information
     -n, --name <NAME>    
+    -h, --help           Print help information
     -V, --version        Print version information
 
 $ 03_02_option

--- a/examples/tutorial_builder/04_03_relations.md
+++ b/examples/tutorial_builder/04_03_relations.md
@@ -10,13 +10,13 @@ ARGS:
     <INPUT_FILE>    some regular input
 
 OPTIONS:
-    -c <CONFIG>                
-    -h, --help                 Print help information
+        --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
         --patch                auto inc patch
-        --set-ver <VER>        set version manually
         --spec-in <SPEC_IN>    some special input argument
+    -c <CONFIG>                
+    -h, --help                 Print help information
     -V, --version              Print version information
 
 $ 04_03_relations

--- a/examples/tutorial_builder/04_04_custom.md
+++ b/examples/tutorial_builder/04_04_custom.md
@@ -10,13 +10,13 @@ ARGS:
     <INPUT_FILE>    some regular input
 
 OPTIONS:
-    -c <CONFIG>                
-    -h, --help                 Print help information
+        --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
         --patch                auto inc patch
-        --set-ver <VER>        set version manually
         --spec-in <SPEC_IN>    some special input argument
+    -c <CONFIG>                
+    -h, --help                 Print help information
     -V, --version              Print version information
 
 $ 04_04_custom

--- a/examples/tutorial_derive/01_quick.md
+++ b/examples/tutorial_derive/01_quick.md
@@ -16,8 +16,8 @@ OPTIONS:
     -V, --version          Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    does testing things
+    help    Print this message or the help of the given subcommand(s)
 
 ```
 

--- a/examples/tutorial_derive/02_app_settings.rs
+++ b/examples/tutorial_derive/02_app_settings.rs
@@ -1,9 +1,8 @@
-use clap::{AppSettings, Parser};
+use clap::Parser;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 #[clap(allow_negative_numbers = true)]
-#[clap(global_setting(AppSettings::DeriveDisplayOrder))]
 struct Cli {
     #[clap(long, value_parser)]
     two: String,

--- a/examples/tutorial_derive/02_apps.md
+++ b/examples/tutorial_derive/02_apps.md
@@ -8,9 +8,9 @@ USAGE:
     02_apps[EXE] --two <VALUE> --one <VALUE>
 
 OPTIONS:
-    -h, --help           Print help information
-        --one <VALUE>    
         --two <VALUE>    
+        --one <VALUE>    
+    -h, --help           Print help information
     -V, --version        Print version information
 
 $ 02_apps --version

--- a/examples/tutorial_derive/02_crate.md
+++ b/examples/tutorial_derive/02_crate.md
@@ -7,9 +7,9 @@ USAGE:
     02_crate[EXE] --two <VALUE> --one <VALUE>
 
 OPTIONS:
-    -h, --help           Print help information
-        --one <VALUE>    
         --two <VALUE>    
+        --one <VALUE>    
+    -h, --help           Print help information
     -V, --version        Print version information
 
 $ 02_crate --version

--- a/examples/tutorial_derive/03_01_flag_bool.md
+++ b/examples/tutorial_derive/03_01_flag_bool.md
@@ -7,8 +7,8 @@ USAGE:
     03_01_flag_bool[EXE] [OPTIONS]
 
 OPTIONS:
-    -h, --help       Print help information
     -v, --verbose    
+    -h, --help       Print help information
     -V, --version    Print version information
 
 $ 03_01_flag_bool

--- a/examples/tutorial_derive/03_01_flag_count.md
+++ b/examples/tutorial_derive/03_01_flag_count.md
@@ -7,8 +7,8 @@ USAGE:
     03_01_flag_count[EXE] [OPTIONS]
 
 OPTIONS:
-    -h, --help       Print help information
     -v, --verbose    
+    -h, --help       Print help information
     -V, --version    Print version information
 
 $ 03_01_flag_count

--- a/examples/tutorial_derive/03_02_option.md
+++ b/examples/tutorial_derive/03_02_option.md
@@ -7,8 +7,8 @@ USAGE:
     03_02_option[EXE] [OPTIONS]
 
 OPTIONS:
-    -h, --help           Print help information
     -n, --name <NAME>    
+    -h, --help           Print help information
     -V, --version        Print version information
 
 $ 03_02_option

--- a/examples/tutorial_derive/04_03_relations.md
+++ b/examples/tutorial_derive/04_03_relations.md
@@ -10,13 +10,13 @@ ARGS:
     <INPUT_FILE>    some regular input
 
 OPTIONS:
-    -c <CONFIG>                
-    -h, --help                 Print help information
+        --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
         --patch                auto inc patch
-        --set-ver <VER>        set version manually
         --spec-in <SPEC_IN>    some special input argument
+    -c <CONFIG>                
+    -h, --help                 Print help information
     -V, --version              Print version information
 
 $ 04_03_relations

--- a/examples/tutorial_derive/04_04_custom.md
+++ b/examples/tutorial_derive/04_04_custom.md
@@ -10,13 +10,13 @@ ARGS:
     <INPUT_FILE>    some regular input
 
 OPTIONS:
-    -c <CONFIG>                
-    -h, --help                 Print help information
+        --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
         --patch                auto inc patch
-        --set-ver <VER>        set version manually
         --spec-in <SPEC_IN>    some special input argument
+    -c <CONFIG>                
+    -h, --help                 Print help information
     -V, --version              Print version information
 
 $ 04_04_custom

--- a/examples/typed-derive.md
+++ b/examples/typed-derive.md
@@ -9,12 +9,12 @@ USAGE:
     typed-derive[EXE] [OPTIONS]
 
 OPTIONS:
+    -O <OPTIMIZATION>        Implicitly using `std::str::FromStr`
+    -I <DIR>                 Allow invalid UTF-8 paths
         --bind <BIND>        Handle IP addresses
+        --sleep <SLEEP>      Allow human-readable durations
     -D <DEFINES>             Hand-written parser for tuples
     -h, --help               Print help information
-    -I <DIR>                 Allow invalid UTF-8 paths
-    -O <OPTIMIZATION>        Implicitly using `std::str::FromStr`
-        --sleep <SLEEP>      Allow human-readable durations
 
 ```
 

--- a/src/builder/app_settings.rs
+++ b/src/builder/app_settings.rs
@@ -13,7 +13,7 @@ use bitflags::bitflags;
 
 #[doc(hidden)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct AppFlags(Flags);
+pub(crate) struct AppFlags(Flags);
 
 impl Default for AppFlags {
     fn default() -> Self {
@@ -29,328 +29,41 @@ impl Default for AppFlags {
 /// [`Command`]: crate::Command
 #[derive(Debug, PartialEq, Copy, Clone)]
 #[non_exhaustive]
-pub enum AppSettings {
-    /// Deprecated, replaced with [`Command::ignore_errors`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.1.0", note = "Replaced with `Command::ignore_errors`")
-    )]
+pub(crate) enum AppSettings {
     IgnoreErrors,
-
-    /// Deprecated, replaced with [`Command::allow_hyphen_values`] and
-    /// [`Arg::is_allow_hyphen_values_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::allow_hyphen_values` and `Arg::is_allow_hyphen_values_set`"
-        )
-    )]
     AllowHyphenValues,
-
-    /// Deprecated, replaced with [`Command::allow_negative_numbers`] and
-    /// [`Command::is_allow_negative_numbers_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::allow_negative_numbers` and `Command::is_allow_negative_numbers_set`"
-        )
-    )]
     AllowNegativeNumbers,
-
-    /// Deprecated, replaced with [`Command::allow_missing_positional`] and
-    /// [`Command::is_allow_missing_positional_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::allow_missing_positional` and `Command::is_allow_missing_positional_set`"
-        )
-    )]
     AllowMissingPositional,
-
-    /// Deprecated, replaced with [`Command::trailing_var_arg`] and [`Command::is_trailing_var_arg_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::trailing_var_arg` and `Command::is_trailing_var_arg_set`"
-        )
-    )]
     TrailingVarArg,
-
-    /// Deprecated, replaced with [`Command::dont_delimit_trailing_values`] and
-    /// [`Command::is_dont_delimit_trailing_values_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::dont_delimit_trailing_values` and `Command::is_dont_delimit_trailing_values_set`"
-        )
-    )]
     DontDelimitTrailingValues,
-
-    /// Deprecated, replaced with [`Command::infer_long_args`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.1.0", note = "Replaced with `Command::infer_long_args`")
-    )]
     InferLongArgs,
-
-    /// Deprecated, replaced with [`Command::infer_subcommands`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.1.0", note = "Replaced with `Command::infer_subcommands`")
-    )]
     InferSubcommands,
-
-    /// Deprecated, replaced with [`Command::subcommand_required`] and
-    /// [`Command::is_subcommand_required_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::subcommand_required` and `Command::is_subcommand_required_set`"
-        )
-    )]
     SubcommandRequired,
-
-    /// Deprecated, replaced with [`Command::allow_external_subcommands`] and
-    /// [`Command::is_allow_external_subcommands_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::allow_external_subcommands` and `Command::is_allow_external_subcommands_set`"
-        )
-    )]
     AllowExternalSubcommands,
-
-    /// Deprecated, replaced with [`Command::multicall`] and [`Command::is_multicall_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::multicall` and `Command::is_multicall_set`"
-        )
-    )]
     Multicall,
-
-    /// Deprecated, replaced with [`Command::allow_invalid_utf8_for_external_subcommands`] and [`Command::is_allow_invalid_utf8_for_external_subcommands_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::allow_invalid_utf8_for_external_subcommands` and `Command::is_allow_invalid_utf8_for_external_subcommands_set`"
-        )
-    )]
     AllowInvalidUtf8ForExternalSubcommands,
-
-    /// Deprecated, this is now the default
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.1.0", note = "This is now the default")
-    )]
-    UseLongFormatForHelpSubcommand,
-
-    /// Deprecated, replaced with [`Command::subcommand_negates_reqs`] and
-    /// [`Command::is_subcommand_negates_reqs_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::subcommand_negates_reqs` and `Command::is_subcommand_negates_reqs_set`"
-        )
-    )]
     SubcommandsNegateReqs,
-
-    /// Deprecated, replaced with [`Command::args_conflicts_with_subcommands`] and
-    /// [`Command::is_args_conflicts_with_subcommands_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::args_conflicts_with_subcommands` and `Command::is_args_conflicts_with_subcommands_set`"
-        )
-    )]
     ArgsNegateSubcommands,
-
-    /// Deprecated, replaced with [`Command::subcommand_precedence_over_arg`] and
-    /// [`Command::is_subcommand_precedence_over_arg_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::subcommand_precedence_over_arg` and `Command::is_subcommand_precedence_over_arg_set`"
-        )
-    )]
     SubcommandPrecedenceOverArg,
-
-    /// Deprecated, replaced with [`Command::arg_required_else_help`] and
-    /// [`Command::is_arg_required_else_help_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::arg_required_else_help` and `Command::is_arg_required_else_help_set`"
-        )
-    )]
     ArgRequiredElseHelp,
-
-    /// Deprecated, replaced with [`Command::dont_collapse_args_in_usage`] and
-    /// [`Command::is_dont_collapse_args_in_usage_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::dont_collapse_args_in_usage` and `Command::is_dont_collapse_args_in_usage_set`"
-        )
-    )]
     DontCollapseArgsInUsage,
-
-    /// Deprecated, replaced with [`Command::next_line_help`] and [`Command::is_next_line_help_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::next_line_help` and `Command::is_next_line_help_set`"
-        )
-    )]
     NextLineHelp,
-
-    /// Deprecated, replaced with [`Command::disable_colored_help`] and
-    /// [`Command::is_disable_colored_help_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::disable_colored_help` and `Command::is_disable_colored_help_set`"
-        )
-    )]
     DisableColoredHelp,
-
-    /// Deprecated, replaced with [`Command::disable_help_flag`] and [`Command::is_disable_help_flag_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::disable_help_flag` and `Command::is_disable_help_flag_set`"
-        )
-    )]
     DisableHelpFlag,
-
-    /// Deprecated, replaced with [`Command::disable_help_subcommand`] and
-    /// [`Command::is_disable_help_subcommand_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::disable_help_subcommand` and `Command::is_disable_help_subcommand_set`"
-        )
-    )]
     DisableHelpSubcommand,
-
-    /// Deprecated, replaced with [`Command::disable_version_flag`] and
-    /// [`Command::is_disable_version_flag_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::disable_version_flag` and `Command::is_disable_version_flag_set`"
-        )
-    )]
     DisableVersionFlag,
-
-    /// Deprecated, replaced with [`Command::propagate_version`] and [`Command::is_propagate_version_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::propagate_version` and `Command::is_propagate_version_set`"
-        )
-    )]
     PropagateVersion,
-
-    /// Deprecated, replaced with [`Command::hide`] and [`Command::is_hide_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::hide` and `Command::is_hide_set`"
-        )
-    )]
     Hidden,
-
-    /// Deprecated, replaced with [`Command::hide_possible_values`] and
-    /// [`Arg::is_hide_possible_values_set`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.1.0",
-            note = "Replaced with `Command::hide_possible_values` and `Arg::is_hide_possible_values_set`"
-        )
-    )]
     HidePossibleValues,
-
-    /// Deprecated, replaced with [`Command::help_expected`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.1.0", note = "Replaced with `Command::help_expected`")
-    )]
     HelpExpected,
-
-    /// Deprecated, replaced with [`Command::no_binary_name`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.1.0", note = "Replaced with `Command::no_binary_name`")
-    )]
     NoBinaryName,
-
-    /// Deprecated, replaced with [`Arg::action`][super::Arg::action]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.2.0", note = "Replaced with `Arg::action`")
-    )]
     NoAutoHelp,
-
-    /// Deprecated, replaced with [`Arg::action`][super::Arg::action]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.2.0", note = "Replaced with `Arg::action`")
-    )]
     NoAutoVersion,
-
-    /// Deprecated, see [`Command::color`][crate::Command::color]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.0.0", note = "Replaced with `Command::color`")
-    )]
-    #[doc(hidden)]
+    #[allow(dead_code)]
     ColorAuto,
-
-    /// Deprecated, replaced with [`Command::color`][crate::Command::color]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.0.0", note = "Replaced with `Command::color`")
-    )]
-    #[doc(hidden)]
     ColorAlways,
-
-    /// Deprecated, replaced with [`Command::color`][crate::Command::color]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(since = "3.0.0", note = "Replaced with `Command::color`")
-    )]
-    #[doc(hidden)]
     ColorNever,
-
-    /// If the cmd is already built, used for caching.
-    #[doc(hidden)]
     Built,
-
-    /// If the cmd's bin name is already built, used for caching.
-    #[doc(hidden)]
     BinNameBuilt,
 }
 
@@ -393,7 +106,6 @@ bitflags! {
         const HELP_REQUIRED                  = 1 << 39;
         const SUBCOMMAND_PRECEDENCE_OVER_ARG = 1 << 40;
         const DISABLE_HELP_FLAG              = 1 << 41;
-        const USE_LONG_FORMAT_FOR_HELP_SC    = 1 << 42;
         const INFER_LONG_ARGS                = 1 << 43;
         const IGNORE_ERRORS                  = 1 << 44;
         const MULTICALL                      = 1 << 45;
@@ -456,8 +168,6 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::SC_NEGATE_REQS,
     SubcommandRequired
         => Flags::SC_REQUIRED,
-    UseLongFormatForHelpSubcommand
-        => Flags::USE_LONG_FORMAT_FOR_HELP_SC,
     TrailingVarArg
         => Flags::TRAILING_VARARG,
     NextLineHelp

--- a/src/builder/app_settings.rs
+++ b/src/builder/app_settings.rs
@@ -198,25 +198,6 @@ pub enum AppSettings {
     )]
     ArgRequiredElseHelp,
 
-    /// Displays the arguments and [`subcommands`] in the help message in the order that they were
-    /// declared in, and not alphabetically which is the default.
-    ///
-    /// To override the declaration order, see [`Arg::display_order`] and [`Command::display_order`].
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{Command, Arg, AppSettings};
-    /// Command::new("myprog")
-    ///     .global_setting(AppSettings::DeriveDisplayOrder)
-    ///     .get_matches();
-    /// ```
-    ///
-    /// [`subcommands`]: crate::Command::subcommand()
-    /// [`Arg::display_order`]: crate::Arg::display_order
-    /// [`Command::display_order`]: crate::Command::display_order
-    DeriveDisplayOrder,
-
     /// Deprecated, replaced with [`Command::dont_collapse_args_in_usage`] and
     /// [`Command::is_dont_collapse_args_in_usage_set`]
     #[cfg_attr(
@@ -392,7 +373,6 @@ bitflags! {
         const LEADING_HYPHEN                 = 1 << 16;
         const NO_POS_VALUES                  = 1 << 17;
         const NEXT_LINE_HELP                 = 1 << 18;
-        const DERIVE_DISP_ORDER              = 1 << 19;
         const DISABLE_COLORED_HELP           = 1 << 20;
         const COLOR_ALWAYS                   = 1 << 21;
         const COLOR_AUTO                     = 1 << 22;
@@ -448,8 +428,6 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::DONT_DELIM_TRAIL,
     DontCollapseArgsInUsage
         => Flags::DONT_COLLAPSE_ARGS,
-    DeriveDisplayOrder
-        => Flags::DERIVE_DISP_ORDER,
     DisableColoredHelp
         => Flags::DISABLE_COLORED_HELP,
     DisableHelpSubcommand

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -70,7 +70,7 @@ pub struct Arg<'help> {
     pub(crate) long: Option<&'help str>,
     pub(crate) aliases: Vec<(&'help str, bool)>, // (name, visible)
     pub(crate) short_aliases: Vec<(char, bool)>, // (name, visible)
-    pub(crate) disp_ord: DisplayOrder,
+    pub(crate) disp_ord: Option<usize>,
     pub(crate) val_names: Vec<&'help str>,
     pub(crate) num_vals: Option<usize>,
     pub(crate) max_vals: Option<usize>,
@@ -2411,7 +2411,7 @@ impl<'help> Arg<'help> {
     #[inline]
     #[must_use]
     pub fn display_order(mut self, ord: usize) -> Self {
-        self.disp_ord.set_explicit(ord);
+        self.disp_ord = Some(ord);
         self
     }
 
@@ -4478,7 +4478,7 @@ impl<'help> Arg<'help> {
     }
 
     pub(crate) fn get_display_order(&self) -> usize {
-        self.disp_ord.get_explicit()
+        self.disp_ord.unwrap_or(999)
     }
 }
 
@@ -4673,43 +4673,6 @@ where
         }
     }
     Ok(())
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum DisplayOrder {
-    None,
-    Implicit(usize),
-    Explicit(usize),
-}
-
-impl DisplayOrder {
-    pub(crate) fn set_explicit(&mut self, explicit: usize) {
-        *self = Self::Explicit(explicit)
-    }
-
-    pub(crate) fn set_implicit(&mut self, implicit: usize) {
-        *self = (*self).max(Self::Implicit(implicit))
-    }
-
-    pub(crate) fn make_explicit(&mut self) {
-        match *self {
-            Self::None | Self::Explicit(_) => {}
-            Self::Implicit(disp) => self.set_explicit(disp),
-        }
-    }
-
-    pub(crate) fn get_explicit(self) -> usize {
-        match self {
-            Self::None | Self::Implicit(_) => 999,
-            Self::Explicit(disp) => disp,
-        }
-    }
-}
-
-impl Default for DisplayOrder {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 // Flags

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -176,7 +176,7 @@ impl<'help> Command<'help> {
         if let Some(current_disp_ord) = self.current_disp_ord.as_mut() {
             if !arg.is_positional() && arg.provider != ArgProvider::Generated {
                 let current = *current_disp_ord;
-                arg.disp_ord.set_implicit(current);
+                arg.disp_ord.get_or_insert(current);
                 *current_disp_ord = current + 1;
             }
         }
@@ -3863,7 +3863,6 @@ impl<'help> Command<'help> {
             self._propagate();
             self._check_help_and_version();
             self._propagate_global_args();
-            self._derive_display_order();
 
             let mut pos_counter = 1;
             let hide_pv = self.is_set(AppSettings::HidePossibleValues);
@@ -4373,24 +4372,6 @@ To change `help`s short, call `cmd.arg(Arg::new(\"help\")...)`.",
                 .unset_global_setting(AppSettings::PropagateVersion);
 
             self.subcommands.push(help_subcmd);
-        }
-    }
-
-    pub(crate) fn _derive_display_order(&mut self) {
-        debug!("Command::_derive_display_order:{}", self.name);
-
-        if self.settings.is_set(AppSettings::DeriveDisplayOrder) {
-            for a in self
-                .args
-                .args_mut()
-                .filter(|a| !a.is_positional())
-                .filter(|a| a.provider != ArgProvider::Generated)
-            {
-                a.disp_ord.make_explicit();
-            }
-        }
-        for sc in &mut self.subcommands {
-            sc._derive_display_order();
         }
     }
 

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -1004,7 +1004,6 @@ impl<'help> Command<'help> {
     #[inline]
     #[must_use]
     pub fn color(self, color: ColorChoice) -> Self {
-        #![allow(deprecated)]
         let cmd = self
             .unset_global_setting(AppSettings::ColorAuto)
             .unset_global_setting(AppSettings::ColorAlways)
@@ -1734,31 +1733,9 @@ impl<'help> Command<'help> {
         self
     }
 
-    /// Apply a setting for the current command or subcommand.
-    ///
-    /// See [`Command::global_setting`] to apply a setting to this command and all subcommands.
-    ///
-    /// See [`AppSettings`] for a full list of possibilities and examples.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{Command, AppSettings};
-    /// Command::new("myprog")
-    ///     .setting(AppSettings::SubcommandRequired)
-    ///     .setting(AppSettings::AllowHyphenValues)
-    /// # ;
-    /// ```
-    /// or
-    /// ```no_run
-    /// # use clap::{Command, AppSettings};
-    /// Command::new("myprog")
-    ///     .setting(AppSettings::SubcommandRequired | AppSettings::AllowHyphenValues)
-    /// # ;
-    /// ```
     #[inline]
     #[must_use]
-    pub fn setting<F>(mut self, setting: F) -> Self
+    pub(crate) fn setting<F>(mut self, setting: F) -> Self
     where
         F: Into<AppFlags>,
     {
@@ -1766,29 +1743,9 @@ impl<'help> Command<'help> {
         self
     }
 
-    /// Remove a setting for the current command or subcommand.
-    ///
-    /// See [`AppSettings`] for a full list of possibilities and examples.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{Command, AppSettings};
-    /// Command::new("myprog")
-    ///     .unset_setting(AppSettings::SubcommandRequired)
-    ///     .setting(AppSettings::AllowHyphenValues)
-    /// # ;
-    /// ```
-    /// or
-    /// ```no_run
-    /// # use clap::{Command, AppSettings};
-    /// Command::new("myprog")
-    ///     .unset_setting(AppSettings::SubcommandRequired | AppSettings::AllowHyphenValues)
-    /// # ;
-    /// ```
     #[inline]
     #[must_use]
-    pub fn unset_setting<F>(mut self, setting: F) -> Self
+    pub(crate) fn unset_setting<F>(mut self, setting: F) -> Self
     where
         F: Into<AppFlags>,
     {
@@ -1796,44 +1753,17 @@ impl<'help> Command<'help> {
         self
     }
 
-    /// Apply a setting for the current command and all subcommands.
-    ///
-    /// See [`Command::setting`] to apply a setting only to this command.
-    ///
-    /// See [`AppSettings`] for a full list of possibilities and examples.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{Command, AppSettings};
-    /// Command::new("myprog")
-    ///     .global_setting(AppSettings::AllowNegativeNumbers)
-    /// # ;
-    /// ```
     #[inline]
     #[must_use]
-    pub fn global_setting(mut self, setting: AppSettings) -> Self {
+    pub(crate) fn global_setting(mut self, setting: AppSettings) -> Self {
         self.settings.set(setting);
         self.g_settings.set(setting);
         self
     }
 
-    /// Remove a setting and stop propagating down to subcommands.
-    ///
-    /// See [`AppSettings`] for a full list of possibilities and examples.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use clap::{Command, AppSettings};
-    /// Command::new("myprog")
-    ///     .unset_global_setting(AppSettings::AllowNegativeNumbers)
-    /// # ;
-    /// ```
-    /// [global]: Command::global_setting()
     #[inline]
     #[must_use]
-    pub fn unset_global_setting(mut self, setting: AppSettings) -> Self {
+    pub(crate) fn unset_global_setting(mut self, setting: AppSettings) -> Self {
         self.settings.unset(setting);
         self.g_settings.unset(setting);
         self
@@ -3347,14 +3277,8 @@ impl<'help> Command<'help> {
         self.long_flag_aliases.iter().map(|a| a.0)
     }
 
-    /// Check if the given [`AppSettings`] variant is currently set on the `Command`.
-    ///
-    /// This checks both [local] and [global settings].
-    ///
-    /// [local]: Command::setting()
-    /// [global settings]: Command::global_setting()
     #[inline]
-    pub fn is_set(&self, s: AppSettings) -> bool {
+    pub(crate) fn is_set(&self, s: AppSettings) -> bool {
         self.settings.is_set(s) || self.g_settings.is_set(s)
     }
 
@@ -3364,7 +3288,6 @@ impl<'help> Command<'help> {
         debug!("Command::color: Color setting...");
 
         if cfg!(feature = "color") {
-            #[allow(deprecated)]
             if self.is_set(AppSettings::ColorNever) {
                 debug!("Never");
                 ColorChoice::Never

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -18,7 +18,6 @@ mod debug_asserts;
 mod tests;
 
 pub use action::ArgAction;
-pub use app_settings::{AppFlags, AppSettings};
 pub use arg::Arg;
 pub use arg_group::ArgGroup;
 pub use command::Command;
@@ -43,6 +42,7 @@ pub use value_parser::OsStringValueParser;
 pub use value_parser::PathBufValueParser;
 
 pub(crate) use action::CountType;
+pub(crate) use app_settings::AppSettings;
 pub(crate) use arg::display_arg_val;
 pub(crate) use arg_predicate::ArgPredicate;
 pub(crate) use arg_settings::{ArgFlags, ArgSettings};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub(crate) use crate::util::color::ColorChoice;
 pub use crate::derive::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 
 #[allow(deprecated)]
-pub use crate::builder::{AppFlags, AppSettings, PossibleValue, ValueHint};
+pub use crate::builder::{PossibleValue, ValueHint};
 pub use crate::error::{ErrorKind, Result};
 #[allow(deprecated)]
 pub use crate::parser::{Indices, ValueSource};

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -29,44 +29,6 @@ OPTIONS:
     -V, --version    Print version information
 ";
 
-static REQUIRE_EQUALS: &str = "clap-test v1.4.8
-
-USAGE:
-    clap-test --opt=<FILE>
-
-OPTIONS:
-    -h, --help          Print help information
-    -o, --opt=<FILE>    some
-    -V, --version       Print version information
-";
-
-static SKIP_POS_VALS: &str = "test 1.3
-Kevin K.
-tests stuff
-
-USAGE:
-    test [OPTIONS] [arg1]
-
-ARGS:
-    <arg1>    some pos arg
-
-OPTIONS:
-    -h, --help         Print help information
-    -o, --opt <opt>    some option
-    -V, --version      Print version information
-";
-
-static ARG_REQUIRED_ELSE_HELP: &str = "test 1.0
-
-USAGE:
-    test [OPTIONS]
-
-OPTIONS:
-    -h, --help       Print help information
-    -i, --info       Provides more info
-    -V, --version    Print version information
-";
-
 #[test]
 fn sub_command_negate_required() {
     Command::new("sub_command_negate")
@@ -163,6 +125,17 @@ fn arg_required_else_help_with_default() {
 
 #[test]
 fn arg_required_else_help_error_message() {
+    static ARG_REQUIRED_ELSE_HELP: &str = "test 1.0
+
+USAGE:
+    test [OPTIONS]
+
+OPTIONS:
+    -i, --info       Provides more info
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+
     let cmd = Command::new("test")
         .arg_required_else_help(true)
         .version("1.0")
@@ -310,6 +283,22 @@ fn no_bin_name() {
 
 #[test]
 fn skip_possible_values() {
+    static SKIP_POS_VALS: &str = "test 1.3
+Kevin K.
+tests stuff
+
+USAGE:
+    test [OPTIONS] [arg1]
+
+ARGS:
+    <arg1>    some pos arg
+
+OPTIONS:
+    -o, --opt <opt>    some option
+    -h, --help         Print help information
+    -V, --version      Print version information
+";
+
     let cmd = Command::new("test")
         .author("Kevin K.")
         .about("tests stuff")
@@ -575,6 +564,17 @@ fn dont_collapse_args() {
 
 #[test]
 fn require_eq() {
+    static REQUIRE_EQUALS: &str = "clap-test v1.4.8
+
+USAGE:
+    clap-test --opt=<FILE>
+
+OPTIONS:
+    -o, --opt=<FILE>    some
+    -h, --help          Print help information
+    -V, --version       Print version information
+";
+
     let cmd = Command::new("clap-test").version("v1.4.8").arg(
         Arg::new("opt")
             .long("opt")

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -2,32 +2,6 @@ use super::utils;
 
 use clap::{arg, Arg, ArgAction, Command};
 
-static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-Some help
-
-USAGE:
-    ct test [OPTIONS]
-
-OPTIONS:
-    -f, --flag         [aliases: v_flg, flag2, flg3]
-    -h, --help         Print help information
-    -o, --opt <opt>    [aliases: visible]
-    -V, --version      Print version information
-";
-
-static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-Some help
-
-USAGE:
-    ct test [OPTIONS]
-
-OPTIONS:
-    -f, --flag         
-    -h, --help         Print help information
-    -o, --opt <opt>    
-    -V, --version      Print version information
-";
-
 #[test]
 fn single_alias_of_option() {
     let a = Command::new("single_alias")
@@ -216,6 +190,19 @@ fn alias_on_a_subcommand_option() {
 
 #[test]
 fn invisible_arg_aliases_help_output() {
+    static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+Some help
+
+USAGE:
+    ct test [OPTIONS]
+
+OPTIONS:
+    -o, --opt <opt>    
+    -f, --flag         
+    -h, --help         Print help information
+    -V, --version      Print version information
+";
+
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(
         Command::new("test")
             .about("Some help")
@@ -234,6 +221,19 @@ fn invisible_arg_aliases_help_output() {
 
 #[test]
 fn visible_arg_aliases_help_output() {
+    static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+Some help
+
+USAGE:
+    ct test [OPTIONS]
+
+OPTIONS:
+    -o, --opt <opt>    [aliases: visible]
+    -f, --flag         [aliases: v_flg, flag2, flg3]
+    -h, --help         Print help information
+    -V, --version      Print version information
+";
+
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(
         Command::new("test")
             .about("Some help")

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -2,32 +2,6 @@ use super::utils;
 
 use clap::{arg, Arg, ArgAction, Command};
 
-static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-Some help
-
-USAGE:
-    ct test [OPTIONS]
-
-OPTIONS:
-    -f, --flag         [aliases: flag1] [short aliases: a, b, 🦆]
-    -h, --help         Print help information
-    -o, --opt <opt>    [short aliases: v]
-    -V, --version      Print version information
-";
-
-static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
-Some help
-
-USAGE:
-    ct test [OPTIONS]
-
-OPTIONS:
-    -f, --flag         
-    -h, --help         Print help information
-    -o, --opt <opt>    
-    -V, --version      Print version information
-";
-
 #[test]
 fn single_short_alias_of_option() {
     let a = Command::new("single_alias")
@@ -183,6 +157,19 @@ fn short_alias_on_a_subcommand_option() {
 
 #[test]
 fn invisible_short_arg_aliases_help_output() {
+    static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+Some help
+
+USAGE:
+    ct test [OPTIONS]
+
+OPTIONS:
+    -o, --opt <opt>    
+    -f, --flag         
+    -h, --help         Print help information
+    -V, --version      Print version information
+";
+
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(
         Command::new("test")
             .about("Some help")
@@ -201,6 +188,19 @@ fn invisible_short_arg_aliases_help_output() {
 
 #[test]
 fn visible_short_arg_aliases_help_output() {
+    static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+Some help
+
+USAGE:
+    ct test [OPTIONS]
+
+OPTIONS:
+    -o, --opt <opt>    [short aliases: v]
+    -f, --flag         [aliases: flag1] [short aliases: a, b, 🦆]
+    -h, --help         Print help information
+    -V, --version      Print version information
+";
+
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(
         Command::new("test")
             .about("Some help")

--- a/tests/builder/derive_order.rs
+++ b/tests/builder/derive_order.rs
@@ -2,111 +2,27 @@ use super::utils;
 
 use std::str;
 
-use clap::{AppSettings, Arg, Command};
-
-static NO_DERIVE_ORDER: &str = "test 1.2
-
-USAGE:
-    test [OPTIONS]
-
-OPTIONS:
-        --flag_a                 second flag
-        --flag_b                 first flag
-    -h, --help                   Print help information
-        --option_a <option_a>    second option
-        --option_b <option_b>    first option
-    -V, --version                Print version information
-";
-
-static UNIFIED_HELP_AND_DERIVE: &str = "test 1.2
-
-USAGE:
-    test [OPTIONS]
-
-OPTIONS:
-        --flag_b                 first flag
-        --option_b <option_b>    first option
-        --flag_a                 second flag
-        --option_a <option_a>    second option
-    -h, --help                   Print help information
-    -V, --version                Print version information
-";
-
-static UNIFIED_DERIVE_SC_PROP: &str = "test-sub 1.2
-
-USAGE:
-    test sub [OPTIONS]
-
-OPTIONS:
-        --flag_b                 first flag
-        --option_b <option_b>    first option
-        --flag_a                 second flag
-        --option_a <option_a>    second option
-    -h, --help                   Print help information
-    -V, --version                Print version information
-";
-
-static UNIFIED_DERIVE_SC_PROP_EXPLICIT_ORDER: &str = "test-sub 1.2
-
-USAGE:
-    test sub [OPTIONS]
-
-OPTIONS:
-        --flag_a                 second flag
-        --flag_b                 first flag
-        --option_b <option_b>    first option
-        --option_a <option_a>    second option
-    -h, --help                   Print help information
-    -V, --version                Print version information
-";
-
-static PREFER_USER_HELP_DERIVE_ORDER: &str = "test 1.2
-
-USAGE:
-    test [OPTIONS]
-
-OPTIONS:
-    -h, --help       Print help message
-        --flag_b     first flag
-        --flag_a     second flag
-    -V, --version    Print version information
-";
-
-static PREFER_USER_HELP_SUBCMD_DERIVE_ORDER: &str = "test-sub 1.2
-
-USAGE:
-    test sub [OPTIONS]
-
-OPTIONS:
-    -h, --help       Print help message
-        --flag_b     first flag
-        --flag_a     second flag
-    -V, --version    Print version information
-";
+use clap::{Arg, Command};
 
 #[test]
 fn no_derive_order() {
-    let cmd = Command::new("test").version("1.2").args(&[
-        Arg::new("flag_b").long("flag_b").help("first flag"),
-        Arg::new("option_b")
-            .long("option_b")
-            .takes_value(true)
-            .help("first option"),
-        Arg::new("flag_a").long("flag_a").help("second flag"),
-        Arg::new("option_a")
-            .long("option_a")
-            .takes_value(true)
-            .help("second option"),
-    ]);
+    static NO_DERIVE_ORDER: &str = "test 1.2
 
-    utils::assert_output(cmd, "test --help", NO_DERIVE_ORDER, false);
-}
+USAGE:
+    test [OPTIONS]
 
-#[test]
-fn derive_order() {
+OPTIONS:
+        --flag_a                 second flag
+        --flag_b                 first flag
+    -h, --help                   Print help information
+        --option_a <option_a>    second option
+        --option_b <option_b>    first option
+    -V, --version                Print version information
+";
+
     let cmd = Command::new("test")
-        .setting(AppSettings::DeriveDisplayOrder)
         .version("1.2")
+        .next_display_order(None)
         .args(&[
             Arg::new("flag_b").long("flag_b").help("first flag"),
             Arg::new("option_b")
@@ -119,6 +35,38 @@ fn derive_order() {
                 .takes_value(true)
                 .help("second option"),
         ]);
+
+    utils::assert_output(cmd, "test --help", NO_DERIVE_ORDER, false);
+}
+
+#[test]
+fn derive_order() {
+    static UNIFIED_HELP_AND_DERIVE: &str = "test 1.2
+
+USAGE:
+    test [OPTIONS]
+
+OPTIONS:
+        --flag_b                 first flag
+        --option_b <option_b>    first option
+        --flag_a                 second flag
+        --option_a <option_a>    second option
+    -h, --help                   Print help information
+    -V, --version                Print version information
+";
+
+    let cmd = Command::new("test").version("1.2").args(&[
+        Arg::new("flag_b").long("flag_b").help("first flag"),
+        Arg::new("option_b")
+            .long("option_b")
+            .takes_value(true)
+            .help("first option"),
+        Arg::new("flag_a").long("flag_a").help("second flag"),
+        Arg::new("option_a")
+            .long("option_a")
+            .takes_value(true)
+            .help("second option"),
+    ]);
 
     utils::assert_output(cmd, "test --help", UNIFIED_HELP_AND_DERIVE, false);
 }
@@ -140,7 +88,6 @@ OPTIONS:
 ";
 
     let cmd = Command::new("test")
-        .setting(AppSettings::DeriveDisplayOrder)
         .version("1.2")
         .next_display_order(10000)
         .arg(Arg::new("flag_a").long("flag_a").help("second flag"))
@@ -179,7 +126,6 @@ OPTIONS:
 ";
 
     let cmd = Command::new("test")
-        .setting(AppSettings::DeriveDisplayOrder)
         .version("1.2")
         .next_display_order(None)
         .arg(Arg::new("flag_a").long("flag_a").help("first flag"))
@@ -202,47 +148,71 @@ OPTIONS:
 
 #[test]
 fn derive_order_subcommand_propagate() {
-    let cmd = Command::new("test")
-        .global_setting(AppSettings::DeriveDisplayOrder)
-        .subcommand(
-            Command::new("sub").version("1.2").args(&[
-                Arg::new("flag_b").long("flag_b").help("first flag"),
-                Arg::new("option_b")
-                    .long("option_b")
-                    .takes_value(true)
-                    .help("first option"),
-                Arg::new("flag_a").long("flag_a").help("second flag"),
-                Arg::new("option_a")
-                    .long("option_a")
-                    .takes_value(true)
-                    .help("second option"),
-            ]),
-        );
+    static UNIFIED_DERIVE_SC_PROP: &str = "test-sub 1.2
+
+USAGE:
+    test sub [OPTIONS]
+
+OPTIONS:
+        --flag_b                 first flag
+        --option_b <option_b>    first option
+        --flag_a                 second flag
+        --option_a <option_a>    second option
+    -h, --help                   Print help information
+    -V, --version                Print version information
+";
+
+    let cmd = Command::new("test").subcommand(
+        Command::new("sub").version("1.2").args(&[
+            Arg::new("flag_b").long("flag_b").help("first flag"),
+            Arg::new("option_b")
+                .long("option_b")
+                .takes_value(true)
+                .help("first option"),
+            Arg::new("flag_a").long("flag_a").help("second flag"),
+            Arg::new("option_a")
+                .long("option_a")
+                .takes_value(true)
+                .help("second option"),
+        ]),
+    );
 
     utils::assert_output(cmd, "test sub --help", UNIFIED_DERIVE_SC_PROP, false);
 }
 
 #[test]
 fn derive_order_subcommand_propagate_with_explicit_display_order() {
-    let cmd = Command::new("test")
-        .global_setting(AppSettings::DeriveDisplayOrder)
-        .subcommand(
-            Command::new("sub").version("1.2").args(&[
-                Arg::new("flag_b").long("flag_b").help("first flag"),
-                Arg::new("option_b")
-                    .long("option_b")
-                    .takes_value(true)
-                    .help("first option"),
-                Arg::new("flag_a")
-                    .long("flag_a")
-                    .help("second flag")
-                    .display_order(0),
-                Arg::new("option_a")
-                    .long("option_a")
-                    .takes_value(true)
-                    .help("second option"),
-            ]),
-        );
+    static UNIFIED_DERIVE_SC_PROP_EXPLICIT_ORDER: &str = "test-sub 1.2
+
+USAGE:
+    test sub [OPTIONS]
+
+OPTIONS:
+        --flag_a                 second flag
+        --flag_b                 first flag
+        --option_b <option_b>    first option
+        --option_a <option_a>    second option
+    -h, --help                   Print help information
+    -V, --version                Print version information
+";
+
+    let cmd = Command::new("test").subcommand(
+        Command::new("sub").version("1.2").args(&[
+            Arg::new("flag_b").long("flag_b").help("first flag"),
+            Arg::new("option_b")
+                .long("option_b")
+                .takes_value(true)
+                .help("first option"),
+            Arg::new("flag_a")
+                .long("flag_a")
+                .help("second flag")
+                .display_order(0),
+            Arg::new("option_a")
+                .long("option_a")
+                .takes_value(true)
+                .help("second option"),
+        ]),
+    );
 
     utils::assert_output(
         cmd,
@@ -254,35 +224,54 @@ fn derive_order_subcommand_propagate_with_explicit_display_order() {
 
 #[test]
 fn prefer_user_help_with_derive_order() {
-    let cmd = Command::new("test")
-        .setting(AppSettings::DeriveDisplayOrder)
-        .version("1.2")
-        .args(&[
-            Arg::new("help")
-                .long("help")
-                .short('h')
-                .help("Print help message"),
-            Arg::new("flag_b").long("flag_b").help("first flag"),
-            Arg::new("flag_a").long("flag_a").help("second flag"),
-        ]);
+    static PREFER_USER_HELP_DERIVE_ORDER: &str = "test 1.2
+
+USAGE:
+    test [OPTIONS]
+
+OPTIONS:
+    -h, --help       Print help message
+        --flag_b     first flag
+        --flag_a     second flag
+    -V, --version    Print version information
+";
+
+    let cmd = Command::new("test").version("1.2").args(&[
+        Arg::new("help")
+            .long("help")
+            .short('h')
+            .help("Print help message"),
+        Arg::new("flag_b").long("flag_b").help("first flag"),
+        Arg::new("flag_a").long("flag_a").help("second flag"),
+    ]);
 
     utils::assert_output(cmd, "test --help", PREFER_USER_HELP_DERIVE_ORDER, false);
 }
 
 #[test]
 fn prefer_user_help_in_subcommand_with_derive_order() {
-    let cmd = Command::new("test")
-        .global_setting(AppSettings::DeriveDisplayOrder)
-        .subcommand(
-            Command::new("sub").version("1.2").args(&[
-                Arg::new("help")
-                    .long("help")
-                    .short('h')
-                    .help("Print help message"),
-                Arg::new("flag_b").long("flag_b").help("first flag"),
-                Arg::new("flag_a").long("flag_a").help("second flag"),
-            ]),
-        );
+    static PREFER_USER_HELP_SUBCMD_DERIVE_ORDER: &str = "test-sub 1.2
+
+USAGE:
+    test sub [OPTIONS]
+
+OPTIONS:
+    -h, --help       Print help message
+        --flag_b     first flag
+        --flag_a     second flag
+    -V, --version    Print version information
+";
+
+    let cmd = Command::new("test").subcommand(
+        Command::new("sub").version("1.2").args(&[
+            Arg::new("help")
+                .long("help")
+                .short('h')
+                .help("Print help message"),
+            Arg::new("flag_b").long("flag_b").help("first flag"),
+            Arg::new("flag_a").long("flag_a").help("second flag"),
+        ]),
+    );
 
     utils::assert_output(
         cmd,

--- a/tests/builder/derive_order.rs
+++ b/tests/builder/derive_order.rs
@@ -291,3 +291,74 @@ fn prefer_user_help_in_subcommand_with_derive_order() {
         false,
     );
 }
+
+#[test]
+fn subcommand_sorted_display_order() {
+    static SUBCMD_ALPHA_ORDER: &str = "test 1
+
+USAGE:
+    test [SUBCOMMAND]
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    a1      blah a1
+    b1      blah b1
+    help    Print this message or the help of the given subcommand(s)
+";
+
+    let app_subcmd_alpha_order = Command::new("test")
+        .version("1")
+        .next_display_order(None)
+        .subcommands(vec![
+            Command::new("b1")
+                .about("blah b1")
+                .arg(Arg::new("test").short('t')),
+            Command::new("a1")
+                .about("blah a1")
+                .arg(Arg::new("roster").short('r')),
+        ]);
+
+    utils::assert_output(
+        app_subcmd_alpha_order,
+        "test --help",
+        SUBCMD_ALPHA_ORDER,
+        false,
+    );
+}
+
+#[test]
+fn subcommand_derived_display_order() {
+    static SUBCMD_DECL_ORDER: &str = "test 1
+
+USAGE:
+    test [SUBCOMMAND]
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    b1      blah b1
+    a1      blah a1
+    help    Print this message or the help of the given subcommand(s)
+";
+
+    let app_subcmd_decl_order = Command::new("test").version("1").subcommands(vec![
+        Command::new("b1")
+            .about("blah b1")
+            .arg(Arg::new("test").short('t')),
+        Command::new("a1")
+            .about("blah a1")
+            .arg(Arg::new("roster").short('r')),
+    ]);
+
+    utils::assert_output(
+        app_subcmd_decl_order,
+        "test --help",
+        SUBCMD_DECL_ORDER,
+        false,
+    );
+}

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -499,9 +499,9 @@ USAGE:
     pacman {query|--query|-Q} [OPTIONS]
 
 OPTIONS:
-    -h, --help                  Print help information
-    -i, --info <info>...        view package information
     -s, --search <search>...    search locally installed packages for matching strings
+    -i, --info <info>...        view package information
+    -h, --help                  Print help information
 ";
 
 #[test]
@@ -548,9 +548,9 @@ USAGE:
     pacman {query|--query} [OPTIONS]
 
 OPTIONS:
-    -h, --help                  Print help information
-    -i, --info <info>...        view package information
     -s, --search <search>...    search locally installed packages for matching strings
+    -i, --info <info>...        view package information
+    -h, --help                  Print help information
 ";
 
 #[test]
@@ -601,9 +601,9 @@ USAGE:
     pacman {query|-Q} [OPTIONS]
 
 OPTIONS:
-    -h, --help                  Print help information
-    -i, --info <info>...        view package information
     -s, --search <search>...    search locally installed packages for matching strings
+    -i, --info <info>...        view package information
+    -h, --help                  Print help information
 ";
 
 #[test]

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2,610 +2,6 @@ use super::utils;
 
 use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgGroup, Command, PossibleValue};
 
-static REQUIRE_DELIM_HELP: &str = "test 1.3
-Kevin K.
-tests stuff
-
-USAGE:
-    test --fake <some>:<val>
-
-OPTIONS:
-    -f, --fake <some>:<val>    some help
-    -h, --help                 Print help information
-    -V, --version              Print version information
-";
-
-static HELP: &str = "clap-test v1.4.8
-Kevin K. <kbknapp@gmail.com>
-tests clap library
-
-USAGE:
-    clap-test [OPTIONS] [ARGS] [SUBCOMMAND]
-
-ARGS:
-    <positional>        tests positionals
-    <positional2>       tests positionals with exclusions
-    <positional3>...    tests specific values [possible values: vi, emacs]
-
-OPTIONS:
-    -f, --flag                       tests flags
-    -F                               tests flags with exclusions
-    -h, --help                       Print help information
-        --long-option-2 <option2>    tests long options with exclusions
-        --maxvals3 <maxvals>...      Tests 3 max vals
-        --minvals2 <minvals>...      Tests 2 min vals
-        --multvals <one> <two>       Tests multiple values, not mult occs
-        --multvalsmo <one> <two>     Tests multiple values, and mult occs
-    -o, --option <opt>...            tests options
-    -O, --option3 <option3>          specific vals [possible values: fast, slow]
-        --optvaleq[=<optval>]        Tests optional value, require = sign
-        --optvalnoeq [<optval>]      Tests optional value
-    -V, --version                    Print version information
-
-SUBCOMMANDS:
-    subcmd    tests subcommands
-    help      Print this message or the help of the given subcommand(s)
-";
-
-static SC_NEGATES_REQS: &str = "prog 1.0
-
-USAGE:
-    prog --opt <FILE> [PATH]
-    prog [PATH] <SUBCOMMAND>
-
-ARGS:
-    <PATH>    help
-
-OPTIONS:
-    -h, --help          Print help information
-    -o, --opt <FILE>    tests options
-    -V, --version       Print version information
-
-SUBCOMMANDS:
-    test    
-    help    Print this message or the help of the given subcommand(s)
-";
-
-static ARGS_NEGATE_SC: &str = "prog 1.0
-
-USAGE:
-    prog [OPTIONS] [PATH]
-    prog <SUBCOMMAND>
-
-ARGS:
-    <PATH>    help
-
-OPTIONS:
-    -f, --flag          testing flags
-    -h, --help          Print help information
-    -o, --opt <FILE>    tests options
-    -V, --version       Print version information
-
-SUBCOMMANDS:
-    test    
-    help    Print this message or the help of the given subcommand(s)
-";
-
-static AFTER_HELP: &str = "some text that comes before the help
-
-clap-test v1.4.8
-tests clap library
-
-USAGE:
-    clap-test
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-some text that comes after the help
-";
-
-static AFTER_LONG_HELP: &str = "some longer text that comes before the help
-
-clap-test v1.4.8
-tests clap library
-
-USAGE:
-    clap-test
-
-OPTIONS:
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
-
-some longer text that comes after the help
-";
-
-static HIDDEN_ARGS: &str = "prog 1.0
-
-USAGE:
-    prog [OPTIONS]
-
-OPTIONS:
-    -f, --flag          testing flags
-    -h, --help          Print help information
-    -o, --opt <FILE>    tests options
-    -V, --version       Print version information
-";
-
-static SC_HELP: &str = "clap-test-subcmd 0.1
-Kevin K. <kbknapp@gmail.com>
-tests subcommands
-
-USAGE:
-    clap-test subcmd [OPTIONS] [--] [scpositional]
-
-ARGS:
-    <scpositional>    tests positionals
-
-OPTIONS:
-    -f, --flag                     tests flags
-    -h, --help                     Print help information
-    -o, --option <scoption>...     tests options
-    -s, --subcmdarg <subcmdarg>    tests other args
-    -V, --version                  Print version information
-";
-
-static ISSUE_1046_HIDDEN_SCS: &str = "prog 1.0
-
-USAGE:
-    prog [OPTIONS] [PATH]
-
-ARGS:
-    <PATH>    some
-
-OPTIONS:
-    -f, --flag          testing flags
-    -h, --help          Print help information
-    -o, --opt <FILE>    tests options
-    -V, --version       Print version information
-";
-
-// Using number_of_values(1) with multiple_values(true) misaligns help message
-static ISSUE_760: &str = "ctest 0.1
-
-USAGE:
-    ctest [OPTIONS]
-
-OPTIONS:
-    -h, --help               Print help information
-    -o, --option <option>    tests options
-    -O, --opt <opt>          tests options
-    -V, --version            Print version information
-";
-
-static RIPGREP_USAGE: &str = "ripgrep 0.5
-
-USAGE:
-    rg [OPTIONS] <pattern> [<path> ...]
-    rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]
-    rg [OPTIONS] --files [<path> ...]
-    rg [OPTIONS] --type-list
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-";
-
-static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
-Kevin K. <kbknapp@gmail.com>
-tests subcommands
-
-USAGE:
-    ctest subcmd multi [OPTIONS]
-
-OPTIONS:
-    -f, --flag                    tests flags
-    -h, --help                    Print help information
-    -o, --option <scoption>...    tests options
-    -V, --version                 Print version information
-";
-
-static ISSUE_626_CUTOFF: &str = "ctest 0.1
-
-USAGE:
-    ctest [OPTIONS]
-
-OPTIONS:
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café is an
-                         establishment which primarily serves hot
-                         coffee, related coffee beverages (e.g., café
-                         latte, cappuccino, espresso), tea, and other
-                         hot beverages. Some coffeehouses also serve
-                         cold beverages such as iced coffee and iced
-                         tea. Many cafés also serve some type of food,
-                         such as light snacks, muffins, or pastries.
-    -h, --help           Print help information
-    -V, --version        Print version information
-";
-
-static ISSUE_626_PANIC: &str = "ctest 0.1
-
-USAGE:
-    ctest [OPTIONS]
-
-OPTIONS:
-    -c, --cafe <FILE>
-            La culture du café est très développée
-            dans de nombreux pays à climat chaud
-            d\'Amérique, d\'Afrique et d\'Asie, dans
-            des plantations qui sont cultivées pour
-            les marchés d\'exportation. Le café est
-            souvent une contribution majeure aux
-            exportations des régions productrices.
-
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
-";
-
-static HIDE_POS_VALS: &str = "ctest 0.1
-
-USAGE:
-    ctest [OPTIONS]
-
-OPTIONS:
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
-    -h, --help           Print help information
-    -p, --pos <VAL>      Some vals [possible values: fast, slow]
-    -V, --version        Print version information
-";
-
-static FINAL_WORD_WRAPPING: &str = "ctest 0.1
-
-USAGE:
-    ctest
-
-OPTIONS:
-    -h, --help
-            Print help
-            information
-
-    -V, --version
-            Print
-            version
-            information
-";
-
-static OLD_NEWLINE_CHARS: &str = "ctest 0.1
-
-USAGE:
-    ctest [OPTIONS]
-
-OPTIONS:
-    -h, --help       Print help information
-    -m               Some help with some wrapping
-                     (Defaults to something)
-    -V, --version    Print version information
-";
-
-static WRAPPING_NEWLINE_CHARS: &str = "ctest 0.1
-
-USAGE:
-    ctest [mode]
-
-ARGS:
-    <mode>    x, max, maximum   20 characters, contains
-              symbols.
-              l, long           Copy-friendly, 14
-              characters, contains symbols.
-              m, med, medium    Copy-friendly, 8
-              characters, contains symbols.
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-";
-
-static ISSUE_688: &str = "ctest 0.1
-
-USAGE:
-    ctest [OPTIONS]
-
-OPTIONS:
-        --filter <filter>    Sets the filter, or sampling method, to use for interpolation when resizing the particle
-                             images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic,
-                             Gaussian, Lanczos3]
-    -h, --help               Print help information
-    -V, --version            Print version information
-";
-
-static ISSUE_702: &str = "myapp 1.0
-foo
-bar
-
-USAGE:
-    myapp [OPTIONS] [--] [ARGS]
-
-ARGS:
-    <arg1>       some option
-    <arg2>...    some option
-
-OPTIONS:
-    -h, --help                Print help information
-    -l, --label <label>...    a label
-    -o, --other <other>       some other option
-    -s, --some <some>         some option
-    -V, --version             Print version information
-";
-
-static ISSUE_777: &str = "A cmd with a crazy very long long
-long name hahaha 1.0
-Some Very Long Name and crazy long
-email <email@server.com>
-Show how the about text is not
-wrapped
-
-USAGE:
-    ctest
-
-OPTIONS:
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version
-            information
-";
-
-static ISSUE_1642: &str = "prog 
-
-USAGE:
-    prog [OPTIONS]
-
-OPTIONS:
-        --config
-            The config file used by the myprog must be in JSON format
-            with only valid keys and may not contain other nonsense
-            that cannot be read by this program. Obviously I'm going on
-            and on, so I'll stop now.
-
-    -h, --help
-            Print help information
-";
-
-static HELP_CONFLICT: &str = "conflict 
-
-USAGE:
-    conflict [OPTIONS]
-
-OPTIONS:
-    -h            
-        --help    Print help information
-";
-
-static LAST_ARG: &str = "last 0.1
-
-USAGE:
-    last <TARGET> [CORPUS] [-- <ARGS>...]
-
-ARGS:
-    <TARGET>     some
-    <CORPUS>     some
-    <ARGS>...    some
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-";
-
-static LAST_ARG_SC: &str = "last 0.1
-
-USAGE:
-    last <TARGET> [CORPUS] [-- <ARGS>...]
-    last <SUBCOMMAND>
-
-ARGS:
-    <TARGET>     some
-    <CORPUS>     some
-    <ARGS>...    some
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    test    some
-    help    Print this message or the help of the given subcommand(s)
-";
-
-static LAST_ARG_REQ: &str = "last 0.1
-
-USAGE:
-    last <TARGET> [CORPUS] -- <ARGS>...
-
-ARGS:
-    <TARGET>     some
-    <CORPUS>     some
-    <ARGS>...    some
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-";
-
-static LAST_ARG_REQ_SC: &str = "last 0.1
-
-USAGE:
-    last <TARGET> [CORPUS] -- <ARGS>...
-    last <SUBCOMMAND>
-
-ARGS:
-    <TARGET>     some
-    <CORPUS>     some
-    <ARGS>...    some
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    test    some
-    help    Print this message or the help of the given subcommand(s)
-";
-
-static HIDE_DEFAULT_VAL: &str = "default 0.1
-
-USAGE:
-    default [OPTIONS]
-
-OPTIONS:
-        --arg <argument>    Pass an argument to the program. [default: default-argument]
-    -h, --help              Print help information
-    -V, --version           Print version information
-";
-
-static ESCAPED_DEFAULT_VAL: &str = "default 0.1
-
-USAGE:
-    default [OPTIONS]
-
-OPTIONS:
-        --arg <argument>    Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
-                            other]
-    -h, --help              Print help information
-    -V, --version           Print version information
-";
-
-static LAST_ARG_USAGE: &str = "flamegraph 0.1
-
-USAGE:
-    flamegraph [OPTIONS] [BINFILE] [-- <ARGS>...]
-
-ARGS:
-    <BINFILE>    The path of the binary to be profiled. for a binary.
-    <ARGS>...    Any arguments you wish to pass to the being profiled.
-
-OPTIONS:
-    -f, --frequency <HERTZ>    The sampling frequency.
-    -h, --help                 Print help information
-    -t, --timeout <SECONDS>    Timeout in seconds.
-    -v, --verbose              Prints out more stuff.
-    -V, --version              Print version information
-";
-
-static LAST_ARG_REQ_MULT: &str = "example 1.0
-
-USAGE:
-    example <FIRST>... [--] <SECOND>...
-
-ARGS:
-    <FIRST>...     First
-    <SECOND>...    Second
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-";
-
-static DEFAULT_HELP: &str = "ctest 1.0
-
-USAGE:
-    ctest
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-";
-
-static LONG_ABOUT: &str = "myapp 1.0
-foo
-something really really long, with
-multiple lines of text
-that should be displayed
-
-USAGE:
-    myapp [arg1]
-
-ARGS:
-    <arg1>
-            some option
-
-OPTIONS:
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
-";
-
-static CUSTOM_HELP_SECTION: &str = "blorp 1.4
-Will M.
-does stuff
-
-USAGE:
-    test [OPTIONS] --fake <some>:<val>
-
-OPTIONS:
-    -f, --fake <some>:<val>    some help
-    -h, --help                 Print help information
-    -V, --version              Print version information
-
-NETWORKING:
-    -n, --no-proxy    Do not use system proxy settings
-        --port        
-";
-
-static ISSUE_1487: &str = "test 
-
-USAGE:
-    ctest <arg1|arg2>
-
-ARGS:
-    <arg1>    
-    <arg2>    
-
-OPTIONS:
-    -h, --help    Print help information
-";
-
-static ISSUE_1364: &str = "demo 
-
-USAGE:
-    demo [OPTIONS] [FILES]...
-
-ARGS:
-    <FILES>...    
-
-OPTIONS:
-    -f            
-    -h, --help    Print help information
-";
-
-static OPTION_USAGE_ORDER: &str = "order 
-
-USAGE:
-    order [OPTIONS]
-
-OPTIONS:
-    -a                     
-    -b                     
-    -B                     
-    -h, --help             Print help information
-    -s                     
-        --select_file      
-        --select_folder    
-    -x                     
-";
-
-static ABOUT_IN_SUBCOMMANDS_LIST: &str = "about-in-subcommands-list 
-
-USAGE:
-    about-in-subcommands-list [SUBCOMMAND]
-
-OPTIONS:
-    -h, --help    Print help information
-
-SUBCOMMANDS:
-    sub     short about sub
-    help    Print this message or the help of the given subcommand(s)
-";
-
 fn setup() -> Command<'static> {
     Command::new("test")
         .author("Kevin K.")
@@ -692,6 +88,20 @@ For more information try --help
 
 #[test]
 fn req_last_arg_usage() {
+    static LAST_ARG_REQ_MULT: &str = "example 1.0
+
+USAGE:
+    example <FIRST>... [--] <SECOND>...
+
+ARGS:
+    <FIRST>...     First
+    <SECOND>...    Second
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+
     let cmd = Command::new("example")
         .version("1.0")
         .arg(
@@ -712,6 +122,23 @@ fn req_last_arg_usage() {
 
 #[test]
 fn args_with_last_usage() {
+    static LAST_ARG_USAGE: &str = "flamegraph 0.1
+
+USAGE:
+    flamegraph [OPTIONS] [BINFILE] [-- <ARGS>...]
+
+ARGS:
+    <BINFILE>    The path of the binary to be profiled. for a binary.
+    <ARGS>...    Any arguments you wish to pass to the being profiled.
+
+OPTIONS:
+    -v, --verbose              Prints out more stuff.
+    -t, --timeout <SECONDS>    Timeout in seconds.
+    -f, --frequency <HERTZ>    The sampling frequency.
+    -h, --help                 Print help information
+    -V, --version              Print version information
+";
+
     let cmd = Command::new("flamegraph")
         .version("0.1")
         .trailing_var_arg(true)
@@ -778,11 +205,58 @@ fn subcommand_help_rev() {
 
 #[test]
 fn complex_help_output() {
+    static HELP: &str = "clap-test v1.4.8
+Kevin K. <kbknapp@gmail.com>
+tests clap library
+
+USAGE:
+    clap-test [OPTIONS] [ARGS] [SUBCOMMAND]
+
+ARGS:
+    <positional>        tests positionals
+    <positional2>       tests positionals with exclusions
+    <positional3>...    tests specific values [possible values: vi, emacs]
+
+OPTIONS:
+    -o, --option <opt>...            tests options
+    -f, --flag                       tests flags
+    -F                               tests flags with exclusions
+        --long-option-2 <option2>    tests long options with exclusions
+    -O, --option3 <option3>          specific vals [possible values: fast, slow]
+        --multvals <one> <two>       Tests multiple values, not mult occs
+        --multvalsmo <one> <two>     Tests multiple values, and mult occs
+        --minvals2 <minvals>...      Tests 2 min vals
+        --maxvals3 <maxvals>...      Tests 3 max vals
+        --optvaleq[=<optval>]        Tests optional value, require = sign
+        --optvalnoeq [<optval>]      Tests optional value
+    -h, --help                       Print help information
+    -V, --version                    Print version information
+
+SUBCOMMANDS:
+    subcmd    tests subcommands
+    help      Print this message or the help of the given subcommand(s)
+";
+
     utils::assert_output(utils::complex_app(), "clap-test --help", HELP, false);
 }
 
 #[test]
 fn after_and_before_help_output() {
+    static AFTER_HELP: &str = "some text that comes before the help
+
+clap-test v1.4.8
+tests clap library
+
+USAGE:
+    clap-test
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+some text that comes after the help
+";
+
     let cmd = Command::new("clap-test")
         .version("v1.4.8")
         .about("tests clap library")
@@ -794,6 +268,39 @@ fn after_and_before_help_output() {
 
 #[test]
 fn after_and_before_long_help_output() {
+    static AFTER_HELP: &str = "some text that comes before the help
+
+clap-test v1.4.8
+tests clap library
+
+USAGE:
+    clap-test
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+some text that comes after the help
+";
+
+    static AFTER_LONG_HELP: &str = "some longer text that comes before the help
+
+clap-test v1.4.8
+tests clap library
+
+USAGE:
+    clap-test
+
+OPTIONS:
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+
+some longer text that comes after the help
+";
+
     let cmd = Command::new("clap-test")
         .version("v1.4.8")
         .about("tests clap library")
@@ -804,6 +311,20 @@ fn after_and_before_long_help_output() {
     utils::assert_output(cmd.clone(), "clap-test --help", AFTER_LONG_HELP, false);
     utils::assert_output(cmd, "clap-test -h", AFTER_HELP, false);
 }
+
+static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
+Kevin K. <kbknapp@gmail.com>
+tests subcommands
+
+USAGE:
+    ctest subcmd multi [OPTIONS]
+
+OPTIONS:
+    -f, --flag                    tests flags
+    -o, --option <scoption>...    tests options
+    -h, --help                    Print help information
+    -V, --version                 Print version information
+";
 
 #[test]
 fn multi_level_sc_help() {
@@ -839,6 +360,16 @@ fn no_wrap_help() {
 
 #[test]
 fn no_wrap_default_help() {
+    static DEFAULT_HELP: &str = "ctest 1.0
+
+USAGE:
+    ctest
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+
     let cmd = Command::new("ctest").version("1.0").term_width(0);
     utils::assert_output(cmd, "ctest --help", DEFAULT_HELP, false);
 }
@@ -860,14 +391,14 @@ OPTIONS:
             Specify inter dependency version numbers exactly with
             `=`
 
-    -h, --help
-            Print help information
-
         --no-git-commit
             Do not commit version changes
 
         --no-git-push
             Do not push generated commit and tags to git remote
+
+    -h, --help
+            Print help information
 ";
     let cmd = Command::new("test")
         .term_width(67)
@@ -908,10 +439,10 @@ OPTIONS:
                            (will not be published)
         --exact            Specify inter dependency version numbers
                            exactly with `=`
-    -h, --help             Print help information
         --no-git-commit    Do not commit version changes
         --no-git-push      Do not push generated commit and tags to
                            git remote
+    -h, --help             Print help information
 ";
     let cmd = Command::new("test")
         .term_width(68)
@@ -948,9 +479,6 @@ USAGE:
     test [OPTIONS]
 
 OPTIONS:
-    -h, --help
-            Print help information
-
         --possible-values <possible_values>
             Possible values:
               - short_name:
@@ -969,6 +497,9 @@ OPTIONS:
             Possible values:
               - name:   Short enough help message with no wrapping
               - second: short help
+
+    -h, --help
+            Print help information
 ";
     let cmd = Command::new("test")
         .term_width(67)
@@ -1007,12 +538,48 @@ OPTIONS:
 
 #[test]
 fn complex_subcommand_help_output() {
+    static SC_HELP: &str = "clap-test-subcmd 0.1
+Kevin K. <kbknapp@gmail.com>
+tests subcommands
+
+USAGE:
+    clap-test subcmd [OPTIONS] [--] [scpositional]
+
+ARGS:
+    <scpositional>    tests positionals
+
+OPTIONS:
+    -o, --option <scoption>...     tests options
+    -f, --flag                     tests flags
+    -s, --subcmdarg <subcmdarg>    tests other args
+    -h, --help                     Print help information
+    -V, --version                  Print version information
+";
+
     let a = utils::complex_app();
     utils::assert_output(a, "clap-test subcmd --help", SC_HELP, false);
 }
 
 #[test]
 fn issue_626_unicode_cutoff() {
+    static ISSUE_626_CUTOFF: &str = "ctest 0.1
+
+USAGE:
+    ctest [OPTIONS]
+
+OPTIONS:
+    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café is an
+                         establishment which primarily serves hot
+                         coffee, related coffee beverages (e.g., café
+                         latte, cappuccino, espresso), tea, and other
+                         hot beverages. Some coffeehouses also serve
+                         cold beverages such as iced coffee and iced
+                         tea. Many cafés also serve some type of food,
+                         such as light snacks, muffins, or pastries.
+    -h, --help           Print help information
+    -V, --version        Print version information
+";
+
     let cmd = Command::new("ctest").version("0.1").term_width(70).arg(
         Arg::new("cafe")
             .short('c')
@@ -1030,6 +597,18 @@ fn issue_626_unicode_cutoff() {
     );
     utils::assert_output(cmd, "ctest --help", ISSUE_626_CUTOFF, false);
 }
+
+static HIDE_POS_VALS: &str = "ctest 0.1
+
+USAGE:
+    ctest [OPTIONS]
+
+OPTIONS:
+    -p, --pos <VAL>      Some vals [possible values: fast, slow]
+    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
+    -h, --help           Print help information
+    -V, --version        Print version information
+";
 
 #[test]
 fn hide_possible_vals() {
@@ -1093,18 +672,18 @@ USAGE:
     ctest [OPTIONS]
 
 OPTIONS:
-    -c, --cafe <FILE>
-            A coffeehouse, coffee shop, or café.
-
-    -h, --help
-            Print help information
-
     -p, --pos <VAL>
             Some vals
 
             Possible values:
               - fast
               - slow: not as fast
+
+    -c, --cafe <FILE>
+            A coffeehouse, coffee shop, or café.
+
+    -h, --help
+            Print help information
 
     -V, --version
             Print version information
@@ -1137,6 +716,28 @@ OPTIONS:
 
 #[test]
 fn issue_626_panic() {
+    static ISSUE_626_PANIC: &str = "ctest 0.1
+
+USAGE:
+    ctest [OPTIONS]
+
+OPTIONS:
+    -c, --cafe <FILE>
+            La culture du café est très développée
+            dans de nombreux pays à climat chaud
+            d\'Amérique, d\'Afrique et d\'Asie, dans
+            des plantations qui sont cultivées pour
+            les marchés d\'exportation. Le café est
+            souvent une contribution majeure aux
+            exportations des régions productrices.
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+";
+
     let cmd = Command::new("ctest")
         .version("0.1")
         .term_width(52)
@@ -1171,9 +772,43 @@ fn issue_626_variable_panic() {
 
 #[test]
 fn final_word_wrapping() {
+    static FINAL_WORD_WRAPPING: &str = "ctest 0.1
+
+USAGE:
+    ctest
+
+OPTIONS:
+    -h, --help
+            Print help
+            information
+
+    -V, --version
+            Print
+            version
+            information
+";
+
     let cmd = Command::new("ctest").version("0.1").term_width(24);
     utils::assert_output(cmd, "ctest --help", FINAL_WORD_WRAPPING, false);
 }
+
+static WRAPPING_NEWLINE_CHARS: &str = "ctest 0.1
+
+USAGE:
+    ctest [mode]
+
+ARGS:
+    <mode>    x, max, maximum   20 characters, contains
+              symbols.
+              l, long           Copy-friendly, 14
+              characters, contains symbols.
+              m, med, medium    Copy-friendly, 8
+              characters, contains symbols.
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
 
 #[test]
 fn wrapping_newline_chars() {
@@ -1232,6 +867,18 @@ OPTIONS:
     utils::assert_output(cmd, "Example update --help", EXPECTED, false);
 }
 
+static OLD_NEWLINE_CHARS: &str = "ctest 0.1
+
+USAGE:
+    ctest [OPTIONS]
+
+OPTIONS:
+    -m               Some help with some wrapping
+                     (Defaults to something)
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+
 #[test]
 fn old_newline_chars() {
     let cmd = Command::new("ctest").version("0.1").arg(
@@ -1254,6 +901,19 @@ fn old_newline_variables() {
 
 #[test]
 fn issue_688_hide_pos_vals() {
+    static ISSUE_688: &str = "ctest 0.1
+
+USAGE:
+    ctest [OPTIONS]
+
+OPTIONS:
+        --filter <filter>    Sets the filter, or sampling method, to use for interpolation when resizing the particle
+                             images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic,
+                             Gaussian, Lanczos3]
+    -h, --help               Print help information
+    -V, --version            Print version information
+";
+
     let filter_values = ["Nearest", "Linear", "Cubic", "Gaussian", "Lanczos3"];
 
     let app1 = Command::new("ctest")
@@ -1292,6 +952,25 @@ fn issue_688_hide_pos_vals() {
 
 #[test]
 fn issue_702_multiple_values() {
+    static ISSUE_702: &str = "myapp 1.0
+foo
+bar
+
+USAGE:
+    myapp [OPTIONS] [--] [ARGS]
+
+ARGS:
+    <arg1>       some option
+    <arg2>...    some option
+
+OPTIONS:
+    -s, --some <some>         some option
+    -o, --other <other>       some other option
+    -l, --label <label>...    a label
+    -h, --help                Print help information
+    -V, --version             Print version information
+";
+
     let cmd = Command::new("myapp")
         .version("1.0")
         .author("foo")
@@ -1330,6 +1009,27 @@ fn issue_702_multiple_values() {
 
 #[test]
 fn long_about() {
+    static LONG_ABOUT: &str = "myapp 1.0
+foo
+something really really long, with
+multiple lines of text
+that should be displayed
+
+USAGE:
+    myapp [arg1]
+
+ARGS:
+    <arg1>
+            some option
+
+OPTIONS:
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+";
+
     let cmd = Command::new("myapp")
         .version("1.0")
         .author("foo")
@@ -1343,6 +1043,19 @@ fn long_about() {
 
 #[test]
 fn issue_760() {
+    // Using number_of_values(1) with multiple_values(true) misaligns help message
+    static ISSUE_760: &str = "ctest 0.1
+
+USAGE:
+    ctest [OPTIONS]
+
+OPTIONS:
+    -o, --option <option>    tests options
+    -O, --opt <opt>          tests options
+    -h, --help               Print help information
+    -V, --version            Print version information
+";
+
     let cmd = Command::new("ctest")
         .version("0.1")
         .arg(
@@ -1383,12 +1096,25 @@ USAGE:
     hello [OPTIONS]
 
 OPTIONS:
-    -h, --help              Print help information
     -p, --package <name>    
+    -h, --help              Print help information
 ",
         false,
     );
 }
+
+static RIPGREP_USAGE: &str = "ripgrep 0.5
+
+USAGE:
+    rg [OPTIONS] <pattern> [<path> ...]
+    rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]
+    rg [OPTIONS] --files [<path> ...]
+    rg [OPTIONS] --type-list
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
 
 #[test]
 fn ripgrep_usage() {
@@ -1428,6 +1154,25 @@ OPTIONS:
 
 #[test]
 fn sc_negates_reqs() {
+    static SC_NEGATES_REQS: &str = "prog 1.0
+
+USAGE:
+    prog --opt <FILE> [PATH]
+    prog [PATH] <SUBCOMMAND>
+
+ARGS:
+    <PATH>    help
+
+OPTIONS:
+    -o, --opt <FILE>    tests options
+    -h, --help          Print help information
+    -V, --version       Print version information
+
+SUBCOMMANDS:
+    test    
+    help    Print this message or the help of the given subcommand(s)
+";
+
     let cmd = Command::new("prog")
         .version("1.0")
         .subcommand_negates_reqs(true)
@@ -1439,6 +1184,18 @@ fn sc_negates_reqs() {
 
 #[test]
 fn hide_args() {
+    static HIDDEN_ARGS: &str = "prog 1.0
+
+USAGE:
+    prog [OPTIONS]
+
+OPTIONS:
+    -f, --flag          testing flags
+    -o, --opt <FILE>    tests options
+    -h, --help          Print help information
+    -V, --version       Print version information
+";
+
     let cmd = Command::new("prog")
         .version("1.0")
         .arg(arg!(-f --flag "testing flags"))
@@ -1449,6 +1206,26 @@ fn hide_args() {
 
 #[test]
 fn args_negate_sc() {
+    static ARGS_NEGATE_SC: &str = "prog 1.0
+
+USAGE:
+    prog [OPTIONS] [PATH]
+    prog <SUBCOMMAND>
+
+ARGS:
+    <PATH>    help
+
+OPTIONS:
+    -f, --flag          testing flags
+    -o, --opt <FILE>    tests options
+    -h, --help          Print help information
+    -V, --version       Print version information
+
+SUBCOMMANDS:
+    test    
+    help    Print this message or the help of the given subcommand(s)
+";
+
     let cmd = Command::new("prog")
         .version("1.0")
         .args_conflicts_with_subcommands(true)
@@ -1461,6 +1238,21 @@ fn args_negate_sc() {
 
 #[test]
 fn issue_1046_hide_scs() {
+    static ISSUE_1046_HIDDEN_SCS: &str = "prog 1.0
+
+USAGE:
+    prog [OPTIONS] [PATH]
+
+ARGS:
+    <PATH>    some
+
+OPTIONS:
+    -f, --flag          testing flags
+    -o, --opt <FILE>    tests options
+    -h, --help          Print help information
+    -V, --version       Print version information
+";
+
     let cmd = Command::new("prog")
         .version("1.0")
         .arg(arg!(-f --flag "testing flags"))
@@ -1472,6 +1264,25 @@ fn issue_1046_hide_scs() {
 
 #[test]
 fn issue_777_wrap_all_things() {
+    static ISSUE_777: &str = "A cmd with a crazy very long long
+long name hahaha 1.0
+Some Very Long Name and crazy long
+email <email@server.com>
+Show how the about text is not
+wrapped
+
+USAGE:
+    ctest
+
+OPTIONS:
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version
+            information
+";
+
     let cmd = Command::new("A cmd with a crazy very long long long name hahaha")
         .version("1.0")
         .author("Some Very Long Name and crazy long email <email@server.com>")
@@ -1542,6 +1353,16 @@ fn override_help_about() {
 
 #[test]
 fn arg_short_conflict_with_help() {
+    static HELP_CONFLICT: &str = "conflict 
+
+USAGE:
+    conflict [OPTIONS]
+
+OPTIONS:
+    -h            
+        --help    Print help information
+";
+
     let cmd = Command::new("conflict").arg(Arg::new("home").short('h'));
 
     utils::assert_output(cmd, "conflict --help", HELP_CONFLICT, false);
@@ -1559,6 +1380,21 @@ fn arg_short_conflict_with_help_mut_arg() {
 
 #[test]
 fn last_arg_mult_usage() {
+    static LAST_ARG: &str = "last 0.1
+
+USAGE:
+    last <TARGET> [CORPUS] [-- <ARGS>...]
+
+ARGS:
+    <TARGET>     some
+    <CORPUS>     some
+    <ARGS>...    some
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+
     let cmd = Command::new("last")
         .version("0.1")
         .arg(Arg::new("TARGET").required(true).help("some"))
@@ -1575,6 +1411,21 @@ fn last_arg_mult_usage() {
 
 #[test]
 fn last_arg_mult_usage_req() {
+    static LAST_ARG_REQ: &str = "last 0.1
+
+USAGE:
+    last <TARGET> [CORPUS] -- <ARGS>...
+
+ARGS:
+    <TARGET>     some
+    <CORPUS>     some
+    <ARGS>...    some
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+
     let cmd = Command::new("last")
         .version("0.1")
         .arg(Arg::new("TARGET").required(true).help("some"))
@@ -1592,6 +1443,26 @@ fn last_arg_mult_usage_req() {
 
 #[test]
 fn last_arg_mult_usage_req_with_sc() {
+    static LAST_ARG_REQ_SC: &str = "last 0.1
+
+USAGE:
+    last <TARGET> [CORPUS] -- <ARGS>...
+    last <SUBCOMMAND>
+
+ARGS:
+    <TARGET>     some
+    <CORPUS>     some
+    <ARGS>...    some
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    test    some
+    help    Print this message or the help of the given subcommand(s)
+";
+
     let cmd = Command::new("last")
         .version("0.1")
         .subcommand_negates_reqs(true)
@@ -1611,6 +1482,26 @@ fn last_arg_mult_usage_req_with_sc() {
 
 #[test]
 fn last_arg_mult_usage_with_sc() {
+    static LAST_ARG_SC: &str = "last 0.1
+
+USAGE:
+    last <TARGET> [CORPUS] [-- <ARGS>...]
+    last <SUBCOMMAND>
+
+ARGS:
+    <TARGET>     some
+    <CORPUS>     some
+    <ARGS>...    some
+
+OPTIONS:
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    test    some
+    help    Print this message or the help of the given subcommand(s)
+";
+
     let cmd = Command::new("last")
         .version("0.1")
         .args_conflicts_with_subcommands(true)
@@ -1626,6 +1517,17 @@ fn last_arg_mult_usage_with_sc() {
         .subcommand(Command::new("test").about("some"));
     utils::assert_output(cmd, "last --help", LAST_ARG_SC, false);
 }
+
+static HIDE_DEFAULT_VAL: &str = "default 0.1
+
+USAGE:
+    default [OPTIONS]
+
+OPTIONS:
+        --arg <argument>    Pass an argument to the program. [default: default-argument]
+    -h, --help              Print help information
+    -V, --version           Print version information
+";
 
 #[test]
 fn hide_default_val() {
@@ -1649,6 +1551,18 @@ fn hide_default_val() {
 
 #[test]
 fn escaped_whitespace_values() {
+    static ESCAPED_DEFAULT_VAL: &str = "default 0.1
+
+USAGE:
+    default [OPTIONS]
+
+OPTIONS:
+        --arg <argument>    Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
+                            other]
+    -h, --help              Print help information
+    -V, --version           Print version information
+";
+
     let app1 = Command::new("default").version("0.1").term_width(120).arg(
         Arg::new("argument")
             .help("Pass an argument to the program.")
@@ -1726,6 +1640,19 @@ fn prefer_user_subcmd_help_short_1112() {
 
 #[test]
 fn issue_1052_require_delim_help() {
+    static REQUIRE_DELIM_HELP: &str = "test 1.3
+Kevin K.
+tests stuff
+
+USAGE:
+    test --fake <some>:<val>
+
+OPTIONS:
+    -f, --fake <some>:<val>    some help
+    -h, --help                 Print help information
+    -V, --version              Print version information
+";
+
     let cmd = Command::new("test")
         .author("Kevin K.")
         .about("tests stuff")
@@ -1745,6 +1672,23 @@ fn issue_1052_require_delim_help() {
 
 #[test]
 fn custom_headers_headers() {
+    static CUSTOM_HELP_SECTION: &str = "blorp 1.4
+Will M.
+does stuff
+
+USAGE:
+    test [OPTIONS] --fake <some>:<val>
+
+OPTIONS:
+    -f, --fake <some>:<val>    some help
+    -h, --help                 Print help information
+    -V, --version              Print version information
+
+NETWORKING:
+    -n, --no-proxy    Do not use system proxy settings
+        --port        
+";
+
     let cmd = Command::new("blorp")
         .author("Will M.")
         .about("does stuff")
@@ -1779,14 +1723,14 @@ USAGE:
 
 OPTIONS:
     -f, --fake <some>:<val>    some help
-    -h, --help                 Print help information
-    -s, --speed <SPEED>        How fast? [possible values: fast, slow]
         --style <style>        Choose musical style to play the song
+    -s, --speed <SPEED>        How fast? [possible values: fast, slow]
+    -h, --help                 Print help information
     -V, --version              Print version information
 
 NETWORKING:
-    -a, --server-addr    Set server address
     -n, --no-proxy       Do not use system proxy settings
+    -a, --server-addr    Set server address
 
 OVERRIDE SPECIAL:
     -b, --birthday-song <song>    Change which song is played for birthdays
@@ -1953,6 +1897,19 @@ fn show_short_about_issue_897() {
 
 #[test]
 fn issue_1364_no_short_options() {
+    static ISSUE_1364: &str = "demo 
+
+USAGE:
+    demo [OPTIONS] [FILES]...
+
+ARGS:
+    <FILES>...    
+
+OPTIONS:
+    -f            
+    -h, --help    Print help information
+";
+
     let cmd = Command::new("demo")
         .arg(Arg::new("foo").short('f'))
         .arg(
@@ -1974,6 +1931,19 @@ fn issue_1364_no_short_options() {
 #[rustfmt::skip]
 #[test]
 fn issue_1487() {
+static ISSUE_1487: &str = "test 
+
+USAGE:
+    ctest <arg1|arg2>
+
+ARGS:
+    <arg1>    
+    <arg2>    
+
+OPTIONS:
+    -h, --help    Print help information
+";
+
     let cmd = Command::new("test")
         .arg(Arg::new("arg1")
             .group("group1"))
@@ -2083,6 +2053,22 @@ fn help_required_and_no_args() {
 
 #[test]
 fn issue_1642_long_help_spacing() {
+    static ISSUE_1642: &str = "prog 
+
+USAGE:
+    prog [OPTIONS]
+
+OPTIONS:
+        --config
+            The config file used by the myprog must be in JSON format
+            with only valid keys and may not contain other nonsense
+            that cannot be read by this program. Obviously I'm going on
+            and on, so I'll stop now.
+
+    -h, --help
+            Print help information
+";
+
     let cmd = Command::new("prog").arg(Arg::new("cfg").long("config").long_help(
         "The config file used by the myprog must be in JSON format
 with only valid keys and may not contain other nonsense
@@ -2241,6 +2227,22 @@ fn help_about_multi_subcmd_override() {
 
 #[test]
 fn option_usage_order() {
+    static OPTION_USAGE_ORDER: &str = "order 
+
+USAGE:
+    order [OPTIONS]
+
+OPTIONS:
+    -a                     
+    -B                     
+    -b                     
+    -s                     
+        --select_file      
+        --select_folder    
+    -x                     
+    -h, --help             Print help information
+";
+
     let cmd = Command::new("order").args(&[
         Arg::new("a").short('a'),
         Arg::new("B").short('B'),
@@ -2256,6 +2258,19 @@ fn option_usage_order() {
 
 #[test]
 fn prefer_about_over_long_about_in_subcommands_list() {
+    static ABOUT_IN_SUBCOMMANDS_LIST: &str = "about-in-subcommands-list 
+
+USAGE:
+    about-in-subcommands-list [SUBCOMMAND]
+
+OPTIONS:
+    -h, --help    Print help information
+
+SUBCOMMANDS:
+    sub     short about sub
+    help    Print this message or the help of the given subcommand(s)
+";
+
     let cmd = Command::new("about-in-subcommands-list").subcommand(
         Command::new("sub")
             .long_about("long about sub")
@@ -2282,8 +2297,8 @@ ARGS:
     <pos2>    
 
 OPTIONS:
-    -h, --help       Print help information
         --option1    
+    -h, --help       Print help information
 ";
 
     let cmd = clap::Command::new("hello")
@@ -2388,9 +2403,9 @@ USAGE:
     my_app [OPTIONS]
 
 OPTIONS:
-    -h, --help                              Print help information
         --some_arg <some_arg> <some_arg>    
         --some_arg_issue <ARG> <ARG>        
+    -h, --help                              Print help information
 ",
         false,
     );

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -43,8 +43,8 @@ OPTIONS:
     -V, --version                    Print version information
 
 SUBCOMMANDS:
-    help      Print this message or the help of the given subcommand(s)
     subcmd    tests subcommands
+    help      Print this message or the help of the given subcommand(s)
 ";
 
 static SC_NEGATES_REQS: &str = "prog 1.0
@@ -62,8 +62,8 @@ OPTIONS:
     -V, --version       Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 static ARGS_NEGATE_SC: &str = "prog 1.0
@@ -82,8 +82,8 @@ OPTIONS:
     -V, --version       Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 static AFTER_HELP: &str = "some text that comes before the help
@@ -410,8 +410,8 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    some
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 static LAST_ARG_REQ: &str = "last 0.1
@@ -445,8 +445,8 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    some
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 static HIDE_DEFAULT_VAL: &str = "default 0.1
@@ -602,8 +602,8 @@ OPTIONS:
     -h, --help    Print help information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     sub     short about sub
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 fn setup() -> Command<'static> {

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -11,8 +11,8 @@ USAGE:
 
 OPTIONS:
     -F, --flag2           some other flag
-    -h, --help            Print help information
         --option <opt>    some option
+    -h, --help            Print help information
     -V, --version         Print version information
 ";
 
@@ -39,30 +39,9 @@ USAGE:
     test [OPTIONS]
 
 OPTIONS:
-    -h, --help       Print help information
     -v, --visible    This text should be visible
+    -h, --help       Print help information
     -V, --version    Print version information
-";
-
-static HIDDEN_SHORT_ARGS_LONG_HELP: &str = "test 2.31.2
-Steve P.
-hides short args
-
-USAGE:
-    test [OPTIONS]
-
-OPTIONS:
-    -c, --config
-            Some help text describing the --config arg
-
-    -h, --help
-            Print help information
-
-    -v, --visible
-            This text should be visible
-
-    -V, --version
-            Print version information
 ";
 
 /// Ensure hide with short option
@@ -90,6 +69,27 @@ fn hide_short_args() {
 /// Ensure visible with opposite option
 #[test]
 fn hide_short_args_long_help() {
+    static HIDDEN_SHORT_ARGS_LONG_HELP: &str = "test 2.31.2
+Steve P.
+hides short args
+
+USAGE:
+    test [OPTIONS]
+
+OPTIONS:
+    -c, --config
+            Some help text describing the --config arg
+
+    -v, --visible
+            This text should be visible
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+";
+
     let cmd = Command::new("test")
         .about("hides short args")
         .author("Steve P.")
@@ -117,11 +117,11 @@ USAGE:
     test [OPTIONS]
 
 OPTIONS:
-    -h, --help
-            Print help information
-
     -v, --visible
             This text should be visible
+
+    -h, --help
+            Print help information
 
     -V, --version
             Print version information
@@ -157,8 +157,8 @@ USAGE:
 
 OPTIONS:
     -c, --config     Some help text describing the --config arg
-    -h, --help       Print help information
     -v, --visible    This text should be visible
+    -h, --help       Print help information
     -V, --version    Print version information
 ";
 

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -12,8 +12,8 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    Some help [aliases: dongle, done]
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 static INVISIBLE_ALIAS_HELP: &str = "clap-test 2.6
@@ -26,37 +26,7 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    Some help
-";
-
-static SUBCMD_ALPHA_ORDER: &str = "test 1
-
-USAGE:
-    test [SUBCOMMAND]
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    a1      blah a1
-    b1      blah b1
-    help    Print this message or the help of the given subcommand(s)
-";
-
-static SUBCMD_DECL_ORDER: &str = "test 1
-
-USAGE:
-    test [SUBCOMMAND]
-
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    b1      blah b1
-    a1      blah a1
     help    Print this message or the help of the given subcommand(s)
 ";
 
@@ -166,44 +136,6 @@ fn subcommand_multiple() {
     assert_eq!(
         sub_m.get_one::<String>("test").map(|v| v.as_str()).unwrap(),
         "testing"
-    );
-}
-
-#[test]
-fn subcommand_display_order() {
-    let app_subcmd_alpha_order = Command::new("test").version("1").subcommands(vec![
-        Command::new("b1")
-            .about("blah b1")
-            .arg(Arg::new("test").short('t')),
-        Command::new("a1")
-            .about("blah a1")
-            .arg(Arg::new("roster").short('r')),
-    ]);
-
-    utils::assert_output(
-        app_subcmd_alpha_order,
-        "test --help",
-        SUBCMD_ALPHA_ORDER,
-        false,
-    );
-
-    let app_subcmd_decl_order = Command::new("test")
-        .version("1")
-        .setting(clap::AppSettings::DeriveDisplayOrder)
-        .subcommands(vec![
-            Command::new("b1")
-                .about("blah b1")
-                .arg(Arg::new("test").short('t')),
-            Command::new("a1")
-                .about("blah a1")
-                .arg(Arg::new("roster").short('r')),
-        ]);
-
-    utils::assert_output(
-        app_subcmd_decl_order,
-        "test --help",
-        SUBCMD_DECL_ORDER,
-        false,
     );
 }
 

--- a/tests/builder/template_help.rs
+++ b/tests/builder/template_help.rs
@@ -40,8 +40,8 @@ OPTIONS:
 ARGS:
     <output>    Sets an optional output file
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    does testing things
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 static SIMPLE_TEMPLATE: &str = "MyApp 1.0
@@ -61,8 +61,8 @@ OPTIONS:
     -V, --version          Print version information
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     test    does testing things
+    help    Print this message or the help of the given subcommand(s)
 ";
 
 #[test]

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -1,4 +1,4 @@
-use clap::{AppSettings, Args, CommandFactory, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 
 #[test]
 fn arg_help_heading_applied() {
@@ -247,7 +247,6 @@ OPTIONS:
 
     #[derive(Parser, Debug)]
     #[clap(name = "test", version = "1.2")]
-    #[clap(setting = AppSettings::DeriveDisplayOrder)]
     struct Args {
         #[clap(flatten)]
         a: A,
@@ -303,7 +302,6 @@ OPTIONS:
 ";
 
     #[derive(Parser, Debug)]
-    #[clap(setting = AppSettings::DeriveDisplayOrder)]
     #[clap(name = "test", version = "1.2")]
     struct Args {
         #[clap(flatten)]
@@ -361,7 +359,6 @@ OPTIONS:
 
     #[derive(Parser, Debug)]
     #[clap(name = "test", version = "1.2")]
-    #[clap(setting = AppSettings::DeriveDisplayOrder)]
     #[clap(next_display_order = None)]
     struct Args {
         #[clap(flatten)]

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -14,6 +14,6 @@ OPTIONS:
         --verbose    log
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     more    
+    help    Print this message or the help of the given subcommand(s)
 """

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -9,9 +9,9 @@ USAGE:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
+        --verbose    log
     -h, --help       Print help information
     -V, --version    Print version information
-        --verbose    log
 
 SUBCOMMANDS:
     more    

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -13,7 +13,7 @@ OPTIONS:
         --verbose    log
 
 SUBCOMMANDS:
-    help    Print this message or the help of the given subcommand(s)
     more    
+    help    Print this message or the help of the given subcommand(s)
 """
 stderr = ""

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -8,9 +8,9 @@ USAGE:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
+        --verbose    log
     -h, --help       Print help information
     -V, --version    Print version information
-        --verbose    log
 
 SUBCOMMANDS:
     more    

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -18,9 +18,9 @@ OPTIONS:
             more log
 
 SUBCOMMANDS:
-    help
-            Print this message or the help of the given subcommand(s)
     more
             
+    help
+            Print this message or the help of the given subcommand(s)
 """
 stderr = ""

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -8,14 +8,14 @@ USAGE:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
+        --verbose
+            more log
+
     -h, --help
             Print help information
 
     -V, --version
             Print version information
-
-        --verbose
-            more log
 
 SUBCOMMANDS:
     more

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -18,9 +18,9 @@ OPTIONS:
             more log
 
 SUBCOMMANDS:
-    help
-            Print this message or the help of the given subcommand(s)
     more
             
+    help
+            Print this message or the help of the given subcommand(s)
 """
 stderr = ""

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -8,14 +8,14 @@ USAGE:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
+        --verbose
+            more log
+
     -h, --help
             Print help information
 
     -V, --version
             Print version information
-
-        --verbose
-            more log
 
 SUBCOMMANDS:
     more


### PR DESCRIPTION
Force sorting with `next_display_order(None)`

This also extends to subcommands.

Previous behavior:
- They'd be sorted by default
- They'd derive display order if `DeriveDisplayOrder` was set
  - This could be set recursively
- The initial display order value for subcommands was 0

New behavior:
- Sorted order is derived by default
- Sorting is turned on by `cmd.next_display_order(None)`
  - This is not recursive, it must be set on each level
- The display order incrementing is mixed with arguments
  - This does make it slightly more difficult to predict

And with that, we can remove `AppSettings` from the API, helping towards #3021

Fixes #2808