### PR TITLE
chore: Bump MSRV to 1.60.0 

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.56.1"  # MSRV
+msrv = "1.60.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         build: [msrv, wasm, wasm-wasi, debug, release]
         include:
           - build: msrv
-            rust: 1.56.1  # MSRV
+            rust: 1.60.0  # MSRV
             target: x86_64-unknown-linux-gnu
             features: full
           - build: wasm
@@ -122,7 +122,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56.1  # MSRV
+        toolchain: 1.60.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v1
@@ -172,7 +172,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.56.1  # MSRV
+        toolchain: 1.60.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -92,9 +92,9 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.56.1  # MSRV
+        - 1.60.0  # MSRV
         - stable
-    continue-on-error: ${{ matrix.rust != '1.56.1' }}  # MSRV
+    continue-on-error: ${{ matrix.rust != '1.60.0' }}  # MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - *(derive)* Changed the default for arguments from `parse` to `value_parser`., removing `parse` support
 - *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp` (#3280)
 
+### Compatibility
+
+MSRV is now 1.60.0
+
 ### Features
 
 - `Arg::num_args` now accepts ranges, allowing setting both the minimum and maximum number of values per occurrence

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "bytes"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cast"
@@ -131,7 +131,7 @@ dependencies = [
  "once_cell",
  "rustversion",
  "shlex",
- "snapbox",
+ "snapbox 0.2.10",
  "static_assertions",
  "strsim",
  "termcolor",
@@ -162,7 +162,7 @@ dependencies = [
  "pathdiff",
  "pretty_assertions",
  "shlex",
- "snapbox",
+ "snapbox 0.2.10",
  "trycmd",
  "unicode-xid",
 ]
@@ -173,7 +173,7 @@ version = "4.0.0-alpha.0"
 dependencies = [
  "clap 4.0.0-alpha.0",
  "clap_complete",
- "snapbox",
+ "snapbox 0.2.10",
 ]
 
 [[package]]
@@ -200,14 +200,14 @@ version = "0.1.10"
 dependencies = [
  "clap 4.0.0-alpha.0",
  "roff",
- "snapbox",
+ "snapbox 0.2.10",
 ]
 
 [[package]]
 name = "combine"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
  "quote",
  "syn",
@@ -485,15 +485,15 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -506,9 +506,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "output_vt100"
@@ -692,18 +692,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -781,15 +781,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -808,9 +808,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -838,11 +838,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
- "itoa 1.0.2",
+ "itoa 1.0.3",
  "ryu",
  "serde",
 ]
@@ -855,9 +855,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "similar"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
 
 [[package]]
 name = "snapbox"
@@ -867,9 +867,22 @@ checksum = "767a1d5da232b6959cd1bd5c9e8db8a7cce09c3038e89deedb49a549a2aefd93"
 dependencies = [
  "concolor",
  "normalize-line-endings",
+ "similar",
+ "snapbox-macros 0.2.1",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9f6603988128836d0ed032a28fac5fb049958e21578e9aed2ed05f69bb562a"
+dependencies = [
+ "concolor",
+ "normalize-line-endings",
  "os_pipe",
  "similar",
- "snapbox-macros",
+ "snapbox-macros 0.3.0",
  "wait-timeout",
  "yansi",
 ]
@@ -879,6 +892,12 @@ name = "snapbox-macros"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c01dea7e04cbb27ef4c86e9922184608185f7cd95c1763bc30d727cda4a5e930"
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a253e6f894cfa440cba00600a249fa90869d8e0ec45ab274a456e043a0ce8f2"
 
 [[package]]
 name = "static_assertions"
@@ -894,9 +913,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -984,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764b9e244b482a9b81bde596aa37aa6f1347bf8007adab25e59f901b32b4e0a0"
+checksum = "e7f408301c7480f9e6294eb779cfc907f54bd901a9660ef24d7f233ed5376485"
 dependencies = [
  "glob",
  "once_cell",
@@ -999,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "trycmd"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4185126cc904642173a54c185083f410c86d1202ada6761aacf7c40829f13"
+checksum = "62a09d4fff814904dc04bf60dc19fd7ed41715e3e00dd423eb1c5636a942e2a4"
 dependencies = [
  "escargot",
  "glob",
@@ -1010,7 +1029,7 @@ dependencies = [
  "rayon",
  "serde",
  "shlex",
- "snapbox",
+ "snapbox 0.3.1",
  "toml_edit",
 ]
 
@@ -1025,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-width"
@@ -1069,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1079,13 +1098,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1094,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1104,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1117,15 +1136,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ rustversion = "1"
 # Cutting out `filesystem` feature
 trycmd = { version = "0.13", default-features = false, features = ["color-auto", "diff", "examples"] }
 humantime = "2"
-snapbox = "0.2.9"
+snapbox = "0.2"
 shlex = "1.1.0"
 static_assertions = "1.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"  # MSRV
+rust-version = "1.60.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",
@@ -59,28 +59,26 @@ default = [
   "color",
   "suggestions",
 ]
-debug = ["clap_derive/debug", "backtrace"] # Enables debug messages
+debug = ["clap_derive/debug", "dep:backtrace"] # Enables debug messages
 unstable-doc = ["derive", "cargo", "wrap_help", "env", "unicode", "unstable-replace", "unstable-grouped"] # for docs.rs
 
 # Used in default
 std = ["indexmap/std"] # support for no_std in a backwards-compatible way
-color = ["atty", "termcolor"]
-suggestions = ["strsim"]
+color = ["dep:atty", "dep:termcolor"]
+suggestions = ["dep:strsim"]
 
 # Optional
-# note: this will always enable clap_derive, change this to `clap_derive?/unstable-v4` when MSRV is bigger than 1.60
-deprecated = ["clap_derive/deprecated"] # Guided experience to prepare for next breaking release (at different stages of development, this may become default)
-derive = ["clap_derive", "once_cell"]
-cargo = ["once_cell"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
-wrap_help = ["terminal_size", "textwrap/terminal_size"]
+deprecated = ["clap_derive?/deprecated"] # Guided experience to prepare for next breaking release (at different stages of development, this may become default)
+derive = ["clap_derive", "dep:once_cell"]
+cargo = ["dep:once_cell"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
+wrap_help = ["dep:terminal_size", "textwrap/terminal_size"]
 env = [] # Use environment variables during arg parsing
-unicode = ["textwrap/unicode-width", "unicase"]  # Support for unicode characters in arguments and help messages
+unicode = ["textwrap/unicode-width", "dep:unicase"]  # Support for unicode characters in arguments and help messages
 
 # In-work features
 unstable-replace = []
 unstable-grouped = []
-# note: this will always enable clap_derive, change this to `clap_derive?/unstable-v5` when MSRV is bigger than 1.60
-unstable-v5 = ["clap_derive/unstable-v5", "deprecated"]
+unstable-v5 = ["clap_derive?/unstable-v5", "deprecated"]
 
 [lib]
 bench = false

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq (${TOOLCHAIN_TARGET},)
   ARGS+=--target ${TOOLCHAIN_TARGET}
 endif
 
-MSRV?=1.56.1
+MSRV?=1.60.0
 
 _FEATURES = minimal default wasm full debug release
 _FEATURES_minimal = --no-default-features --features "std"

--- a/clap_bench/Cargo.toml
+++ b/clap_bench/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Benchmarks for clap"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"  # MSRV
+rust-version = "1.60.0"  # MSRV
 publish = false
 
 [package.metadata.release]

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"  # MSRV
+rust-version = "1.60.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",
@@ -61,5 +61,5 @@ required-features = ["unstable-dynamic"]
 
 [features]
 default = []
-unstable-dynamic = ["clap_lex", "shlex", "unicode-xid", "os_str_bytes", "clap/derive", "is_executable", "pathdiff"]
+unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:unicode-xid", "dep:os_str_bytes", "clap/derive", "dep:is_executable", "dep:pathdiff"]
 debug = ["clap/debug"]

--- a/clap_complete_fig/Cargo.toml
+++ b/clap_complete_fig/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"  # MSRV
+rust-version = "1.60.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"  # MSRV
+rust-version = "1.60.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_lex/Cargo.toml
+++ b/clap_lex/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"  # MSRV
+rust-version = "1.60.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.56.1"  # MSRV
+rust-version = "1.60.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/examples/tutorial_derive/04_04_custom.rs
+++ b/examples/tutorial_derive/04_04_custom.rs
@@ -73,8 +73,6 @@ fn main() {
 
     // Check for usage of -c
     if let Some(config) = cli.config.as_deref() {
-        // todo: remove `#[allow(clippy::or_fun_call)]` lint when MSRV is bumped.
-        #[allow(clippy::or_fun_call)]
         let input = cli
             .input_file
             .as_deref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!   - Leverage feature flags to keep to one active branch
 //!   - Being under [WG-CLI](https://github.com/rust-cli/team/) to increase the bus factor
 //! - We follow semver and will wait about 6-9 months between major breaking changes
