### PR TITLE
fix!: Prefer `IntoIterator` over `&[]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `Command::disable_version_flag`) and mark the custom flags as `global(true)`.
 - Looking up a group in `ArgMatches` now returns the arg `Id`s, rather than the values.
 - Various `Arg`, `Command`, and `ArgGroup` calls were switched from accepting `&[]` to `[]` via `IntoIterator`
+- `Arg::short_aliases` and other builder functions that took `&[]` need the `&` dropped
 - *(help)* Make `DeriveDisplayOrder` the default and removed the setting.  To sort help, set `next_display_order(None)` (#2808)
 - *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value (#2808)
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)

--- a/clap_bench/benches/03_complex.rs
+++ b/clap_bench/benches/03_complex.rs
@@ -13,7 +13,7 @@ macro_rules! create_app {
             .arg(arg!(-o --option <opt> ... "tests options").required(false))
             .arg(arg!([positional] "tests positionals"))
             .arg(arg!(-f --flag ... "tests flags").global(true))
-            .args(&[
+            .args([
                 arg!(flag2: -F "tests flags with exclusions")
                     .conflicts_with("flag")
                     .requires("option2"),
@@ -27,10 +27,10 @@ macro_rules! create_app {
                     .value_parser(OPT3_VALS),
                 arg!([positional3] ... "tests positionals with specific values")
                     .value_parser(POS3_VALS),
-                arg!(--multvals <s> "Tests multiple values not mult occs").required(false).value_names(&["one", "two"]),
+                arg!(--multvals <s> "Tests multiple values not mult occs").required(false).value_names(["one", "two"]),
                 arg!(
                     --multvalsmo <s> "Tests multiple values, not mult occs"
-                ).required(false).value_names(&["one", "two"]),
+                ).required(false).value_names(["one", "two"]),
                 arg!(--minvals2 <minvals> ... "Tests 2 min vals").num_args(2..).required(false),
                 arg!(--maxvals3 <maxvals> ... "Tests 3 max vals").num_args(1..=3).required(false),
             ])
@@ -109,14 +109,14 @@ pub fn build_from_builder(c: &mut Criterion) {
                     Arg::new("multvals")
                         .long("multvals")
                         .help("Tests multiple values, not mult occs")
-                        .value_names(&["one", "two"]),
+                        .value_names(["one", "two"]),
                 )
                 .arg(
                     Arg::new("multvalsmo")
                         .long("multvalsmo")
                         .action(ArgAction::Append)
                         .help("Tests multiple values, not mult occs")
-                        .value_names(&["one", "two"]),
+                        .value_names(["one", "two"]),
                 )
                 .arg(
                     Arg::new("minvals")

--- a/clap_bench/benches/04_new_help.rs
+++ b/clap_bench/benches/04_new_help.rs
@@ -45,7 +45,7 @@ fn app_example3<'c>() -> Command<'c> {
                 .short('d')
                 .action(ArgAction::SetTrue),
         )
-        .args(&[
+        .args([
             Arg::new("config")
                 .help("sets the config file to use")
                 .action(ArgAction::Set)

--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -561,7 +561,7 @@ impl Attrs {
                                 static DEFAULT_VALUES: clap::__macro_refs::once_cell::sync::Lazy<Vec<&str>> = clap::__macro_refs::once_cell::sync::Lazy::new(|| {
                                     iter_to_vals(#expr)
                                 });
-                                &*DEFAULT_VALUES.as_slice()
+                                DEFAULT_VALUES.iter().copied()
                             }
                         })
                     } else {
@@ -582,7 +582,7 @@ impl Attrs {
                                 static DEFAULT_VALUES: clap::__macro_refs::once_cell::sync::Lazy<Vec<&str>> = clap::__macro_refs::once_cell::sync::Lazy::new(|| {
                                     DEFAULT_STRINGS.iter().map(::std::string::String::as_str).collect()
                                 });
-                                &*DEFAULT_VALUES.as_slice()
+                                DEFAULT_VALUES.iter().copied()
                             }
                         })
                     };
@@ -677,7 +677,7 @@ impl Attrs {
                                 static DEFAULT_VALUES: clap::__macro_refs::once_cell::sync::Lazy<Vec<&::std::ffi::OsStr>> = clap::__macro_refs::once_cell::sync::Lazy::new(|| {
                                     iter_to_vals(#expr)
                                 });
-                                &*DEFAULT_VALUES.as_slice()
+                                DEFAULT_VALUES.iter().copied()
                             }
                         })
                     } else {
@@ -698,7 +698,7 @@ impl Attrs {
                                 static DEFAULT_VALUES: clap::__macro_refs::once_cell::sync::Lazy<Vec<&::std::ffi::OsStr>> = clap::__macro_refs::once_cell::sync::Lazy::new(|| {
                                     DEFAULT_OS_STRINGS.iter().map(::std::ffi::OsString::as_os_str).collect()
                                 });
-                                &*DEFAULT_VALUES.as_slice()
+                                DEFAULT_VALUES.iter().copied()
                             }
                         })
                     };

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -247,7 +247,7 @@ impl<'help> Arg<'help> {
     /// let m = Command::new("prog")
     ///             .arg(Arg::new("test")
     ///                     .long("test")
-    ///                     .aliases(&["do-stuff", "do-tests", "tests"])
+    ///                     .aliases(["do-stuff", "do-tests", "tests"])
     ///                     .action(ArgAction::SetTrue)
     ///                     .help("the file to add")
     ///                     .required(false))
@@ -257,8 +257,9 @@ impl<'help> Arg<'help> {
     /// assert_eq!(*m.get_one::<bool>("test").expect("defaulted by clap"), true);
     /// ```
     #[must_use]
