### PR TITLE
fix(derive)!: Remove value_parser/action defaulted attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## 5.0.0 - Upcoming
+
+### Breaking Changes
+
+- *(derive)* Removed `#[clap(value_parser)]` and `#[clap(action)]` defaulted attributes (its the default) (#3976)
+
 ## 4.0.0 - Upcoming
 
 ### Breaking Changes

--- a/clap_complete/examples/completion-derive.rs
+++ b/clap_complete/examples/completion-derive.rs
@@ -26,34 +26,34 @@ use std::path::PathBuf;
 )]
 struct Opt {
     /// If provided, outputs the completion file for given shell
-    #[clap(long = "generate", arg_enum, value_parser)]
+    #[clap(long = "generate", arg_enum)]
     generator: Option<Shell>,
     // Showcasing all possible ValueHints:
-    #[clap(long, value_hint = ValueHint::Unknown, value_parser)]
+    #[clap(long, value_hint = ValueHint::Unknown)]
     unknown: Option<String>,
-    #[clap(long, value_hint = ValueHint::Other, value_parser)]
+    #[clap(long, value_hint = ValueHint::Other)]
     other: Option<String>,
-    #[clap(short, long, value_hint = ValueHint::AnyPath, value_parser)]
+    #[clap(short, long, value_hint = ValueHint::AnyPath)]
     path: Option<PathBuf>,
-    #[clap(short, long, value_hint = ValueHint::FilePath, value_parser)]
+    #[clap(short, long, value_hint = ValueHint::FilePath)]
     file: Option<PathBuf>,
-    #[clap(short, long, value_hint = ValueHint::DirPath, value_parser)]
+    #[clap(short, long, value_hint = ValueHint::DirPath)]
     dir: Option<PathBuf>,
-    #[clap(short, long, value_hint = ValueHint::ExecutablePath, value_parser)]
+    #[clap(short, long, value_hint = ValueHint::ExecutablePath)]
     exe: Option<PathBuf>,
-    #[clap(long, value_hint = ValueHint::CommandName, value_parser)]
+    #[clap(long, value_hint = ValueHint::CommandName)]
     cmd_name: Option<OsString>,
-    #[clap(short, long, value_hint = ValueHint::CommandString, value_parser)]
+    #[clap(short, long, value_hint = ValueHint::CommandString)]
     cmd: Option<String>,
-    #[clap(value_hint = ValueHint::CommandWithArguments, value_parser)]
+    #[clap(value_hint = ValueHint::CommandWithArguments)]
     command_with_args: Vec<String>,
-    #[clap(short, long, value_hint = ValueHint::Username, value_parser)]
+    #[clap(short, long, value_hint = ValueHint::Username)]
     user: Option<String>,
-    #[clap(short, long, value_hint = ValueHint::Hostname, value_parser)]
+    #[clap(short, long, value_hint = ValueHint::Hostname)]
     host: Option<String>,
-    #[clap(long, value_hint = ValueHint::Url, value_parser)]
+    #[clap(long, value_hint = ValueHint::Url)]
     url: Option<String>,
-    #[clap(long, value_hint = ValueHint::EmailAddress, value_parser)]
+    #[clap(long, value_hint = ValueHint::EmailAddress)]
     email: Option<String>,
 }
 

--- a/clap_complete/src/dynamic.rs
+++ b/clap_complete/src/dynamic.rs
@@ -22,7 +22,7 @@ pub mod bash {
     #[derive(Clone, Debug)]
     pub struct CompleteArgs {
         /// Path to write completion-registration to
-        #[clap(long, required = true, value_parser)]
+        #[clap(long, required = true)]
         register: Option<std::path::PathBuf>,
 
         #[clap(
@@ -30,36 +30,33 @@ pub mod bash {
             required = true,
             value_name = "COMP_CWORD",
             hide_short_help = true,
-            group = "complete",
-            value_parser
+            group = "complete"
         )]
         index: Option<usize>,
 
-        #[clap(long, hide_short_help = true, group = "complete", value_parser)]
+        #[clap(long, hide_short_help = true, group = "complete")]
         ifs: Option<String>,
 
         #[clap(
             long = "type",
             required = true,
             hide_short_help = true,
-            group = "complete",
-            value_parser
+            group = "complete"
         )]
         comp_type: Option<CompType>,
 
