### PR TITLE
fix(assert)!: Prevent repeated subcommand names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - *(assert)* Add missing `#[track_caller]`s to make it easier to debug asserts
 - *(assert)* Ensure `overrides_with` IDs are valid
 - *(assert)* Ensure no self-`overrides_with` now that Actions replace it
+- *(assert)* Ensure subcommand names are not duplicated
 - *(help)* Use `Command::display_name` in the help title rather than `Command::bin_name`
 - *(version)* Use `Command::display_name` rather than `Command::bin_name`
 - *(parser)* Assert on unknown args when using external subcommands (#3703)

--- a/src/builder/debug_asserts.rs
+++ b/src/builder/debug_asserts.rs
@@ -309,6 +309,25 @@ pub(crate) fn assert_app(cmd: &Command) {
     detect_duplicate_flags(&long_flags, "long");
     detect_duplicate_flags(&short_flags, "short");
 
+    let mut subs = indexmap::IndexSet::new();
+    for sc in cmd.get_subcommands() {
+        assert!(
+            subs.insert(sc.get_name()),
+            "Command {}: command name `{}` is duplicated",
+            cmd.get_name(),
+            sc.get_name()
+        );
+        for alias in sc.get_all_aliases() {
+            assert!(
+                subs.insert(alias),
+                "Command {}: command `{}` alias `{}` is duplicated",
+                cmd.get_name(),
+                sc.get_name(),
+                alias
+            );
+        }
+    }
+
     _verify_positionals(cmd);
 
     if let Some(help_template) = cmd.get_help_template() {

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -645,3 +645,21 @@ OPTIONS:
     subcmd.write_help(&mut buf).unwrap();
     utils::assert_eq(EXPECTED, String::from_utf8(buf).unwrap());
 }
+
+#[test]
+#[should_panic = "Command test: command name `repeat` is duplicated"]
+fn duplicate_subcommand() {
+    Command::new("test")
+        .subcommand(Command::new("repeat"))
+        .subcommand(Command::new("repeat"))
+        .build()
+}
+
+#[test]
+#[should_panic = "Command test: command `unique` alias `repeat` is duplicated"]
+fn duplicate_subcommand_alias() {
+    Command::new("test")
+        .subcommand(Command::new("repeat"))
+        .subcommand(Command::new("unique").alias("repeat"))
+        .build()
+}


### PR DESCRIPTION
Fixes #3888