### PR TITLE
fix(parser)!: Split on value delimiter after validating num_args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replace `Arg::number_of_values` (average across occurrences) with `Arg::num_args` (per occurrence, raw CLI args, not parsed values)
   - `num_args(0)` no longer implies `takes_value(true).multiple_values(true)`
   - `num_args(1)` no longer implies `multiple_values(true)`
-  - Does not check default values, only what the user explicitly passes in
+  - Does not check default or env values, only what the user explicitly passes in
+  - No longer terminates on delimited values
+- `Arg::value_terminator` must stand on its own now rather than being in a delimited list
 - Sometimes `Arg::default_missing_value` didn't require `num_args(0..=1)`, now it does
 - Replace `Arg::min_values` (across all occurrences) with `Arg::num_args(N..)` (per occurrence)
 - Replace `Arg::max_values` (across all occurrences) with `Arg::num_args(1..=M)` (per occurrence)

--- a/src/error/kind.rs
+++ b/src/error/kind.rs
@@ -104,9 +104,8 @@ pub enum ErrorKind {
     /// # use clap::{Command, Arg, error::ErrorKind};
     /// let result = Command::new("prog")
     ///     .arg(Arg::new("arg")
-    ///         .num_args(1..=2)
-    ///         .require_value_delimiter(true))
-    ///     .try_get_matches_from(vec!["prog", "too,many,values"]);
+    ///         .num_args(1..=2))
+    ///     .try_get_matches_from(vec!["prog", "too", "many", "values"]);
     /// assert!(result.is_err());
     /// assert_eq!(result.unwrap_err().kind(), ErrorKind::TooManyValues);
     /// ```

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -334,33 +334,6 @@ fn multiple_vals_pos_arg_equals() {
 }
 
 #[test]
-fn multiple_vals_pos_arg_delim() {
-    let r = Command::new("mvae")
-        .arg(
-            arg!(o: -o <opt> "some opt")
-                .num_args(1..)
-                .value_delimiter(','),
-        )
-        .arg(arg!([file] "some file"))
-        .try_get_matches_from(vec!["", "-o", "1,2", "some"]);
-    assert!(r.is_ok(), "{}", r.unwrap_err());
-    let m = r.unwrap();
-    assert!(m.contains_id("o"));
-    assert_eq!(
-        m.get_many::<String>("o")
-            .unwrap()
-            .map(|v| v.as_str())
-            .collect::<Vec<_>>(),
-        &["1", "2"]
-    );
-    assert!(m.contains_id("file"));
-    assert_eq!(
-        m.get_one::<String>("file").map(|v| v.as_str()).unwrap(),
-        "some"
-    );
-}
-
-#[test]
 fn require_delims_no_delim() {
     let r = Command::new("mvae")
         .arg(


### PR DESCRIPTION
This will allow `num_args(0..=1).value_delimiter(',')` to work properly.

This hacks in support for `require_value_delimiter` until we can remove
it.

This no longer recognzes value terminators in delimited lists.

It looks like there is a bug with recognizing value terminators in
positionals arguments.  We'll need to dig into that more.

This is a part of #2688

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
