### PR TITLE
chore: Update version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.14"
+version = "4.0.0-alpha.0"
 dependencies = [
  "atty",
  "backtrace",
@@ -146,16 +146,16 @@ dependencies = [
 name = "clap_bench"
 version = "0.0.0"
 dependencies = [
- "clap 3.2.14",
+ "clap 4.0.0-alpha.0",
  "criterion",
  "lazy_static",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.3"
+version = "4.0.0-alpha.0"
 dependencies = [
- "clap 3.2.14",
+ "clap 4.0.0-alpha.0",
  "clap_lex",
  "is_executable",
  "os_str_bytes",
@@ -169,16 +169,16 @@ dependencies = [
 
 [[package]]
 name = "clap_complete_fig"
-version = "3.2.4"
+version = "4.0.0-alpha.0"
 dependencies = [
- "clap 3.2.14",
+ "clap 4.0.0-alpha.0",
  "clap_complete",
  "snapbox",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "4.0.0-alpha.0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -198,7 +198,7 @@ dependencies = [
 name = "clap_mangen"
 version = "0.1.10"
 dependencies = [
- "clap 3.2.14",
+ "clap 4.0.0-alpha.0",
  "roff",
  "snapbox",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 
 [package]
 name = "clap"
-version = "3.2.14"
+version = "4.0.0-alpha.0"
 description = "A simple to use, efficient, and full-featured Command Line Argument Parser"
 repository = "https://github.com/clap-rs/clap"
 categories = ["command-line-interface"]
@@ -86,7 +86,7 @@ unstable-v5 = ["clap_derive/unstable-v5", "deprecated"]
 bench = false
 
 [dependencies]
-clap_derive = { path = "./clap_derive", version = "=3.2.7", optional = true }
+clap_derive = { path = "./clap_derive", version = "=4.0.0-alpha.0", optional = true }
 clap_lex = { path = "./clap_lex", version = "0.2.2" }
 bitflags = "1.2"
 textwrap = { version = "0.15.0", default-features = false, features = [] }

--- a/clap_bench/Cargo.toml
+++ b/clap_bench/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 release = false
 
 [dev-dependencies]
-clap = { path = "../", version = "3.2.1", default-features = false, features = ["std"] }
+clap = { path = "../", version = "4.0.0-alpha.0", default-features = false, features = ["std"] }
 criterion = "0.3.2"
 lazy_static = "1"
 

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap_complete"
-version = "3.2.3"
+version = "4.0.0-alpha.0"
 description = "Generate shell completion scripts for your clap::Command"
 repository = "https://github.com/clap-rs/clap/tree/master/clap_complete"
 categories = ["command-line-interface"]
@@ -40,7 +40,7 @@ pre-release-replacements = [
 bench = false
 
 [dependencies]
-clap = { path = "../", version = "3.2.1", default-features = false, features = ["std"] }
+clap = { path = "../", version = "4.0.0-alpha.0", default-features = false, features = ["std"] }
 clap_lex = { path = "../clap_lex", version = "0.2.2", optional = true }
 is_executable = { version = "1.0.1", optional = true }
 os_str_bytes = { version = "6.0", default-features = false, features = ["raw_os_str"], optional = true }
@@ -53,7 +53,7 @@ pretty_assertions = "1.0"
 snapbox = { version = "0.2", features = ["diff"] }
 # Cutting out `filesystem` feature
 trycmd = { version = "0.13", default-features = false, features = ["color-auto", "diff", "examples"] }
-clap = { path = "../", version = "3.2.1", default-features = false, features = ["std", "derive"] }
+clap = { path = "../", version = "4.0.0-alpha.0", default-features = false, features = ["std", "derive"] }
 
 [[example]]
 name = "dynamic"

--- a/clap_complete_fig/Cargo.toml
+++ b/clap_complete_fig/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap_complete_fig"
-version = "3.2.4"
+version = "4.0.0-alpha.0"
 description = "A generator library used with clap for Fig completion scripts"
 repository = "https://github.com/clap-rs/clap/tree/master/clap_complete_fig"
 categories = ["command-line-interface"]
@@ -39,8 +39,8 @@ pre-release-replacements = [
 bench = false
 
 [dependencies]
-clap = { path = "../", version = "3.2.1", default-features = false, features = ["std"] }
-clap_complete = { path = "../clap_complete", version = "3.2.1" }
+clap = { path = "../", version = "4.0.0-alpha.0", default-features = false, features = ["std"] }
+clap_complete = { path = "../clap_complete", version = "4.0.0-alpha.0" }
 
 [dev-dependencies]
 snapbox = { version = "0.2", features = ["diff"] }

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap_derive"
-version = "3.2.7"
+version = "4.0.0-alpha.0"
 description = "Parse command line argument by defining a struct, derive crate."
 repository = "https://github.com/clap-rs/clap/tree/master/clap_derive"
 categories = ["command-line-interface", "development-tools::procedural-macro-helpers"]

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -41,11 +41,11 @@ bench = false
 
 [dependencies]
 roff = "0.2.1"
-clap = { path = "../", version = "3.2.1", default-features = false, features = ["std", "env"] }
+clap = { path = "../", version = "4.0.0-alpha.0", default-features = false, features = ["std", "env"] }
 
 [dev-dependencies]
 snapbox = { version = "0.2", features = ["diff"] }
-clap = { path = "../", version = "3.2.1", default-features = false, features = ["std"] }
+clap = { path = "../", version = "4.0.0-alpha.0", default-features = false, features = ["std"] }
 
 [features]
 default = []


### PR DESCRIPTION
The main goal is to reduce the risk of people developing on the wrong
release, assuming they are using something like starship to raise the
visibility of the crate version.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