-        #[clap(long, hide_short_help = true, group = "complete", action)]
+        #[clap(long, hide_short_help = true, group = "complete")]
         space: bool,
 
         #[clap(
             long,
             conflicts_with = "space",
             hide_short_help = true,
-            group = "complete",
-            action
+            group = "complete"
         )]
         no_space: bool,
 
-        #[clap(raw = true, hide_short_help = true, group = "complete", value_parser)]
+        #[clap(raw = true, hide_short_help = true, group = "complete")]
         comp_words: Vec<OsString>,
     }
 

--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -429,11 +429,13 @@ impl Attrs {
                     self.push_method(ident, self.name.clone().translate(*self.casing));
                 }
 
+                #[cfg(not(feature = "unstable-v5"))]
                 ValueParser(ident) => {
                     use crate::attrs::ValueParser;
                     self.value_parser = Some(ValueParser::Implicit(ident));
                 }
 
+                #[cfg(not(feature = "unstable-v5"))]
                 Action(ident) => {
                     use crate::attrs::Action;
                     self.action = Some(Action::Implicit(ident));

--- a/clap_derive/src/parse.rs
+++ b/clap_derive/src/parse.rs
@@ -25,7 +25,9 @@ pub enum ClapAttr {
     // single-identifier attributes
     Short(Ident),
     Long(Ident),
+    #[cfg(not(feature = "unstable-v5"))]
     ValueParser(Ident),
+    #[cfg(not(feature = "unstable-v5"))]
     Action(Ident),
     Env(Ident),
     Flatten(Ident),
@@ -143,7 +145,9 @@ impl Parse for ClapAttr {
             match name_str.as_ref() {
                 "long" => Ok(Long(name)),
                 "short" => Ok(Short(name)),
+                #[cfg(not(feature = "unstable-v5"))]
                 "value_parser" => Ok(ValueParser(name)),
+                #[cfg(not(feature = "unstable-v5"))]
                 "action" => Ok(Action(name)),
                 "env" => Ok(Env(name)),
                 "flatten" => Ok(Flatten(name)),

--- a/examples/cargo-example-derive.rs
+++ b/examples/cargo-example-derive.rs
@@ -10,7 +10,7 @@ enum Cargo {
 #[derive(clap::Args)]
 #[clap(author, version, about, long_about = None)]
 struct ExampleDerive {
-    #[clap(long, value_parser)]
+    #[clap(long)]
     manifest_path: Option<std::path::PathBuf>,
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,11 +5,11 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// Name of the person to greet
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     name: String,
 
     /// Number of times to greet
-    #[clap(short, long, value_parser, default_value_t = 1)]
+    #[clap(short, long, default_value_t = 1)]
     count: u8,
 }
 

--- a/examples/derive_ref/augment_args.rs
+++ b/examples/derive_ref/augment_args.rs
@@ -2,7 +2,7 @@ use clap::{arg, Args, Command, FromArgMatches as _};
 
 #[derive(Args, Debug)]
 struct DerivedArgs {
-    #[clap(short, long, action)]
+    #[clap(short, long)]
     derived: bool,
 }
 

--- a/examples/derive_ref/augment_subcommands.rs
+++ b/examples/derive_ref/augment_subcommands.rs
@@ -3,7 +3,7 @@ use clap::{Command, FromArgMatches as _, Parser, Subcommand as _};
 #[derive(Parser, Debug)]
 enum Subcommands {
     Derived {
-        #[clap(short, long, action)]
+        #[clap(short, long)]
         derived_flag: bool,
     },
 }

--- a/examples/derive_ref/flatten_hand_args.rs
+++ b/examples/derive_ref/flatten_hand_args.rs
@@ -69,7 +69,7 @@ impl Args for CliArgs {
 
 #[derive(Parser, Debug)]
 struct Cli {
-    #[clap(short, long, action)]
+    #[clap(short, long)]
     top_level: bool,
     #[clap(flatten)]
     more_args: CliArgs,

--- a/examples/derive_ref/hand_subcommand.rs
+++ b/examples/derive_ref/hand_subcommand.rs
@@ -3,14 +3,12 @@ use clap::{ArgMatches, Args as _, Command, FromArgMatches, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 struct AddArgs {
-    #[clap(value_parser)]
     name: Vec<String>,
 }
 #[derive(Parser, Debug)]
 struct RemoveArgs {
-    #[clap(short, long, action)]
+    #[clap(short, long)]
     force: bool,
-    #[clap(value_parser)]
     name: Vec<String>,
 }
 
@@ -69,7 +67,7 @@ impl Subcommand for CliSub {
 
 #[derive(Parser, Debug)]
 struct Cli {
-    #[clap(short, long, action)]
+    #[clap(short, long)]
     top_level: bool,
     #[clap(subcommand)]
     subcommand: CliSub,

--- a/examples/escaped-positional-derive.rs
+++ b/examples/escaped-positional-derive.rs
@@ -3,13 +3,13 @@ use clap::Parser;
 #[derive(Parser)] // requires `derive` feature
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short = 'f', action)]
+    #[clap(short = 'f')]
     eff: bool,
 
-    #[clap(short = 'p', value_name = "PEAR", value_parser)]
+    #[clap(short = 'p', value_name = "PEAR")]
     pea: Option<String>,
 
-    #[clap(last = true, value_parser)]
+    #[clap(last = true)]
     slop: Vec<String>,
 }
 

--- a/examples/git-derive.rs
+++ b/examples/git-derive.rs
@@ -18,21 +18,19 @@ enum Commands {
     #[clap(arg_required_else_help = true)]
     Clone {
         /// The remote to clone
-        #[clap(value_parser)]
         remote: String,
     },
     /// pushes things
     #[clap(arg_required_else_help = true)]
     Push {
         /// The remote to target
-        #[clap(value_parser)]
         remote: String,
     },
     /// adds things
     #[clap(arg_required_else_help = true)]
     Add {
         /// Stuff to add
-        #[clap(required = true, value_parser)]
+        #[clap(required = true)]
         path: Vec<PathBuf>,
     },
     Stash(Stash),
@@ -53,19 +51,13 @@ struct Stash {
 #[derive(Debug, Subcommand)]
 enum StashCommands {
     Push(StashPush),
-    Pop {
-        #[clap(value_parser)]
-        stash: Option<String>,
-    },
-    Apply {
-        #[clap(value_parser)]
-        stash: Option<String>,
-    },
+    Pop { stash: Option<String> },
+    Apply { stash: Option<String> },
 }
 
 #[derive(Debug, Args)]
 struct StashPush {
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     message: Option<String>,
 }
 

--- a/examples/tutorial_derive/01_quick.rs
+++ b/examples/tutorial_derive/01_quick.rs
@@ -6,11 +6,10 @@ use clap::{Parser, Subcommand};
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Optional name to operate on
-    #[clap(value_parser)]
     name: Option<String>,
 
     /// Sets a custom config file
-    #[clap(short, long, value_parser, value_name = "FILE")]
+    #[clap(short, long, value_name = "FILE")]
     config: Option<PathBuf>,
 
     /// Turn debugging information on
@@ -26,7 +25,7 @@ enum Commands {
     /// does testing things
     Test {
         /// lists test values
-        #[clap(short, long, action)]
+        #[clap(short, long)]
         list: bool,
     },
 }

--- a/examples/tutorial_derive/02_app_settings.rs
+++ b/examples/tutorial_derive/02_app_settings.rs
@@ -4,9 +4,9 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 #[clap(allow_negative_numbers = true)]
 struct Cli {
-    #[clap(long, value_parser)]
+    #[clap(long)]
     two: String,
-    #[clap(long, value_parser)]
+    #[clap(long)]
     one: String,
 }
 

--- a/examples/tutorial_derive/02_apps.rs
+++ b/examples/tutorial_derive/02_apps.rs
@@ -6,9 +6,9 @@ use clap::Parser;
 #[clap(version = "1.0")]
 #[clap(about = "Does awesome things", long_about = None)]
 struct Cli {
-    #[clap(long, value_parser)]
+    #[clap(long)]
     two: String,
-    #[clap(long, value_parser)]
+    #[clap(long)]
     one: String,
 }
 

--- a/examples/tutorial_derive/02_crate.rs
+++ b/examples/tutorial_derive/02_crate.rs
@@ -3,9 +3,9 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)] // Read from `Cargo.toml`
 struct Cli {
-    #[clap(long, value_parser)]
+    #[clap(long)]
     two: String,
-    #[clap(long, value_parser)]
+    #[clap(long)]
     one: String,
 }
 

--- a/examples/tutorial_derive/03_01_flag_bool.rs
+++ b/examples/tutorial_derive/03_01_flag_bool.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long, action)]
+    #[clap(short, long)]
     verbose: bool,
 }
 

--- a/examples/tutorial_derive/03_02_option.rs
+++ b/examples/tutorial_derive/03_02_option.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long, value_parser)]
+    #[clap(short, long)]
     name: Option<String>,
 }
 

--- a/examples/tutorial_derive/03_03_positional.rs
+++ b/examples/tutorial_derive/03_03_positional.rs
@@ -3,7 +3,6 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(value_parser)]
     name: Option<String>,
 }
 

