### PR TITLE
fix(error): Don't underline indentation

### DIFF
--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -32,7 +32,8 @@ impl<'cmd> Usage<'cmd> {
     pub(crate) fn create_usage_with_title(&self, used: &[Id]) -> StyledStr {
         debug!("Usage::create_usage_with_title");
         let mut styled = StyledStr::new();
-        styled.header("USAGE:\n    ");
+        styled.header("USAGE:");
+        styled.none("\n    ");
         styled.extend(self.create_usage_no_title(used).into_iter());
         styled
     }


### PR DESCRIPTION
This is a follow up to #4117.  Didn't notice due to the differences in rendering ANSI codes between machines.