### PR TITLE
fix!: Remove Arg::use_value_delimiter in favor of Arg::value_delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove `Arg::min_values` (across all occurrences) with `Arg::number_of_values(N..)` (per occurrence)
 - Remove `Arg::max_values` (across all occurrences) with `Arg::number_of_values(1..=M)` (per occurrence)
 - Remove `Arg::multiple_values(true)` with `Arg::number_of_values(1..)` and `Arg::multiple_values(false)` with `Arg::number_of_values(0)`
+- Remove `Arg::use_value_delimiter` in favor of `Arg::value_delimiter`
 - `ArgAction::SetTrue` and `ArgAction::SetFalse` now prioritize `Arg::default_missing_value` over their standard behavior
 - *(help)* Make `DeriveDisplayOrder` the default and removed the setting.  To sort help, set `next_display_order(None)` (#2808)
 - *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value (#2808)

--- a/examples/multicall-busybox.rs
+++ b/examples/multicall-busybox.rs
@@ -25,8 +25,7 @@ fn main() {
                         .exclusive(true)
                         .action(ArgAction::Set)
                         .default_missing_value("/usr/local/bin")
-                        .value_parser(value_parser!(PathBuf))
-                        .use_value_delimiter(false),
+                        .value_parser(value_parser!(PathBuf)),
                 )
                 .subcommands(applet_commands()),
         )

--- a/src/builder/arg_settings.rs
+++ b/src/builder/arg_settings.rs
@@ -32,7 +32,6 @@ pub(crate) enum ArgSettings {
     Global,
     Hidden,
     TakesValue,
-    UseValueDelimiter,
     NextLineHelp,
     RequireDelimiter,
     HidePossibleValues,
@@ -56,7 +55,6 @@ bitflags! {
         const GLOBAL           = 1 << 3;
         const HIDDEN           = 1 << 4;
         const TAKES_VAL        = 1 << 5;
-        const USE_DELIM        = 1 << 6;
         const NEXT_LINE_HELP   = 1 << 7;
         const REQ_DELIM        = 1 << 9;
         const DELIM_NOT_SET    = 1 << 10;
@@ -84,7 +82,6 @@ impl_settings! { ArgSettings, ArgFlags,
     Global => Flags::GLOBAL,
     Hidden => Flags::HIDDEN,
     TakesValue => Flags::TAKES_VAL,
-    UseValueDelimiter => Flags::USE_DELIM,
     NextLineHelp => Flags::NEXT_LINE_HELP,
     RequireDelimiter => Flags::REQ_DELIM,
     HidePossibleValues => Flags::HIDE_POS_VALS,

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -972,7 +972,7 @@ impl<'help> Command<'help> {
     /// was used.
     ///
     /// **NOTE:** The same thing can be done manually by setting the final positional argument to
-    /// [`Arg::use_value_delimiter(false)`]. Using this setting is safer, because it's easier to locate
+    /// [`Arg::value_delimiter(None)`]. Using this setting is safer, because it's easier to locate
     /// when making changes.
     ///
     /// **NOTE:** This choice is propagated to all child subcommands.
@@ -986,7 +986,7 @@ impl<'help> Command<'help> {
     ///     .get_matches();
     /// ```
     ///
-    /// [`Arg::use_value_delimiter(false)`]: crate::Arg::use_value_delimiter()
+    /// [`Arg::value_delimiter(None)`]: crate::Arg::value_delimiter()
     #[inline]
     pub fn dont_delimit_trailing_values(self, yes: bool) -> Self {
         if yes {

--- a/src/builder/debug_asserts.rs
+++ b/src/builder/debug_asserts.rs
@@ -759,7 +759,6 @@ fn assert_arg_flags(arg: &Arg) {
     }
 
     checker!(is_require_value_delimiter_set requires is_takes_value_set);
-    checker!(is_require_value_delimiter_set requires is_use_value_delimiter_set);
     checker!(is_hide_possible_values_set requires is_takes_value_set);
     checker!(is_allow_hyphen_values_set requires is_takes_value_set);
     checker!(is_require_equals_set requires is_takes_value_set);

--- a/src/error/kind.rs
+++ b/src/error/kind.rs
@@ -105,7 +105,6 @@ pub enum ErrorKind {
     /// let result = Command::new("prog")
     ///     .arg(Arg::new("arg")
     ///         .number_of_values(1..=2)
-    ///         .use_value_delimiter(true)
     ///         .require_value_delimiter(true))
     ///     .try_get_matches_from(vec!["prog", "too,many,values"]);
     /// assert!(result.is_err());

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -543,7 +543,7 @@ impl ArgMatches {
     /// let m = Command::new("myapp")
     ///     .arg(Arg::new("option")
     ///         .short('o')
-    ///         .use_value_delimiter(true)
+    ///         .value_delimiter(',')
     ///         .number_of_values(1..))
     ///     .get_matches_from(vec!["myapp", "-o=val1,val2,val3"]);
     ///            // ARGV indices: ^0       ^1
@@ -585,7 +585,7 @@ impl ArgMatches {
     /// let m = Command::new("myapp")
     ///     .arg(Arg::new("option")
     ///         .short('o')
-    ///         .use_value_delimiter(true))
+    ///         .value_delimiter(','))
     ///     .get_matches_from(vec!["myapp", "-o=val1,val2,val3"]);
     ///            // ARGV indices: ^0       ^1
     ///            // clap indices:             ^2   ^3   ^4

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -395,7 +395,7 @@ fn delim_values_only_pos_follows_with_delim() {
     let r = Command::new("onlypos")
         .args(&[
             arg!(f: -f [flag] "some opt"),
-            arg!([arg] ... "some arg").use_value_delimiter(true),
+            arg!([arg] ... "some arg").value_delimiter(','),
         ])
         .try_get_matches_from(vec!["", "--", "-f", "-g,x"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -415,7 +415,7 @@ fn delim_values_only_pos_follows_with_delim() {
 fn delim_values_trailingvararg_with_delim() {
     let m = Command::new("positional")
         .trailing_var_arg(true)
-        .arg(arg!([opt] ... "some pos").use_value_delimiter(true))
+        .arg(arg!([opt] ... "some pos").value_delimiter(','))
         .try_get_matches_from(vec!["", "test", "--foo", "-Wl,-bar"])
         .unwrap();
     assert!(m.contains_id("opt"));
@@ -1150,7 +1150,7 @@ fn aaos_opts_mult_req_delims() {
         .arg(
             arg!(--opt <val> ... "some option")
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true)
                 .action(ArgAction::Append),
         )
@@ -1219,11 +1219,7 @@ fn aaos_pos_mult() {
 #[test]
 fn aaos_option_use_delim_false() {
     let m = Command::new("posix")
-        .arg(
-            arg!(--opt <val> "some option")
-                .use_value_delimiter(false)
-                .action(ArgAction::Set),
-        )
+        .arg(arg!(--opt <val> "some option").action(ArgAction::Set))
         .try_get_matches_from(vec!["", "--opt=some,other", "--opt=one,two"])
         .unwrap();
     assert!(m.contains_id("opt"));

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -822,7 +822,7 @@ fn valid_delimited_default_values() {
         .arg(
             Arg::new("arg")
                 .value_parser(clap::value_parser!(u32))
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true)
                 .default_value("1,2,3"),
         )
@@ -839,7 +839,7 @@ fn invalid_delimited_default_values() {
         .arg(
             Arg::new("arg")
                 .value_parser(clap::value_parser!(u32))
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true)
                 .default_value("one,two"),
         )

--- a/tests/builder/delimiters.rs
+++ b/tests/builder/delimiters.rs
@@ -109,7 +109,7 @@ fn opt_eq_mult_def_delim() {
                 .long("opt")
                 .action(ArgAction::Set)
                 .number_of_values(1..)
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .try_get_matches_from(vec!["", "--opt=val1,val2,val3"]);
 

--- a/tests/builder/env.rs
+++ b/tests/builder/env.rs
@@ -229,7 +229,7 @@ fn multiple_one() {
             arg!([arg] "some opt")
                 .env("CLP_TEST_ENV_MO")
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .number_of_values(1..),
         )
         .try_get_matches_from(vec![""]);
@@ -255,7 +255,7 @@ fn multiple_three() {
             arg!([arg] "some opt")
                 .env("CLP_TEST_ENV_MULTI1")
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .number_of_values(1..),
         )
         .try_get_matches_from(vec![""]);

--- a/tests/builder/grouped_values.rs
+++ b/tests/builder/grouped_values.rs
@@ -68,7 +68,7 @@ fn grouped_value_long_flag_delimiter() {
             Arg::new("option")
                 .long("option")
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .number_of_values(1..)
                 .action(ArgAction::Append),
         )
@@ -98,7 +98,7 @@ fn grouped_value_short_flag_delimiter() {
             Arg::new("option")
                 .short('o')
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .number_of_values(1..)
                 .action(ArgAction::Append),
         )

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1602,7 +1602,7 @@ OPTIONS:
                 .required(true)
                 .value_names(&["some", "val"])
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true)
                 .value_delimiter(':'),
         );
@@ -1638,7 +1638,7 @@ NETWORKING:
                 .required(true)
                 .value_names(&["some", "val"])
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true)
                 .value_delimiter(':'),
         )
@@ -1691,7 +1691,7 @@ fn multiple_custom_help_headers() {
                 .required(true)
                 .value_names(&["some", "val"])
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true)
                 .value_delimiter(':'),
         )

--- a/tests/builder/indices.rs
+++ b/tests/builder/indices.rs
@@ -135,7 +135,7 @@ fn indices_mult_opt_value_delim_eq() {
             Arg::new("option")
                 .short('o')
                 .action(ArgAction::Set)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .number_of_values(1..),
         )
         .try_get_matches_from(vec!["myapp", "-o=val1,val2,val3"])

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -643,7 +643,7 @@ fn sep_long_equals() {
             Arg::new("option")
                 .long("option")
                 .help("multiple options")
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .try_get_matches_from(vec!["", "--option=val1,val2,val3"]);
 
@@ -667,7 +667,7 @@ fn sep_long_space() {
             Arg::new("option")
                 .long("option")
                 .help("multiple options")
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .try_get_matches_from(vec!["", "--option", "val1,val2,val3"]);
 
@@ -691,7 +691,7 @@ fn sep_short_equals() {
             Arg::new("option")
                 .short('o')
                 .help("multiple options")
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .try_get_matches_from(vec!["", "-o=val1,val2,val3"]);
 
@@ -715,7 +715,7 @@ fn sep_short_space() {
             Arg::new("option")
                 .short('o')
                 .help("multiple options")
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .try_get_matches_from(vec!["", "-o", "val1,val2,val3"]);
 
@@ -739,7 +739,7 @@ fn sep_short_no_space() {
             Arg::new("option")
                 .short('o')
                 .help("multiple options")
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .try_get_matches_from(vec!["", "-oval1,val2,val3"]);
 
@@ -762,7 +762,7 @@ fn sep_positional() {
         .arg(
             Arg::new("option")
                 .help("multiple options")
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .try_get_matches_from(vec!["", "val1,val2,val3"]);
 
@@ -833,8 +833,7 @@ fn no_sep() {
             Arg::new("option")
                 .long("option")
                 .help("multiple options")
-                .action(ArgAction::Set)
-                .use_value_delimiter(false),
+                .action(ArgAction::Set),
         )
         .try_get_matches_from(vec!["", "--option=val1,val2,val3"]);
 
@@ -854,8 +853,7 @@ fn no_sep_positional() {
         .arg(
             Arg::new("option")
                 .help("multiple options")
-                .action(ArgAction::Set)
-                .use_value_delimiter(false),
+                .action(ArgAction::Set),
         )
         .try_get_matches_from(vec!["", "val1,val2,val3"]);
 
@@ -876,7 +874,7 @@ fn req_delimiter_long() {
             Arg::new("option")
                 .long("option")
                 .number_of_values(1..)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(
@@ -914,7 +912,7 @@ fn req_delimiter_long_with_equal() {
             Arg::new("option")
                 .long("option")
                 .number_of_values(1..)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(
@@ -952,7 +950,7 @@ fn req_delimiter_short_with_space() {
             Arg::new("option")
                 .short('o')
                 .number_of_values(1..)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(
@@ -990,7 +988,7 @@ fn req_delimiter_short_with_no_space() {
             Arg::new("option")
                 .short('o')
                 .number_of_values(1..)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(
@@ -1028,7 +1026,7 @@ fn req_delimiter_short_with_equal() {
             Arg::new("option")
                 .short('o')
                 .number_of_values(1..)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(
@@ -1068,7 +1066,7 @@ fn req_delimiter_complex() {
                 .short('o')
                 .number_of_values(1..)
                 .action(ArgAction::Append)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(Arg::new("args").number_of_values(1..).index(1))

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -339,7 +339,7 @@ fn multiple_vals_pos_arg_delim() {
         .arg(
             arg!(o: -o <opt> "some opt")
                 .number_of_values(1..)
-                .use_value_delimiter(true),
+                .value_delimiter(','),
         )
         .arg(arg!([file] "some file"))
         .try_get_matches_from(vec!["", "-o", "1,2", "some"]);
@@ -365,7 +365,7 @@ fn require_delims_no_delim() {
     let r = Command::new("mvae")
         .arg(
             arg!(o: -o [opt] ... "some opt")
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(arg!([file] "some file"))
@@ -381,7 +381,7 @@ fn require_delims() {
         .arg(
             arg!(o: -o <opt> "some opt")
                 .number_of_values(1..)
-                .use_value_delimiter(true)
+                .value_delimiter(',')
                 .require_value_delimiter(true),
         )
         .arg(arg!([file] "some file"))


### PR DESCRIPTION
This is part of #2688