-//! - We will support the last two minor Rust releases (MSRV, currently 1.56.1)
+//! - We will support the last two minor Rust releases (MSRV, currently 1.60.0)
 //!
 //! While these aspirations can be at odds with fast build times and low binary
 //! size, we will still strive to keep these reasonable for the flexibility you

--- a/tests/derive_ui.rs
+++ b/tests/derive_ui.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 
 #[cfg(feature = "derive")]
-#[rustversion::attr(any(not(stable), before(1.56), since(1.57)), ignore)] // MSRV
+#[rustversion::attr(any(not(stable), before(1.60), since(1.61)), ignore)] // MSRV
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/derive_ui/bool_value_enum.stderr
+++ b/tests/derive_ui/bool_value_enum.stderr
@@ -1,11 +1,5 @@
 error[E0277]: the trait bound `bool: ValueEnum` is not satisfied
-   --> tests/derive_ui/bool_value_enum.rs:6:31
-    |
-6   |     #[clap(short, value_enum, default_value_t)]
-    |                               ^^^^^^^^^^^^^^^ the trait `ValueEnum` is not implemented for `bool`
-    |
-note: required by `to_possible_value`
-   --> src/derive.rs
-    |
-    |     fn to_possible_value<'a>(&self) -> Option<PossibleValue<'a>>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> tests/derive_ui/bool_value_enum.rs:6:31
+  |
+6 |     #[clap(short, value_enum, default_value_t)]
+  |                               ^^^^^^^^^^^^^^^ the trait `ValueEnum` is not implemented for `bool`

