### PR TITLE
docs: Add `#[clap(global)]` example & docs

### DIFF
--- a/examples/tutorial_derive/03_06_globals.md
+++ b/examples/tutorial_derive/03_06_globals.md
@@ -1,0 +1,48 @@
+```console
+$ 03_06_globals_derive help
+clap [..]
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+USAGE:
+    03_06_globals_derive[EXE] <SUBCOMMAND>
+
+OPTIONS:
+    -h, --help       Print help information
+    --lowercase      Converts any file names to lowercase.
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    add     Adds files to myapp
+    help    Print this message or the help of the given subcommand(s)
+
+$ 03_06_globals_derive help add
+clap-add [..]
+Adds files to myapp
+
+USAGE:
+    03_06_globals_derive[EXE] add [NAME]
+
+ARGS:
+    <NAME>    
+
+OPTIONS:
+    -h, --help       Print help information
+    --lowercase      Converts any file names to lowercase.
+    -V, --version    Print version information
+
+$ 03_06_globals_derive add bob
+'myapp add' was used, name is: Some("bob")
+
+```
+
+The `--lowercase` argument can be used at any level, top-level or in any subcommand:
+```console
+$ 03_06_globals_derive add MyFileName
+'myapp add' was used, name is: Some("MyFileName")
+
+$ 03_06_globals_derive --lowercase add MyFileName
+'myapp add' was used, name is: Some("myfilename")
+
+$ 03_06_globals_derive add MyFileName --lowercase
+'myapp add' was used, name is: Some("myfilename")
+```

--- a/examples/tutorial_derive/03_06_globals.rs
+++ b/examples/tutorial_derive/03_06_globals.rs
@@ -1,0 +1,35 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+#[clap(propagate_version = true)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+
+    #[clap(global)]
+    /// Converts any file names to lowercase.
+    lowercase: bool,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Adds files to myapp
+    Add { name: String },
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    // You can check for the existence of subcommands, and if found use their
+    // matches just as you would the top level cmd
+    match &cli.command {
+        Commands::Add { name } => {
+            if cli.lowercase {
+                println!("'myapp add' was used, name is: {:?}", name.to_lowercase())
+            } else {
+                println!("'myapp add' was used, name is: {:?}", name)
+            }
+        }
+    }
+}

--- a/src/_derive/_tutorial.rs
+++ b/src/_derive/_tutorial.rs
@@ -17,6 +17,7 @@
 //!     3. [Flags](#flags)
 //!     4. [Subcommands](#subcommands)
 //!     5. [Defaults](#defaults)
+//!     6. [Globals](#globals)
 //! 4. Validation
 //!     1. [Enumerated values](#enumerated-values)
 //!     2. [Validated values](#validated-values)
@@ -151,6 +152,16 @@
 #![doc = include_str!("../../examples/tutorial_derive/03_05_default_values.rs")]
 //! ```
 #![doc = include_str!("../../examples/tutorial_derive/03_05_default_values.md")]
+//!
+//! ### Globals
+//!
+//! We've previously showed subcommands, but sometimes you want an argument to interact with any subcommand.
+//! In this case a `#[clap(global)]` argument can be specified, allowing it to be used from any position.
+//!
+//! ```rust
+#![doc = include_str!("../../examples/tutorial_derive/03_06_globals.rs")]
+//! ```
+#![doc = include_str!("../../examples/tutorial_derive/03_06_globals.md")]
 //!
 //! ## Validation
 //!

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -213,6 +213,8 @@
 //! - `subcommand`: Delegates definition of subcommands to the field (must implement
 //!   [`Subcommand`][crate::Subcommand])
 //!   - When `Option<T>`, the subcommand becomes optional
+//! - `global = <bool>`: [`Arg::global`][crate::Arg::global]
+//!   - When not present: only reads the argument from the specified level of command (no sub-commands).
 //! - `from_global`: Read a [`Arg::global`][crate::Arg::global] argument (raw attribute), regardless of what subcommand you are in
 //! - `value_enum`: Parse the value using the [`ValueEnum`][crate::ValueEnum]
 //! - `skip [= <expr>]`: Ignore this field, filling in with `<expr>`


### PR DESCRIPTION
Noticed this was absent from the docs.

Useful feature for CLIs with subcommands.

----

Didn't see an obvious existing issue for this, also i don't actually know how to run this example so i did my best to fix the output by hand.

Please let me know of any adjustments that should be made.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
