### PR TITLE
fix!: Remove deprecated ArgActions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `ErrorKind::EmptyValue` replaced with `ErrorKind::InvalidValue`
 - `ErrorKind::UnrecognizedSubcommand` replaced with `ErrorKind::InvalidSubcommand` (#3676)
 - `arg!` now sets `ArgAction::SetTrue`, `ArgAction::Count`, `ArgAction::Set`, or `ArgAction::Append` as appropriate (#3795)
+- Default actions are now `Set` and `SetTrue`
 - *(help)* Make `DeriveDisplayOrder` the default and removed the setting.  To sort help, set `next_display_order(None)` (#2808)
 - *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value (#2808)
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)

--- a/clap_complete/tests/snapshots/aliases.zsh
+++ b/clap_complete/tests/snapshots/aliases.zsh
@@ -15,18 +15,18 @@ _my-app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" /
-'-o+[cmd option]: : ' /
-'-O+[cmd option]: : ' /
-'--option=[cmd option]: : ' /
-'--opt=[cmd option]: : ' /
+'*-o+[cmd option]: : ' /
+'*-O+[cmd option]: : ' /
+'*--option=[cmd option]: : ' /
+'*--opt=[cmd option]: : ' /
 '-h[Print help information]' /
 '--help[Print help information]' /
 '-V[Print version information]' /
 '--version[Print version information]' /
-'-f[cmd flag]' /
-'-F[cmd flag]' /
-'--flag[cmd flag]' /
-'--flg[cmd flag]' /
+'*-f[cmd flag]' /
+'*-F[cmd flag]' /
+'*--flag[cmd flag]' /
+'*--flg[cmd flag]' /
 '::positional:' /
 && ret=0
 }

--- a/clap_complete/tests/snapshots/basic.zsh
+++ b/clap_complete/tests/snapshots/basic.zsh
@@ -17,8 +17,8 @@ _my-app() {
     _arguments "${_arguments_options[@]}" /
 '-h[Print help information]' /
 '--help[Print help information]' /
-'-c[]' /
-'(-c)-v[]' /
+'*-c[]' /
+'(-c)*-v[]' /
 ":: :_my-app_commands" /
 "*::: :->my-app" /
 && ret=0
@@ -33,12 +33,12 @@ _arguments "${_arguments_options[@]}" /
 '*-d[]' /
 '-h[Print help information]' /
 '--help[Print help information]' /
-'-c[]' /
+'*-c[]' /
 && ret=0
 ;;
 (help)
 _arguments "${_arguments_options[@]}" /
-'-c[]' /
+'*-c[]' /
 '*::subcommand -- The subcommand whose help message to display:' /
 && ret=0
 ;;

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -36,7 +36,7 @@ _my-app() {
         case $line[3] in
             (test)
 _arguments "${_arguments_options[@]}" /
-'--case=[the case to test]: : ' /
+'*--case=[the case to test]: : ' /
 '-h[Print help information]' /
 '--help[Print help information]' /
 '-V[Print version information]' /

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -19,12 +19,12 @@ _my-app() {
 '--help[Print help information]' /
 '-V[Print version information]' /
 '--version[Print version information]' /
-'--single-quotes[Can be '/''always'/'', '/''auto'/'', or '/''never'/'']' /
-'--double-quotes[Can be "always", "auto", or "never"]' /
-'--backticks[For more information see `echo test`]' /
-'--backslash[Avoid '/''//n'/'']' /
-'--brackets[List packages /[filter/]]' /
-'--expansions[Execute the shell command with $SHELL]' /
+'*--single-quotes[Can be '/''always'/'', '/''auto'/'', or '/''never'/'']' /
+'*--double-quotes[Can be "always", "auto", or "never"]' /
+'*--backticks[For more information see `echo test`]' /
+'*--backslash[Avoid '/''//n'/'']' /
+'*--brackets[List packages /[filter/]]' /
+'*--expansions[Execute the shell command with $SHELL]' /
 ":: :_my-app_commands" /
 "*::: :->my-app" /
 && ret=0

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -36,7 +36,7 @@ _my-app() {
         case $line[3] in
             (test)
 _arguments "${_arguments_options[@]}" /
-'--case=[the case to test]: : ' /
+'*--case=[the case to test]: : ' /
 '-h[Print help information]' /
 '--help[Print help information]' /
 '-V[Print version information]' /
@@ -45,7 +45,7 @@ _arguments "${_arguments_options[@]}" /
 ;;
 (some_cmd)
 _arguments "${_arguments_options[@]}" /
-'--config=[the other case to test]: : ' /
+'*--config=[the other case to test]: : ' /
 '-h[Print help information]' /
 '--help[Print help information]' /
 '-V[Print version information]' /

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -36,7 +36,7 @@ _my-app() {
         case $line[3] in
             (test)
 _arguments "${_arguments_options[@]}" /
-'--case=[the case to test]: : ' /
+'*--case=[the case to test]: : ' /
 '-h[Print help information]' /
 '--help[Print help information]' /
 '-V[Print version information]' /
@@ -61,7 +61,7 @@ _arguments "${_arguments_options[@]}" /
         case $line[1] in
             (sub_cmd)
 _arguments "${_arguments_options[@]}" /
-'--config=[the other case to test]: :(Lest quotes aren't escaped.)' /
+'*--config=[the other case to test]: :(Lest quotes aren't escaped.)' /
 '-h[Print help information]' /
 '--help[Print help information]' /
 '-V[Print version information]' /

--- a/clap_complete/tests/snapshots/value_hint.zsh
+++ b/clap_complete/tests/snapshots/value_hint.zsh
@@ -15,26 +15,26 @@ _my-app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" /
-'--choice=[]: :(bash fish zsh)' /
-'--unknown=[]: : ' /
-'--other=[]: :( )' /
-'-p+[]: :_files' /
-'--path=[]: :_files' /
-'-f+[]: :_files' /
-'--file=[]: :_files' /
-'-d+[]: :_files -/' /
-'--dir=[]: :_files -/' /
-'-e+[]: :_absolute_command_paths' /
-'--exe=[]: :_absolute_command_paths' /
-'--cmd-name=[]: :_command_names -e' /
-'-c+[]: :_cmdstring' /
-'--cmd=[]: :_cmdstring' /
-'-u+[]: :_users' /
-'--user=[]: :_users' /
-'-h+[]: :_hosts' /
-'--host=[]: :_hosts' /
-'--url=[]: :_urls' /
-'--email=[]: :_email_addresses' /
+'*--choice=[]: :(bash fish zsh)' /
+'*--unknown=[]: : ' /
+'*--other=[]: :( )' /
+'*-p+[]: :_files' /
+'*--path=[]: :_files' /
+'*-f+[]: :_files' /
+'*--file=[]: :_files' /
+'*-d+[]: :_files -/' /
+'*--dir=[]: :_files -/' /
+'*-e+[]: :_absolute_command_paths' /
+'*--exe=[]: :_absolute_command_paths' /
+'*--cmd-name=[]: :_command_names -e' /
+'*-c+[]: :_cmdstring' /
+'*--cmd=[]: :_cmdstring' /
+'*-u+[]: :_users' /
+'*--user=[]: :_users' /
+'*-h+[]: :_hosts' /
+'*--host=[]: :_hosts' /
+'*--url=[]: :_urls' /
+'*--email=[]: :_email_addresses' /
 '--help[Print help information]' /
 '*::command_with_args:_cmdambivalent' /
 && ret=0

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -216,19 +216,6 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
             }
 
-            #[allow(deprecated)]
-            if matches!(
-                option.get_action(),
-                ArgAction::StoreValue | ArgAction::IncOccurrence
-            ) && option.is_multiple_occurrences_set()
-            {
-                buffer.push_str(&format!(
-                    "{:indent$}isRepeatable: true,\n",
-                    "",
-                    indent = indent + 4
-                ));
-            }
-
             if let ArgAction::Set | ArgAction::Append | ArgAction::Count = option.get_action() {
                 buffer.push_str(&format!(
                     "{:indent$}isRepeatable: true,\n",
@@ -314,19 +301,6 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 }
 
                 buffer.push_str(&format!("{:indent$}],\n", "", indent = indent + 4));
-            }
-
-            #[allow(deprecated)]
-            if matches!(
-                flag.get_action(),
-                ArgAction::StoreValue | ArgAction::IncOccurrence
-            ) && flag.is_multiple_occurrences_set()
-            {
-                buffer.push_str(&format!(
-                    "{:indent$}isRepeatable: true,\n",
-                    "",
-                    indent = indent + 4
-                ));
             }
 
             if let ArgAction::Set | ArgAction::Append | ArgAction::Count = flag.get_action() {

--- a/clap_complete_fig/tests/snapshots/aliases.fig.js
+++ b/clap_complete_fig/tests/snapshots/aliases.fig.js
@@ -5,6 +5,7 @@ const completion: Fig.Spec = {
     {
       name: ["-o", "-O", "--option", "--opt"],
       description: "cmd option",
+      isRepeatable: true,
       args: {
         name: "option",
         isOptional: true,

--- a/clap_complete_fig/tests/snapshots/feature_sample.fig.js
+++ b/clap_complete_fig/tests/snapshots/feature_sample.fig.js
@@ -9,6 +9,7 @@ const completion: Fig.Spec = {
         {
           name: "--case",
           description: "the case to test",
+          isRepeatable: true,
           args: {
             name: "case",
             isOptional: true,

--- a/clap_complete_fig/tests/snapshots/special_commands.fig.js
+++ b/clap_complete_fig/tests/snapshots/special_commands.fig.js
@@ -9,6 +9,7 @@ const completion: Fig.Spec = {
         {
           name: "--case",
           description: "the case to test",
+          isRepeatable: true,
           args: {
             name: "case",
             isOptional: true,
@@ -32,6 +33,7 @@ const completion: Fig.Spec = {
           name: "--config",
           description: "the other case to test",
           hidden: true,
+          isRepeatable: true,
           requiresEquals: true,
           args: {
             name: "config",

--- a/clap_complete_fig/tests/snapshots/sub_subcommands.fig.js
+++ b/clap_complete_fig/tests/snapshots/sub_subcommands.fig.js
@@ -9,6 +9,7 @@ const completion: Fig.Spec = {
         {
           name: "--case",
           description: "the case to test",
+          isRepeatable: true,
           args: {
             name: "case",
             isOptional: true,
@@ -35,6 +36,7 @@ const completion: Fig.Spec = {
             {
               name: "--config",
               description: "the other case to test",
+              isRepeatable: true,
               args: {
                 name: "config",
                 isOptional: true,

--- a/clap_complete_fig/tests/snapshots/value_hint.fig.js
+++ b/clap_complete_fig/tests/snapshots/value_hint.fig.js
@@ -4,6 +4,7 @@ const completion: Fig.Spec = {
   options: [
     {
       name: "--choice",
+      isRepeatable: true,
       args: {
         name: "choice",
         isOptional: true,
@@ -16,6 +17,7 @@ const completion: Fig.Spec = {
     },
     {
       name: "--unknown",
+      isRepeatable: true,
       args: {
         name: "unknown",
         isOptional: true,
@@ -23,6 +25,7 @@ const completion: Fig.Spec = {
     },
     {
       name: "--other",
+      isRepeatable: true,
       args: {
         name: "other",
         isOptional: true,
@@ -30,6 +33,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-p", "--path"],
+      isRepeatable: true,
       args: {
         name: "path",
         isOptional: true,
@@ -38,6 +42,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-f", "--file"],
+      isRepeatable: true,
       args: {
         name: "file",
         isOptional: true,
@@ -46,6 +51,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-d", "--dir"],
+      isRepeatable: true,
       args: {
         name: "dir",
         isOptional: true,
@@ -54,6 +60,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-e", "--exe"],
+      isRepeatable: true,
       args: {
         name: "exe",
         isOptional: true,
@@ -62,6 +69,7 @@ const completion: Fig.Spec = {
     },
     {
       name: "--cmd-name",
+      isRepeatable: true,
       args: {
         name: "cmd_name",
         isOptional: true,
@@ -70,6 +78,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-c", "--cmd"],
+      isRepeatable: true,
       args: {
         name: "cmd",
         isOptional: true,
@@ -78,6 +87,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-u", "--user"],
+      isRepeatable: true,
       args: {
         name: "user",
         isOptional: true,
@@ -85,6 +95,7 @@ const completion: Fig.Spec = {
     },
     {
       name: ["-h", "--host"],
+      isRepeatable: true,
       args: {
         name: "host",
         isOptional: true,
@@ -92,6 +103,7 @@ const completion: Fig.Spec = {
     },
     {
       name: "--url",
+      isRepeatable: true,
       args: {
         name: "url",
         isOptional: true,
@@ -99,6 +111,7 @@ const completion: Fig.Spec = {
     },
     {
       name: "--email",
+      isRepeatable: true,
       args: {
         name: "email",
         isOptional: true,

--- a/clap_mangen/tests/snapshots/aliases.bash.roff
+++ b/clap_mangen/tests/snapshots/aliases.bash.roff
@@ -15,7 +15,7 @@ Print help information
 /fB/-V/fR, /fB/-/-version/fR
 Print version information
 .TP
-/fB/-f/fR, /fB/-/-flag/fR
+/fB/-f/fR, /fB/-/-flag/fR [default: false]
 cmd flag
 .TP
 /fB/-o/fR, /fB/-/-option/fR

--- a/clap_mangen/tests/snapshots/basic.bash.roff
+++ b/clap_mangen/tests/snapshots/basic.bash.roff
@@ -11,10 +11,10 @@ my/-app
 /fB/-h/fR, /fB/-/-help/fR
 Print help information
 .TP
-/fB/-c/fR
+/fB/-c/fR [default: false]
 
 .TP
-/fB/-v/fR
+/fB/-v/fR [default: false]
 
 .SH SUBCOMMANDS
 .TP

--- a/clap_mangen/tests/snapshots/feature_sample.bash.roff
+++ b/clap_mangen/tests/snapshots/feature_sample.bash.roff
@@ -15,7 +15,7 @@ Print help information
 /fB/-V/fR, /fB/-/-version/fR
 Print version information
 .TP
-/fB/-c/fR, /fB/-/-config/fR
+/fB/-c/fR, /fB/-/-config/fR [default: false]
 some config file
 .TP
 [/fIfile/fR]

--- a/clap_mangen/tests/snapshots/quoting.bash.roff
+++ b/clap_mangen/tests/snapshots/quoting.bash.roff
@@ -14,22 +14,22 @@ Print help information
 /fB/-V/fR, /fB/-/-version/fR
 Print version information
 .TP
-/fB/-/-single/-quotes/fR
+/fB/-/-single/-quotes/fR [default: false]
 Can be /*(Aqalways/*(Aq, /*(Aqauto/*(Aq, or /*(Aqnever/*(Aq
 .TP
-/fB/-/-double/-quotes/fR
+/fB/-/-double/-quotes/fR [default: false]
 Can be "always", "auto", or "never"
 .TP
-/fB/-/-backticks/fR
+/fB/-/-backticks/fR [default: false]
 For more information see `echo test`
 .TP
-/fB/-/-backslash/fR
+/fB/-/-backslash/fR [default: false]
 Avoid /*(Aq//n/*(Aq
 .TP
-/fB/-/-brackets/fR
+/fB/-/-brackets/fR [default: false]
 List packages [filter]
 .TP
-/fB/-/-expansions/fR
+/fB/-/-expansions/fR [default: false]
 Execute the shell command with $SHELL
 .SH SUBCOMMANDS
 .TP

--- a/clap_mangen/tests/snapshots/special_commands.bash.roff
+++ b/clap_mangen/tests/snapshots/special_commands.bash.roff
@@ -15,7 +15,7 @@ Print help information
 /fB/-V/fR, /fB/-/-version/fR
 Print version information
 .TP
-/fB/-c/fR, /fB/-/-config/fR
+/fB/-c/fR, /fB/-/-config/fR [default: false]
 some config file
 .TP
 [/fIfile/fR]

--- a/clap_mangen/tests/snapshots/sub_subcommands.bash.roff
+++ b/clap_mangen/tests/snapshots/sub_subcommands.bash.roff
@@ -15,7 +15,7 @@ Print help information
 /fB/-V/fR, /fB/-/-version/fR
 Print version information
 .TP
-/fB/-c/fR, /fB/-/-config/fR
+/fB/-c/fR, /fB/-/-config/fR [default: false]
 some config file
 .TP
 [/fIfile/fR]

--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -70,24 +70,6 @@ pub enum ArgAction {
     /// );
     /// ```
     Append,
-    /// Deprecated, replaced with [`ArgAction::Set`] or [`ArgAction::Append`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.2.0",
-            note = "Replaced with `ArgAction::Set` or `ArgAction::Append`"
-        )
-    )]
-    StoreValue,
-    /// Deprecated, replaced with [`ArgAction::SetTrue`] or [`ArgAction::Count`]
-    #[cfg_attr(
-        feature = "deprecated",
-        deprecated(
-            since = "3.2.0",
-            note = "Replaced with `ArgAction::SetTrue` or `ArgAction::Count`"
-        )
-    )]
-    IncOccurrence,
     /// When encountered, act as if `"true"` was encountered on the command-line
     ///
     /// If no [`default_value`][super::Arg::default_value] is set, it will be `false`.
@@ -258,10 +240,6 @@ impl ArgAction {
         match self {
             Self::Set => true,
             Self::Append => true,
-            #[allow(deprecated)]
-            Self::StoreValue => true,
-            #[allow(deprecated)]
-            Self::IncOccurrence => false,
             Self::SetTrue => false,
             Self::SetFalse => false,
             Self::Count => false,
@@ -274,10 +252,6 @@ impl ArgAction {
         match self {
             Self::Set => None,
             Self::Append => None,
-            #[allow(deprecated)]
-            Self::StoreValue => None,
-            #[allow(deprecated)]
-            Self::IncOccurrence => None,
             Self::SetTrue => Some(std::ffi::OsStr::new("false")),
             Self::SetFalse => Some(std::ffi::OsStr::new("true")),
             Self::Count => Some(std::ffi::OsStr::new("0")),
@@ -290,10 +264,6 @@ impl ArgAction {
         match self {
             Self::Set => None,
             Self::Append => None,
-            #[allow(deprecated)]
-            Self::StoreValue => None,
-            #[allow(deprecated)]
-            Self::IncOccurrence => None,
             Self::SetTrue => Some(super::ValueParser::bool()),
             Self::SetFalse => Some(super::ValueParser::bool()),
             Self::Count => Some(crate::value_parser!(u8).into()),
@@ -309,10 +279,6 @@ impl ArgAction {
         match self {
             Self::Set => None,
             Self::Append => None,
-            #[allow(deprecated)]
-            Self::StoreValue => None,
-            #[allow(deprecated)]
-            Self::IncOccurrence => None,
             Self::SetTrue => Some(AnyValueId::of::<bool>()),
             Self::SetFalse => Some(AnyValueId::of::<bool>()),
             Self::Count => Some(AnyValueId::of::<CountType>()),

--- a/src/builder/app_settings.rs
+++ b/src/builder/app_settings.rs
@@ -57,8 +57,6 @@ pub(crate) enum AppSettings {
     HidePossibleValues,
     HelpExpected,
     NoBinaryName,
-    NoAutoHelp,
-    NoAutoVersion,
     #[allow(dead_code)]
     ColorAuto,
     ColorAlways,
@@ -75,8 +73,6 @@ bitflags! {
         const PROPAGATE_VERSION              = 1 << 3;
         const DISABLE_VERSION_FOR_SC         = 1 << 4;
         const WAIT_ON_ERROR                  = 1 << 6;
-        const NO_AUTO_HELP                   = 1 << 8;
-        const NO_AUTO_VERSION                = 1 << 9;
         const DISABLE_VERSION_FLAG           = 1 << 10;
         const HIDDEN                         = 1 << 11;
         const TRAILING_VARARG                = 1 << 12;
@@ -158,10 +154,6 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::HIDDEN,
     Multicall
         => Flags::MULTICALL,
-    NoAutoHelp
-        => Flags::NO_AUTO_HELP,
-    NoAutoVersion
-        => Flags::NO_AUTO_VERSION,
     NoBinaryName
         => Flags::NO_BIN_NAME,
     SubcommandsNegateReqs

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -4400,10 +4400,7 @@ impl<'help> Arg<'help> {
                 self.settings.unset(ArgSettings::TakesValue);
             }
             match action {
-                ArgAction::StoreValue
-                | ArgAction::IncOccurrence
-                | ArgAction::Help
-                | ArgAction::Version => {}
+                ArgAction::Help | ArgAction::Version => {}
                 ArgAction::Set
                 | ArgAction::Append
                 | ArgAction::SetTrue

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -4361,6 +4361,21 @@ impl<'help> Arg<'help> {
         if self.is_positional() {
             self.settings.set(ArgSettings::TakesValue);
         }
+        if self.action.is_none() {
+            if self.get_id() == "help" && !self.is_takes_value_set() {
+                let action = super::ArgAction::Help;
+                self.action = Some(action);
+            } else if self.get_id() == "version" && !self.is_takes_value_set() {
+                let action = super::ArgAction::Version;
+                self.action = Some(action);
+            } else if self.is_takes_value_set() {
+                let action = super::ArgAction::StoreValue;
+                self.action = Some(action);
+            } else {
+                let action = super::ArgAction::IncOccurrence;
+                self.action = Some(action);
+            }
+        }
         if let Some(action) = self.action.as_ref() {
             if let Some(default_value) = action.default_value() {
                 if self.default_vals.is_empty() {

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -2153,7 +2153,7 @@ impl<'help> Arg<'help> {
     ///         "prog"
     ///     ]);
     ///
-    /// assert_eq!(m.get_one::<String>("true_flag"), None);
+    /// assert!(m.is_present("true_flag"));
     /// assert!(!m.is_present("false_flag"));
     /// assert!(!m.is_present("absent_flag"));
     /// ```

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -995,21 +995,22 @@ impl<'help> Arg<'help> {
     /// assert_eq!(files, ["file1", "file2", "file3"]);
     /// ```
     ///
-    /// Although `multiple_values` has been specified, we cannot use the argument more than once.
+    /// Although `multiple_values` has been specified, the last argument still wins
     ///
     /// ```rust
     /// # use clap::{Command, Arg, ErrorKind};
-    /// let res = Command::new("prog")
+    /// let m = Command::new("prog")
     ///     .arg(Arg::new("file")
     ///         .takes_value(true)
     ///         .multiple_values(true)
     ///         .short('F'))
-    ///     .try_get_matches_from(vec![
+    ///     .get_matches_from(vec![
     ///         "prog", "-F", "file1", "-F", "file2", "-F", "file3"
     ///     ]);
     ///
-    /// assert!(res.is_err());
-    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::UnexpectedMultipleUsage)
+    /// assert!(m.contains_id("file"));
+    /// let files: Vec<_> = m.get_many::<String>("file").unwrap().collect();
+    /// assert_eq!(files, ["file3"]);
     /// ```
     ///
     /// A common mistake is to define an option which allows multiple values, and a positional
@@ -2128,13 +2129,16 @@ impl<'help> Arg<'help> {
     ///
     /// In this example, because [`Arg::takes_value(false)`] (by default),
     /// `prog` is a flag that accepts an optional, case-insensitive boolean literal.
-    /// A `false` literal is `n`, `no`, `f`, `false`, `off` or `0`.
-    /// An absent environment variable will also be considered as `false`.
-    /// Anything else will considered as `true`.
+    ///
+    /// Note that the value parser controls how flags are parsed.  In this case we've selected
+    /// [`FalseyValueParser`][crate::builder::FalseyValueParser].  A `false` literal is `n`, `no`,
+    /// `f`, `false`, `off` or `0`.  An absent environment variable will also be considered as
+    /// `false`.  Anything else will considered as `true`.
     ///
     /// ```rust
     /// # use std::env;
     /// # use clap::{Command, Arg};
+    /// # use clap::builder::FalseyValueParser;
     ///
     /// env::set_var("TRUE_FLAG", "true");
     /// env::set_var("FALSE_FLAG", "0");
@@ -2142,20 +2146,23 @@ impl<'help> Arg<'help> {
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("true_flag")
     ///         .long("true_flag")
+    ///         .value_parser(FalseyValueParser::new())
     ///         .env("TRUE_FLAG"))
     ///     .arg(Arg::new("false_flag")
     ///         .long("false_flag")
+    ///         .value_parser(FalseyValueParser::new())
     ///         .env("FALSE_FLAG"))
     ///     .arg(Arg::new("absent_flag")
     ///         .long("absent_flag")
+    ///         .value_parser(FalseyValueParser::new())
     ///         .env("ABSENT_FLAG"))
     ///     .get_matches_from(vec![
     ///         "prog"
     ///     ]);
     ///
-    /// assert!(m.is_present("true_flag"));
-    /// assert!(!m.is_present("false_flag"));
-    /// assert!(!m.is_present("absent_flag"));
+    /// assert!(*m.get_one::<bool>("true_flag").unwrap());
+    /// assert!(!*m.get_one::<bool>("false_flag").unwrap());
+    /// assert!(!*m.get_one::<bool>("absent_flag").unwrap());
     /// ```
     ///
     /// In this example, we show the variable coming from an option on the CLI:
@@ -2920,7 +2927,7 @@ impl<'help> Arg<'help> {
     ///         .long("flag"))
     ///     .arg(Arg::new("other")
     ///         .long("other")
-    ///         .default_value_if("flag", None, Some("default")))
+    ///         .default_value_if("flag", Some("true"), Some("default")))
     ///     .get_matches_from(vec![
     ///         "prog"
     ///     ]);
@@ -2976,7 +2983,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("other")
     ///         .long("other")
     ///         .default_value("default")
-    ///         .default_value_if("flag", None, None))
+    ///         .default_value_if("flag", Some("true"), None))
     ///     .get_matches_from(vec![
     ///         "prog", "--flag"
     ///     ]);
@@ -3034,7 +3041,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("other")
     ///         .long("other")
     ///         .default_value_ifs(&[
-    ///             ("flag", None, Some("default")),
+    ///             ("flag", Some("true"), Some("default")),
     ///             ("opt", Some("channal"), Some("chan")),
     ///         ]))
     ///     .get_matches_from(vec![
@@ -3054,7 +3061,7 @@ impl<'help> Arg<'help> {
     ///     .arg(Arg::new("other")
     ///         .long("other")
     ///         .default_value_ifs(&[
-    ///             ("flag", None, Some("default")),
+    ///             ("flag", Some("true"), Some("default")),
     ///             ("opt", Some("channal"), Some("chan")),
     ///         ]))
     ///     .get_matches_from(vec![
@@ -4249,7 +4256,7 @@ impl<'help> Arg<'help> {
 
     /// Behavior when parsing the argument
     pub fn get_action(&self) -> &super::ArgAction {
-        const DEFAULT: super::ArgAction = super::ArgAction::StoreValue;
+        const DEFAULT: super::ArgAction = super::ArgAction::Set;
         self.action.as_ref().unwrap_or(&DEFAULT)
     }
 
@@ -4369,10 +4376,15 @@ impl<'help> Arg<'help> {
                 let action = super::ArgAction::Version;
                 self.action = Some(action);
             } else if self.is_takes_value_set() {
-                let action = super::ArgAction::StoreValue;
+                let action = if self.is_positional() && self.is_multiple_values_set() {
+                    // Allow collecting arguments interleaved with flags
+                    super::ArgAction::Append
+                } else {
+                    super::ArgAction::Set
+                };
                 self.action = Some(action);
             } else {
-                let action = super::ArgAction::IncOccurrence;
+                let action = super::ArgAction::SetTrue;
                 self.action = Some(action);
             }
         }

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -3789,10 +3789,6 @@ impl<'help> Command<'help> {
 
             let mut pos_counter = 1;
             let hide_pv = self.is_set(AppSettings::HidePossibleValues);
-            let auto_help =
-                !self.is_set(AppSettings::NoAutoHelp) && !self.is_disable_help_flag_set();
-            let auto_version =
-                !self.is_set(AppSettings::NoAutoVersion) && !self.is_disable_version_flag_set();
             for a in self.args.args_mut() {
                 // Fill in the groups
                 for g in &a.groups {
@@ -3819,10 +3815,10 @@ impl<'help> Command<'help> {
                 // required.  Otherwise, most of this won't be needed because when we can break
                 // compat, actions will reign supreme (default to `Store`)
                 if a.action.is_none() {
-                    if a.get_id() == "help" && auto_help && !a.is_takes_value_set() {
+                    if a.get_id() == "help" && !a.is_takes_value_set() {
                         let action = super::ArgAction::Help;
                         a.action = Some(action);
-                    } else if a.get_id() == "version" && auto_version && !a.is_takes_value_set() {
+                    } else if a.get_id() == "version" && !a.is_takes_value_set() {
                         let action = super::ArgAction::Version;
                         a.action = Some(action);
                     } else if a.is_takes_value_set() {

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -3811,24 +3811,6 @@ impl<'help> Command<'help> {
                     a.settings.set(ArgSettings::HidePossibleValues);
                 }
                 a._build();
-                // HACK: Setting up action at this level while auto-help / disable help flag is
-                // required.  Otherwise, most of this won't be needed because when we can break
-                // compat, actions will reign supreme (default to `Store`)
-                if a.action.is_none() {
-                    if a.get_id() == "help" && !a.is_takes_value_set() {
-                        let action = super::ArgAction::Help;
-                        a.action = Some(action);
-                    } else if a.get_id() == "version" && !a.is_takes_value_set() {
-                        let action = super::ArgAction::Version;
-                        a.action = Some(action);
-                    } else if a.is_takes_value_set() {
-                        let action = super::ArgAction::StoreValue;
-                        a.action = Some(action);
-                    } else {
-                        let action = super::ArgAction::IncOccurrence;
-                        a.action = Some(action);
-                    }
-                }
                 if a.is_positional() && a.index.is_none() {
                     a.index = Some(pos_counter);
                     pos_counter += 1;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -42,7 +42,6 @@ pub use value_parser::OsStringValueParser;
 pub use value_parser::PathBufValueParser;
 
 pub(crate) use action::CountType;
-pub(crate) use app_settings::AppSettings;
 pub(crate) use arg::display_arg_val;
 pub(crate) use arg_predicate::ArgPredicate;
 pub(crate) use arg_settings::{ArgFlags, ArgSettings};

--- a/src/error/kind.rs
+++ b/src/error/kind.rs
@@ -208,19 +208,6 @@ pub enum ErrorKind {
     MissingSubcommand,
 
     /// Occurs when the user provides multiple values to an argument which doesn't allow that.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use clap::{Command, Arg, ErrorKind};
-    /// let result = Command::new("prog")
-    ///     .arg(Arg::new("debug")
-    ///         .long("debug")
-    ///         .multiple_occurrences(false))
-    ///     .try_get_matches_from(vec!["prog", "--debug", "--debug"]);
-    /// assert!(result.is_err());
-    /// assert_eq!(result.unwrap_err().kind(), ErrorKind::UnexpectedMultipleUsage);
-    /// ```
     UnexpectedMultipleUsage,
 
     /// Occurs when the user provides a value containing invalid UTF-8.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -393,6 +393,8 @@ macro_rules! arg_impl {
             ({
                 if $arg.get_long().is_none() && $arg.get_short().is_none() {
                     $arg.multiple_values(true)
+                        // Allow collecting arguments interleaved with flags
+                        .action($crate::ArgAction::Append)
                 } else if $arg.is_takes_value_set() {
                     $arg.action($crate::ArgAction::Append)
                 } else {

--- a/src/parser/matches/matched_arg.rs
+++ b/src/parser/matches/matched_arg.rs
@@ -73,11 +73,6 @@ impl MatchedArg {
     }
 
     #[cfg_attr(feature = "deprecated", deprecated(since = "3.2.0"))]
-    pub(crate) fn set_occurrences(&mut self, occurs: u64) {
-        self.occurs = occurs
-    }
-
-    #[cfg_attr(feature = "deprecated", deprecated(since = "3.2.0"))]
     pub(crate) fn get_occurrences(&self) -> u64 {
         self.occurs
     }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -8,7 +8,6 @@ use std::{
 use clap_lex::RawOsStr;
 
 // Internal
-use crate::builder::AppSettings as AS;
 use crate::builder::{Arg, Command};
 use crate::error::Error as ClapError;
 use crate::error::Result as ClapResult;
@@ -107,11 +106,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                     let sc_name = self.possible_subcommand(arg_os.to_value(), valid_arg_found);
                     debug!("Parser::get_matches_with: sc={:?}", sc_name);
                     if let Some(sc_name) = sc_name {
-                        #[allow(deprecated)]
-                        if sc_name == "help"
-                            && !self.is_set(AS::NoAutoHelp)
-                            && !self.cmd.is_disable_help_subcommand_set()
-                        {
+                        if sc_name == "help" && !self.cmd.is_disable_help_subcommand_set() {
                             self.parse_help_subcommand(raw_args.remaining(&mut args_cursor))?;
                             unreachable!("`parse_help_subcommand` always errors");
                         } else {
@@ -1662,13 +1657,6 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         let mut c = Colorizer::new(Stream::Stdout, self.cmd.color_help());
         c.none(msg);
         ClapError::display_version(self.cmd, c)
-    }
-}
-
-// Query Methods
-impl<'help, 'cmd> Parser<'help, 'cmd> {
-    pub(crate) fn is_set(&self, s: AS) -> bool {
-        self.cmd.is_set(s)
     }
 }
 

--- a/tests/builder/grouped_values.rs
+++ b/tests/builder/grouped_values.rs
@@ -191,7 +191,7 @@ fn grouped_interleaved_positional_values() {
         .unwrap();
 
     let pos: Vec<_> = m.grouped_values_of("pos").unwrap().collect();
-    assert_eq!(pos, vec![vec!["1", "2", "3", "4"]]);
+    assert_eq!(pos, vec![vec!["1", "2"], vec!["3"], vec!["4"]]);
 
     let flag: Vec<_> = m.grouped_values_of("flag").unwrap().collect();
     assert_eq!(flag, vec![vec!["a"], vec!["b"]]);
@@ -214,7 +214,7 @@ fn grouped_interleaved_positional_occurrences() {
         .unwrap();
 
     let pos: Vec<_> = m.grouped_values_of("pos").unwrap().collect();
-    assert_eq!(pos, vec![vec!["1", "2", "3", "4"]]);
+    assert_eq!(pos, vec![vec!["1", "2"], vec!["3"], vec!["4"]]);
 
     let flag: Vec<_> = m.grouped_values_of("flag").unwrap().collect();
     assert_eq!(flag, vec![vec!["a"], vec!["b"]]);

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -520,10 +520,6 @@ fn issue_1047_min_zero_vals_default_val() {
         )
         .try_get_matches_from(vec!["foo", "-d"])
         .unwrap();
-    #[allow(deprecated)]
-    {
-        assert_eq!(m.occurrences_of("del"), 1);
-    }
     assert_eq!(
         m.get_one::<String>("del").map(|v| v.as_str()),
         Some("default")

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -184,7 +184,7 @@ mod arg {
         let arg = clap::arg!(<NUM> ...);
         assert_eq!(arg.get_id(), "NUM");
         assert_eq!(arg.get_value_names(), Some(vec!["NUM"].as_slice()));
-        assert!(matches!(arg.get_action(), clap::ArgAction::Set));
+        assert!(matches!(arg.get_action(), clap::ArgAction::Append));
         assert!(arg.is_multiple_values_set());
         assert!(arg.is_required_set());
         assert_eq!(arg.get_help(), None);


### PR DESCRIPTION
This required changing the default
- flags: `SetTrue`
- positionals with multiple values: `Append`
  - So `pos1 pos2 --flag pos3` doesn't cause `pos3` to overwrite `pos1 post2` but appends to it
- all else: `Set`

To get the defaulted actions working properly, we had to move the defaulting code into `Arg` which required removing the non-accessible "NoAuto` settings.