### PR TITLE
refactor: Move off of HashMap/IndexMap to flat containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,6 @@ dependencies = [
  "clap_derive",
  "clap_lex",
  "humantime",
- "indexmap",
  "once_cell",
  "rustversion",
  "shlex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ debug = ["clap_derive/debug", "dep:backtrace"] # Enables debug messages
 unstable-doc = ["derive", "cargo", "wrap_help", "env", "unicode", "unstable-replace", "unstable-grouped"] # for docs.rs
 
 # Used in default
-std = ["indexmap/std"] # support for no_std in a backwards-compatible way
+std = [] # support for no_std in a backwards-compatible way
 color = ["dep:atty", "dep:termcolor"]
 suggestions = ["dep:strsim"]
 
@@ -89,7 +89,6 @@ clap_lex = { path = "./clap_lex", version = "0.2.2" }
 bitflags = "1.2"
 textwrap = { version = "0.15.0", default-features = false, features = [] }
 unicase = { version = "2.6", optional = true }
-indexmap = "1.0"
 strsim = { version = "0.10",  optional = true }
 atty = { version = "0.2",  optional = true }
 termcolor = { version = "1.1.1", optional = true }

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -1,5 +1,4 @@
 // Std
-use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
@@ -20,6 +19,7 @@ use crate::output::fmt::Stream;
 use crate::output::{fmt::Colorizer, Help, HelpWriter, Usage};
 use crate::parser::{ArgMatcher, ArgMatches, Parser};
 use crate::util::ChildGraph;
+use crate::util::FlatMap;
 use crate::util::{color::ColorChoice, Id, Key};
 use crate::{Error, INTERNAL_ERROR_MSG};
 
@@ -93,7 +93,7 @@ pub struct Command<'help> {
     g_settings: AppFlags,
     args: MKeyMap<'help>,
     subcommands: Vec<Command<'help>>,
-    replacers: HashMap<&'help str, &'help [&'help str]>,
+    replacers: FlatMap<&'help str, &'help [&'help str]>,
     groups: Vec<ArgGroup<'help>>,
     current_help_heading: Option<&'help str>,
     current_disp_ord: Option<usize>,

--- a/src/builder/debug_asserts.rs
+++ b/src/builder/debug_asserts.rs
@@ -4,6 +4,7 @@ use clap_lex::RawOsStr;
 
 use crate::builder::ValueRange;
 use crate::mkeymap::KeyType;
+use crate::util::FlatSet;
 use crate::util::Id;
 use crate::ArgAction;
 use crate::INTERNAL_ERROR_MSG;
@@ -308,7 +309,7 @@ pub(crate) fn assert_app(cmd: &Command) {
     detect_duplicate_flags(&long_flags, "long");
     detect_duplicate_flags(&short_flags, "short");
 
-    let mut subs = indexmap::IndexSet::new();
+    let mut subs = FlatSet::new();
     for sc in cmd.get_subcommands() {
         assert!(
             subs.insert(sc.get_name()),

--- a/src/builder/value_parser.rs
+++ b/src/builder/value_parser.rs
@@ -12,7 +12,7 @@ use crate::parser::AnyValueId;
 /// use within an application.
 ///
 /// See
-/// - [`value_parser!`] for automatically selecting an implementation for a given type
+/// - [`value_parser!`][crate::value_parser] for automatically selecting an implementation for a given type
 /// - [`ValueParser::new`] for additional [`TypedValueParser`] that can be used
 ///
 /// # Example

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -9,10 +9,10 @@ use std::usize;
 use crate::builder::PossibleValue;
 use crate::builder::{render_arg_val, Arg, Command};
 use crate::output::{fmt::Colorizer, Usage};
+use crate::util::FlatSet;
 use crate::ArgAction;
 
 // Third party
-use indexmap::IndexSet;
 use textwrap::core::display_width;
 
 /// `clap` Help Writer.
@@ -821,7 +821,7 @@ impl<'help, 'cmd, 'writer> Help<'help, 'cmd, 'writer> {
             .cmd
             .get_arguments()
             .filter_map(|arg| arg.get_help_heading())
-            .collect::<IndexSet<_>>();
+            .collect::<FlatSet<_>>();
 
         let mut first = if !pos.is_empty() {
             // Write positional args if any

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -1,9 +1,8 @@
-use indexmap::IndexSet;
-
 // Internal
 use crate::builder::{Arg, ArgPredicate, Command};
 use crate::parser::ArgMatcher;
 use crate::util::ChildGraph;
+use crate::util::FlatSet;
 use crate::util::Id;
 use crate::INTERNAL_ERROR_MSG;
 
@@ -329,16 +328,16 @@ impl<'help, 'cmd> Usage<'help, 'cmd> {
         incls: &[Id],
         matcher: Option<&ArgMatcher>,
         incl_last: bool,
-    ) -> IndexSet<String> {
+    ) -> FlatSet<String> {
         debug!(
             "Usage::get_required_usage_from: incls={:?}, matcher={:?}, incl_last={:?}",
             incls,
             matcher.is_some(),
             incl_last
         );
-        let mut ret_val = IndexSet::new();
+        let mut ret_val = FlatSet::new();
 
-        let mut unrolled_reqs = IndexSet::new();
+        let mut unrolled_reqs = FlatSet::new();
 
         let required_owned;
         let required = if let Some(required) = self.required {
@@ -378,9 +377,9 @@ impl<'help, 'cmd> Usage<'help, 'cmd> {
             unrolled_reqs
         );
 
-        let mut required_groups_members = IndexSet::new();
-        let mut required_opts = IndexSet::new();
-        let mut required_groups = IndexSet::new();
+        let mut required_groups_members = FlatSet::new();
+        let mut required_opts = FlatSet::new();
+        let mut required_groups = FlatSet::new();
         let mut required_positionals = Vec::new();
         for req in unrolled_reqs.iter().chain(incls.iter()) {
             if let Some(arg) = self.cmd.find(req) {

--- a/src/parser/arg_matcher.rs
+++ b/src/parser/arg_matcher.rs
@@ -1,5 +1,4 @@
 // Std
-use std::collections::HashMap;
 use std::ffi::OsString;
 use std::mem;
 use std::ops::Deref;
@@ -10,6 +9,7 @@ use crate::parser::AnyValue;
 use crate::parser::Identifier;
 use crate::parser::PendingArg;
 use crate::parser::{ArgMatches, MatchedArg, SubCommand, ValueSource};
+use crate::util::FlatMap;
 use crate::util::Id;
 use crate::INTERNAL_ERROR_MSG;
 
@@ -46,14 +46,14 @@ impl ArgMatcher {
             "ArgMatcher::get_global_values: global_arg_vec={:?}",
             global_arg_vec
         );
-        let mut vals_map = HashMap::new();
+        let mut vals_map = FlatMap::new();
         self.fill_in_global_values(global_arg_vec, &mut vals_map);
     }
 
     fn fill_in_global_values(
         &mut self,
         global_arg_vec: &[Id],
-        vals_map: &mut HashMap<Id, MatchedArg>,
+        vals_map: &mut FlatMap<Id, MatchedArg>,
     ) {
         for global_arg in global_arg_vec {
             if let Some(ma) = self.get(global_arg) {
@@ -99,18 +99,18 @@ impl ArgMatcher {
     }
 
     pub(crate) fn remove(&mut self, arg: &Id) {
-        self.matches.args.swap_remove(arg);
+        self.matches.args.remove(arg);
     }
 
     pub(crate) fn contains(&self, arg: &Id) -> bool {
         self.matches.args.contains_key(arg)
     }
 
-    pub(crate) fn arg_ids(&self) -> indexmap::map::Keys<Id, MatchedArg> {
+    pub(crate) fn arg_ids(&self) -> std::slice::Iter<'_, Id> {
         self.matches.args.keys()
     }
 
-    pub(crate) fn entry(&mut self, arg: &Id) -> indexmap::map::Entry<Id, MatchedArg> {
+    pub(crate) fn entry(&mut self, arg: &Id) -> crate::util::Entry<Id, MatchedArg> {
         self.matches.args.entry(arg.clone())
     }
 

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -5,15 +5,13 @@ use std::fmt::Debug;
 use std::iter::{Cloned, Flatten, Map};
 use std::slice::Iter;
 
-// Third Party
-use indexmap::IndexMap;
-
 // Internal
 use crate::parser::AnyValue;
 use crate::parser::AnyValueId;
 use crate::parser::MatchedArg;
 use crate::parser::MatchesError;
 use crate::parser::ValueSource;
+use crate::util::FlatMap;
 use crate::util::{Id, Key};
 use crate::INTERNAL_ERROR_MSG;
 
@@ -68,7 +66,7 @@ pub struct ArgMatches {
     pub(crate) valid_args: Vec<Id>,
     #[cfg(debug_assertions)]
     pub(crate) valid_subcommands: Vec<Id>,
-    pub(crate) args: IndexMap<Id, MatchedArg>,
+    pub(crate) args: FlatMap<Id, MatchedArg>,
     pub(crate) subcommand: Option<Box<SubCommand>>,
 }
 

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -5,6 +5,7 @@ use crate::output::fmt::Stream;
 use crate::output::Usage;
 use crate::parser::{ArgMatcher, ParseState};
 use crate::util::ChildGraph;
+use crate::util::FlatSet;
 use crate::util::Id;
 use crate::INTERNAL_ERROR_MSG;
 
@@ -153,7 +154,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
         }
 
         debug!("Validator::build_conflict_err: name={:?}", name);
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = FlatSet::new();
         let conflicts = conflict_ids
             .iter()
             .flat_map(|c_id| {

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -5,6 +5,7 @@ use crate::output::fmt::Stream;
 use crate::output::Usage;
 use crate::parser::{ArgMatcher, ParseState};
 use crate::util::ChildGraph;
+use crate::util::FlatMap;
 use crate::util::FlatSet;
 use crate::util::Id;
 use crate::INTERNAL_ERROR_MSG;
@@ -383,7 +384,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
 
 #[derive(Default, Clone, Debug)]
 struct Conflicts {
-    potential: std::collections::HashMap<Id, Vec<Id>>,
+    potential: FlatMap<Id, Vec<Id>>,
 }
 
 impl Conflicts {

--- a/src/util/flat_map.rs
+++ b/src/util/flat_map.rs
@@ -1,0 +1,190 @@
+use std::borrow::Borrow;
+
+/// Flat (Vec) backed map
+///
+/// This preserves insertion order
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FlatMap<K, V> {
+    keys: Vec<K>,
+    values: Vec<V>,
+}
+
+impl<K: PartialEq + Eq, V> FlatMap<K, V> {
+    pub(crate) fn new() -> Self {
+        Default::default()
+    }
+
+    pub(crate) fn insert(&mut self, key: K, mut value: V) -> Option<V> {
+        for (index, existing) in self.keys.iter().enumerate() {
+            if *existing == key {
+                std::mem::swap(&mut self.values[index], &mut value);
+                return Some(value);
+            }
+        }
+
+        self.keys.push(key);
+        self.values.push(value);
+        None
+    }
+
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        for existing in &self.keys {
+            if existing.borrow() == key {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        let index = self
+            .keys
+            .iter()
+            .enumerate()
+            .find_map(|(i, k)| (k.borrow() == key).then(|| i))?;
+        self.keys.remove(index);
+        Some(self.values.remove(index))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
+    pub fn entry(&mut self, key: K) -> Entry<K, V> {
+        for (index, existing) in self.keys.iter().enumerate() {
+            if *existing == key {
+                return Entry::Occupied(OccupiedEntry { v: self, index });
+            }
+        }
+        Entry::Vacant(VacantEntry { v: self, key })
+    }
+
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        for (index, existing) in self.keys.iter().enumerate() {
+            if existing.borrow() == k {
+                return Some(&self.values[index]);
+            }
+        }
+        None
+    }
+
+    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        for (index, existing) in self.keys.iter().enumerate() {
+            if existing.borrow() == k {
+                return Some(&mut self.values[index]);
+            }
+        }
+        None
+    }
+
+    pub fn keys(&self) -> std::slice::Iter<'_, K> {
+        self.keys.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<K, V> {
+        IterMut {
+            keys: self.keys.iter_mut(),
+            values: self.values.iter_mut(),
+        }
+    }
+}
+
+impl<K: PartialEq + Eq, V> Default for FlatMap<K, V> {
+    fn default() -> Self {
+        Self {
+            keys: Default::default(),
+            values: Default::default(),
+        }
+    }
+}
+
+pub enum Entry<'a, K: 'a, V: 'a> {
+    Vacant(VacantEntry<'a, K, V>),
+    Occupied(OccupiedEntry<'a, K, V>),
+}
+
+impl<'a, K: 'a, V: 'a> Entry<'a, K, V> {
+    pub fn or_insert(self, default: V) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => &mut entry.v.values[entry.index],
+            Entry::Vacant(entry) => {
+                entry.v.keys.push(entry.key);
+                entry.v.values.push(default);
+                entry.v.values.last_mut().unwrap()
+            }
+        }
+    }
+
+    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        match self {
+            Entry::Occupied(entry) => &mut entry.v.values[entry.index],
+            Entry::Vacant(entry) => {
+                entry.v.keys.push(entry.key);
+                entry.v.values.push(default());
+                entry.v.values.last_mut().unwrap()
+            }
+        }
+    }
+}
+
+pub struct VacantEntry<'a, K: 'a, V: 'a> {
+    v: &'a mut FlatMap<K, V>,
+    key: K,
+}
+
+pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
+    v: &'a mut FlatMap<K, V>,
+    index: usize,
+}
+
+pub struct IterMut<'a, K: 'a, V: 'a> {
+    keys: std::slice::IterMut<'a, K>,
+    values: std::slice::IterMut<'a, V>,
+}
+
+impl<'a, K, V> Iterator for IterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+
+    fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
+        match self.keys.next() {
+            Some(k) => {
+                let v = self.values.next().unwrap();
+                Some((k, v))
+            }
+            None => None,
+        }
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.keys.size_hint()
+    }
+}
+
+impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
+    fn next_back(&mut self) -> Option<(&'a K, &'a mut V)> {
+        match self.keys.next_back() {
+            Some(k) => {
+                let v = self.values.next_back().unwrap();
+                Some((k, v))
+            }
+            None => None,
+        }
+    }
+}
+
+impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {}

--- a/src/util/flat_set.rs
+++ b/src/util/flat_set.rs
@@ -1,0 +1,97 @@
+use std::borrow::Borrow;
+
+/// Flat (Vec) backed set
+///
+/// This preserves insertion order
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FlatSet<T> {
+    inner: Vec<T>,
+}
+
+impl<T: PartialEq + Eq> FlatSet<T> {
+    pub(crate) fn new() -> Self {
+        Default::default()
+    }
+
+    pub(crate) fn insert(&mut self, value: T) -> bool {
+        for existing in &self.inner {
+            if *existing == value {
+                return false;
+            }
+        }
+        self.inner.push(value);
+        true
+    }
+
+    pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        for existing in &self.inner {
+            if existing.borrow() == value {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        self.inner.retain(f);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.inner.iter()
+    }
+}
+
+impl<T: PartialEq + Eq> Default for FlatSet<T> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
+
+impl<T: PartialEq + Eq> IntoIterator for FlatSet<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'s, T: PartialEq + Eq> IntoIterator for &'s FlatSet<T> {
+    type Item = &'s T;
+    type IntoIter = std::slice::Iter<'s, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}
+
+impl<T: PartialEq + Eq> Extend<T> for FlatSet<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for value in iter {
+            self.insert(value);
+        }
+    }
+}
+
+impl<T: PartialEq + Eq> FromIterator<T> for FlatSet<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut set = Self::new();
+        for value in iter {
+            set.insert(value);
+        }
+        set
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::single_component_path_imports)]
 
+mod flat_set;
 mod fnv;
 mod graph;
 mod id;
@@ -7,6 +8,7 @@ mod str_to_bool;
 
 pub use self::fnv::Key;
 
+pub(crate) use self::flat_set::FlatSet;
 pub(crate) use self::str_to_bool::str_to_bool;
 pub(crate) use self::str_to_bool::FALSE_LITERALS;
 pub(crate) use self::str_to_bool::TRUE_LITERALS;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::single_component_path_imports)]
 
+mod flat_map;
 mod flat_set;
 mod fnv;
 mod graph;
@@ -8,6 +9,8 @@ mod str_to_bool;
 
 pub use self::fnv::Key;
 
+pub(crate) use self::flat_map::Entry;
+pub(crate) use self::flat_map::FlatMap;
 pub(crate) use self::flat_set::FlatSet;
 pub(crate) use self::str_to_bool::str_to_bool;
 pub(crate) use self::str_to_bool::FALSE_LITERALS;


### PR DESCRIPTION
For the number of items we manage, straight iteration is probably fast enough or faster and this reduces the amount of memory we use.

The map is modeled after the proposed version in C++ so that the keys are more likely to be in cache lines.  If we ever add sorting to this, it'll get messy though.  Since this is all internal, direct types are exposed rather than newtypes.

This is a good step towards #1365.  The `.text` size dropped by 30.8KB according to 
```console
$ cargo bloat --features cargo --example cargo-example --release
```

While I didn't measure build times, things should be improved for #2037 because we are sending less code to LLVM.