### PR TITLE
fix: Show possible values in generated man file

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -106,9 +106,23 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
             header.push(roman(&defs));
         }
 
+
         let mut body = vec![];
         if let Some(help) = opt.get_long_help().or_else(|| opt.get_help()) {
             body.push(roman(help));
+        }
+
+        let possibles = &opt.get_possible_values();
+        if !possibles.is_empty() {
+            let pos_options: Vec<&str> = possibles
+                .iter()
+                .filter(|pos| !pos.is_hide_set())
+                .map(|pos| pos.get_name())
+                .collect();
+            body.push(Inline::LineBreak);
+            body.push(roman("[possible values: "));
+            body.push(italic(pos_options.join(", ")));
+            body.push(roman("]"));
         }
 
         roff.control("TP", []);

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -106,23 +106,23 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
             header.push(roman(&defs));
         }
 
-
         let mut body = vec![];
+        let mut help_written = false;
         if let Some(help) = opt.get_long_help().or_else(|| opt.get_help()) {
+            help_written = true;
             body.push(roman(help));
         }
 
         let possibles = &opt.get_possible_values();
-        if !possibles.is_empty() {
-            let pos_options: Vec<&str> = possibles
-                .iter()
-                .filter(|pos| !pos.is_hide_set())
-                .map(|pos| pos.get_name())
-                .collect();
-            body.push(Inline::LineBreak);
-            body.push(roman("[possible values: "));
-            body.push(italic(pos_options.join(", ")));
-            body.push(roman("]"));
+
+        if !(possibles.is_empty() || opt.is_hide_possible_values_set()) {
+            if help_written {
+                // It looks nice to have a separation between the help and the values
+                body.push(Inline::LineBreak);
+            }
+
+            let possible_vals = possibles.iter().filter(|pos| !pos.is_hide_set()).collect();
+            body.append(&mut format_possible_values(possible_vals));
         }
 
         roff.control("TP", []);
@@ -251,4 +251,42 @@ fn option_default_values(opt: &clap::Arg) -> Option<String> {
     }
 
     None
+}
+
+/// Generates a Vector of Inline Commands to push to the roff
+/// to properly format possible values that an option can take.
+fn format_possible_values(values: Vec<&clap::builder::PossibleValue>) -> Vec<Inline> {
+    let mut formats: Vec<Inline> = vec![];
+    // With Help
+    if values.iter().any(|p| p.get_help().is_some()) {
+        formats.push(Inline::LineBreak);
+        formats.push(roman("Possible values:"));
+        formats.push(Inline::LineBreak);
+        for value in values {
+            formats.push(roman("  - "));
+            formats.push(roman(value.get_name().as_str()));
+            match value.get_help() {
+                Some(help) => {
+                    formats.push(roman(": "));
+                    formats.push(roman(help.as_str()));
+                }
+                None => {}
+            }
+            formats.push(Inline::LineBreak);
+        }
+    }
+    // Without help
+    else {
+        formats.push(Inline::LineBreak);
+        formats.push(roman("[possible values: "));
+        formats.push(italic(
+            values
+                .iter()
+                .map(|p| p.get_name().as_str())
+                .collect::<Vec<&str>>()
+                .join(", "),
+        ));
+        formats.push(roman("]"));
+    }
+    formats
 }

--- a/clap_mangen/tests/common.rs
+++ b/clap_mangen/tests/common.rs
@@ -281,7 +281,7 @@ pub fn assert_matches_path(expected_path: impl AsRef<std::path::Path>, cmd: clap
         .matches_path(expected_path, buf);
 }
 