-    pub fn aliases(mut self, names: &[&'help str]) -> Self {
-        self.aliases.extend(names.iter().map(|&x| (x, false)));
+    pub fn aliases(mut self, names: impl IntoIterator<Item = impl Into<&'help str>>) -> Self {
+        self.aliases
+            .extend(names.into_iter().map(|x| (x.into(), false)));
         self
     }
 
@@ -274,7 +275,7 @@ impl<'help> Arg<'help> {
     /// let m = Command::new("prog")
     ///             .arg(Arg::new("test")
     ///                     .short('t')
-    ///                     .short_aliases(&['e', 's'])
+    ///                     .short_aliases(['e', 's'])
     ///                     .action(ArgAction::SetTrue)
     ///                     .help("the file to add")
     ///                     .required(false))
@@ -284,10 +285,10 @@ impl<'help> Arg<'help> {
     /// assert_eq!(*m.get_one::<bool>("test").expect("defaulted by clap"), true);
     /// ```
     #[must_use]
-    pub fn short_aliases(mut self, names: &[char]) -> Self {
+    pub fn short_aliases(mut self, names: impl IntoIterator<Item = char>) -> Self {
         for s in names {
-            assert!(s != &'-', "short alias name cannot be `-`");
-            self.short_aliases.push((*s, false));
+            assert!(s != '-', "short alias name cannot be `-`");
+            self.short_aliases.push((s, false));
         }
         self
     }
@@ -355,7 +356,7 @@ impl<'help> Arg<'help> {
     ///             .arg(Arg::new("test")
     ///                 .long("test")
     ///                 .action(ArgAction::SetTrue)
-    ///                 .visible_aliases(&["something", "awesome", "cool"]))
+    ///                 .visible_aliases(["something", "awesome", "cool"]))
     ///        .get_matches_from(vec![
     ///             "prog", "--awesome"
     ///         ]);
@@ -363,8 +364,12 @@ impl<'help> Arg<'help> {
     /// ```
     /// [`Command::aliases`]: Arg::aliases()
     #[must_use]
-    pub fn visible_aliases(mut self, names: &[&'help str]) -> Self {
-        self.aliases.extend(names.iter().map(|n| (*n, true)));
+    pub fn visible_aliases(
+        mut self,
+        names: impl IntoIterator<Item = impl Into<&'help str>>,
+    ) -> Self {
+        self.aliases
+            .extend(names.into_iter().map(|n| (n.into(), true)));
         self
     }
 
@@ -380,17 +385,17 @@ impl<'help> Arg<'help> {
     ///             .arg(Arg::new("test")
     ///                 .long("test")
     ///                 .action(ArgAction::SetTrue)
-    ///                 .visible_short_aliases(&['t', 'e']))
+    ///                 .visible_short_aliases(['t', 'e']))
     ///        .get_matches_from(vec![
     ///             "prog", "-t"
     ///         ]);
     /// assert_eq!(*m.get_one::<bool>("test").expect("defaulted by clap"), true);
     /// ```
     #[must_use]
-    pub fn visible_short_aliases(mut self, names: &[char]) -> Self {
+    pub fn visible_short_aliases(mut self, names: impl IntoIterator<Item = char>) -> Self {
         for n in names {
-            assert!(n != &'-', "short alias name cannot be `-`");
-            self.short_aliases.push((*n, true));
+            assert!(n != '-', "short alias name cannot be `-`");
+            self.short_aliases.push((n, true));
         }
         self
     }
@@ -1070,7 +1075,7 @@ impl<'help> Arg<'help> {
     #[inline]
     #[must_use]
     pub fn value_name(self, name: &'help str) -> Self {
-        self.value_names(&[name])
+        self.value_names([name])
     }
 
     /// Placeholders for the argument's values in the help message / usage.
@@ -1095,7 +1100,7 @@ impl<'help> Arg<'help> {
     /// # use clap::{Command, Arg};
     /// Arg::new("speed")
     ///     .short('s')
-    ///     .value_names(&["fast", "slow"]);
+    ///     .value_names(["fast", "slow"]);
     /// ```
     ///
     /// ```rust
@@ -1103,7 +1108,7 @@ impl<'help> Arg<'help> {
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("io")
     ///         .long("io-files")
-    ///         .value_names(&["INFILE", "OUTFILE"]))
+    ///         .value_names(["INFILE", "OUTFILE"]))
     ///     .get_matches_from(vec![
     ///         "prog", "--help"
     ///     ]);
@@ -1127,8 +1132,8 @@ impl<'help> Arg<'help> {
     /// [`Arg::action(ArgAction::Set)`]: Arg::action()
     /// [`Arg::num_args(1..)`]: Arg::num_args()
     #[must_use]
-    pub fn value_names(mut self, names: &[&'help str]) -> Self {
-        self.val_names = names.to_vec();
+    pub fn value_names(mut self, names: impl IntoIterator<Item = impl Into<&'help str>>) -> Self {
+        self.val_names = names.into_iter().map(|s| s.into()).collect();
         self
     }
 
@@ -1509,7 +1514,7 @@ impl<'help> Arg<'help> {
     #[inline]
     #[must_use]
     pub fn default_value(self, val: &'help str) -> Self {
-        self.default_values_os(&[OsStr::new(val)])
+        self.default_values_os([OsStr::new(val)])
     }
 
     /// Value for the argument when not present.
@@ -1521,7 +1526,7 @@ impl<'help> Arg<'help> {
     #[inline]
     #[must_use]
     pub fn default_value_os(self, val: &'help OsStr) -> Self {
-        self.default_values_os(&[val])
+        self.default_values_os([val])
     }
 
     /// Value for the argument when not present.
@@ -1531,9 +1536,9 @@ impl<'help> Arg<'help> {
     /// [`Arg::default_value`]: Arg::default_value()
     #[inline]
     #[must_use]
-    pub fn default_values(self, vals: &[&'help str]) -> Self {
-        let vals_vec: Vec<_> = vals.iter().map(|val| OsStr::new(*val)).collect();
-        self.default_values_os(&vals_vec[..])
+    pub fn default_values(self, vals: impl IntoIterator<Item = impl Into<&'help str>>) -> Self {
+        let vals_vec = vals.into_iter().map(|val| OsStr::new(val.into()));
+        self.default_values_os(vals_vec)
     }
 
     /// Value for the argument when not present.
@@ -1544,8 +1549,11 @@ impl<'help> Arg<'help> {
     /// [`OsStr`]: std::ffi::OsStr
     #[inline]
     #[must_use]
-    pub fn default_values_os(mut self, vals: &[&'help OsStr]) -> Self {
-        self.default_vals = vals.to_vec();
+    pub fn default_values_os(
+        mut self,
+        vals: impl IntoIterator<Item = impl Into<&'help OsStr>>,
+    ) -> Self {
+        self.default_vals = vals.into_iter().map(|s| s.into()).collect();
         self
     }
 
@@ -1641,7 +1649,7 @@ impl<'help> Arg<'help> {
     #[inline]
     #[must_use]
     pub fn default_missing_value(self, val: &'help str) -> Self {
-        self.default_missing_values_os(&[OsStr::new(val)])
+        self.default_missing_values_os([OsStr::new(val)])
     }
 
     /// Value for the argument when the flag is present but no value is specified.
@@ -1653,7 +1661,7 @@ impl<'help> Arg<'help> {
     #[inline]
     #[must_use]
     pub fn default_missing_value_os(self, val: &'help OsStr) -> Self {
-        self.default_missing_values_os(&[val])
+        self.default_missing_values_os([val])
     }
 
     /// Value for the argument when the flag is present but no value is specified.
@@ -1663,9 +1671,12 @@ impl<'help> Arg<'help> {
     /// [`Arg::default_missing_value`]: Arg::default_missing_value()
     #[inline]
     #[must_use]
-    pub fn default_missing_values(self, vals: &[&'help str]) -> Self {
-        let vals_vec: Vec<_> = vals.iter().map(|val| OsStr::new(*val)).collect();
-        self.default_missing_values_os(&vals_vec[..])
+    pub fn default_missing_values(
+        self,
+        vals: impl IntoIterator<Item = impl Into<&'help str>>,
+    ) -> Self {
+        let vals_vec = vals.into_iter().map(|val| OsStr::new(val.into()));
+        self.default_missing_values_os(vals_vec)
     }
 
     /// Value for the argument when the flag is present but no value is specified.
@@ -1676,8 +1687,11 @@ impl<'help> Arg<'help> {
     /// [`OsStr`]: std::ffi::OsStr
     #[inline]
     #[must_use]
-    pub fn default_missing_values_os(mut self, vals: &[&'help OsStr]) -> Self {
-        self.default_missing_vals = vals.to_vec();
+    pub fn default_missing_values_os(
+        mut self,
+        vals: impl IntoIterator<Item = impl Into<&'help OsStr>>,
+    ) -> Self {
+        self.default_missing_vals = vals.into_iter().map(|s| s.into()).collect();
         self
     }
 
@@ -2049,7 +2063,7 @@ impl<'help> Arg<'help> {
     ///         .short('o')
     ///         .action(ArgAction::Set)
     ///         .next_line_help(true)
-    ///         .value_names(&["value1", "value2"])
+    ///         .value_names(["value1", "value2"])
     ///         .help("Some really long help and complex\n\
     ///                help that makes more sense to be\n\
     ///                on a line after the option"))
@@ -3046,7 +3060,7 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting `Arg::required_if_eq_any(&[(arg, val)])` makes this arg required if any of the `arg`s
+    /// Setting `Arg::required_if_eq_any([(arg, val)])` makes this arg required if any of the `arg`s
     /// are used at runtime and it's corresponding value is equal to `val`. If the `arg`'s value is
     /// anything other than `val`, this argument isn't required.
     ///
@@ -3073,7 +3087,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok()); // We didn't use --option=spec, or --extra=val so "cfg" isn't required
     /// ```
     ///
-    /// Setting `Arg::required_if_eq_any(&[(arg, val)])` and having any of the `arg`s used with its
+    /// Setting `Arg::required_if_eq_any([(arg, val)])` and having any of the `arg`s used with its
     /// value of `val` but *not* using this arg is an error.
     ///
     /// ```rust
@@ -3129,7 +3143,7 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting `Arg::required_if_eq_all(&[(arg, val)])` makes this arg required if all of the `arg`s
+    /// Setting `Arg::required_if_eq_all([(arg, val)])` makes this arg required if all of the `arg`s
     /// are used at runtime and every value is equal to its corresponding `val`. If the `arg`'s value is
     /// anything other than `val`, this argument isn't required.
     ///
@@ -3156,7 +3170,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok()); // We didn't use --option=spec --extra=val so "cfg" isn't required
     /// ```
     ///
-    /// Setting `Arg::required_if_eq_all(&[(arg, val)])` and having all of the `arg`s used with its
+    /// Setting `Arg::required_if_eq_all([(arg, val)])` and having all of the `arg`s used with its
     /// value of `val` but *not* using this arg is an error.
     ///
     /// ```rust
@@ -3271,7 +3285,7 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting `Arg::requires_ifs(&["val", "arg"])` requires that the `arg` be used at runtime if the
+    /// Setting `Arg::requires_ifs(["val", "arg"])` requires that the `arg` be used at runtime if the
     /// defining argument's value is equal to `val`. If the defining argument's value is anything other
     /// than `val`, `arg` isn't required.
     ///
@@ -3327,7 +3341,7 @@ impl<'help> Arg<'help> {
     /// # ;
     /// ```
     ///
-    /// Setting `Arg::requires_all(&[arg, arg2])` requires that all the arguments be used at
+    /// Setting `Arg::requires_all([arg, arg2])` requires that all the arguments be used at
     /// runtime if the defining argument is used. If the defining argument isn't used, the other
     /// argument isn't required
     ///
@@ -3347,7 +3361,7 @@ impl<'help> Arg<'help> {
     /// assert!(res.is_ok()); // We didn't use cfg, so input and output weren't required
     /// ```
     ///
-    /// Setting `Arg::requires_all(&[arg, arg2])` and *not* supplying all the arguments is an
+    /// Setting `Arg::requires_all([arg, arg2])` and *not* supplying all the arguments is an
     /// error.
     ///
     /// ```rust
@@ -4290,7 +4304,7 @@ mod test {
             .short('o')
             .action(ArgAction::Set)
             .num_args(0..)
-            .value_names(&["file"]);
+            .value_names(["file"]);
         o._build();
 
         assert_eq!(o.to_string(), "-o [<file>...]");
@@ -4302,7 +4316,7 @@ mod test {
             .short('o')
             .action(ArgAction::Set)
             .num_args(1..)
-            .value_names(&["file"]);
+            .value_names(["file"]);
         o._build();
 
         assert_eq!(o.to_string(), "-o <file>...");
@@ -4324,7 +4338,7 @@ mod test {
         let mut o = Arg::new("opt")
             .short('o')
             .action(ArgAction::Set)
-            .value_names(&["file", "name"]);
+            .value_names(["file", "name"]);
         o._build();
 
         assert_eq!(o.to_string(), "-o <file> <name>");
@@ -4336,7 +4350,7 @@ mod test {
             .short('o')
             .num_args(1..)
             .action(ArgAction::Set)
-            .value_names(&["file", "name"]);
+            .value_names(["file", "name"]);
         o._build();
 
         assert_eq!(o.to_string(), "-o <file> <name>...");
@@ -4358,7 +4372,7 @@ mod test {
         let mut o = Arg::new("opt")
             .long("option")
             .action(ArgAction::Set)
-            .visible_aliases(&["als2", "als3", "als4"])
+            .visible_aliases(["als2", "als3", "als4"])
             .alias("als_not_visible");
         o._build();
 
@@ -4381,7 +4395,7 @@ mod test {
         let mut o = Arg::new("opt")
             .short('a')
             .action(ArgAction::Set)
-            .visible_short_aliases(&['b', 'c', 'd'])
+            .visible_short_aliases(['b', 'c', 'd'])
             .short_alias('e');
         o._build();
 
@@ -4443,7 +4457,7 @@ mod test {
 
     #[test]
     fn positional_display_val_names() {
-        let mut p = Arg::new("pos").index(1).value_names(&["file1", "file2"]);
+        let mut p = Arg::new("pos").index(1).value_names(["file1", "file2"]);
         p._build();
 
         assert_eq!(p.to_string(), "<file1> <file2>");
@@ -4454,7 +4468,7 @@ mod test {
         let mut p = Arg::new("pos")
             .index(1)
             .required(true)
-            .value_names(&["file1", "file2"]);
+            .value_names(["file1", "file2"]);
         p._build();
 
         assert_eq!(p.to_string(), "<file1> <file2>");

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -181,7 +181,7 @@ impl<'help> Command<'help> {
     /// ```no_run
     /// # use clap::{Command, arg, Arg};
     /// Command::new("myprog")
-    ///     .args(&[
+    ///     .args([
     ///         arg!("[debug] -d 'turns on debugging info'"),
     ///         Arg::new("input").help("the input file to use")
     ///     ])
@@ -189,11 +189,7 @@ impl<'help> Command<'help> {
     /// ```
     /// [arguments]: Arg
     #[must_use]
-    pub fn args<I, T>(mut self, args: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Arg<'help>>,
-    {
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<Arg<'help>>>) -> Self {
         let args = args.into_iter();
         let (lower, _) = args.size_hint();
         self.args.reserve(lower);
@@ -336,7 +332,7 @@ impl<'help> Command<'help> {
     ///     .arg(arg!("--patch         'auto increase patch'"))
     ///     .arg(arg!("-c [FILE]       'a config file'"))
     ///     .arg(arg!("-i [IFACE]      'an interface'"))
-    ///     .groups(&[
+    ///     .groups([
     ///         ArgGroup::new("vers")
     ///             .args(["set-ver", "major", "minor","patch"])
     ///             .required(true),
@@ -346,11 +342,7 @@ impl<'help> Command<'help> {
     /// # ;
     /// ```
     #[must_use]
-    pub fn groups<I, T>(mut self, groups: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<ArgGroup>,
-    {
+    pub fn groups(mut self, groups: impl IntoIterator<Item = impl Into<ArgGroup>>) -> Self {
         for g in groups.into_iter() {
             self = self.group(g.into());
         }
@@ -401,7 +393,7 @@ impl<'help> Command<'help> {
     /// ```rust
     /// # use clap::{Command, Arg, };
     /// # Command::new("myprog")
-    /// .subcommands( vec![
+    /// .subcommands( [
     ///        Command::new("config").about("Controls configuration functionality")
     ///                                 .arg(Arg::new("config_file")),
     ///        Command::new("debug").about("Controls debug functionality")])
@@ -409,11 +401,7 @@ impl<'help> Command<'help> {
     /// ```
     /// [`IntoIterator`]: std::iter::IntoIterator
     #[must_use]
-    pub fn subcommands<I, T>(mut self, subcmds: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Self>,
-    {
+    pub fn subcommands(mut self, subcmds: impl IntoIterator<Item = impl Into<Self>>) -> Self {
         let subcmds = subcmds.into_iter();
         let (lower, _) = subcmds.size_hint();
         self.subcommands.reserve(lower);
@@ -2294,7 +2282,7 @@ impl<'help> Command<'help> {
     /// # use clap::{Command, Arg};
     /// let m = Command::new("myprog")
     ///     .subcommand(Command::new("test")
-    ///         .aliases(&["do-stuff", "do-tests", "tests"]))
+    ///         .aliases(["do-stuff", "do-tests", "tests"]))
     ///         .arg(Arg::new("input")
     ///             .help("the file to add")
     ///             .required(false))
@@ -2303,8 +2291,9 @@ impl<'help> Command<'help> {
     /// ```
     /// [`Command::visible_aliases`]: Command::visible_aliases()
     #[must_use]
-    pub fn aliases(mut self, names: &[&'help str]) -> Self {
-        self.aliases.extend(names.iter().map(|n| (*n, false)));
+    pub fn aliases(mut self, names: impl IntoIterator<Item = impl Into<&'help str>>) -> Self {
+        self.aliases
+            .extend(names.into_iter().map(|n| (n.into(), false)));
         self
     }
 
@@ -2320,7 +2309,7 @@ impl<'help> Command<'help> {
     /// # use clap::{Command, Arg, };
     /// let m = Command::new("myprog")
     ///     .subcommand(Command::new("test").short_flag('t')
-    ///         .short_flag_aliases(&['a', 'b', 'c']))
+    ///         .short_flag_aliases(['a', 'b', 'c']))
     ///         .arg(Arg::new("input")
     ///             .help("the file to add")
     ///             .required(false))
@@ -2328,10 +2317,10 @@ impl<'help> Command<'help> {
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
     #[must_use]
-    pub fn short_flag_aliases(mut self, names: &[char]) -> Self {
+    pub fn short_flag_aliases(mut self, names: impl IntoIterator<Item = char>) -> Self {
         for s in names {
-            assert!(s != &'-', "short alias name cannot be `-`");
-            self.short_flag_aliases.push((*s, false));
+            assert!(s != '-', "short alias name cannot be `-`");
+            self.short_flag_aliases.push((s, false));
         }
         self
     }
@@ -2348,7 +2337,7 @@ impl<'help> Command<'help> {
     /// # use clap::{Command, Arg, };
     /// let m = Command::new("myprog")
     ///             .subcommand(Command::new("test").long_flag("test")
-    ///                 .long_flag_aliases(&["testing", "testall", "test_all"]))
+    ///                 .long_flag_aliases(["testing", "testall", "test_all"]))
     ///                 .arg(Arg::new("input")
     ///                             .help("the file to add")
     ///                             .required(false))
@@ -2356,9 +2345,12 @@ impl<'help> Command<'help> {
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
     #[must_use]
-    pub fn long_flag_aliases(mut self, names: &[&'help str]) -> Self {
+    pub fn long_flag_aliases(
+        mut self,
+        names: impl IntoIterator<Item = impl Into<&'help str>>,
+    ) -> Self {
         for s in names {
-            self.long_flag_aliases.push((s, false));
+            self.long_flag_aliases.push((s.into(), false));
         }
         self
     }
@@ -2469,14 +2461,18 @@ impl<'help> Command<'help> {
     /// # use clap::{Command, Arg, };
     /// let m = Command::new("myprog")
     ///     .subcommand(Command::new("test")
-    ///         .visible_aliases(&["do-stuff", "tests"]))
+    ///         .visible_aliases(["do-stuff", "tests"]))
     ///     .get_matches_from(vec!["myprog", "do-stuff"]);
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
     /// [`Command::alias`]: Command::alias()
     #[must_use]
-    pub fn visible_aliases(mut self, names: &[&'help str]) -> Self {
-        self.aliases.extend(names.iter().map(|n| (*n, true)));
+    pub fn visible_aliases(
+        mut self,
+        names: impl IntoIterator<Item = impl Into<&'help str>>,
+    ) -> Self {
+        self.aliases
+            .extend(names.into_iter().map(|n| (n.into(), true)));
         self
     }
 
@@ -2490,16 +2486,16 @@ impl<'help> Command<'help> {
     /// # use clap::{Command, Arg, };
     /// let m = Command::new("myprog")
     ///             .subcommand(Command::new("test").short_flag('b')
-    ///                 .visible_short_flag_aliases(&['t']))
+    ///                 .visible_short_flag_aliases(['t']))
     ///             .get_matches_from(vec!["myprog", "-t"]);
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
     /// [`Command::short_flag_aliases`]: Command::short_flag_aliases()
     #[must_use]
-    pub fn visible_short_flag_aliases(mut self, names: &[char]) -> Self {
+    pub fn visible_short_flag_aliases(mut self, names: impl IntoIterator<Item = char>) -> Self {
         for s in names {
-            assert!(s != &'-', "short alias name cannot be `-`");
-            self.short_flag_aliases.push((*s, true));
+            assert!(s != '-', "short alias name cannot be `-`");
+            self.short_flag_aliases.push((s, true));
         }
         self
     }
@@ -2514,15 +2510,18 @@ impl<'help> Command<'help> {
     /// # use clap::{Command, Arg, };
     /// let m = Command::new("myprog")
     ///             .subcommand(Command::new("test").long_flag("test")
-    ///                 .visible_long_flag_aliases(&["testing", "testall", "test_all"]))
+    ///                 .visible_long_flag_aliases(["testing", "testall", "test_all"]))
     ///             .get_matches_from(vec!["myprog", "--testing"]);
     /// assert_eq!(m.subcommand_name(), Some("test"));
     /// ```
     /// [`Command::long_flag_aliases`]: Command::long_flag_aliases()
     #[must_use]
-    pub fn visible_long_flag_aliases(mut self, names: &[&'help str]) -> Self {
+    pub fn visible_long_flag_aliases(
+        mut self,
+        names: impl IntoIterator<Item = impl Into<&'help str>>,
+    ) -> Self {
         for s in names {
-            self.long_flag_aliases.push((s, true));
+            self.long_flag_aliases.push((s.into(), true));
         }
         self
     }
@@ -4481,6 +4480,12 @@ impl<'help> Index<&'_ Id> for Command<'help> {
 
     fn index(&self, key: &Id) -> &Self::Output {
         self.find(key).expect(INTERNAL_ERROR_MSG)
+    }
+}
+
+impl<'help> From<&'_ Command<'help>> for Command<'help> {
+    fn from(cmd: &'_ Command<'help>) -> Self {
+        cmd.clone()
     }
 }
 

--- a/src/builder/possible_value.rs
+++ b/src/builder/possible_value.rs
@@ -225,8 +225,8 @@ impl<'help> From<&'help str> for PossibleValue<'help> {
     }
 }
 
-impl<'help> From<&'help &'help str> for PossibleValue<'help> {
-    fn from(s: &'help &'help str) -> Self {
+impl<'help> From<&'_ &'help str> for PossibleValue<'help> {
+    fn from(s: &'_ &'help str) -> Self {
         Self::new(s)
     }
 }

--- a/src/util/id.rs
+++ b/src/util/id.rs
@@ -49,8 +49,8 @@ impl From<String> for Id {
     }
 }
 
-impl<'s> From<&'s String> for Id {
-    fn from(name: &'s String) -> Self {
+impl From<&'_ String> for Id {
+    fn from(name: &'_ String) -> Self {
         Self::from_ref(name.as_str())
     }
 }
@@ -58,6 +58,12 @@ impl<'s> From<&'s String> for Id {
 impl From<&'static str> for Id {
     fn from(name: &'static str) -> Self {
         Self::from_static_ref(name)
+    }
+}
+
+impl From<&'_ &'static str> for Id {
+    fn from(name: &'_ &'static str) -> Self {
+        Self::from_static_ref(*name)
     }
 }
 

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -29,7 +29,7 @@ fn multiple_aliases_of_option() {
             .long("aliases")
             .action(ArgAction::Set)
             .help("multiple aliases")
-            .aliases(&["alias1", "alias2", "alias3"]),
+            .aliases(["alias1", "alias2", "alias3"]),
     );
     let long = a
         .clone()
@@ -91,10 +91,10 @@ fn get_aliases() {
         .long("aliases")
         .action(ArgAction::Set)
         .help("multiple aliases")
-        .aliases(&["alias1", "alias2", "alias3"])
-        .short_aliases(&['a', 'b', 'c'])
-        .visible_aliases(&["alias4", "alias5", "alias6"])
-        .visible_short_aliases(&['d', 'e', 'f']);
+        .aliases(["alias1", "alias2", "alias3"])
+        .short_aliases(['a', 'b', 'c'])
+        .visible_aliases(["alias4", "alias5", "alias6"])
+        .visible_short_aliases(['d', 'e', 'f']);
 
     assert!(a.get_short_and_visible_aliases().is_none());
     assert_eq!(
@@ -136,7 +136,7 @@ fn multiple_aliases_of_flag() {
     let a = Command::new("test").arg(
         Arg::new("flag")
             .long("flag")
-            .aliases(&["invisible", "set", "of", "cool", "aliases"])
+            .aliases(["invisible", "set", "of", "cool", "aliases"])
             .action(ArgAction::SetTrue),
     );
 
@@ -175,7 +175,7 @@ fn alias_on_a_subcommand_option() {
                     .help("testing testing"),
             ),
         )
-        .arg(Arg::new("other").long("other").aliases(&["o1", "o2", "o3"]))
+        .arg(Arg::new("other").long("other").aliases(["o1", "o2", "o3"]))
         .try_get_matches_from(vec!["test", "some", "--opt", "awesome"])
         .unwrap();
 
@@ -212,9 +212,9 @@ OPTIONS:
                     .long("opt")
                     .short('o')
                     .action(ArgAction::Set)
-                    .aliases(&["invisible", "als1", "more"]),
+                    .aliases(["invisible", "als1", "more"]),
             )
-            .arg(arg!(-f - -flag).aliases(&["unseeable", "flg1", "anyway"])),
+            .arg(arg!(-f - -flag).aliases(["unseeable", "flg1", "anyway"])),
     );
     utils::assert_output(cmd, "ct test --help", SC_INVISIBLE_ALIAS_HELP, false);
 }
@@ -251,7 +251,7 @@ OPTIONS:
                     .long("flag")
                     .short('f')
                     .action(ArgAction::SetTrue)
-                    .visible_aliases(&["v_flg", "flag2", "flg3"]),
+                    .visible_aliases(["v_flg", "flag2", "flg3"]),
             ),
     );
     utils::assert_output(cmd, "ct test --help", SC_VISIBLE_ALIAS_HELP, false);

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -29,7 +29,7 @@ fn multiple_short_aliases_of_option() {
             .long("aliases")
             .action(ArgAction::Set)
             .help("multiple aliases")
-            .short_aliases(&['1', '2', '3']),
+            .short_aliases(['1', '2', '3']),
     );
     let long = a
         .clone()
@@ -99,7 +99,7 @@ fn multiple_short_aliases_of_flag() {
     let a = Command::new("test").arg(
         Arg::new("flag")
             .long("flag")
-            .short_aliases(&['a', 'b', 'c', 'd', 'e'])
+            .short_aliases(['a', 'b', 'c', 'd', 'e'])
             .action(ArgAction::SetTrue),
     );
 
@@ -141,7 +141,7 @@ fn short_alias_on_a_subcommand_option() {
         .arg(
             Arg::new("other")
                 .long("other")
-                .short_aliases(&['1', '2', '3']),
+                .short_aliases(['1', '2', '3']),
         )
         .try_get_matches_from(vec!["test", "some", "-o", "awesome"])
         .unwrap();
@@ -179,9 +179,9 @@ OPTIONS:
                     .long("opt")
                     .short('o')
                     .action(ArgAction::Set)
-                    .short_aliases(&['a', 'b', 'c']),
+                    .short_aliases(['a', 'b', 'c']),
             )
-            .arg(arg!(-f - -flag).short_aliases(&['x', 'y', 'z'])),
+            .arg(arg!(-f - -flag).short_aliases(['x', 'y', 'z'])),
     );
     utils::assert_output(cmd, "ct test --help", SC_INVISIBLE_ALIAS_HELP, false);
 }
@@ -219,7 +219,7 @@ OPTIONS:
                     .short('f')
                     .action(ArgAction::SetTrue)
                     .visible_alias("flag1")
-                    .visible_short_aliases(&['a', 'b', '🦆']),
+                    .visible_short_aliases(['a', 'b', '🦆']),
             ),
     );
     utils::assert_output(cmd, "ct test --help", SC_VISIBLE_ALIAS_HELP, false);

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -675,7 +675,7 @@ fn multiple_defaults() {
             Arg::new("files")
                 .long("files")
                 .num_args(2)
-                .default_values(&["old", "new"]),
+                .default_values(["old", "new"]),
         )
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -694,7 +694,7 @@ fn multiple_defaults_override() {
             Arg::new("files")
                 .long("files")
                 .num_args(2)
-                .default_values(&["old", "new"]),
+                .default_values(["old", "new"]),
         )
         .try_get_matches_from(vec!["", "--files", "other", "mine"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -873,7 +873,7 @@ fn missing_with_value_delimiter() {
             .long("option")
             .value_delimiter(';')
             .num_args(0..=1)
-            .default_missing_values(&["value1;value2;value3", "value4;value5"]),
+            .default_missing_values(["value1;value2;value3", "value4;value5"]),
     );
 
     let matches = cmd

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -148,7 +148,7 @@ fn flag_subcommand_short_with_aliases_vis_and_hidden() {
                     .long("test")
                     .help("testing testing"),
             )
-            .visible_short_flag_aliases(&['M', 'B'])
+            .visible_short_flag_aliases(['M', 'B'])
             .short_flag_alias('C'),
     );
     let app1 = cmd.clone();
@@ -177,7 +177,7 @@ fn flag_subcommand_short_with_aliases() {
                         .help("testing testing")
                         .action(ArgAction::SetTrue),
                 )
-                .short_flag_aliases(&['M', 'B']),
+                .short_flag_aliases(['M', 'B']),
         )
         .try_get_matches_from(vec!["myprog", "-Bt"])
         .unwrap();
@@ -220,7 +220,7 @@ fn flag_subcommand_short_with_aliases_hyphen() {
                         .long("test")
                         .help("testing testing"),
                 )
-                .short_flag_aliases(&['-', '-', '-']),
+                .short_flag_aliases(['-', '-', '-']),
         )
         .try_get_matches_from(vec!["myprog", "-Bt"])
         .unwrap();
@@ -301,7 +301,7 @@ fn flag_subcommand_long_with_aliases() {
                         .help("testing testing")
                         .action(ArgAction::SetTrue),
                 )
-                .long_flag_aliases(&["result", "someall"]),
+                .long_flag_aliases(["result", "someall"]),
         )
         .try_get_matches_from(vec!["myprog", "--result", "--test"])
         .unwrap();

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1611,7 +1611,7 @@ OPTIONS:
         .arg(
             arg!(-f --fake <s> "some help")
                 .required(true)
-                .value_names(&["some", "val"])
+                .value_names(["some", "val"])
                 .action(ArgAction::Set)
                 .value_delimiter(':'),
         );
@@ -1645,7 +1645,7 @@ NETWORKING:
         .arg(
             arg!(-f --fake <s> "some help")
                 .required(true)
-                .value_names(&["some", "val"])
+                .value_names(["some", "val"])
                 .action(ArgAction::Set)
                 .value_delimiter(':'),
         )
@@ -1657,7 +1657,7 @@ NETWORKING:
                 .action(ArgAction::SetTrue)
                 .help("Do not use system proxy settings"),
         )
-        .args(&[Arg::new("port").long("port").action(ArgAction::SetTrue)]);
+        .args([Arg::new("port").long("port").action(ArgAction::SetTrue)]);
 
     utils::assert_output(cmd, "test --help", CUSTOM_HELP_SECTION, false);
 }
@@ -1696,7 +1696,7 @@ fn multiple_custom_help_headers() {
         .arg(
             arg!(-f --fake <s> "some help")
                 .required(true)
-                .value_names(&["some", "val"])
+                .value_names(["some", "val"])
                 .action(ArgAction::Set)
                 .value_delimiter(':'),
         )
@@ -2115,7 +2115,7 @@ OPTIONS:
     -h, --help             Print help information
 ";
 
-    let cmd = Command::new("order").args(&[
+    let cmd = Command::new("order").args([
         Arg::new("a").short('a').action(ArgAction::SetTrue),
         Arg::new("B").short('B').action(ArgAction::SetTrue),
         Arg::new("b").short('b').action(ArgAction::SetTrue),
@@ -2455,7 +2455,7 @@ fn too_few_value_names_is_dotted() {
             .required(true)
             .action(ArgAction::Set)
             .num_args(3)
-            .value_names(&["one", "two"]),
+            .value_names(["one", "two"]),
     );
     utils::assert_output(
         cmd,
@@ -2483,7 +2483,7 @@ fn too_many_value_names_panics() {
                 .required(true)
                 .action(ArgAction::Set)
                 .num_args(1)
-                .value_names(&["one", "two"]),
+                .value_names(["one", "two"]),
         )
         .debug_assert()
 }

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1454,7 +1454,7 @@ fn value_names_building_num_vals() {
         .arg(
             Arg::new("pos")
                 .long("pos")
-                .value_names(&["who", "what", "why"]),
+                .value_names(["who", "what", "why"]),
         )
         .try_get_matches_from(vec!["myprog", "--pos", "val1", "val2", "val3"]);
 
@@ -1473,7 +1473,7 @@ fn value_names_building_num_vals() {
 #[test]
 fn value_names_building_num_vals_for_positional() {
     let m = Command::new("test")
-        .arg(Arg::new("pos").value_names(&["who", "what", "why"]))
+        .arg(Arg::new("pos").value_names(["who", "what", "why"]))
         .try_get_matches_from(vec!["myprog", "val1", "val2", "val3"]);
 
     assert!(m.is_ok(), "{}", m.unwrap_err());
@@ -1495,7 +1495,7 @@ fn num_args_preferred_over_value_names() {
             Arg::new("pos")
                 .long("pos")
                 .num_args(4)
-                .value_names(&["who", "what", "why"]),
+                .value_names(["who", "what", "why"]),
         )
         .try_get_matches_from(vec!["myprog", "--pos", "val1", "val2", "val3", "val4"]);
 

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -151,7 +151,7 @@ fn single_alias() {
 #[test]
 fn multiple_aliases() {
     let m = Command::new("myprog")
-        .subcommand(Command::new("test").aliases(&["do-stuff", "test-stuff"]))
+        .subcommand(Command::new("test").aliases(["do-stuff", "test-stuff"]))
         .try_get_matches_from(vec!["myprog", "test-stuff"])
         .unwrap();
     assert_eq!(m.subcommand_name(), Some("test"));

--- a/tests/builder/utils.rs
+++ b/tests/builder/utils.rs
@@ -58,7 +58,7 @@ pub fn complex_app() -> Command<'static> {
                 .action(ArgAction::Count)
                 .global(true),
         )
-        .args(&[
+        .args([
             arg!(flag2: -F "tests flags with exclusions")
                 .conflicts_with("flag")
                 .requires("long-option-2")
@@ -73,10 +73,10 @@ pub fn complex_app() -> Command<'static> {
                 .value_parser(opt3_vals),
             arg!([positional3] ... "tests specific values").value_parser(pos3_vals),
             arg!(--multvals <val> "Tests multiple values, not mult occs")
-                .value_names(&["one", "two"])
+                .value_names(["one", "two"])
                 .required(false),
             arg!(--multvalsmo <val> ... "Tests multiple values, and mult occs")
-                .value_names(&["one", "two"])
+                .value_names(["one", "two"])
                 .required(false),
             arg!(--minvals2 <minvals> "Tests 2 min vals")
                 .required(false)

--- a/tests/derive/non_literal_attributes.rs
+++ b/tests/derive/non_literal_attributes.rs
@@ -31,7 +31,7 @@ struct Opt {
     )]
     x: i32,
 
-    #[clap(short = 'l', long = "level", aliases = &["set-level", "lvl"])]
+    #[clap(short = 'l', long = "level", aliases = ["set-level", "lvl"])]
     level: String,
 
     #[clap(long("values"))]


### PR DESCRIPTION
The main breakinge change cases:
- `&[char]`: now requires removing `&`
- All other non-ID `&[_]`: hopefully #1041 will make these non-breaking

Fixes #2870

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
