### PR TITLE
fix: Always ensure `num_args` is initialized

### DIFF
--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -3984,6 +3984,14 @@ impl<'help> Arg<'help> {
         if val_names_len > 1 {
             self.settings.set(ArgSettings::MultipleValues);
             self.num_vals.get_or_insert(val_names_len.into());
+        } else {
+            if self.is_multiple_values_set() {
+                self.num_vals.get_or_insert((1..).into());
+            } else if self.is_takes_value_set() {
+                self.num_vals.get_or_insert(1.into());
+            } else {
+                self.num_vals.get_or_insert(0.into());
+            }
         }
     }
 

--- a/src/builder/debug_asserts.rs
+++ b/src/builder/debug_asserts.rs
@@ -692,12 +692,15 @@ fn assert_arg(arg: &Arg) {
 
     if let Some(num_vals) = arg.get_num_args() {
         // This can be the cause of later asserts, so put this first
-        let num_val_names = arg.get_value_names().unwrap_or(&[]).len();
-        if num_vals.max_values() < num_val_names {
-            panic!(
-                "Argument {}: Too many value names ({}) compared to number_of_values ({})",
-                arg.name, num_val_names, num_vals
-            );
+        if num_vals != 0.into() {
+            // HACK: Don't check for flags to make the derive easier
+            let num_val_names = arg.get_value_names().unwrap_or(&[]).len();
+            if num_vals.max_values() < num_val_names {
+                panic!(
+                    "Argument {}: Too many value names ({}) compared to number_of_values ({})",
+                    arg.name, num_val_names, num_vals
+                );
+            }
         }
 
         assert_eq!(


### PR DESCRIPTION
As we move people off takes_value/multiple_values, this will provide
something to check.

This was previously blocked on other issues related to flag handling
(#4023)

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