--- a/examples/tutorial_derive/03_04_subcommands.rs
+++ b/examples/tutorial_derive/03_04_subcommands.rs
@@ -11,10 +11,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Adds files to myapp
-    Add {
-        #[clap(value_parser)]
-        name: Option<String>,
-    },
+    Add { name: Option<String> },
 }
 
 fn main() {

--- a/examples/tutorial_derive/03_04_subcommands_alt.rs
+++ b/examples/tutorial_derive/03_04_subcommands_alt.rs
@@ -16,7 +16,6 @@ enum Commands {
 
 #[derive(Args)]
 struct Add {
-    #[clap(value_parser)]
     name: Option<String>,
 }
 

--- a/examples/tutorial_derive/03_05_default_values.rs
+++ b/examples/tutorial_derive/03_05_default_values.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(default_value_t = String::from("alice"), value_parser)]
+    #[clap(default_value_t = String::from("alice"))]
     name: String,
 }
 

--- a/examples/tutorial_derive/04_01_enum.rs
+++ b/examples/tutorial_derive/04_01_enum.rs
@@ -4,7 +4,7 @@ use clap::{ArgEnum, Parser};
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// What mode to run the program in
-    #[clap(arg_enum, value_parser)]
+    #[clap(arg_enum)]
     mode: Mode,
 }
 