-pub fn possible_values_command(name: &'static str) -> clap::Command<'static> {
+pub fn possible_values_command(name: &'static str) -> clap::Command {
     clap::Command::new(name)
         .trailing_var_arg(true)
         .arg(
@@ -292,12 +292,24 @@ pub fn possible_values_command(name: &'static str) -> clap::Command<'static> {
         )
         .arg(
             clap::Arg::new("method")
-            .long("method")
-            .action(clap::ArgAction::Set)
-            .value_parser([
-                PossibleValue::new("fast").help("use the Fast method"),
-                PossibleValue::new("slow").help("use the slow method"),
-                PossibleValue::new("normal").help("use normal mode").hide(true)
-            ])
+                .long("method")
+                .action(clap::ArgAction::Set)
+                .value_parser([
+                    PossibleValue::new("fast").help("use the Fast method"),
+                    PossibleValue::new("slow").help("use the slow method"),
+                    PossibleValue::new("normal")
+                        .help("use normal mode")
+                        .hide(true),
+                ]),
+        )
+        .arg(
+            clap::Arg::new("positional_choice")
+                .action(clap::ArgAction::Set)
+                .help("Pick the Position you want the command to run in")
+                .value_parser([
+                    PossibleValue::new("left").help("run left adjusted"),
+                    PossibleValue::new("right"),
+                    PossibleValue::new("center").hide(true),
+                ]),
         )
 }

--- a/clap_mangen/tests/common.rs
+++ b/clap_mangen/tests/common.rs
@@ -1,3 +1,5 @@
+use clap::builder::PossibleValue;
+
 pub fn basic_command(name: &'static str) -> clap::Command {
     clap::Command::new(name)
         .arg(
@@ -277,4 +279,25 @@ pub fn assert_matches_path(expected_path: impl AsRef<std::path::Path>, cmd: clap
     snapbox::Assert::new()
         .action_env("SNAPSHOTS")
         .matches_path(expected_path, buf);
+}
+
+pub fn possible_values_command(name: &'static str) -> clap::Command<'static> {
+    clap::Command::new(name)
+        .trailing_var_arg(true)
+        .arg(
+            clap::Arg::new("choice")
+                .long("choice")
+                .action(clap::ArgAction::Set)
+                .value_parser(["bash", "fish", "zsh"]),
+        )
+        .arg(
+            clap::Arg::new("method")
+            .long("method")
+            .action(clap::ArgAction::Set)
+            .value_parser([
+                PossibleValue::new("fast").help("use the Fast method"),
+                PossibleValue::new("slow").help("use the slow method"),
+                PossibleValue::new("normal").help("use normal mode").hide(true)
+            ])
+        )
 }

--- a/clap_mangen/tests/roff.rs
+++ b/clap_mangen/tests/roff.rs
@@ -62,3 +62,10 @@ fn value_env() {
     let cmd = common::env_value_command(name);
     common::assert_matches_path("tests/snapshots/value_env.bash.roff", cmd);
 }
+
+#[test]
+fn possible_values() {
+    let name = "my-app";
+    let cmd = common::possible_values_command(name);
+    common::assert_matches_path("tests/snapshots/possible_values.bash.roff", cmd);
+}

--- a/clap_mangen/tests/snapshots/feature_sample.bash.roff
+++ b/clap_mangen/tests/snapshots/feature_sample.bash.roff
@@ -23,6 +23,8 @@ some input file
 .TP
 [/fIchoice/fR]
 
+.br
+[/fIpossible values: /fRfirst, second]
 .SH SUBCOMMANDS
 .TP
 my/-app/-test(1)

--- a/clap_mangen/tests/snapshots/possible_values.bash.roff
+++ b/clap_mangen/tests/snapshots/possible_values.bash.roff
@@ -4,14 +4,14 @@
 .SH NAME
 my/-app
 .SH SYNOPSIS
-/fBmy/-app/fR [/fB/-/-choice/fR] [/fB/-/-method/fR] [/fB/-h/fR|/fB/-/-help/fR] 
+/fBmy/-app/fR [/fB/-/-choice/fR] [/fB/-/-method/fR] [/fB/-h/fR|/fB/-/-help/fR] [/fIpositional_choice/fR] 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
 /fB/-/-choice/fR
 
 .br
-/fI[possible values: /fRbash, fish, zsh]
+[/fIpossible values: /fRbash, fish, zsh]
 .TP
 /fB/-/-method/fR
 
@@ -26,3 +26,16 @@ slow: use the slow method
 .TP
 /fB/-h/fR, /fB/-/-help/fR
 Print help information
+.TP
+[/fIpositional_choice/fR]
+Pick the Position you want the command to run in
+.br
+
+.br
+/fIPossible values:/fR
+.RS 14
+.IP /(bu 2
+left: run left adjusted
+.IP /(bu 2
+right
+.RE

--- a/clap_mangen/tests/snapshots/possible_values.bash.roff
+++ b/clap_mangen/tests/snapshots/possible_values.bash.roff
@@ -1,0 +1,28 @@
+.ie /n(.g .ds Aq /(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my/-app
+.SH SYNOPSIS
+/fBmy/-app/fR [/fB/-/-choice/fR] [/fB/-/-method/fR] [/fB/-h/fR|/fB/-/-help/fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+/fB/-/-choice/fR
+
+.br
+/fI[possible values: /fRbash, fish, zsh]
+.TP
+/fB/-/-method/fR
+
+.br
+/fIPossible values:/fR
+.RS 14
+.IP /(bu 2
+fast: use the Fast method
+.IP /(bu 2
+slow: use the slow method
+.RE
+.TP
+/fB/-h/fR, /fB/-/-help/fR
+Print help information

--- a/clap_mangen/tests/snapshots/special_commands.bash.roff
+++ b/clap_mangen/tests/snapshots/special_commands.bash.roff
@@ -23,6 +23,8 @@ some input file
 .TP
 [/fIchoice/fR]
 
+.br
+[/fIpossible values: /fRfirst, second]
 .SH SUBCOMMANDS
 .TP
 my/-app/-test(1)

--- a/clap_mangen/tests/snapshots/sub_subcommands.bash.roff
+++ b/clap_mangen/tests/snapshots/sub_subcommands.bash.roff
@@ -23,6 +23,8 @@ some input file
 .TP
 [/fIchoice/fR]
 
+.br
+[/fIpossible values: /fRfirst, second]
 .SH SUBCOMMANDS
 .TP
 my/-app/-test(1)

--- a/clap_mangen/tests/snapshots/value_hint.bash.roff
+++ b/clap_mangen/tests/snapshots/value_hint.bash.roff
@@ -9,8 +9,9 @@ my/-app
 .SH OPTIONS
 .TP
 /fB/-/-choice/fR
+
 .br
-[possible values: /fIbash, fish, zsh/fR]
+/fI[possible values: /fRbash, fish, zsh]
 .TP
 /fB/-/-unknown/fR
 

--- a/clap_mangen/tests/snapshots/value_hint.bash.roff
+++ b/clap_mangen/tests/snapshots/value_hint.bash.roff
@@ -9,7 +9,8 @@ my/-app
 .SH OPTIONS
 .TP
 /fB/-/-choice/fR
-
+.br
+[possible values: /fIbash, fish, zsh/fR]
 .TP
 /fB/-/-unknown/fR
 

--- a/clap_mangen/tests/snapshots/value_hint.bash.roff
+++ b/clap_mangen/tests/snapshots/value_hint.bash.roff
@@ -11,7 +11,7 @@ my/-app
 /fB/-/-choice/fR
 
 .br
-/fI[possible values: /fRbash, fish, zsh]
+[/fIpossible values: /fRbash, fish, zsh]
 .TP
 /fB/-/-unknown/fR
 

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -3656,7 +3656,9 @@ impl Arg {
         Some(longs)
     }
 
-    pub(crate) fn get_possible_values(&self) -> Vec<PossibleValue> {
+    /// Get the names of possible values for this argument. Only useful for user
+    /// facing applications, such as building help messages or man files
+    pub fn get_possible_values(&self) -> Vec<PossibleValue> {
         if !self.is_takes_value_set() {
             vec![]
         } else {
@@ -3676,6 +3678,19 @@ impl Arg {
             Some(&self.val_names)
         }
     }
+
+    // Get the names of possible values for this argument
+    // pub fn get_possible_value_names(&self) -> Option<Vec<&'help str>> {
+        // let possible_values = self.get_possible_values();
+        // if !possible_values.is_empty() {
+            // let possible_options: Vec<&str> = possible_values.iter().map(|pos| pos.get_name()).collect();
+            // Some(possible_options)
+        // }
+        // else {
+            // None
+        // }
+
+    // }
 
     /// Get the number of values for this argument.
     #[inline]

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -3679,19 +3679,6 @@ impl Arg {
         }
     }
 
-    // Get the names of possible values for this argument
-    // pub fn get_possible_value_names(&self) -> Option<Vec<&'help str>> {
-        // let possible_values = self.get_possible_values();
-        // if !possible_values.is_empty() {
-            // let possible_options: Vec<&str> = possible_values.iter().map(|pos| pos.get_name()).collect();
-            // Some(possible_options)
-        // }
-        // else {
-            // None
-        // }
-
-    // }
-
     /// Get the number of values for this argument.
     #[inline]
     pub fn get_num_args(&self) -> Option<ValueRange> {


### PR DESCRIPTION
This adds feature parity for mangen with the standard help output. Users
will now see the list of possible values for value arguments.

One change that was made to make this possible was adding the method
`get_possible_values` to the public API for an arg. I tried to think of
a way to get around this, but because this is the interface that the
help generation uses, and it is part of the crate public interface
I thing adding it as a part of the public API might be for the best.
If that is not the best option, please let me know and i can go back and look at it.

fixes: #3861

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
