### PR TITLE
fix!: Remove lifetime from PossibleValue 

### DIFF
--- a/clap_complete/src/dynamic.rs
+++ b/clap_complete/src/dynamic.rs
@@ -231,7 +231,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                 Self::Menu,
             ]
         }
-        fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::builder::PossibleValue<'a>> {
+        fn to_possible_value(&self) -> ::std::option::Option<clap::builder::PossibleValue> {
             match self {
                 Self::Normal => {
                     let value = "9";

--- a/clap_complete/src/generator/utils.rs
+++ b/clap_complete/src/generator/utils.rs
@@ -127,7 +127,7 @@ pub fn flags<'help>(p: &Command<'help>) -> Vec<Arg<'help>> {
 }
 
 /// Get the possible values for completion
-pub fn possible_values<'help>(a: &Arg<'help>) -> Option<Vec<clap::builder::PossibleValue<'help>>> {
+pub fn possible_values(a: &Arg<'_>) -> Option<Vec<clap::builder::PossibleValue>> {
     if !a.get_num_args().expect("built").takes_values() {
         None
     } else {

--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Write as _, io::Write};
 
-use clap::builder::PossibleValue;
 use clap::*;
 
 use crate::generator::{utils, Generator};
@@ -180,7 +179,7 @@ fn vals_for(o: &Arg) -> String {
             "$(compgen -W \"{}\" -- \"${{cur}}\")",
             vals.iter()
                 .filter(|pv| !pv.is_hide_set())
-                .map(PossibleValue::get_name)
+                .map(|n| n.get_name().as_str())
                 .collect::<Vec<_>>()
                 .join(" ")
         )

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -164,7 +164,8 @@ fn value_completion(option: &Arg) -> String {
                     Some(format!(
                         "{}\t{}",
                         escape_string(value.get_name()).as_str(),
-                        escape_string(value.get_help().unwrap_or_default()).as_str()
+                        escape_string(value.get_help().map(|s| s.as_str()).unwrap_or_default())
+                            .as_str()
                     ))
                 })
                 .collect::<Vec<_>>()

--- a/clap_complete/src/shells/shell.rs
+++ b/clap_complete/src/shells/shell.rs
@@ -57,7 +57,7 @@ impl ValueEnum for Shell {
         ]
     }
 
-    fn to_possible_value<'a>(&self) -> Option<PossibleValue<'a>> {
+    fn to_possible_value<'a>(&self) -> Option<PossibleValue> {
         Some(match self {
             Shell::Bash => PossibleValue::new("bash"),
             Shell::Elvish => PossibleValue::new("elvish"),

--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -1,6 +1,5 @@
 use std::io::Write;
 
-use clap::builder::PossibleValue;
 use clap::*;
 
 use crate::generator::{utils, Generator};
@@ -375,8 +374,12 @@ fn value_completion(arg: &Arg) -> Option<String> {
                         } else {
                             Some(format!(
                                 r#"{name}\:"{tooltip}""#,
-                                name = escape_value(value.get_name()),
-                                tooltip = value.get_help().map(escape_help).unwrap_or_default()
+                                name = escape_value(value.get_name().as_str()),
+                                tooltip = value
+                                    .get_help()
+                                    .map(|s| s.as_str())
+                                    .map(escape_help)
+                                    .unwrap_or_default()
                             ))
                         }
                     })
@@ -389,7 +392,7 @@ fn value_completion(arg: &Arg) -> Option<String> {
                 values
                     .iter()
                     .filter(|pv| !pv.is_hide_set())
-                    .map(PossibleValue::get_name)
+                    .map(|n| n.get_name().as_str())
                     .collect::<Vec<_>>()
                     .join(" ")
             ))