--- a/examples/tutorial_derive/04_03_relations.rs
+++ b/examples/tutorial_derive/04_03_relations.rs
@@ -9,30 +9,30 @@ use clap::{ArgGroup, Parser};
         ))]
 struct Cli {
     /// set version manually
-    #[clap(long, value_name = "VER", value_parser)]
+    #[clap(long, value_name = "VER")]
     set_ver: Option<String>,
 
     /// auto inc major
-    #[clap(long, action)]
+    #[clap(long)]
     major: bool,
 
     /// auto inc minor
-    #[clap(long, action)]
+    #[clap(long)]
     minor: bool,
 
     /// auto inc patch
-    #[clap(long, action)]
+    #[clap(long)]
     patch: bool,
 
     /// some regular input
-    #[clap(group = "input", value_parser)]
+    #[clap(group = "input")]
     input_file: Option<String>,
 
     /// some special input argument
-    #[clap(long, group = "input", value_parser)]
+    #[clap(long, group = "input")]
     spec_in: Option<String>,
 
-    #[clap(short, requires = "input", value_parser)]
+    #[clap(short, requires = "input")]
     config: Option<String>,
 }
 

--- a/examples/tutorial_derive/04_04_custom.rs
+++ b/examples/tutorial_derive/04_04_custom.rs
@@ -4,30 +4,29 @@ use clap::{CommandFactory, ErrorKind, Parser};
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// set version manually
-    #[clap(long, value_name = "VER", value_parser)]
+    #[clap(long, value_name = "VER")]
     set_ver: Option<String>,
 
     /// auto inc major
