### PR TITLE
fix(parser)!: Apply default_missing_value per occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Disallow more `value_names` than `number_of_values` (#2695)
 - Replaced `cmd.allow_invalid_for_utf8_external_subcommands` with `cmd.external_subcommand_value_parser` (#3733)
 - Changed the default type of `allow_external_subcommands` from `String` to `OsString`
+- `Arg::default_missing_value` now applies per occurrence rather than if a value is missing across all occurrences
 - *(assert)* Always enforce that version is specified when the `ArgAction::Version` is used
 - *(assert)* Add missing `#[track_caller]`s to make it easier to debug asserts
 - *(assert)* Ensure `overrides_with` IDs are valid

--- a/tests/builder/default_missing_vals.rs
+++ b/tests/builder/default_missing_vals.rs
@@ -144,6 +144,28 @@ fn opt_default_user_override() {
 }
 
 #[test]
+fn default_missing_value_per_occurrence() {
+    // assert no change to usual argument handling when adding default_missing_value()
+    let r = Command::new("cmd")
+        .arg(
+            arg!(o: -o <opt> ... "some opt")
+                .min_values(0)
+                .default_value("default")
+                .default_missing_value("default_missing"),
+        )
+        .try_get_matches_from(vec!["", "-o", "-o=value", "-o"]);
+    assert!(r.is_ok(), "{}", r.unwrap_err());
+    let m = r.unwrap();
+    assert_eq!(
+        m.get_many::<String>("o")
+            .unwrap()
+            .map(|v| v.as_str())
+            .collect::<Vec<_>>(),
+        vec!["default_missing", "value", "default_missing"]
+    );
+}
+
+#[test]
 #[allow(clippy::bool_assert_comparison)]
 fn default_missing_value_flag_value() {
     let cmd = Command::new("test").arg(


### PR DESCRIPTION
This both simplifies the code and the model we present to the user,
making more sense.

There is room for further exploration of tying flag actions into this.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
