### PR TITLE
Remove ellipsis from help subcommand argument

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -4112,8 +4112,8 @@ impl<'help> Command<'help> {
                 .about("Print this message or the help of the given subcommand(s)")
                 .arg(
                     Arg::new("subcommand")
-                        .action(ArgAction::Append)
-                        .num_args(..)
+                        .action(ArgAction::Set)
+                        .num_args(0..=1)
                         .value_name("SUBCOMMAND")
                         .help("The subcommand whose help message to display"),
                 );

--- a/src/builder/range.rs
+++ b/src/builder/range.rs
@@ -88,7 +88,7 @@ impl ValueRange {
     }
 
     pub(crate) fn is_multiple(&self) -> bool {
-        self.start_inclusive != self.end_inclusive || 1 < self.start_inclusive
+        1 < self.end_inclusive
     }
 
     pub(crate) fn num_values(&self) -> Option<usize> {

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2062,10 +2062,10 @@ fn help_subcmd_help() {
 Print this message or the help of the given subcommand(s)
 
 USAGE:
-    myapp help [SUBCOMMAND]...
+    myapp help [SUBCOMMAND]
 
 ARGS:
-    <SUBCOMMAND>...    The subcommand whose help message to display
+    <SUBCOMMAND>    The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -2080,10 +2080,10 @@ fn subcmd_help_subcmd_help() {
 Print this message or the help of the given subcommand(s)
 
 USAGE:
-    myapp subcmd help [SUBCOMMAND]...
+    myapp subcmd help [SUBCOMMAND]
 
 ARGS:
-    <SUBCOMMAND>...    The subcommand whose help message to display
+    <SUBCOMMAND>    The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -2566,10 +2566,10 @@ fn subcommand_help_doesnt_have_useless_help_flag() {
 Print this message or the help of the given subcommand(s)
 
 USAGE:
-    example help [SUBCOMMAND]...
+    example help [SUBCOMMAND]
 
 ARGS:
-    <SUBCOMMAND>...    The subcommand whose help message to display
+    <SUBCOMMAND>    The subcommand whose help message to display
 ",
         false,
     );
@@ -2609,10 +2609,10 @@ fn dont_propagate_version_to_help_subcommand() {
 Print this message or the help of the given subcommand(s)
 
 USAGE:
-    example help [SUBCOMMAND]...
+    example help [SUBCOMMAND]
 
 ARGS:
-    <SUBCOMMAND>...    The subcommand whose help message to display
+    <SUBCOMMAND>    The subcommand whose help message to display
 ",
         false,
     );


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
This fixes #4100.

If I understand correctly, `is_multiple` should return true if the argument could take more than one value.

I have changed `ArgAction::Append` to `ArgAction::Set` since `ArgAction::Append` also creates the ellipsis.
https://github.com/clap-rs/clap/blob/c023db3a98d1de3ca7067f92f31ba8109d954b99/src/builder/arg.rs#L3942-L3951