-    #[clap(long, action)]
+    #[clap(long)]
     major: bool,
 
     /// auto inc minor
-    #[clap(long, action)]
+    #[clap(long)]
     minor: bool,
 
     /// auto inc patch
-    #[clap(long, action)]
+    #[clap(long)]
     patch: bool,
 
     /// some regular input
-    #[clap(value_parser)]
     input_file: Option<String>,
 
     /// some special input argument
-    #[clap(long, value_parser)]
+    #[clap(long)]
     spec_in: Option<String>,
 
-    #[clap(short, value_parser)]
+    #[clap(short)]
     config: Option<String>,
 }
 

--- a/examples/tutorial_derive/05_01_assert.rs
+++ b/examples/tutorial_derive/05_01_assert.rs
@@ -4,7 +4,6 @@ use clap::Parser;
 #[clap(author, version, about, long_about = None)]
 struct Cli {
     /// Network port to use
-    #[clap(value_parser)]
     port: u16,
 }
 

--- a/examples/typed-derive.rs
+++ b/examples/typed-derive.rs
@@ -4,19 +4,19 @@ use std::error::Error;
 #[derive(Parser, Debug)] // requires `derive` feature
 struct Args {
     /// Implicitly using `std::str::FromStr`
-    #[clap(short = 'O', value_parser)]
+    #[clap(short = 'O')]
     optimization: Option<usize>,
 
     /// Allow invalid UTF-8 paths
-    #[clap(short = 'I', value_parser, value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
+    #[clap(short = 'I', value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
     include: Option<std::path::PathBuf>,
 
     /// Handle IP addresses
-    #[clap(long, value_parser)]
+    #[clap(long)]
     bind: Option<std::net::IpAddr>,
 
     /// Allow human-readable durations
-    #[clap(long, value_parser)]
+    #[clap(long)]
     sleep: Option<humantime::Duration>,
 
     /// Hand-written parser for tuples

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -36,10 +36,10 @@ use std::ffi::OsString;
 /// #[clap(name = "demo")]
 /// struct Context {
 ///     /// More verbose output
-///     #[clap(long, value_parser)]
+///     #[clap(long)]
 ///     verbose: bool,
 ///     /// An optional name
-///     #[clap(short, long, value_parser)]
+///     #[clap(short, long)]
 ///     name: Option<String>,
 /// }
 /// ```
@@ -354,7 +354,7 @@ pub trait Subcommand: FromArgMatches + Sized {
 #[cfg_attr(feature = "derive", doc = " ```")]
 /// #[derive(clap::Parser)]
 /// struct Args {
-///     #[clap(value_enum, value_parser)]
+///     #[clap(value_enum)]
 ///     level: Level,
 /// }
 ///

--- a/tests/derive_ui/default_value_t_invalid.rs
+++ b/tests/derive_ui/default_value_t_invalid.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(name = "basic")]
 struct Opt {
-    #[clap(value_parser, default_value_t = -10)]
+    #[clap(default_value_t = -10)]
     value: u32,
 }
 

--- a/tests/derive_ui/default_value_t_invalid.stderr
+++ b/tests/derive_ui/default_value_t_invalid.stderr
@@ -1,7 +1,7 @@
 error[E0600]: cannot apply unary operator `-` to type `u32`
-  --> $DIR/default_value_t_invalid.rs:14:44
+  --> tests/derive_ui/default_value_t_invalid.rs:14:30
    |
-14 |     #[clap(value_parser, default_value_t = -10)]
-   |                                            ^^^ cannot apply unary operator `-`
+14 |     #[clap(default_value_t = -10)]
+   |                              ^^^ cannot apply unary operator `-`
    |
    = note: unsigned values cannot be negated

--- a/tests/derive_ui/flatten_and_methods.rs
+++ b/tests/derive_ui/flatten_and_methods.rs
@@ -10,9 +10,9 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct DaemonOpts {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     user: String,
-    #[clap(short, value_parser)]
+    #[clap(short)]
     group: String,
 }
 

--- a/tests/derive_ui/skip_flatten.rs
+++ b/tests/derive_ui/skip_flatten.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(name = "make-cookie")]
 struct MakeCookie {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     s: String,
 
     #[clap(skip, flatten)]
@@ -22,13 +22,10 @@ struct MakeCookie {
 enum Command {
     #[clap(name = "pound")]
     /// Pound acorns into flour for cookie dough.
-    Pound {
-        #[clap(value_parser)]
-        acorns: u32,
-    },
+    Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short, value_parser)]
+        #[clap(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/skip_subcommand.rs
+++ b/tests/derive_ui/skip_subcommand.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(name = "make-cookie")]
 struct MakeCookie {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     s: String,
 
     #[clap(subcommand, skip)]
@@ -22,13 +22,10 @@ struct MakeCookie {
 enum Command {
     #[clap(name = "pound")]
     /// Pound acorns into flour for cookie dough.
-    Pound {
-        #[clap(value_parser)]
-        acorns: u32,
-    },
+    Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short, value_parser)]
+        #[clap(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/skip_without_default.rs
+++ b/tests/derive_ui/skip_without_default.rs
@@ -17,7 +17,7 @@ enum Kind {
 #[derive(Parser, Debug)]
 #[clap(name = "test")]
 pub struct Opt {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     number: u32,
     #[clap(skip)]
     k: Kind,

--- a/tests/derive_ui/struct_subcommand.rs
+++ b/tests/derive_ui/struct_subcommand.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 #[clap(name = "basic", subcommand)]
 struct Opt {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     s: String,
 }
 

--- a/tests/derive_ui/subcommand_and_flatten.rs
+++ b/tests/derive_ui/subcommand_and_flatten.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     s: String,
 
     #[clap(subcommand, flatten)]
@@ -20,13 +20,10 @@ struct MakeCookie {
 #[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
-    Pound {
-        #[clap(value_parser)]
-        acorns: u32,
-    },
+    Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short, value_parser)]
+        #[clap(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/subcommand_and_methods.rs
+++ b/tests/derive_ui/subcommand_and_methods.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     s: String,
 
     #[clap(subcommand, long)]
@@ -20,13 +20,10 @@ struct MakeCookie {
 #[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
-    Pound {
-        #[clap(value_parser)]
-        acorns: u32,
-    },
+    Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short, value_parser)]
+        #[clap(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/subcommand_opt_opt.rs
+++ b/tests/derive_ui/subcommand_opt_opt.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     s: String,
 
     #[clap(subcommand)]
@@ -20,13 +20,10 @@ struct MakeCookie {
 #[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
-    Pound {
-        #[clap(value_parser)]
-        acorns: u32,
-    },
+    Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short, value_parser)]
+        #[clap(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/subcommand_opt_vec.rs
+++ b/tests/derive_ui/subcommand_opt_vec.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short, value_parser)]
+    #[clap(short)]
     s: String,
 
     #[clap(subcommand)]
@@ -20,13 +20,10 @@ struct MakeCookie {
 #[derive(Parser, Debug)]
 enum Command {
     /// Pound acorns into flour for cookie dough.
-    Pound {
-        #[clap(value_parser)]
-        acorns: u32,
-    },
+    Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short, value_parser)]
+        #[clap(short)]
         color: String,
     },
 }


### PR DESCRIPTION
Leaving these in for v4's lifetime to give people a chance to transition off to be less disruptive.