### PR TITLE
fix: Allow non-bool value_parsers for SetTrue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ MSRV is now 1.60.0
 - `Arg::default_missing_value` now applies per occurrence rather than if a value is missing across all occurrences
 - `arg!(--long [value])` to accept `0..=1` per occurrence rather than across all occurrences, making it safe to use with `ArgAction::Append`
 - Allow `OsStr`s for `Arg::{required_if_eq,required_if_eq_any,required_if_eq_all}`
+- Allow non-bool `value_parser`s for `ArgAction::SetTrue` / `ArgAction::SetFalse`
 - *(assert)* Always enforce that version is specified when the `ArgAction::Version` is used
 - *(assert)* Add missing `#[track_caller]`s to make it easier to debug asserts
 - *(assert)* Ensure `overrides_with` IDs are valid

--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -283,8 +283,8 @@ impl ArgAction {
         match self {
             Self::Set => None,
             Self::Append => None,
-            Self::SetTrue => Some(AnyValueId::of::<bool>()),
-            Self::SetFalse => Some(AnyValueId::of::<bool>()),
+            Self::SetTrue => None,
+            Self::SetFalse => None,
             Self::Count => Some(AnyValueId::of::<CountType>()),
             Self::Help => None,
             Self::Version => None,


### PR DESCRIPTION
Not sure if we could have originally made this work but it definitely
does now that we use `default_missing_value` for this (#4000)

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
