### PR TITLE
feat(parser): Add method to disable escape arg

### DIFF
--- a/src/builder/app_settings.rs
+++ b/src/builder/app_settings.rs
@@ -49,6 +49,7 @@ pub(crate) enum AppSettings {
     DisableHelpFlag,
     DisableHelpSubcommand,
     DisableVersionFlag,
+    DisableEscapeArg,
     PropagateVersion,
     Hidden,
     HidePossibleValues,
@@ -101,6 +102,7 @@ bitflags! {
         const INFER_LONG_ARGS                = 1 << 43;
         const IGNORE_ERRORS                  = 1 << 44;
         const MULTICALL                      = 1 << 45;
+        const DISABLE_ESCAPE_ARG             = 1 << 46;
         const NO_OP                          = 0;
     }
 }
@@ -138,6 +140,8 @@ impl_settings! { AppSettings, AppFlags,
         => Flags::DISABLE_HELP_FLAG,
     DisableVersionFlag
         => Flags::DISABLE_VERSION_FLAG,
+    DisableEscapeArg
+        => Flags::DISABLE_ESCAPE_ARG,
     PropagateVersion
         => Flags::PROPAGATE_VERSION,
     HidePossibleValues

--- a/src/builder/debug_asserts.rs
+++ b/src/builder/debug_asserts.rs
@@ -248,6 +248,12 @@ pub(crate) fn assert_app(cmd: &Command) {
                     cmd.get_name(),
                 arg.name
             );
+            assert!(
+                !cmd.is_disable_escape_arg_set(),
+                "Command {}: Argument {} has last(true) which conflicts with `disable_escape_arg(true)`",
+                cmd.get_name(),
+                arg.name
+            );
         }
 
         assert!(

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -119,7 +119,8 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 }
 
                 if arg_os.is_escape() {
-                    if matches!(&parse_state, ParseState::Opt(opt) | ParseState::Pos(opt) if
+                    if self.cmd.is_disable_escape_arg_set()
+                        || matches!(&parse_state, ParseState::Opt(opt) | ParseState::Pos(opt) if
                         self.cmd[opt].is_allow_hyphen_values_set())
                     {
                         // ParseResult::MaybeHyphenValue, do nothing

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -540,6 +540,28 @@ fn leading_double_hyphen_trailingvararg() {
 }
 
 #[test]
+fn disable_escape_arg() {
+    let m = Command::new("extsubcmd")
+        .trailing_var_arg(true)
+        .disable_escape_arg(true)
+        .arg(arg!(<VAL>))
+        .arg(arg!([ARGS] ... "some args").allow_hyphen_values(true))
+        .try_get_matches_from(vec!["", "do-the-thing", "--", "--foo", "bar"])
+        .unwrap();
+
+    assert!(m.contains_id("VAL"));
+    assert!(m.contains_id("ARGS"));
+    assert_eq!(m.get_one::<String>("VAL").unwrap(), "do-the-thing");
+    assert_eq!(
+        m.get_many::<String>("ARGS")
+            .unwrap()
+            .map(|v| v.as_str())
+            .collect::<Vec<_>>(),
+        &["--", "--foo", "bar"]
+    );
+}
+
+#[test]
 fn disable_help_subcommand() {
     let result = Command::new("disablehelp")
         .disable_help_subcommand(true)


### PR DESCRIPTION
allows for the disabling of the `--` escape arg. this, along with #4039, should be the final piece to fully enable "named" external subcommands (see the `disable_escape_arg` test for an example).