--- a/tests/derive_ui/default_value_wo_value_removed.stderr
+++ b/tests/derive_ui/default_value_wo_value_removed.stderr
@@ -1,8 +1,8 @@
 error: `#[clap(default_value)` attribute (without a value) has been replaced by `#[clap(default_value_t)]`.
 
-  = help: Change the attribute to `#[clap(default_value_t)]`
+         = help: Change the attribute to `#[clap(default_value_t)]`
 
-  --> $DIR/default_value_wo_value_removed.rs:14:12
+  --> tests/derive_ui/default_value_wo_value_removed.rs:14:12
    |
 14 |     #[clap(default_value)]
    |            ^^^^^^^^^^^^^

--- a/tests/derive_ui/default_values_t_invalid.stderr
+++ b/tests/derive_ui/default_values_t_invalid.stderr
@@ -1,6 +1,6 @@
 error: #[clap(default_values_t)] can be used only on Vec types
 
-  = note: see https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md#magic-attributes
+         = note: see https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md#magic-attributes
 
  --> tests/derive_ui/default_values_t_invalid.rs:6:12
   |

--- a/tests/derive_ui/enum_variant_not_args.stderr
+++ b/tests/derive_ui/enum_variant_not_args.stderr
@@ -1,23 +1,5 @@
 error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
