### PR TITLE
refactor: We don't need MultipleValues for bookkeeping afterall

### DIFF
--- a/src/builder/arg_settings.rs
+++ b/src/builder/arg_settings.rs
@@ -28,7 +28,6 @@ impl Default for ArgFlags {
 #[non_exhaustive]
 pub(crate) enum ArgSettings {
     Required,
-    MultipleValues,
     Global,
     Hidden,
     TakesValue,
@@ -66,7 +65,6 @@ bitflags! {
         const HIDE_ENV_VALS    = 1 << 17;
         const HIDDEN_SHORT_H   = 1 << 18;
         const HIDDEN_LONG_H    = 1 << 19;
-        const MULTIPLE_VALS    = 1 << 20;
         #[cfg(feature = "env")]
         const HIDE_ENV         = 1 << 21;
         const EXCLUSIVE        = 1 << 23;
@@ -76,7 +74,6 @@ bitflags! {
 
 impl_settings! { ArgSettings, ArgFlags,
     Required => Flags::REQUIRED,
-    MultipleValues => Flags::MULTIPLE_VALS,
     Global => Flags::GLOBAL,
     Hidden => Flags::HIDDEN,
     TakesValue => Flags::TAKES_VAL,


### PR DESCRIPTION
TakesValue helps because it provides a way for a lot of settings to say
a value is needed without specifying how many.  Multiple values didn't
have enough call sites to make this worthwhile.

This is a part of #2688

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
