### PR TITLE
fix!: Require/default conditional APIs are more explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Looking up a group in `ArgMatches` now returns the arg `Id`s, rather than the values.
 - Various `Arg`, `Command`, and `ArgGroup` calls were switched from accepting `&[]` to `[]` via `IntoIterator`
 - `Arg::short_aliases` and other builder functions that took `&[]` need the `&` dropped
+- Changed `Arg::requires_ifs` and `Arg::default_value*_ifs*` to taking an `ArgPredicate`, removing ambiguity with `None` when accepting owned and borrowed types
+- Replaced `Arg::requires_all` with `Arg::requires_ifs` now that it takes an `ArgPredicate`
 - *(help)* Make `DeriveDisplayOrder` the default and removed the setting.  To sort help, set `next_display_order(None)` (#2808)
 - *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value (#2808)
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ MSRV is now 1.60.0
 - Changed the default type of `allow_external_subcommands` from `String` to `OsString`
 - `Arg::default_missing_value` now applies per occurrence rather than if a value is missing across all occurrences
 - `arg!(--long [value])` to accept `0..=1` per occurrence rather than across all occurrences, making it safe to use with `ArgAction::Append`
+- Allow `OsStr`s for `Arg::{required_if_eq,required_if_eq_any,required_if_eq_all}`
 - *(assert)* Always enforce that version is specified when the `ArgAction::Version` is used
 - *(assert)* Add missing `#[track_caller]`s to make it easier to debug asserts
 - *(assert)* Ensure `overrides_with` IDs are valid

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -59,7 +59,7 @@ pub struct Arg<'help> {
     pub(crate) settings: ArgFlags,
     pub(crate) overrides: Vec<Id>,
     pub(crate) groups: Vec<Id>,
-    pub(crate) requires: Vec<(ArgPredicate<'help>, Id)>,
+    pub(crate) requires: Vec<(ArgPredicate, Id)>,
     pub(crate) r_ifs: Vec<(Id, OsString)>,
     pub(crate) r_ifs_all: Vec<(Id, OsString)>,
     pub(crate) r_unless: Vec<Id>,
@@ -73,7 +73,7 @@ pub struct Arg<'help> {
     pub(crate) num_vals: Option<ValueRange>,
     pub(crate) val_delim: Option<char>,
     pub(crate) default_vals: Vec<&'help OsStr>,
-    pub(crate) default_vals_ifs: Vec<(Id, ArgPredicate<'help>, Option<&'help OsStr>)>,
+    pub(crate) default_vals_ifs: Vec<(Id, ArgPredicate, Option<&'help OsStr>)>,
     pub(crate) default_missing_vals: Vec<&'help OsStr>,
     #[cfg(feature = "env")]
     pub(crate) env: Option<(&'help OsStr, Option<OsString>)>,
@@ -3266,7 +3266,7 @@ impl<'help> Arg<'help> {
     #[must_use]
     pub fn requires_if(mut self, val: &'help str, arg_id: impl Into<Id>) -> Self {
         self.requires
-            .push((ArgPredicate::Equals(OsStr::new(val)), arg_id.into()));
+            .push((ArgPredicate::Equals(val.to_owned().into()), arg_id.into()));
         self
     }
 
@@ -3321,7 +3321,7 @@ impl<'help> Arg<'help> {
     ) -> Self {
         self.requires.extend(
             ifs.into_iter()
-                .map(|(val, arg)| (ArgPredicate::Equals(OsStr::new(val)), arg.into())),
+                .map(|(val, arg)| (ArgPredicate::Equals(val.to_owned().into()), arg.into())),
         );
         self
     }

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -1,13 +1,14 @@
 // Std
+#[cfg(feature = "env")]
+use std::env;
 use std::{
     borrow::Cow,
     cmp::{Ord, Ordering},
     ffi::OsStr,
+    ffi::OsString,
     fmt::{self, Display, Formatter},
     str,
 };
-#[cfg(feature = "env")]
-use std::{env, ffi::OsString};
 
 // Internal
 use super::{ArgFlags, ArgSettings};
@@ -59,8 +60,8 @@ pub struct Arg<'help> {
     pub(crate) overrides: Vec<Id>,
     pub(crate) groups: Vec<Id>,
     pub(crate) requires: Vec<(ArgPredicate<'help>, Id)>,
-    pub(crate) r_ifs: Vec<(Id, &'help str)>,
-    pub(crate) r_ifs_all: Vec<(Id, &'help str)>,
+    pub(crate) r_ifs: Vec<(Id, OsString)>,
+    pub(crate) r_ifs_all: Vec<(Id, OsString)>,
     pub(crate) r_unless: Vec<Id>,
     pub(crate) r_unless_all: Vec<Id>,
     pub(crate) short: Option<char>,
@@ -3038,8 +3039,8 @@ impl<'help> Arg<'help> {
     /// [Conflicting]: Arg::conflicts_with()
     /// [required]: Arg::required()
     #[must_use]
-    pub fn required_if_eq(mut self, arg_id: impl Into<Id>, val: &'help str) -> Self {
-        self.r_ifs.push((arg_id.into(), val));
+    pub fn required_if_eq(mut self, arg_id: impl Into<Id>, val: impl Into<OsString>) -> Self {
+        self.r_ifs.push((arg_id.into(), val.into()));
         self
     }
 
@@ -3119,10 +3120,10 @@ impl<'help> Arg<'help> {
     #[must_use]
     pub fn required_if_eq_any(
         mut self,
-        ifs: impl IntoIterator<Item = (impl Into<Id>, &'help str)>,
+        ifs: impl IntoIterator<Item = (impl Into<Id>, impl Into<OsString>)>,
     ) -> Self {
         self.r_ifs
-            .extend(ifs.into_iter().map(|(id, val)| (id.into(), val)));
+            .extend(ifs.into_iter().map(|(id, val)| (id.into(), val.into())));
         self
     }
 
@@ -3200,10 +3201,10 @@ impl<'help> Arg<'help> {
     #[must_use]
     pub fn required_if_eq_all(
         mut self,
-        ifs: impl IntoIterator<Item = (impl Into<Id>, &'help str)>,
+        ifs: impl IntoIterator<Item = (impl Into<Id>, impl Into<OsString>)>,
     ) -> Self {
         self.r_ifs_all
-            .extend(ifs.into_iter().map(|(id, val)| (id.into(), val)));
+            .extend(ifs.into_iter().map(|(id, val)| (id.into(), val.into())));
         self
     }
 

--- a/src/builder/arg_group.rs
+++ b/src/builder/arg_group.rs
@@ -355,7 +355,7 @@ impl ArgGroup {
     /// assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     /// ```
     /// [required group]: ArgGroup::required()
-    /// [argument requirement rules]: crate::Arg::requires_all()
+    /// [argument requirement rules]: crate::Arg::requires_ifs()
     #[must_use]
     pub fn requires_all(mut self, ns: impl IntoIterator<Item = impl Into<Id>>) -> Self {
         for n in ns {

--- a/src/builder/arg_predicate.rs
+++ b/src/builder/arg_predicate.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ArgPredicate<'help> {
     IsPresent,
     Equals(&'help std::ffi::OsStr),

--- a/src/builder/arg_predicate.rs
+++ b/src/builder/arg_predicate.rs
@@ -1,16 +1,18 @@
 use crate::OsStr;
 
+/// Operations to perform on argument values
+///
+/// These do not apply to [`ValueSource::DefaultValue`][crate::parser::ValueSource::DefaultValue]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ArgPredicate {
+pub enum ArgPredicate {
+    /// Is the argument present?
     IsPresent,
+    /// Does the argument match the specified value?
     Equals(OsStr),
 }
 
-impl<'help> From<Option<&'help std::ffi::OsStr>> for ArgPredicate {
-    fn from(other: Option<&'help std::ffi::OsStr>) -> Self {
-        match other {
-            Some(other) => Self::Equals(other.to_owned().into()),
-            None => Self::IsPresent,
-        }
+impl<S: Into<OsStr>> From<S> for ArgPredicate {
+    fn from(other: S) -> Self {
+        Self::Equals(other.into())
     }
 }

--- a/src/builder/arg_predicate.rs
+++ b/src/builder/arg_predicate.rs
@@ -1,13 +1,15 @@
+use crate::OsStr;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ArgPredicate<'help> {
+pub(crate) enum ArgPredicate {
     IsPresent,
-    Equals(&'help std::ffi::OsStr),
+    Equals(OsStr),
 }
 
-impl<'help> From<Option<&'help std::ffi::OsStr>> for ArgPredicate<'help> {
+impl<'help> From<Option<&'help std::ffi::OsStr>> for ArgPredicate {
     fn from(other: Option<&'help std::ffi::OsStr>) -> Self {
         match other {
-            Some(other) => Self::Equals(other),
+            Some(other) => Self::Equals(other.to_owned().into()),
             None => Self::IsPresent,
         }
     }

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -4333,7 +4333,7 @@ impl<'help> Command<'help> {
 
     pub(crate) fn unroll_arg_requires<F>(&self, func: F, arg: &Id) -> Vec<Id>
     where
-        F: Fn(&(ArgPredicate<'_>, Id)) -> Option<Id>,
+        F: Fn(&(ArgPredicate, Id)) -> Option<Id>,
     {
         let mut processed = vec![];
         let mut r_vec = vec![arg];

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -21,6 +21,7 @@ mod tests;
 pub use action::ArgAction;
 pub use arg::Arg;
 pub use arg_group::ArgGroup;
+pub use arg_predicate::ArgPredicate;
 pub use command::Command;
 pub use possible_value::PossibleValue;
 pub use range::ValueRange;
@@ -45,5 +46,4 @@ pub use value_parser::_AnonymousValueParser;
 
 pub(crate) use action::CountType;
 pub(crate) use arg::render_arg_val;
-pub(crate) use arg_predicate::ArgPredicate;
 pub(crate) use arg_settings::{ArgFlags, ArgSettings};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub use crate::util::color::ColorChoice;
 #[allow(unused_imports)]
 pub(crate) use crate::util::color::ColorChoice;
 pub use crate::util::Id;
+pub(crate) use crate::util::OsStr;
 pub(crate) use crate::util::Str;
 
 pub use crate::derive::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub use crate::util::color::ColorChoice;
 #[allow(unused_imports)]
 pub(crate) use crate::util::color::ColorChoice;
 pub use crate::util::Id;
+pub(crate) use crate::util::Str;
 
 pub use crate::derive::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -359,7 +359,7 @@ impl<'help, 'cmd> Usage<'help, 'cmd> {
         };
 
         for a in required.iter() {
-            let is_relevant = |(val, req_arg): &(ArgPredicate<'_>, Id)| -> Option<Id> {
+            let is_relevant = |(val, req_arg): &(ArgPredicate, Id)| -> Option<Id> {
                 let required = match val {
                     ArgPredicate::Equals(_) => {
                         if let Some(matcher) = matcher {

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -363,7 +363,7 @@ impl<'help, 'cmd> Usage<'help, 'cmd> {
                 let required = match val {
                     ArgPredicate::Equals(_) => {
                         if let Some(matcher) = matcher {
-                            matcher.check_explicit(a, *val)
+                            matcher.check_explicit(a, val)
                         } else {
                             false
                         }
@@ -395,7 +395,7 @@ impl<'help, 'cmd> Usage<'help, 'cmd> {
         for req in unrolled_reqs.iter().chain(incls.iter()) {
             if let Some(arg) = self.cmd.find(req) {
                 let is_present = matcher
-                    .map(|m| m.check_explicit(req, ArgPredicate::IsPresent))
+                    .map(|m| m.check_explicit(req, &ArgPredicate::IsPresent))
                     .unwrap_or(false);
                 debug!(
                     "Usage::get_required_usage_from:iter:{:?} arg is_present={}",
@@ -417,7 +417,7 @@ impl<'help, 'cmd> Usage<'help, 'cmd> {
                     .map(|m| {
                         group_members
                             .iter()
-                            .any(|arg| m.check_explicit(arg, ArgPredicate::IsPresent))
+                            .any(|arg| m.check_explicit(arg, &ArgPredicate::IsPresent))
                     })
                     .unwrap_or(false);
                 debug!(

--- a/src/parser/arg_matcher.rs
+++ b/src/parser/arg_matcher.rs
@@ -125,7 +125,7 @@ impl ArgMatcher {
         self.matches.subcommand_name()
     }
 
-    pub(crate) fn check_explicit<'a>(&self, arg: &Id, predicate: &ArgPredicate<'a>) -> bool {
+    pub(crate) fn check_explicit(&self, arg: &Id, predicate: &ArgPredicate) -> bool {
         self.get(arg).map_or(false, |a| a.check_explicit(predicate))
     }
 

--- a/src/parser/arg_matcher.rs
+++ b/src/parser/arg_matcher.rs
@@ -125,7 +125,7 @@ impl ArgMatcher {
         self.matches.subcommand_name()
     }
 
-    pub(crate) fn check_explicit<'a>(&self, arg: &Id, predicate: ArgPredicate<'a>) -> bool {
+    pub(crate) fn check_explicit<'a>(&self, arg: &Id, predicate: &ArgPredicate<'a>) -> bool {
         self.get(arg).map_or(false, |a| a.check_explicit(predicate))
     }
 

--- a/src/parser/matches/matched_arg.rs
+++ b/src/parser/matches/matched_arg.rs
@@ -129,7 +129,7 @@ impl MatchedArg {
         self.vals.iter().flatten().count() == 0
     }
 
-    pub(crate) fn check_explicit(&self, predicate: ArgPredicate) -> bool {
+    pub(crate) fn check_explicit(&self, predicate: &ArgPredicate) -> bool {
         if self.source == Some(ValueSource::DefaultValue) {
             return false;
         }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -778,7 +778,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 let used: Vec<Id> = matcher
                     .arg_ids()
                     .filter(|arg_id| {
-                        matcher.check_explicit(arg_id, crate::builder::ArgPredicate::IsPresent)
+                        matcher.check_explicit(arg_id, &crate::builder::ArgPredicate::IsPresent)
                     })
                     .filter(|&n| {
                         self.cmd
@@ -1513,7 +1513,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
         let used: Vec<Id> = matcher
             .arg_ids()
             .filter(|arg_id| {
-                matcher.check_explicit(arg_id, crate::builder::ArgPredicate::IsPresent)
+                matcher.check_explicit(arg_id, &crate::builder::ArgPredicate::IsPresent)
             })
             .filter(|n| self.cmd.find(n).map_or(true, |a| !a.is_hide_set()))
             .cloned()

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -215,7 +215,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
         {
             debug!("Validator::gather_requires:iter:{:?}", name);
             if let Some(arg) = self.cmd.find(name) {
-                let is_relevant = |(val, req_arg): &(ArgPredicate<'_>, Id)| -> Option<Id> {
+                let is_relevant = |(val, req_arg): &(ArgPredicate, Id)| -> Option<Id> {
                     let required = matcher.check_explicit(&arg.id, val);
                     required.then(|| req_arg.clone())
                 };
@@ -281,7 +281,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
         // Validate the conditionally required args
         for a in self.cmd.get_arguments() {
             for (other, val) in &a.r_ifs {
-                if matcher.check_explicit(other, &ArgPredicate::Equals(val.as_os_str()))
+                if matcher.check_explicit(other, &ArgPredicate::Equals(val.into()))
                     && !matcher.check_explicit(&a.id, &ArgPredicate::IsPresent)
                 {
                     return self.missing_required_error(matcher, vec![a.id.clone()]);
@@ -289,7 +289,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
             }
 
             let match_all = a.r_ifs_all.iter().all(|(other, val)| {
-                matcher.check_explicit(other, &ArgPredicate::Equals(val.as_os_str()))
+                matcher.check_explicit(other, &ArgPredicate::Equals(val.into()))
             });
             if match_all
                 && !a.r_ifs_all.is_empty()

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -281,7 +281,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
         // Validate the conditionally required args
         for a in self.cmd.get_arguments() {
             for (other, val) in &a.r_ifs {
-                if matcher.check_explicit(other, &ArgPredicate::Equals(std::ffi::OsStr::new(*val)))
+                if matcher.check_explicit(other, &ArgPredicate::Equals(val.as_os_str()))
                     && !matcher.check_explicit(&a.id, &ArgPredicate::IsPresent)
                 {
                     return self.missing_required_error(matcher, vec![a.id.clone()]);
@@ -289,7 +289,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
             }
 
             let match_all = a.r_ifs_all.iter().all(|(other, val)| {
-                matcher.check_explicit(other, &ArgPredicate::Equals(std::ffi::OsStr::new(*val)))
+                matcher.check_explicit(other, &ArgPredicate::Equals(val.as_os_str()))
             });
             if match_all
                 && !a.r_ifs_all.is_empty()

--- a/src/util/id.rs
+++ b/src/util/id.rs
@@ -100,7 +100,7 @@ impl PartialEq<str> for Id {
     }
 }
 
-impl<'s> PartialEq<&'s str> for Id {
+impl PartialEq<&'_ str> for Id {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
         PartialEq::eq(self.as_str(), *other)

--- a/src/util/id.rs
+++ b/src/util/id.rs
@@ -1,69 +1,67 @@
+use crate::Str;
+
 /// [`Arg`][crate::Arg] or [`ArgGroup`][crate::ArgGroup] identifier
 ///
 /// This is used for accessing the value in [`ArgMatches`][crate::ArgMatches] or defining
 /// relationships between `Arg`s and `ArgGroup`s with functions like
 /// [`Arg::conflicts_with`][crate::Arg::conflicts_with].
 #[derive(Default, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct Id {
-    name: Inner,
-}
+pub struct Id(Str);
 
 impl Id {
     pub(crate) const HELP: Self = Self::from_static_ref("help");
     pub(crate) const VERSION: Self = Self::from_static_ref("version");
     pub(crate) const EXTERNAL: Self = Self::from_static_ref("");
 
-    fn from_string(name: String) -> Self {
-        Self {
-            name: Inner::Owned(name.into_boxed_str()),
-        }
-    }
-
-    fn from_ref(name: &str) -> Self {
-        Self {
-            name: Inner::Owned(Box::from(name)),
-        }
-    }
-
     const fn from_static_ref(name: &'static str) -> Self {
-        Self {
-            name: Inner::Static(name),
-        }
+        Self(Str::from_static_ref(name))
     }
 
     /// Get the raw string of the `Id`
     pub fn as_str(&self) -> &str {
-        self.name.as_str()
+        self.0.as_str()
     }
 }
 
-impl<'s> From<&'s Id> for Id {
-    fn from(id: &'s Id) -> Self {
+impl From<&'_ Id> for Id {
+    fn from(id: &'_ Id) -> Self {
         id.clone()
     }
 }
 
-impl From<String> for Id {
-    fn from(name: String) -> Self {
-        Self::from_string(name)
+impl From<Str> for Id {
+    fn from(name: Str) -> Self {
+        Self(name)
     }
 }
 
-impl From<&'_ String> for Id {
-    fn from(name: &'_ String) -> Self {
-        Self::from_ref(name.as_str())
+impl From<&'_ Str> for Id {
+    fn from(name: &'_ Str) -> Self {
+        Self(name.into())
+    }
+}
+
+impl From<std::string::String> for Id {
+    fn from(name: std::string::String) -> Self {
+        Self(name.into())
+    }
+}
+
+impl From<&'_ std::string::String> for Id {
+    fn from(name: &'_ std::string::String) -> Self {
+        Self(name.into())
     }
 }
 
 impl From<&'static str> for Id {
     fn from(name: &'static str) -> Self {
-        Self::from_static_ref(name)
+        Self(name.into())
     }
 }
 
 impl From<&'_ &'static str> for Id {
     fn from(name: &'_ &'static str) -> Self {
-        Self::from_static_ref(*name)
+        Self(name.into())
     }
 }
 
@@ -109,57 +107,16 @@ impl<'s> PartialEq<&'s str> for Id {
     }
 }
 
-impl PartialEq<String> for Id {
+impl PartialEq<Str> for Id {
     #[inline]
-    fn eq(&self, other: &String) -> bool {
+    fn eq(&self, other: &Str) -> bool {
         PartialEq::eq(self.as_str(), other.as_str())
     }
 }
 
-#[derive(Clone)]
-enum Inner {
-    Static(&'static str),
-    Owned(Box<str>),
-}
-
-impl Inner {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Static(s) => s,
-            Self::Owned(s) => s.as_ref(),
-        }
-    }
-}
-
-impl Default for Inner {
-    fn default() -> Self {
-        Self::Static("")
-    }
-}
-
-impl PartialEq for Inner {
-    fn eq(&self, other: &Inner) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl PartialOrd for Inner {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.as_str().partial_cmp(other.as_str())
-    }
-}
-
-impl Ord for Inner {
-    fn cmp(&self, other: &Inner) -> std::cmp::Ordering {
-        self.as_str().cmp(other.as_str())
-    }
-}
-
-impl Eq for Inner {}
-
-impl std::hash::Hash for Inner {
+impl PartialEq<std::string::String> for Id {
     #[inline]
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_str().hash(state);
+    fn eq(&self, other: &std::string::String) -> bool {
+        PartialEq::eq(self.as_str(), other.as_str())
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,9 +4,11 @@ mod flat_map;
 mod flat_set;
 mod graph;
 mod id;
+mod str;
 mod str_to_bool;
 
 pub use self::id::Id;
+pub use self::str::Str;
 
 pub(crate) use self::flat_map::Entry;
 pub(crate) use self::flat_map::FlatMap;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,10 +4,12 @@ mod flat_map;
 mod flat_set;
 mod graph;
 mod id;
+mod os_str;
 mod str;
 mod str_to_bool;
 
 pub use self::id::Id;
+pub use self::os_str::OsStr;
 pub use self::str::Str;
 
 pub(crate) use self::flat_map::Entry;

--- a/src/util/os_str.rs
+++ b/src/util/os_str.rs
@@ -1,0 +1,204 @@
+/// A UTF-8-encoded fixed string
+#[derive(Default, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct OsStr {
+    name: Inner,
+}
+
+impl OsStr {
+    pub(crate) fn from_string(name: std::ffi::OsString) -> Self {
+        Self {
+            name: Inner::Owned(name.into_boxed_os_str()),
+        }
+    }
+
+    pub(crate) fn from_ref(name: &std::ffi::OsStr) -> Self {
+        Self {
+            name: Inner::Owned(Box::from(name)),
+        }
+    }
+
+    pub(crate) const fn from_static_ref(name: &'static std::ffi::OsStr) -> Self {
+        Self {
+            name: Inner::Static(name),
+        }
+    }
+
+    /// Get the raw string of the `OsStr`
+    pub fn as_os_str(&self) -> &std::ffi::OsStr {
+        self.name.as_os_str()
+    }
+}
+
+impl From<&'_ OsStr> for OsStr {
+    fn from(id: &'_ OsStr) -> Self {
+        id.clone()
+    }
+}
+
+impl From<std::ffi::OsString> for OsStr {
+    fn from(name: std::ffi::OsString) -> Self {
+        Self::from_string(name)
+    }
+}
+
+impl From<&'_ std::ffi::OsString> for OsStr {
+    fn from(name: &'_ std::ffi::OsString) -> Self {
+        Self::from_ref(name.as_os_str())
+    }
+}
+
+impl From<std::string::String> for OsStr {
+    fn from(name: std::string::String) -> Self {
+        Self::from_string(name.into())
+    }
+}
+
+impl From<&'_ std::string::String> for OsStr {
+    fn from(name: &'_ std::string::String) -> Self {
+        Self::from_ref(name.as_str().as_ref())
+    }
+}
+
+impl From<&'static std::ffi::OsStr> for OsStr {
+    fn from(name: &'static std::ffi::OsStr) -> Self {
+        Self::from_static_ref(name)
+    }
+}
+
+impl From<&'_ &'static std::ffi::OsStr> for OsStr {
+    fn from(name: &'_ &'static std::ffi::OsStr) -> Self {
+        Self::from_static_ref(*name)
+    }
+}
+
+impl From<&'static str> for OsStr {
+    fn from(name: &'static str) -> Self {
+        Self::from_static_ref(name.as_ref())
+    }
+}
+
+impl From<&'_ &'static str> for OsStr {
+    fn from(name: &'_ &'static str) -> Self {
+        Self::from_static_ref((*name).as_ref())
+    }
+}
+
+impl std::fmt::Debug for OsStr {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self.as_os_str(), f)
+    }
+}
+
+impl std::ops::Deref for OsStr {
+    type Target = std::ffi::OsStr;
+
+    #[inline]
+    fn deref(&self) -> &std::ffi::OsStr {
+        self.as_os_str()
+    }
+}
+
+impl AsRef<std::ffi::OsStr> for OsStr {
+    #[inline]
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.as_os_str()
+    }
+}
+
+impl AsRef<std::path::Path> for OsStr {
+    #[inline]
+    fn as_ref(&self) -> &std::path::Path {
+        std::path::Path::new(self)
+    }
+}
+
+impl std::borrow::Borrow<std::ffi::OsStr> for OsStr {
+    #[inline]
+    fn borrow(&self) -> &std::ffi::OsStr {
+        self.as_os_str()
+    }
+}
+
+impl PartialEq<str> for OsStr {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        PartialEq::eq(self.as_os_str(), other)
+    }
+}
+
+impl PartialEq<&'_ str> for OsStr {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        PartialEq::eq(self.as_os_str(), *other)
+    }
+}
+
+impl<'s> PartialEq<&'s std::ffi::OsStr> for OsStr {
+    #[inline]
+    fn eq(&self, other: &&std::ffi::OsStr) -> bool {
+        PartialEq::eq(self.as_os_str(), *other)
+    }
+}
+
+impl PartialEq<std::string::String> for OsStr {
+    #[inline]
+    fn eq(&self, other: &std::string::String) -> bool {
+        PartialEq::eq(self.as_os_str(), other.as_str())
+    }
+}
+
+impl PartialEq<std::ffi::OsString> for OsStr {
+    #[inline]
+    fn eq(&self, other: &std::ffi::OsString) -> bool {
+        PartialEq::eq(self.as_os_str(), other.as_os_str())
+    }
+}
+
+#[derive(Clone)]
+enum Inner {
+    Static(&'static std::ffi::OsStr),
+    Owned(Box<std::ffi::OsStr>),
+}
+
+impl Inner {
+    fn as_os_str(&self) -> &std::ffi::OsStr {
+        match self {
+            Self::Static(s) => s,
+            Self::Owned(s) => s.as_ref(),
+        }
+    }
+}
+
+impl Default for Inner {
+    fn default() -> Self {
+        Self::Static(std::ffi::OsStr::new(""))
+    }
+}
+
+impl PartialEq for Inner {
+    fn eq(&self, other: &Inner) -> bool {
+        self.as_os_str() == other.as_os_str()
+    }
+}
+
+impl PartialOrd for Inner {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_os_str().partial_cmp(other.as_os_str())
+    }
+}
+
+impl Ord for Inner {
+    fn cmp(&self, other: &Inner) -> std::cmp::Ordering {
+        self.as_os_str().cmp(other.as_os_str())
+    }
+}
+
+impl Eq for Inner {}
+
+impl std::hash::Hash for Inner {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_os_str().hash(state);
+    }
+}

--- a/src/util/str.rs
+++ b/src/util/str.rs
@@ -124,7 +124,7 @@ impl PartialEq<str> for Str {
     }
 }
 
-impl<'s> PartialEq<&'s str> for Str {
+impl PartialEq<&'_ str> for Str {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
         PartialEq::eq(self.as_str(), *other)

--- a/src/util/str.rs
+++ b/src/util/str.rs
@@ -1,0 +1,187 @@
+/// A UTF-8-encoded fixed string
+#[derive(Default, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct Str {
+    name: Inner,
+}
+
+impl Str {
+    pub(crate) fn from_string(name: std::string::String) -> Self {
+        Self {
+            name: Inner::Owned(name.into_boxed_str()),
+        }
+    }
+
+    pub(crate) fn from_ref(name: &str) -> Self {
+        Self {
+            name: Inner::Owned(Box::from(name)),
+        }
+    }
+
+    pub(crate) const fn from_static_ref(name: &'static str) -> Self {
+        Self {
+            name: Inner::Static(name),
+        }
+    }
+
+    /// Get the raw string of the `Str`
+    pub fn as_str(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl From<&'_ Str> for Str {
+    fn from(id: &'_ Str) -> Self {
+        id.clone()
+    }
+}
+
+impl From<std::string::String> for Str {
+    fn from(name: std::string::String) -> Self {
+        Self::from_string(name)
+    }
+}
+
+impl From<&'_ std::string::String> for Str {
+    fn from(name: &'_ std::string::String) -> Self {
+        Self::from_ref(name.as_str())
+    }
+}
+
+impl From<&'static str> for Str {
+    fn from(name: &'static str) -> Self {
+        Self::from_static_ref(name)
+    }
+}
+
+impl From<&'_ &'static str> for Str {
+    fn from(name: &'_ &'static str) -> Self {
+        Self::from_static_ref(*name)
+    }
+}
+
+impl std::fmt::Display for Str {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+impl std::fmt::Debug for Str {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl std::ops::Deref for Str {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for Str {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<[u8]> for Str {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl AsRef<std::ffi::OsStr> for Str {
+    #[inline]
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        (&**self).as_ref()
+    }
+}
+
+impl AsRef<std::path::Path> for Str {
+    #[inline]
+    fn as_ref(&self) -> &std::path::Path {
+        std::path::Path::new(self)
+    }
+}
+
+impl std::borrow::Borrow<str> for Str {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl PartialEq<str> for Str {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        PartialEq::eq(self.as_str(), other)
+    }
+}
+
+impl<'s> PartialEq<&'s str> for Str {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        PartialEq::eq(self.as_str(), *other)
+    }
+}
+
+impl PartialEq<std::string::String> for Str {
+    #[inline]
+    fn eq(&self, other: &std::string::String) -> bool {
+        PartialEq::eq(self.as_str(), other.as_str())
+    }
+}
+
+#[derive(Clone)]
+enum Inner {
+    Static(&'static str),
+    Owned(Box<str>),
+}
+
+impl Inner {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Static(s) => s,
+            Self::Owned(s) => s.as_ref(),
+        }
+    }
+}
+
+impl Default for Inner {
+    fn default() -> Self {
+        Self::Static("")
+    }
+}
+
+impl PartialEq for Inner {
+    fn eq(&self, other: &Inner) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl PartialOrd for Inner {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl Ord for Inner {
+    fn cmp(&self, other: &Inner) -> std::cmp::Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl Eq for Inner {}
+
+impl std::hash::Hash for Inner {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}

--- a/tests/builder/action.rs
+++ b/tests/builder/action.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::bool_assert_comparison)]
 
+use clap::builder::ArgPredicate;
 use clap::Arg;
 use clap::ArgAction;
 use clap::Command;
@@ -126,7 +127,7 @@ fn set_true_with_default_value_if_present() {
             Arg::new("mammal")
                 .long("mammal")
                 .action(ArgAction::SetTrue)
-                .default_value_if("dog", None, Some("true")),
+                .default_value_if("dog", ArgPredicate::IsPresent, Some("true")),
         )
         .arg(Arg::new("dog").long("dog").action(ArgAction::SetTrue));
 
@@ -153,7 +154,7 @@ fn set_true_with_default_value_if_value() {
             Arg::new("mammal")
                 .long("mammal")
                 .action(ArgAction::SetTrue)
-                .default_value_if("dog", Some("true"), Some("true")),
+                .default_value_if("dog", "true", Some("true")),
         )
         .arg(Arg::new("dog").long("dog").action(ArgAction::SetTrue));
 
@@ -263,7 +264,7 @@ fn set_false_with_default_value_if_present() {
             Arg::new("mammal")
                 .long("mammal")
                 .action(ArgAction::SetFalse)
-                .default_value_if("dog", None, Some("false")),
+                .default_value_if("dog", ArgPredicate::IsPresent, Some("false")),
         )
         .arg(Arg::new("dog").long("dog").action(ArgAction::SetFalse));
 
@@ -290,7 +291,7 @@ fn set_false_with_default_value_if_value() {
             Arg::new("mammal")
                 .long("mammal")
                 .action(ArgAction::SetFalse)
-                .default_value_if("dog", Some("false"), Some("false")),
+                .default_value_if("dog", "false", Some("false")),
         )
         .arg(Arg::new("dog").long("dog").action(ArgAction::SetFalse));
 
@@ -366,7 +367,7 @@ fn count_with_default_value_if_present() {
             Arg::new("mammal")
                 .long("mammal")
                 .action(ArgAction::Count)
-                .default_value_if("dog", None, Some("10")),
+                .default_value_if("dog", ArgPredicate::IsPresent, Some("10")),
         )
         .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
 
@@ -393,7 +394,7 @@ fn count_with_default_value_if_value() {
             Arg::new("mammal")
                 .long("mammal")
                 .action(ArgAction::Count)
-                .default_value_if("dog", Some("2"), Some("10")),
+                .default_value_if("dog", "2", Some("10")),
         )
         .arg(Arg::new("dog").long("dog").action(ArgAction::Count));
 

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::ffi::OsString;
 
 use super::utils;
+use clap::builder::ArgPredicate;
 use clap::{arg, error::ErrorKind, value_parser, Arg, ArgAction, Command};
 
 #[test]
@@ -184,7 +185,11 @@ fn osstr_positional_user_override() {
 fn default_if_arg_present_no_default() {
     let r = Command::new("df")
         .arg(arg!(--opt <FILE> "some arg").required(true))
-        .arg(arg!([arg] "some arg").default_value_if("opt", None, Some("default")))
+        .arg(arg!([arg] "some arg").default_value_if(
+            "opt",
+            ArgPredicate::IsPresent,
+            Some("default"),
+        ))
         .try_get_matches_from(vec!["", "--opt", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
@@ -199,7 +204,11 @@ fn default_if_arg_present_no_default() {
 fn default_if_arg_present_no_default_user_override() {
     let r = Command::new("df")
         .arg(arg!(--opt <FILE> "some arg").required(false))
-        .arg(arg!([arg] "some arg").default_value_if("opt", None, Some("default")))
+        .arg(arg!([arg] "some arg").default_value_if(
+            "opt",
+            ArgPredicate::IsPresent,
+            Some("default"),
+        ))
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
@@ -217,7 +226,7 @@ fn default_if_arg_present_no_arg_with_default() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", None, Some("default")),
+                .default_value_if("opt", ArgPredicate::IsPresent, Some("default")),
         )
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -236,7 +245,7 @@ fn default_if_arg_present_with_default() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", None, Some("default")),
+                .default_value_if("opt", ArgPredicate::IsPresent, Some("default")),
         )
         .try_get_matches_from(vec!["", "--opt", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -255,7 +264,7 @@ fn default_if_arg_present_with_default_user_override() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", None, Some("default")),
+                .default_value_if("opt", ArgPredicate::IsPresent, Some("default")),
         )
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -274,7 +283,7 @@ fn default_if_arg_present_no_arg_with_default_user_override() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", None, Some("default")),
+                .default_value_if("opt", ArgPredicate::IsPresent, Some("default")),
         )
         .try_get_matches_from(vec!["", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -292,7 +301,7 @@ fn default_if_arg_present_no_arg_with_default_user_override() {
 fn default_if_arg_present_with_value_no_default() {
     let r = Command::new("df")
         .arg(arg!(--opt <FILE> "some arg").required(false))
-        .arg(arg!([arg] "some arg").default_value_if("opt", Some("value"), Some("default")))
+        .arg(arg!([arg] "some arg").default_value_if("opt", "value", Some("default")))
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
@@ -307,7 +316,7 @@ fn default_if_arg_present_with_value_no_default() {
 fn default_if_arg_present_with_value_no_default_fail() {
     let r = Command::new("df")
         .arg(arg!(--opt <FILE> "some arg").required(false))
-        .arg(arg!([arg] "some arg").default_value_if("opt", Some("value"), Some("default")))
+        .arg(arg!([arg] "some arg").default_value_if("opt", "value", Some("default")))
         .try_get_matches_from(vec!["", "--opt", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
@@ -319,7 +328,7 @@ fn default_if_arg_present_with_value_no_default_fail() {
 fn default_if_arg_present_with_value_no_default_user_override() {
     let r = Command::new("df")
         .arg(arg!(--opt <FILE> "some arg").required(false))
-        .arg(arg!([arg] "some arg").default_value_if("opt", Some("some"), Some("default")))
+        .arg(arg!([arg] "some arg").default_value_if("opt", "some", Some("default")))
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
@@ -337,7 +346,7 @@ fn default_if_arg_present_with_value_no_arg_with_default() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", Some("some"), Some("default")),
+                .default_value_if("opt", "some", Some("default")),
         )
         .try_get_matches_from(vec![""]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -356,7 +365,7 @@ fn default_if_arg_present_with_value_no_arg_with_default_fail() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", Some("some"), Some("default")),
+                .default_value_if("opt", "some", Some("default")),
         )
         .try_get_matches_from(vec!["", "--opt", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -375,7 +384,7 @@ fn default_if_arg_present_with_value_with_default() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", Some("some"), Some("default")),
+                .default_value_if("opt", "some", Some("default")),
         )
         .try_get_matches_from(vec!["", "--opt", "some"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -394,7 +403,7 @@ fn default_if_arg_present_with_value_with_default_user_override() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", Some("some"), Some("default")),
+                .default_value_if("opt", "some", Some("default")),
         )
         .try_get_matches_from(vec!["", "--opt", "some", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -413,7 +422,7 @@ fn default_if_arg_present_no_arg_with_value_with_default_user_override() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", Some("some"), Some("default")),
+                .default_value_if("opt", "some", Some("default")),
         )
         .try_get_matches_from(vec!["", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -432,7 +441,7 @@ fn default_if_arg_present_no_arg_with_value_with_default_user_override_fail() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_if("opt", Some("some"), Some("default")),
+                .default_value_if("opt", "some", Some("default")),
         )
         .try_get_matches_from(vec!["", "--opt", "value", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -450,7 +459,7 @@ fn default_if_arg_present_no_arg_with_value_with_default_user_override_fail() {
 fn no_default_if_arg_present_with_value_no_default() {
     let r = Command::new("df")
         .arg(arg!(--opt <FILE> "some arg").required(false))
-        .arg(arg!([arg] "some arg").default_value_if("opt", Some("value"), None))
+        .arg(arg!([arg] "some arg").default_value_if("opt", "value", None))
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
     let m = r.unwrap();
@@ -464,7 +473,7 @@ fn no_default_if_arg_present_with_value_with_default() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("default")
-                .default_value_if("opt", Some("value"), None),
+                .default_value_if("opt", "value", None),
         )
         .try_get_matches_from(vec!["", "--opt", "value"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -480,7 +489,7 @@ fn no_default_if_arg_present_with_value_with_default_user_override() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("default")
-                .default_value_if("opt", Some("value"), None),
+                .default_value_if("opt", "value", None),
         )
         .try_get_matches_from(vec!["", "--opt", "value", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -499,7 +508,7 @@ fn no_default_if_arg_present_no_arg_with_value_with_default() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("default")
-                .default_value_if("opt", Some("value"), None),
+                .default_value_if("opt", "value", None),
         )
         .try_get_matches_from(vec!["", "--opt", "other"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -522,8 +531,8 @@ fn default_ifs_arg_present() {
             arg!([arg] "some arg")
                 .default_value("first")
                 .default_value_ifs([
-                    ("opt", Some("some"), Some("default")),
-                    ("flag", None, Some("flg")),
+                    ("opt", ArgPredicate::from("some"), Some("default")),
+                    ("flag", ArgPredicate::IsPresent, Some("flg")),
                 ]),
         )
         .try_get_matches_from(vec!["", "--flag"]);
@@ -544,7 +553,10 @@ fn no_default_ifs_arg_present() {
         .arg(
             arg!([arg] "some arg")
                 .default_value("first")
-                .default_value_ifs([("opt", Some("some"), Some("default")), ("flag", None, None)]),
+                .default_value_ifs([
+                    ("opt", ArgPredicate::from("some"), Some("default")),
+                    ("flag", ArgPredicate::IsPresent, None),
+                ]),
         )
         .try_get_matches_from(vec!["", "--flag"]);
     assert!(r.is_ok(), "{}", r.unwrap_err());
@@ -562,8 +574,8 @@ fn default_ifs_arg_present_user_override() {
             arg!([arg] "some arg")
                 .default_value("first")
                 .default_value_ifs([
-                    ("opt", Some("some"), Some("default")),
-                    ("flag", None, Some("flg")),
+                    ("opt", ArgPredicate::from("some"), Some("default")),
+                    ("flag", ArgPredicate::IsPresent, Some("flg")),
                 ]),
         )
         .try_get_matches_from(vec!["", "--flag", "value"]);
@@ -585,8 +597,8 @@ fn default_ifs_arg_present_order() {
             arg!([arg] "some arg")
                 .default_value("first")
                 .default_value_ifs([
-                    ("opt", Some("some"), Some("default")),
-                    ("flag", None, Some("flg")),
+                    ("opt", ArgPredicate::from("some"), Some("default")),
+                    ("flag", ArgPredicate::IsPresent, Some("flg")),
                 ]),
         )
         .try_get_matches_from(vec!["", "--opt=some", "--flag"]);
@@ -612,11 +624,7 @@ fn default_value_ifs_os() {
             Arg::new("other")
                 .long("other")
                 .value_parser(value_parser!(OsString))
-                .default_value_ifs_os([(
-                    "flag",
-                    Some(OsStr::new("标记2")),
-                    Some(OsStr::new("flag=标记2")),
-                )]),
+                .default_value_ifs_os([("flag", "标记2", Some(OsStr::new("flag=标记2")))]),
         );
     let result = cmd.try_get_matches_from(["my_cargo", "--flag", "标记2"]);
     assert!(result.is_ok(), "{}", result.unwrap_err());

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -1,5 +1,6 @@
 use super::utils;
 
+use clap::builder::ArgPredicate;
 use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgGroup, Command};
 
 static REQUIRE_EQUALS: &str = "error: The following required arguments were not provided:
@@ -1047,7 +1048,11 @@ fn issue_1158_app() -> Command<'static> {
             arg!([ID] "ID")
                 .required_unless_present("config")
                 .conflicts_with("config")
-                .requires_all(["x", "y", "z"]),
+                .requires_ifs([
+                    (ArgPredicate::IsPresent, "x"),
+                    (ArgPredicate::IsPresent, "y"),
+                    (ArgPredicate::IsPresent, "z"),
+                ]),
         )
         .arg(arg!(x: -x <X> "X").required(false))
         .arg(arg!(y: -y <Y> "Y").required(false))


### PR DESCRIPTION
This helps with
- API cleanup by not having ambigious `None`, see #950
- Removes ambiguity with `None` when using owned/borrowed types for
  #1041