-   --> tests/derive_ui/enum_variant_not_args.rs:3:9
-    |
-3   |     Sub(SubCmd),
-    |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-    |
-note: required by `augment_args`
-   --> src/derive.rs
-    |
-    |     fn augment_args(cmd: Command<'_>) -> Command<'_>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
-   --> tests/derive_ui/enum_variant_not_args.rs:3:9
-    |
-3   |     Sub(SubCmd),
-    |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-    |
-note: required by `augment_args_for_update`
-   --> src/derive.rs
-    |
-    |     fn augment_args_for_update(cmd: Command<'_>) -> Command<'_>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> tests/derive_ui/enum_variant_not_args.rs:3:9
+  |
+3 |     Sub(SubCmd),
+  |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`

--- a/tests/derive_ui/flatten_enum_in_struct.stderr
+++ b/tests/derive_ui/flatten_enum_in_struct.stderr
@@ -1,23 +1,5 @@
 error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
-   --> tests/derive_ui/flatten_enum_in_struct.rs:3:12
-    |
-3   |     #[clap(flatten)]
-    |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-    |
-note: required by `augment_args`
-   --> src/derive.rs
-    |
-    |     fn augment_args(cmd: Command<'_>) -> Command<'_>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
-   --> tests/derive_ui/flatten_enum_in_struct.rs:3:12
-    |
-3   |     #[clap(flatten)]
-    |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
-    |
-note: required by `augment_args_for_update`
-   --> src/derive.rs
-    |
-    |     fn augment_args_for_update(cmd: Command<'_>) -> Command<'_>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ --> tests/derive_ui/flatten_enum_in_struct.rs:3:12
+  |
+3 |     #[clap(flatten)]
+  |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`

--- a/tests/derive_ui/flatten_struct_in_enum.stderr
+++ b/tests/derive_ui/flatten_struct_in_enum.stderr
@@ -1,38 +1,7 @@
 error[E0277]: the trait bound `SubCmd: Subcommand` is not satisfied
-   --> tests/derive_ui/flatten_struct_in_enum.rs:1:10
-    |
-1   | #[derive(clap::Parser)]
-    |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
-    |
-note: required by `has_subcommand`
-   --> src/derive.rs
-    |
-    |     fn has_subcommand(name: &str) -> bool;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `SubCmd: Subcommand` is not satisfied
-   --> tests/derive_ui/flatten_struct_in_enum.rs:1:10
-    |
-1   | #[derive(clap::Parser)]
-    |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
-    |
-note: required by `augment_subcommands`
-   --> src/derive.rs
-    |
-    |     fn augment_subcommands(cmd: Command<'_>) -> Command<'_>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `SubCmd: Subcommand` is not satisfied
-   --> tests/derive_ui/flatten_struct_in_enum.rs:1:10
-    |
-1   | #[derive(clap::Parser)]
-    |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
-    |
-note: required by `augment_subcommands_for_update`
-   --> src/derive.rs
-    |
-    |     fn augment_subcommands_for_update(cmd: Command<'_>) -> Command<'_>;
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> tests/derive_ui/flatten_struct_in_enum.rs:1:10
+  |
+1 | #[derive(clap::Parser)]
+  |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
+  |
+  = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_ui/skip_without_default.stderr
+++ b/tests/derive_ui/skip_without_default.stderr
@@ -1,7 +1,5 @@
 error[E0277]: the trait bound `Kind: Default` is not satisfied
-   --> tests/derive_ui/skip_without_default.rs:22:12
-    |
-22  |     #[clap(skip)]
-    |            ^^^^ the trait `Default` is not implemented for `Kind`
-    |
-note: required by `std::default::Default::default`
+  --> tests/derive_ui/skip_without_default.rs:22:12
+   |
+22 |     #[clap(skip)]
+   |            ^^^^ the trait `Default` is not implemented for `Kind`


### PR DESCRIPTION
While at it, this cleans up all of the features.  For some reason, I
couldn't do `dep:clap_derive` though.