### PR TITLE
Fix abort message when deriving non-unit enum variants

### DIFF
--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -84,7 +84,7 @@ fn lits(
                 None
             } else {
                 if !matches!(variant.fields, Fields::Unit) {
-                    abort!(variant.span(), "`#[derive(ValueEnum)]` only supports non-unit variants, unless they are skipped");
+                    abort!(variant.span(), "`#[derive(ValueEnum)]` only supports unit variants. Non-unit variants must be skipped");
                 }
                 let fields = attrs.field_methods(false);
                 let name = attrs.cased_name();

--- a/tests/derive_ui/value_enum_non_unit.stderr
+++ b/tests/derive_ui/value_enum_non_unit.stderr
@@ -1,4 +1,4 @@
-error: `#[derive(ValueEnum)]` only supports non-unit variants, unless they are skipped
+error: `#[derive(ValueEnum)]` only supports unit variants. Non-unit variants must be skipped
  --> tests/derive_ui/value_enum_non_unit.rs:5:5
   |
 5 |     Foo(usize),


### PR DESCRIPTION
This PR fixes the `abort!` message when applying the derive directive to enums containing variants that are non-unit. 

I found the previous message confusing due to using double negation:

> "`#[derive(ValueEnum)]` only supports non-unit variants, unless they are skipped"

I believe the message should instead be:

> "`#[derive(ValueEnum)]` only supports non-unit variants if they are skipped"

Or even more explicit, as provided in the patch:

> "`#[derive(ValueEnum)]` only supports unit variants. Non-unit variants must be skipped"