### PR TITLE
[Documentation] fix typo in arg.rs

### DIFF
--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -3666,7 +3666,7 @@ impl<'help> Arg<'help> {
         self
     }
 
-    /// Require these arguments names when this one is presen
+    /// Require these arguments names when this one is present
     ///
     /// i.e. when using this argument, the following arguments *must* be present.
     ///


### PR DESCRIPTION
Just a tiny typo I spotted while reading docs