### PR TITLE
feat(parser): Make customizeing flags easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ MSRV is now 1.60.0
 ### Features
 
 - `Arg::num_args` now accepts ranges, allowing setting both the minimum and maximum number of values per occurrence
+- Added `TypedValueParser::map` to make it easier to reuse existing value parsers
 - *(help)* Show `PossibleValue::help` in long help (`--help`) (#3312)
 
 ### Fixes

--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -101,6 +101,41 @@ pub enum ArgAction {
     ///     Some(false)
     /// );
     /// ```
+    ///
+    /// You can use [`TypedValueParser::map`][crate::builder::TypedValueParser::map] to have the
+    /// flag control an application-specific type:
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// # use clap::builder::TypedValueParser as _;
+    /// # use clap::builder::BoolishValueParser;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .action(clap::ArgAction::SetTrue)
+    ///             .value_parser(
+    ///                 BoolishValueParser::new()
+    ///                 .map(|b| -> usize {
+    ///                     if b { 10 } else { 5 }
+    ///                 })
+    ///             )
+    ///     );
+    ///
+    /// let matches = cmd.clone().try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
+    /// assert!(matches.contains_id("flag"));
+    /// assert_eq!(
+    ///     matches.get_one::<usize>("flag").copied(),
+    ///     Some(10)
+    /// );
+    ///
+    /// let matches = cmd.try_get_matches_from(["mycmd"]).unwrap();
+    /// assert!(matches.contains_id("flag"));
+    /// assert_eq!(
+    ///     matches.get_one::<usize>("flag").copied(),
+    ///     Some(5)
+    /// );
+    /// ```
     SetTrue,
     /// When encountered, act as if `"false"` was encountered on the command-line
     ///

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -32,6 +32,7 @@ pub use value_parser::BoolValueParser;
 pub use value_parser::BoolishValueParser;
 pub use value_parser::EnumValueParser;
 pub use value_parser::FalseyValueParser;
+pub use value_parser::MapValueParser;
 pub use value_parser::NonEmptyStringValueParser;
 pub use value_parser::OsStringValueParser;
 pub use value_parser::PathBufValueParser;

--- a/src/builder/value_parser.rs
+++ b/src/builder/value_parser.rs
@@ -108,7 +108,6 @@ impl ValueParser {
     pub fn new<P>(other: P) -> Self
     where
         P: TypedValueParser,
-        P::Value: Send + Sync + Clone,
     {
         Self(ValueParserInner::Other(Box::new(other)))
     }
@@ -284,7 +283,6 @@ impl ValueParser {
 impl<P> From<P> for ValueParser
 where
     P: TypedValueParser + Send + Sync + 'static,
-    P::Value: Send + Sync + Clone,
 {
     fn from(p: P) -> Self {
         Self::new(p)
@@ -604,7 +602,7 @@ where
 /// Parse/validate argument values
 pub trait TypedValueParser: Clone + Send + Sync + 'static {
     /// Argument's value type
-    type Value;
+    type Value: Send + Sync + Clone;
 
     /// Parse the argument value
     ///
@@ -643,6 +641,7 @@ impl<F, T, E> TypedValueParser for F
 where
     F: Fn(&str) -> Result<T, E> + Clone + Send + Sync + 'static,
     E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    T: Send + Sync + Clone,
 {
     type Value = T;
 

--- a/tests/derive/flags.rs
+++ b/tests/derive/flags.rs
@@ -12,6 +12,8 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
+use clap::builder::BoolishValueParser;
+use clap::builder::TypedValueParser as _;
 use clap::ArgAction;
 use clap::CommandFactory;
 use clap::Parser;
@@ -46,17 +48,19 @@ fn bool_type_is_flag() {
 
 #[test]
 fn non_bool_type_flag() {
-    fn parse_from_flag(b: &str) -> Result<usize, String> {
-        b.parse::<bool>()
-            .map(|b| if b { 10 } else { 5 })
-            .map_err(|e| e.to_string())
+    fn parse_from_flag(b: bool) -> usize {
+        if b {
+            10
+        } else {
+            5
+        }
     }
 
     #[derive(Parser, Debug)]
     struct Opt {
-        #[clap(short, long, action = ArgAction::SetTrue, value_parser = parse_from_flag)]
+        #[clap(short, long, action = ArgAction::SetTrue, value_parser = BoolishValueParser::new().map(parse_from_flag))]
         alice: usize,
-        #[clap(short, long, action = ArgAction::SetTrue, value_parser = parse_from_flag)]
+        #[clap(short, long, action = ArgAction::SetTrue, value_parser = BoolishValueParser::new().map(parse_from_flag))]
         bob: usize,
     }
 


### PR DESCRIPTION
While `TypedValueParser` will generally make it easier to reuse value
parsers, this was particularly written for flags.  Besides having a
concrete API to document, an advantage over `fn(&str) -> Result<bool, E>`
value parsers is you get all of the benefits of the existing value
parsers for environment variable parsing.