--- a/clap_derive/src/attrs.rs
+++ b/clap_derive/src/attrs.rs
@@ -499,7 +499,7 @@ impl Attrs {
                         quote_spanned!(ident.span()=> {
                             {
                                 let val: #ty = #val;
-                                clap::ValueEnum::to_possible_value(&val).unwrap().get_name()
+                                clap::ValueEnum::to_possible_value(&val).unwrap().get_name().to_owned()
                             }
                         })
                     } else {
@@ -544,17 +544,15 @@ impl Attrs {
                     let val = if parsed.iter().any(|a| matches!(a, ValueEnum(_))) {
                         quote_spanned!(ident.span()=> {
                             {
-                                fn iter_to_vals<T>(iterable: impl IntoIterator<Item = T>) -> Vec<&'static str>
+                                fn iter_to_vals<T>(iterable: impl IntoIterator<Item = T>) -> impl Iterator<Item=clap::Str>
                                 where
                                     T: ::std::borrow::Borrow<#inner_type>
                                 {
                                     iterable
                                         .into_iter()
                                         .map(|val| {
-                                            clap::ValueEnum::to_possible_value(val.borrow()).unwrap().get_name()
+                                            clap::ValueEnum::to_possible_value(val.borrow()).unwrap().get_name().to_owned()
                                         })
-                                        .collect()
-
                                 }
 
                                 iter_to_vals(#expr)
@@ -603,7 +601,7 @@ impl Attrs {
                         quote_spanned!(ident.span()=> {
                             {
                                 let val: #ty = #val;
-                                clap::ValueEnum::to_possible_value(&val).unwrap().get_name()
+                                clap::ValueEnum::to_possible_value(&val).unwrap().get_name().to_owned()
                             }
                         })
                     } else {
@@ -648,18 +646,15 @@ impl Attrs {
                     let val = if parsed.iter().any(|a| matches!(a, ValueEnum(_))) {
                         quote_spanned!(ident.span()=> {
                             {
-                                fn iter_to_vals<T>(iterable: impl IntoIterator<Item = T>) -> Vec<&'static ::std::ffi::OsStr>
+                                fn iter_to_vals<T>(iterable: impl IntoIterator<Item = T>) -> impl Iterator<Item=clap::Str>
                                 where
                                     T: ::std::borrow::Borrow<#inner_type>
                                 {
                                     iterable
                                         .into_iter()
                                         .map(|val| {
-                                            clap::ValueEnum::to_possible_value(val.borrow()).unwrap().get_name()
+                                            clap::ValueEnum::to_possible_value(val.borrow()).unwrap().get_name().to_owned()
                                         })
-                                        .map(::std::ffi::OsStr::new)
-                                        .collect()
-
                                 }
 
                                 iter_to_vals(#expr)

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -114,7 +114,7 @@ fn gen_to_possible_value(lits: &[(TokenStream, Ident)]) -> TokenStream {
     let (lit, variant): (Vec<TokenStream>, Vec<Ident>) = lits.iter().cloned().unzip();
 
     quote! {
-        fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::builder::PossibleValue<'a>> {
+        fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::builder::PossibleValue> {
             match self {
                 #(Self::#variant => Some(#lit),)*
                 _ => None

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -82,7 +82,7 @@ pub fn value_enum(name: &Ident) {
             fn from_str(_input: &str, _ignore_case: bool) -> ::std::result::Result<Self, String> {
                 unimplemented!()
             }
-            fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::builder::PossibleValue<'a>>{
+            fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::builder::PossibleValue>{
                 unimplemented!()
             }
         }

--- a/examples/tutorial_builder/04_01_enum.rs
+++ b/examples/tutorial_builder/04_01_enum.rs
@@ -12,7 +12,7 @@ impl ValueEnum for Mode {
         &[Mode::Fast, Mode::Slow]
     }
 
-    fn to_possible_value<'a>(&self) -> Option<PossibleValue<'a>> {
+    fn to_possible_value<'a>(&self) -> Option<PossibleValue> {
         Some(match self {
             Mode::Fast => PossibleValue::new("fast"),
             Mode::Slow => PossibleValue::new("slow"),

--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -3659,7 +3659,7 @@ impl<'help> Arg<'help> {
         Some(longs)
     }
 
-    pub(crate) fn get_possible_values(&self) -> Vec<PossibleValue<'help>> {
+    pub(crate) fn get_possible_values(&self) -> Vec<PossibleValue> {
         if !self.is_takes_value_set() {
             vec![]
         } else {

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -387,7 +387,7 @@ pub trait ValueEnum: Sized + Clone {
     /// The canonical argument value.
     ///
     /// The value is `None` for skipped variants.
-    fn to_possible_value<'a>(&self) -> Option<PossibleValue<'a>>;
+    fn to_possible_value(&self) -> Option<PossibleValue>;
 }
 
 impl<T: Parser> Parser for Box<T> {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -243,7 +243,7 @@ impl Error {
             ])
     }
 
-    pub(crate) fn empty_value(cmd: &Command, good_vals: &[&str], arg: String) -> Self {
+    pub(crate) fn empty_value(cmd: &Command, good_vals: &[String], arg: String) -> Self {
         Self::invalid_value(cmd, "".to_owned(), good_vals, arg)
     }
 
@@ -259,7 +259,7 @@ impl Error {
     pub(crate) fn invalid_value(
         cmd: &Command,
         bad_val: String,
-        good_vals: &[&str],
+        good_vals: &[String],
         arg: String,
     ) -> Self {
         let suggestion = suggestions::did_you_mean(&bad_val, good_vals.iter()).pop();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub use crate::util::color::ColorChoice;
 pub(crate) use crate::util::color::ColorChoice;
 pub use crate::util::Id;
 pub use crate::util::OsStr;
-pub(crate) use crate::util::Str;
+pub use crate::util::Str;
 
 pub use crate::derive::{Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -504,7 +504,7 @@ impl<'help, 'cmd, 'writer> Help<'help, 'cmd, 'writer> {
                     self.none("\n")?;
                     self.spaces(spaces)?;
                     self.none("- ")?;
-                    self.good(pv.get_name())?;
+                    self.good(pv.get_name().as_str())?;
                     if let Some(help) = pv.get_help() {
                         debug!("Help::help: Possible Value help");
 

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -9,7 +9,6 @@ use clap_lex::RawOsStr;
 use clap_lex::RawOsString;
 
 // Internal
-use crate::builder::PossibleValue;
 use crate::builder::{Arg, Command};
 use crate::error::Error as ClapError;
 use crate::error::Result as ClapResult;
@@ -1266,7 +1265,7 @@ impl<'help, 'cmd> Parser<'help, 'cmd> {
                 &super::get_possible_values_cli(arg)
                     .iter()
                     .filter(|pv| !pv.is_hide_set())
-                    .map(PossibleValue::get_name)
+                    .map(|n| n.get_name().as_str().to_owned())
                     .collect::<Vec<_>>(),
                 arg.to_string(),
             ));

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -45,7 +45,7 @@ impl<'help, 'cmd> Validator<'help, 'cmd> {
                     &get_possible_values_cli(o)
                         .iter()
                         .filter(|pv| !pv.is_hide_set())
-                        .map(PossibleValue::get_name)
+                        .map(|n| n.get_name().as_str().to_owned())
                         .collect::<Vec<_>>(),
                     o.to_string(),
                 ));
@@ -455,7 +455,7 @@ impl Conflicts {
     }
 }
 
-pub(crate) fn get_possible_values_cli<'help>(a: &Arg<'help>) -> Vec<PossibleValue<'help>> {
+pub(crate) fn get_possible_values_cli(a: &Arg<'_>) -> Vec<PossibleValue> {
     if !a.is_takes_value_set() {
         vec![]
     } else {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use self::flat_map::Entry;
 pub(crate) use self::flat_map::FlatMap;
 pub(crate) use self::flat_set::FlatSet;
 pub(crate) use self::graph::ChildGraph;
+pub(crate) use self::str::Inner as StrInner;
 pub(crate) use self::str_to_bool::str_to_bool;
 pub(crate) use self::str_to_bool::FALSE_LITERALS;
 pub(crate) use self::str_to_bool::TRUE_LITERALS;

--- a/src/util/os_str.rs
+++ b/src/util/os_str.rs
@@ -40,6 +40,24 @@ impl From<&'_ OsStr> for OsStr {
     }
 }
 
+impl From<crate::Str> for OsStr {
+    fn from(id: crate::Str) -> Self {
+        match id.into_inner() {
+            crate::util::StrInner::Static(s) => Self::from_static_ref(std::ffi::OsStr::new(s)),
+            crate::util::StrInner::Owned(s) => Self::from_ref(std::ffi::OsStr::new(s.as_ref())),
+        }
+    }
+}
+
+impl From<&'_ crate::Str> for OsStr {
+    fn from(id: &'_ crate::Str) -> Self {
+        match id.clone().into_inner() {
+            crate::util::StrInner::Static(s) => Self::from_static_ref(std::ffi::OsStr::new(s)),
+            crate::util::StrInner::Owned(s) => Self::from_ref(std::ffi::OsStr::new(s.as_ref())),
+        }
+    }
+}
+
 impl From<std::ffi::OsString> for OsStr {
     fn from(name: std::ffi::OsString) -> Self {
         Self::from_string(name)

--- a/src/util/str.rs
+++ b/src/util/str.rs
@@ -23,6 +23,10 @@ impl Str {
         }
     }
 
+    pub(crate) fn into_inner(self) -> Inner {
+        self.name
+    }
+
     /// Get the raw string of the `Str`
     pub fn as_str(&self) -> &str {
         self.name.as_str()
@@ -139,7 +143,7 @@ impl PartialEq<std::string::String> for Str {
 }
 
 #[derive(Clone)]
-enum Inner {
+pub(crate) enum Inner {
     Static(&'static str),
     Owned(Box<str>),
 }


### PR DESCRIPTION
Another step towards #1041

This isn't the long term type for `PossibleValue::help`, I just wanted
to get the lifetime out of the way first before figuring out how help
will work.