### PR TITLE
fix(help): Don't rely on ALL CAPS for headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed lifetimes from `Command`, `Arg`, `ArgGroup`, and `PossibleValue`
 - *(help)* Make `DeriveDisplayOrder` the default and removed the setting.  To sort help, set `next_display_order(None)` (#2808)
 - *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value (#2808)
+- *(help)* Help headings are now title cased, making any user-provided help headings inconsistent
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)
 - *(derive)* Changed the default for arguments from `parse` to `value_parser`., removing `parse` support
 - *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp` (#3280)
@@ -83,6 +84,7 @@ MSRV is now 1.60.0
 - *(help)* Use `Command::display_name` in the help title rather than `Command::bin_name`
 - *(help)* Show when a flag is `ArgAction::Count` by adding an `...`
 - *(help)* Use a more neutral palette for coloring
+- *(help)* Don't rely on ALL CAPS for help headers
 - *(version)* Use `Command::display_name` rather than `Command::bin_name`
 - *(parser)* Assert on unknown args when using external subcommands (#3703)
 - *(parser)* Always fill in `""` argument for external subcommands (#3263)

--- a/examples/cargo-example-derive.md
+++ b/examples/cargo-example-derive.md
@@ -8,13 +8,13 @@ The help looks like:
 $ cargo-example-derive --help
 cargo 
 
-USAGE:
+Usage:
     cargo <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     example-derive    A simple to use, efficient, and full-featured Command Line Argument Parser
     help              Print this message or the help of the given subcommand(s)
 
@@ -22,10 +22,10 @@ $ cargo-example-derive example-derive --help
 cargo-example-derive [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     cargo example-derive [OPTIONS]
 
-OPTIONS:
+Options:
         --manifest-path <MANIFEST_PATH>    
     -h, --help                             Print help information
     -V, --version                          Print version information

--- a/examples/cargo-example.md
+++ b/examples/cargo-example.md
@@ -8,13 +8,13 @@ The help looks like:
 $ cargo-example --help
 cargo 
 
-USAGE:
+Usage:
     cargo <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     example    A simple to use, efficient, and full-featured Command Line Argument Parser
     help       Print this message or the help of the given subcommand(s)
 
@@ -22,10 +22,10 @@ $ cargo-example example --help
 cargo-example [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     cargo example [OPTIONS]
 
-OPTIONS:
+Options:
         --manifest-path <PATH>    
     -h, --help                    Print help information
     -V, --version                 Print version information

--- a/examples/demo.md
+++ b/examples/demo.md
@@ -3,10 +3,10 @@ $ demo --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     demo[EXE] [OPTIONS] --name <NAME>
 
-OPTIONS:
+Options:
     -n, --name <NAME>      Name of the person to greet
     -c, --count <COUNT>    Number of times to greet [default: 1]
     -h, --help             Print help information

--- a/examples/derive_ref/custom-bool.md
+++ b/examples/derive_ref/custom-bool.md
@@ -7,13 +7,13 @@ $ custom-bool --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     custom-bool[EXE] [OPTIONS] --foo <FOO> <BOOM>
 
-ARGS:
+Arguments:
     <BOOM>    [possible values: true, false]
 
-OPTIONS:
+Options:
         --foo <FOO>    [possible values: true, false]
         --bar <BAR>    [default: false]
     -h, --help         Print help information
@@ -25,7 +25,7 @@ error: The following required arguments were not provided:
     --foo <FOO>
     <BOOM>
 
-USAGE:
+Usage:
     custom-bool[EXE] [OPTIONS] --foo <FOO> <BOOM>
 
 For more information try --help

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -39,7 +39,7 @@ error: Found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 	If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
-USAGE:
+Usage:
     interop_augment_args[EXE] [OPTIONS]
 
 For more information try --help
@@ -77,7 +77,7 @@ error: Found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 	If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
-USAGE:
+Usage:
     interop_augment_subcommands[EXE] derived [OPTIONS]
 
 For more information try --help
@@ -89,7 +89,7 @@ $ interop_augment_subcommands unknown
 ? failed
 error: Found argument 'unknown' which wasn't expected, or isn't valid in this context
 
-USAGE:
+Usage:
     interop_augment_subcommands[EXE] [SUBCOMMAND]
 
 For more information try --help
@@ -103,14 +103,14 @@ $ interop_hand_subcommand
 ? failed
 clap 
 
-USAGE:
+Usage:
     interop_hand_subcommand[EXE] [OPTIONS] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -t, --top-level    
     -h, --help         Print help information
 
-SUBCOMMANDS:
+Subcommands:
     add       
     remove    
     help      Print this message or the help of the given subcommand(s)
@@ -154,7 +154,7 @@ error: Found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 	If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
-USAGE:
+Usage:
     interop_hand_subcommand[EXE] add [NAME]...
 
 For more information try --help
@@ -198,7 +198,7 @@ $ interop_hand_subcommand unknown
 ? failed
 error: Found argument 'unknown' which wasn't expected, or isn't valid in this context
 
-USAGE:
+Usage:
     interop_hand_subcommand[EXE] [OPTIONS] <SUBCOMMAND>
 
 For more information try --help
@@ -255,7 +255,7 @@ error: Found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 	If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
-USAGE:
+Usage:
     interop_flatten_hand_args[EXE] [OPTIONS]
 
 For more information try --help

--- a/examples/escaped-positional-derive.md
+++ b/examples/escaped-positional-derive.md
@@ -8,13 +8,13 @@ $ escaped-positional-derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     escaped-positional-derive[EXE] [OPTIONS] [-- <SLOP>...]
 
-ARGS:
+Arguments:
     <SLOP>...    
 
-OPTIONS:
+Options:
     -f               
     -p <PEAR>        
     -h, --help       Print help information
@@ -37,7 +37,7 @@ $ escaped-positional-derive foo bar
 ? failed
 error: Found argument 'foo' which wasn't expected, or isn't valid in this context
 
-USAGE:
+Usage:
     escaped-positional-derive[EXE] [OPTIONS] [-- <SLOP>...]
 
 For more information try --help

--- a/examples/escaped-positional.md
+++ b/examples/escaped-positional.md
@@ -8,13 +8,13 @@ $ escaped-positional --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     escaped-positional[EXE] [OPTIONS] [-- <SLOP>...]
 
-ARGS:
+Arguments:
     <SLOP>...    
 
-OPTIONS:
+Options:
     -f               
     -p <PEAR>        
     -h, --help       Print help information
@@ -37,7 +37,7 @@ $ escaped-positional foo bar
 ? failed
 error: Found argument 'foo' which wasn't expected, or isn't valid in this context
 
-USAGE:
+Usage:
     escaped-positional[EXE] [OPTIONS] [-- <SLOP>...]
 
 For more information try --help

--- a/examples/find.md
+++ b/examples/find.md
@@ -5,10 +5,10 @@ $ find --help
 clap 4.0.0-alpha.0
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     find[EXE] [OPTIONS] --name <NAME>
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -9,13 +9,13 @@ $ git-derive
 git 
 A fictional versioning CLI
 
-USAGE:
+Usage:
     git-derive[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -26,13 +26,13 @@ $ git-derive help
 git 
 A fictional versioning CLI
 
-USAGE:
+Usage:
     git-derive[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -43,13 +43,13 @@ $ git-derive help add
 git-add 
 adds things
 
-USAGE:
+Usage:
     git-derive[EXE] add <PATH>...
 
-ARGS:
+Arguments:
     <PATH>...    Stuff to add
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
 ```
@@ -61,13 +61,13 @@ $ git-derive add
 git-add 
 adds things
 
-USAGE:
+Usage:
     git-derive[EXE] add <PATH>...
 
-ARGS:
+Arguments:
     <PATH>...    Stuff to add
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
 $ git-derive add Cargo.toml Cargo.lock
@@ -80,15 +80,15 @@ Default subcommand:
 $ git-derive stash -h
 git-stash 
 
-USAGE:
+Usage:
     git-derive[EXE] stash [OPTIONS]
     git-derive[EXE] stash <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -m, --message <MESSAGE>    
     -h, --help                 Print help information
 
-SUBCOMMANDS:
+Subcommands:
     push     
     pop      
     apply    
@@ -97,23 +97,23 @@ SUBCOMMANDS:
 $ git-derive stash push -h
 git-stash-push 
 
-USAGE:
+Usage:
     git-derive[EXE] stash push [OPTIONS]
 
-OPTIONS:
+Options:
     -m, --message <MESSAGE>    
     -h, --help                 Print help information
 
 $ git-derive stash pop -h
 git-stash-pop 
 
-USAGE:
+Usage:
     git-derive[EXE] stash pop [STASH]
 
-ARGS:
+Arguments:
     <STASH>    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
 $ git-derive stash -m "Prototype"

--- a/examples/git.md
+++ b/examples/git.md
@@ -7,13 +7,13 @@ $ git
 git 
 A fictional versioning CLI
 
-USAGE:
+Usage:
     git[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -24,13 +24,13 @@ $ git help
 git 
 A fictional versioning CLI
 
-USAGE:
+Usage:
     git[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -41,13 +41,13 @@ $ git help add
 git-add 
 adds things
 
-USAGE:
+Usage:
     git[EXE] add <PATH>...
 
-ARGS:
+Arguments:
     <PATH>...    Stuff to add
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
 ```
@@ -59,13 +59,13 @@ $ git add
 git-add 
 adds things
 
-USAGE:
+Usage:
     git[EXE] add <PATH>...
 
-ARGS:
+Arguments:
     <PATH>...    Stuff to add
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
 $ git add Cargo.toml Cargo.lock
@@ -78,15 +78,15 @@ Default subcommand:
 $ git stash -h
 git-stash 
 
-USAGE:
+Usage:
     git[EXE] stash [OPTIONS]
     git[EXE] stash <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -m, --message <MESSAGE>    
     -h, --help                 Print help information
 
-SUBCOMMANDS:
+Subcommands:
     push     
     pop      
     apply    
@@ -95,23 +95,23 @@ SUBCOMMANDS:
 $ git stash push -h
 git-stash-push 
 
-USAGE:
+Usage:
     git[EXE] stash push [OPTIONS]
 
-OPTIONS:
+Options:
     -m, --message <MESSAGE>    
     -h, --help                 Print help information
 
 $ git stash pop -h
 git-stash-pop 
 
-USAGE:
+Usage:
     git[EXE] stash pop [STASH]
 
-ARGS:
+Arguments:
     <STASH>    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
 $ git stash -m "Prototype"

--- a/examples/multicall-busybox.md
+++ b/examples/multicall-busybox.md
@@ -27,10 +27,10 @@ $ busybox
 ? failed
 busybox 
 
-USAGE:
+Usage:
     busybox [OPTIONS] [APPLET]
 
-OPTIONS:
+Options:
         --install <install>    Install hardlinks for all subcommands in path
     -h, --help                 Print help information
 

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -39,14 +39,14 @@ pacman 5.2.1
 Pacman Development Team
 package manager utility
 
-USAGE:
+Usage:
     pacman[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     query -Q --query    Query the package database.
     sync -S --sync      Synchronize packages.
     help                Print this message or the help of the given subcommand(s)
@@ -55,13 +55,13 @@ $ pacman -S -h
 pacman-sync 
 Synchronize packages.
 
-USAGE:
+Usage:
     pacman[EXE] {sync|--sync|-S} [OPTIONS] [--] [package]...
 
-ARGS:
+Arguments:
     <package>...    packages
 
-OPTIONS:
+Options:
     -s, --search <search>...    search remote repositories for matching strings
     -i, --info                  view package information
     -h, --help                  Print help information
@@ -74,7 +74,7 @@ $ pacman -S -s foo -i bar
 ? failed
 error: The argument '--search <search>...' cannot be used with '--info'
 
-USAGE:
+Usage:
     pacman[EXE] {sync|--sync|-S} --search <search>... <package>...
 
 For more information try --help

--- a/examples/tutorial_builder/01_quick.md
+++ b/examples/tutorial_builder/01_quick.md
@@ -3,19 +3,19 @@ $ 01_quick --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     01_quick[EXE] [OPTIONS] [name] [SUBCOMMAND]
 
-ARGS:
+Arguments:
     <name>    Optional name to operate on
 
-OPTIONS:
+Options:
     -c, --config <FILE>    Sets a custom config file
     -d, --debug...         Turn debugging information on
     -h, --help             Print help information
     -V, --version          Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 

--- a/examples/tutorial_builder/02_app_settings.md
+++ b/examples/tutorial_builder/02_app_settings.md
@@ -3,10 +3,10 @@ $ 02_app_settings --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     02_app_settings[EXE] --two <VALUE> --one <VALUE>
 
-OPTIONS:
+Options:
         --two <VALUE>    
         --one <VALUE>    
     -h, --help           Print help information

--- a/examples/tutorial_builder/02_apps.md
+++ b/examples/tutorial_builder/02_apps.md
@@ -4,10 +4,10 @@ MyApp 1.0
 Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
-USAGE:
+Usage:
     02_apps[EXE] --two <VALUE> --one <VALUE>
 
-OPTIONS:
+Options:
         --two <VALUE>    
         --one <VALUE>    
     -h, --help           Print help information

--- a/examples/tutorial_builder/02_crate.md
+++ b/examples/tutorial_builder/02_crate.md
@@ -3,10 +3,10 @@ $ 02_crate --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     02_crate[EXE] --two <VALUE> --one <VALUE>
 
-OPTIONS:
+Options:
         --two <VALUE>    
         --one <VALUE>    
     -h, --help           Print help information

--- a/examples/tutorial_builder/03_01_flag_bool.md
+++ b/examples/tutorial_builder/03_01_flag_bool.md
@@ -3,10 +3,10 @@ $ 03_01_flag_bool --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_01_flag_bool[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -v, --verbose    
     -h, --help       Print help information
     -V, --version    Print version information

--- a/examples/tutorial_builder/03_01_flag_count.md
+++ b/examples/tutorial_builder/03_01_flag_count.md
@@ -3,10 +3,10 @@ $ 03_01_flag_count --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_01_flag_count[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -v, --verbose...    
     -h, --help          Print help information
     -V, --version       Print version information

--- a/examples/tutorial_builder/03_02_option.md
+++ b/examples/tutorial_builder/03_02_option.md
@@ -3,10 +3,10 @@ $ 03_02_option --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_02_option[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -n, --name <name>    
     -h, --help           Print help information
     -V, --version        Print version information

--- a/examples/tutorial_builder/03_02_option_mult.md
+++ b/examples/tutorial_builder/03_02_option_mult.md
@@ -3,10 +3,10 @@ $ 03_02_option_mult --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_02_option_mult[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -n, --name <name>    
     -h, --help           Print help information
     -V, --version        Print version information

--- a/examples/tutorial_builder/03_03_positional.md
+++ b/examples/tutorial_builder/03_03_positional.md
@@ -3,13 +3,13 @@ $ 03_03_positional --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_03_positional[EXE] [name]
 
-ARGS:
+Arguments:
     <name>    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_builder/03_03_positional_mult.md
+++ b/examples/tutorial_builder/03_03_positional_mult.md
@@ -3,13 +3,13 @@ $ 03_03_positional_mult --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_03_positional_mult[EXE] [name]...
 
-ARGS:
+Arguments:
     <name>...    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_builder/03_04_subcommands.md
+++ b/examples/tutorial_builder/03_04_subcommands.md
@@ -3,14 +3,14 @@ $ 03_04_subcommands help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_04_subcommands[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 
@@ -18,13 +18,13 @@ $ 03_04_subcommands help add
 clap-add [..]
 Adds files to myapp
 
-USAGE:
+Usage:
     03_04_subcommands[EXE] add [NAME]
 
-ARGS:
+Arguments:
     <NAME>    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -40,14 +40,14 @@ $ 03_04_subcommands
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_04_subcommands[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 

--- a/examples/tutorial_builder/03_05_default_values.md
+++ b/examples/tutorial_builder/03_05_default_values.md
@@ -3,13 +3,13 @@ $ 03_05_default_values --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_05_default_values[EXE] [NAME]
 
-ARGS:
+Arguments:
     <NAME>    [default: alice]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_builder/04_01_enum.md
+++ b/examples/tutorial_builder/04_01_enum.md
@@ -3,13 +3,13 @@ $ 04_01_enum --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_01_enum[EXE] <MODE>
 
-ARGS:
+Arguments:
     <MODE>    What mode to run the program in [possible values: fast, slow]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_builder/04_01_possible.md
+++ b/examples/tutorial_builder/04_01_possible.md
@@ -3,13 +3,13 @@ $ 04_01_possible --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_01_possible[EXE] <MODE>
 
-ARGS:
+Arguments:
     <MODE>    What mode to run the program in [possible values: fast, slow]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_builder/04_02_parse.md
+++ b/examples/tutorial_builder/04_02_parse.md
@@ -3,13 +3,13 @@ $ 04_02_parse --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_02_parse[EXE] <PORT>
 
-ARGS:
+Arguments:
     <PORT>    Network port to use
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_builder/04_02_validate.md
+++ b/examples/tutorial_builder/04_02_validate.md
@@ -3,13 +3,13 @@ $ 04_02_validate --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_02_validate[EXE] <PORT>
 
-ARGS:
+Arguments:
     <PORT>    Network port to use
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_builder/04_03_relations.md
+++ b/examples/tutorial_builder/04_03_relations.md
@@ -3,13 +3,13 @@ $ 04_03_relations --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_03_relations[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
-ARGS:
+Arguments:
     <INPUT_FILE>    some regular input
 
-OPTIONS:
+Options:
         --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
@@ -24,7 +24,7 @@ $ 04_03_relations
 error: The following required arguments were not provided:
     <--set-ver <VER>|--major|--minor|--patch>
 
-USAGE:
+Usage:
     04_03_relations[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
 For more information try --help
@@ -36,7 +36,7 @@ $ 04_03_relations --major --minor
 ? failed
 error: The argument '--major' cannot be used with '--minor'
 
-USAGE:
+Usage:
     04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch>
 
 For more information try --help
@@ -46,7 +46,7 @@ $ 04_03_relations --major -c config.toml
 error: The following required arguments were not provided:
     <INPUT_FILE|--spec-in <SPEC_IN>>
 
-USAGE:
+Usage:
     04_03_relations[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>
 
 For more information try --help

--- a/examples/tutorial_builder/04_04_custom.md
+++ b/examples/tutorial_builder/04_04_custom.md
@@ -3,13 +3,13 @@ $ 04_04_custom --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
-ARGS:
+Arguments:
     <INPUT_FILE>    some regular input
 
-OPTIONS:
+Options:
         --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
@@ -23,7 +23,7 @@ $ 04_04_custom
 ? failed
 error: Can only modify one version field
 
-USAGE:
+Usage:
     04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
 For more information try --help
@@ -35,7 +35,7 @@ $ 04_04_custom --major --minor
 ? failed
 error: Can only modify one version field
 
-USAGE:
+Usage:
     04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
 For more information try --help
@@ -45,7 +45,7 @@ $ 04_04_custom --major -c config.toml
 Version: 2.2.3
 error: INPUT_FILE or --spec-in is required when using --config
 
-USAGE:
+Usage:
     04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
 For more information try --help

--- a/examples/tutorial_derive/01_quick.md
+++ b/examples/tutorial_derive/01_quick.md
@@ -3,19 +3,19 @@ $ 01_quick_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     01_quick_derive[EXE] [OPTIONS] [NAME] [SUBCOMMAND]
 
-ARGS:
+Arguments:
     <NAME>    Optional name to operate on
 
-OPTIONS:
+Options:
     -c, --config <FILE>    Sets a custom config file
     -d, --debug...         Turn debugging information on
     -h, --help             Print help information
     -V, --version          Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 

--- a/examples/tutorial_derive/02_app_settings.md
+++ b/examples/tutorial_derive/02_app_settings.md
@@ -3,10 +3,10 @@ $ 02_app_settings_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     02_app_settings_derive[EXE] --two <TWO> --one <ONE>
 
-OPTIONS:
+Options:
         --two <TWO>    
         --one <ONE>    
     -h, --help         Print help information

--- a/examples/tutorial_derive/02_apps.md
+++ b/examples/tutorial_derive/02_apps.md
@@ -4,10 +4,10 @@ MyApp 1.0
 Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
-USAGE:
+Usage:
     02_apps_derive[EXE] --two <TWO> --one <ONE>
 
-OPTIONS:
+Options:
         --two <TWO>    
         --one <ONE>    
     -h, --help         Print help information

--- a/examples/tutorial_derive/02_crate.md
+++ b/examples/tutorial_derive/02_crate.md
@@ -3,10 +3,10 @@ $ 02_crate_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     02_crate_derive[EXE] --two <TWO> --one <ONE>
 
-OPTIONS:
+Options:
         --two <TWO>    
         --one <ONE>    
     -h, --help         Print help information

--- a/examples/tutorial_derive/03_01_flag_bool.md
+++ b/examples/tutorial_derive/03_01_flag_bool.md
@@ -3,10 +3,10 @@ $ 03_01_flag_bool_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_01_flag_bool_derive[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -v, --verbose    
     -h, --help       Print help information
     -V, --version    Print version information

--- a/examples/tutorial_derive/03_01_flag_count.md
+++ b/examples/tutorial_derive/03_01_flag_count.md
@@ -3,10 +3,10 @@ $ 03_01_flag_count_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_01_flag_count_derive[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -v, --verbose...    
     -h, --help          Print help information
     -V, --version       Print version information

--- a/examples/tutorial_derive/03_02_option.md
+++ b/examples/tutorial_derive/03_02_option.md
@@ -3,10 +3,10 @@ $ 03_02_option_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_02_option_derive[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -n, --name <NAME>    
     -h, --help           Print help information
     -V, --version        Print version information

--- a/examples/tutorial_derive/03_02_option_mult.md
+++ b/examples/tutorial_derive/03_02_option_mult.md
@@ -3,10 +3,10 @@ $ 03_02_option_mult_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_02_option_mult_derive[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -n, --name <NAME>    
     -h, --help           Print help information
     -V, --version        Print version information

--- a/examples/tutorial_derive/03_03_positional.md
+++ b/examples/tutorial_derive/03_03_positional.md
@@ -3,13 +3,13 @@ $ 03_03_positional_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_03_positional_derive[EXE] [NAME]
 
-ARGS:
+Arguments:
     <NAME>    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_derive/03_03_positional_mult.md
+++ b/examples/tutorial_derive/03_03_positional_mult.md
@@ -3,13 +3,13 @@ $ 03_03_positional_mult_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_03_positional_mult_derive[EXE] [NAME]...
 
-ARGS:
+Arguments:
     <NAME>...    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_derive/03_04_subcommands.md
+++ b/examples/tutorial_derive/03_04_subcommands.md
@@ -3,14 +3,14 @@ $ 03_04_subcommands_derive help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_04_subcommands_derive[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 
@@ -18,13 +18,13 @@ $ 03_04_subcommands_derive help add
 clap-add [..]
 Adds files to myapp
 
-USAGE:
+Usage:
     03_04_subcommands_derive[EXE] add [NAME]
 
-ARGS:
+Arguments:
     <NAME>    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -40,14 +40,14 @@ $ 03_04_subcommands_derive
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_04_subcommands_derive[EXE] <SUBCOMMAND>
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 

--- a/examples/tutorial_derive/03_05_default_values.md
+++ b/examples/tutorial_derive/03_05_default_values.md
@@ -3,13 +3,13 @@ $ 03_05_default_values_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     03_05_default_values_derive[EXE] [NAME]
 
-ARGS:
+Arguments:
     <NAME>    [default: alice]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_derive/04_01_enum.md
+++ b/examples/tutorial_derive/04_01_enum.md
@@ -3,13 +3,13 @@ $ 04_01_enum_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_01_enum_derive[EXE] <MODE>
 
-ARGS:
+Arguments:
     <MODE>    What mode to run the program in [possible values: fast, slow]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_derive/04_02_parse.md
+++ b/examples/tutorial_derive/04_02_parse.md
@@ -3,13 +3,13 @@ $ 04_02_parse_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_02_parse_derive[EXE] <PORT>
 
-ARGS:
+Arguments:
     <PORT>    Network port to use
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_derive/04_02_validate.md
+++ b/examples/tutorial_derive/04_02_validate.md
@@ -3,13 +3,13 @@ $ 04_02_validate_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_02_validate_derive[EXE] <PORT>
 
-ARGS:
+Arguments:
     <PORT>    Network port to use
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/examples/tutorial_derive/04_03_relations.md
+++ b/examples/tutorial_derive/04_03_relations.md
@@ -3,13 +3,13 @@ $ 04_03_relations_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_03_relations_derive[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
-ARGS:
+Arguments:
     <INPUT_FILE>    some regular input
 
-OPTIONS:
+Options:
         --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
@@ -24,7 +24,7 @@ $ 04_03_relations_derive
 error: The following required arguments were not provided:
     <--set-ver <VER>|--major|--minor|--patch>
 
-USAGE:
+Usage:
     04_03_relations_derive[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
 For more information try --help
@@ -36,7 +36,7 @@ $ 04_03_relations_derive --major --minor
 ? failed
 error: The argument '--major' cannot be used with '--minor'
 
-USAGE:
+Usage:
     04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch>
 
 For more information try --help
@@ -46,7 +46,7 @@ $ 04_03_relations_derive --major -c config.toml
 error: The following required arguments were not provided:
     <INPUT_FILE|--spec-in <SPEC_IN>>
 
-USAGE:
+Usage:
     04_03_relations_derive[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>
 
 For more information try --help

--- a/examples/tutorial_derive/04_04_custom.md
+++ b/examples/tutorial_derive/04_04_custom.md
@@ -3,13 +3,13 @@ $ 04_04_custom_derive --help
 clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     04_04_custom_derive[EXE] [OPTIONS] [INPUT_FILE]
 
-ARGS:
+Arguments:
     <INPUT_FILE>    some regular input
 
-OPTIONS:
+Options:
         --set-ver <VER>        set version manually
         --major                auto inc major
         --minor                auto inc minor
@@ -23,7 +23,7 @@ $ 04_04_custom_derive
 ? failed
 error: Can only modify one version field
 
-USAGE:
+Usage:
     clap [OPTIONS] [INPUT_FILE]
 
 For more information try --help
@@ -35,7 +35,7 @@ $ 04_04_custom_derive --major --minor
 ? failed
 error: Can only modify one version field
 
-USAGE:
+Usage:
     clap [OPTIONS] [INPUT_FILE]
 
 For more information try --help
@@ -45,7 +45,7 @@ $ 04_04_custom_derive --major -c config.toml
 Version: 2.2.3
 error: INPUT_FILE or --spec-in is required when using --config
 
-USAGE:
+Usage:
     clap [OPTIONS] [INPUT_FILE]
 
 For more information try --help

--- a/examples/typed-derive.md
+++ b/examples/typed-derive.md
@@ -5,10 +5,10 @@ Help:
 $ typed-derive --help
 clap 
 
-USAGE:
+Usage:
     typed-derive[EXE] [OPTIONS]
 
-OPTIONS:
+Options:
     -O <OPTIMIZATION>        Implicitly using `std::str::FromStr`
     -I <DIR>                 Allow invalid UTF-8 paths
         --bind <BIND>        Handle IP addresses

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -155,7 +155,7 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
                         self.write_about(true, true);
                     }
                     "usage-heading" => {
-                        self.header("USAGE:");
+                        self.header("Usage:");
                     }
                     "usage" => {
                         self.writer
@@ -340,8 +340,8 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
 
         let mut first = if !pos.is_empty() {
             // Write positional args if any
-            self.header("ARGS:\n");
-            self.write_args(&pos, "ARGS", positional_sort_key);
+            self.header("Arguments:\n");
+            self.write_args(&pos, "Arguments", positional_sort_key);
             false
         } else {
             true
@@ -351,8 +351,8 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
             if !first {
                 self.none("\n\n");
             }
-            self.header("OPTIONS:\n");
-            self.write_args(&non_pos, "OPTIONS", option_sort_key);
+            self.header("Options:\n");
+            self.write_args(&non_pos, "Options", option_sort_key);
             first = false;
         }
         if !custom_headings.is_empty() {
@@ -385,7 +385,7 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
                 self.none("\n\n");
             }
 
-            let default_help_heading = Str::from("SUBCOMMANDS");
+            let default_help_heading = Str::from("Subcommands");
             self.header(
                 self.cmd
                     .get_subcommand_help_heading()

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -32,7 +32,7 @@ impl<'cmd> Usage<'cmd> {
     pub(crate) fn create_usage_with_title(&self, used: &[Id]) -> StyledStr {
         debug!("Usage::create_usage_with_title");
         let mut styled = StyledStr::new();
-        styled.header("USAGE:");
+        styled.header("Usage:");
         styled.none("\n    ");
         styled.extend(self.create_usage_no_title(used).into_iter());
         styled

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -6,25 +6,25 @@ use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 
 static ALLOW_EXT_SC: &str = "clap-test v1.4.8
 
-USAGE:
+Usage:
     clap-test [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
 
 static DONT_COLLAPSE_ARGS: &str = "clap-test v1.4.8
 
-USAGE:
+Usage:
     clap-test [arg1] [arg2] [arg3]
 
-ARGS:
+Arguments:
     <arg1>    some
     <arg2>    some
     <arg3>    some
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -127,10 +127,10 @@ fn arg_required_else_help_with_default() {
 fn arg_required_else_help_error_message() {
     static ARG_REQUIRED_ELSE_HELP: &str = "test 1.0
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -i, --info       Provides more info
     -h, --help       Print help information
     -V, --version    Print version information
@@ -288,13 +288,13 @@ fn skip_possible_values() {
 Kevin K.
 tests stuff
 
-USAGE:
+Usage:
     test [OPTIONS] [arg1]
 
-ARGS:
+Arguments:
     <arg1>    some pos arg
 
-OPTIONS:
+Options:
     -o, --opt <opt>    some option
     -h, --help         Print help information
     -V, --version      Print version information
@@ -567,10 +567,10 @@ fn dont_collapse_args() {
 fn require_eq() {
     static REQUIRE_EQUALS: &str = "clap-test v1.4.8
 
-USAGE:
+Usage:
     clap-test --opt=<FILE>
 
-OPTIONS:
+Options:
     -o, --opt=<FILE>    some
     -h, --help          Print help information
     -V, --version       Print version information

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -193,10 +193,10 @@ fn invisible_arg_aliases_help_output() {
     static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
-USAGE:
+Usage:
     ct test [OPTIONS]
 
-OPTIONS:
+Options:
     -o, --opt <opt>    
     -f, --flag         
     -h, --help         Print help information
@@ -224,10 +224,10 @@ fn visible_arg_aliases_help_output() {
     static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
-USAGE:
+Usage:
     ct test [OPTIONS]
 
-OPTIONS:
+Options:
     -o, --opt <opt>    [aliases: visible]
     -f, --flag         [aliases: v_flg, flag2, flg3]
     -h, --help         Print help information

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -160,10 +160,10 @@ fn invisible_short_arg_aliases_help_output() {
     static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
-USAGE:
+Usage:
     ct test [OPTIONS]
 
-OPTIONS:
+Options:
     -o, --opt <opt>    
     -f, --flag         
     -h, --help         Print help information
@@ -191,10 +191,10 @@ fn visible_short_arg_aliases_help_output() {
     static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
 Some help
 
-USAGE:
+Usage:
     ct test [OPTIONS]
 
-OPTIONS:
+Options:
     -o, --opt <opt>    [short aliases: v]
     -f, --flag         [aliases: flag1] [short aliases: a, b, 🦆]
     -h, --help         Print help information

--- a/tests/builder/cargo.rs
+++ b/tests/builder/cargo.rs
@@ -7,10 +7,10 @@ use clap::{
 static DESCRIPTION_ONLY: &str = "prog 1
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     prog
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -18,10 +18,10 @@ OPTIONS:
 static AUTHORS_ONLY: &str = "prog 1
 
 
-USAGE:
+Usage:
     prog
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";

--- a/tests/builder/command.rs
+++ b/tests/builder/command.rs
@@ -5,10 +5,10 @@ use clap::{command, error::ErrorKind};
 static EVERYTHING: &str = "clap {{version}}
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-USAGE:
+Usage:
     clap
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -292,7 +292,7 @@ fn get_arg_conflicts_with_group() {
 fn conflict_output() {
     static CONFLICT_ERR: &str = "error: The argument '--flag...' cannot be used with '-F'
 
-USAGE:
+Usage:
     clap-test --flag... --long-option-2 <option2> <positional> <positional2>
 
 For more information try --help
@@ -310,7 +310,7 @@ For more information try --help
 fn conflict_output_rev() {
     static CONFLICT_ERR_REV: &str = "error: The argument '-F' cannot be used with '--flag...'
 
-USAGE:
+Usage:
     clap-test -F --long-option-2 <option2> <positional> <positional2>
 
 For more information try --help
@@ -328,7 +328,7 @@ For more information try --help
 fn conflict_output_with_required() {
     static CONFLICT_ERR: &str = "error: The argument '--flag...' cannot be used with '-F'
 
-USAGE:
+Usage:
     clap-test --flag... --long-option-2 <option2> <positional> <positional2>
 
 For more information try --help
@@ -346,7 +346,7 @@ For more information try --help
 fn conflict_output_rev_with_required() {
     static CONFLICT_ERR_REV: &str = "error: The argument '-F' cannot be used with '--flag...'
 
-USAGE:
+Usage:
     clap-test -F --long-option-2 <option2> <positional> <positional2>
 
 For more information try --help
@@ -366,7 +366,7 @@ fn conflict_output_three_conflicting() {
     --two
     --three
 
-USAGE:
+Usage:
     three_conflicting_arguments --one
 
 For more information try --help

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -731,7 +731,7 @@ fn default_vals_donnot_show_in_smart_usage() {
         "error: The following required arguments were not provided:
     <input>
 
-USAGE:
+Usage:
     bug [OPTIONS] <input>
 
 For more information try --help

--- a/tests/builder/derive_order.rs
+++ b/tests/builder/derive_order.rs
@@ -8,10 +8,10 @@ use clap::{Arg, ArgAction, Command};
 fn no_derive_order() {
     static NO_DERIVE_ORDER: &str = "test 1.2
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --flag_a                 second flag
         --flag_b                 first flag
     -h, --help                   Print help information
@@ -49,10 +49,10 @@ OPTIONS:
 fn derive_order() {
     static UNIFIED_HELP_AND_DERIVE: &str = "test 1.2
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --flag_b                 first flag
         --option_b <option_b>    first option
         --flag_a                 second flag
@@ -87,10 +87,10 @@ OPTIONS:
 fn derive_order_next_order() {
     static HELP: &str = "test 1.2
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --flag_b                 first flag
         --option_b <option_b>    first option
     -h, --help                   Print help information
@@ -135,10 +135,10 @@ OPTIONS:
 fn derive_order_no_next_order() {
     static HELP: &str = "test 1.2
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --flag_a                 first flag
         --flag_b                 second flag
     -h, --help                   Print help information
@@ -182,10 +182,10 @@ OPTIONS:
 fn derive_order_subcommand_propagate() {
     static UNIFIED_DERIVE_SC_PROP: &str = "test-sub 1.2
 
-USAGE:
+Usage:
     test sub [OPTIONS]
 
-OPTIONS:
+Options:
         --flag_b                 first flag
         --option_b <option_b>    first option
         --flag_a                 second flag
@@ -222,10 +222,10 @@ OPTIONS:
 fn derive_order_subcommand_propagate_with_explicit_display_order() {
     static UNIFIED_DERIVE_SC_PROP_EXPLICIT_ORDER: &str = "test-sub 1.2
 
-USAGE:
+Usage:
     test sub [OPTIONS]
 
-OPTIONS:
+Options:
         --flag_a                 second flag
         --flag_b                 first flag
         --option_b <option_b>    first option
@@ -268,14 +268,14 @@ OPTIONS:
 fn subcommand_sorted_display_order() {
     static SUBCMD_ALPHA_ORDER: &str = "test 1
 
-USAGE:
+Usage:
     test [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     a1      blah a1
     b1      blah b1
     help    Print this message or the help of the given subcommand(s)
@@ -305,14 +305,14 @@ SUBCOMMANDS:
 fn subcommand_derived_display_order() {
     static SUBCMD_DECL_ORDER: &str = "test 1
 
-USAGE:
+Usage:
     test [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     b1      blah b1
     a1      blah a1
     help    Print this message or the help of the given subcommand(s)

--- a/tests/builder/display_order.rs
+++ b/tests/builder/display_order.rs
@@ -11,13 +11,13 @@ fn very_large_display_order() {
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     help    Print this message or the help of the given subcommand(s)
     sub     
 ",

--- a/tests/builder/double_require.rs
+++ b/tests/builder/double_require.rs
@@ -2,10 +2,10 @@ use clap::{error::ErrorKind, Arg, ArgAction, Command};
 
 static HELP: &str = "prog 
 
-USAGE:
+Usage:
     prog [OPTIONS]
 
-OPTIONS:
+Options:
     -a            
     -b            
     -c            
@@ -15,7 +15,7 @@ OPTIONS:
 static ONLY_B_ERROR: &str = "error: The following required arguments were not provided:
     -c
 
-USAGE:
+Usage:
     prog -b -c
 
 For more information try --help
@@ -24,7 +24,7 @@ For more information try --help
 static ONLY_C_ERROR: &str = "error: The following required arguments were not provided:
     -b
 
-USAGE:
+Usage:
     prog -c -b
 
 For more information try --help

--- a/tests/builder/empty_values.rs
+++ b/tests/builder/empty_values.rs
@@ -118,7 +118,7 @@ fn no_empty_values_without_equals_but_requires_equals() {
     static NO_EUQALS_ERROR: &str =
         "error: Equal sign is needed when assigning values to '--config=<config>'.
 
-USAGE:
+Usage:
     config [OPTIONS]
 
 For more information try --help

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -25,7 +25,7 @@ fn assert_error<F: clap::error::ErrorFormatter>(
 fn app_error() {
     static MESSAGE: &str = "error: Failed for mysterious reasons
 
-USAGE:
+Usage:
     test [OPTIONS] --all
 
 For more information try --help
@@ -91,10 +91,10 @@ fn null_prints_help() {
     static MESSAGE: &str = "\
 test 
 
-USAGE:
+Usage:
     test
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ";
     assert_error(err, expected_kind, MESSAGE, false);
@@ -112,10 +112,10 @@ fn raw_prints_help() {
     static MESSAGE: &str = "\
 test 
 
-USAGE:
+Usage:
     test
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ";
     assert_error(err, expected_kind, MESSAGE, false);
@@ -144,7 +144,7 @@ fn rich_formats_validation_error() {
     static MESSAGE: &str = "\
 error: Found argument 'unused' which wasn't expected, or isn't valid in this context
 
-USAGE:
+Usage:
     test
 
 For more information try --help
@@ -165,7 +165,7 @@ fn raw_formats_validation_error() {
 error: Found an argument which wasn't expected or isn't valid in this context
 
 Invalid Argument: unused
-USAGE:
+Usage:
     test
 ";
     assert_error(err, expected_kind, MESSAGE, true);

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -499,10 +499,10 @@ fn flag_subcommand_long_infer_exact_match() {
 static FLAG_SUBCOMMAND_HELP: &str = "pacman-query 
 Query the package database.
 
-USAGE:
+Usage:
     pacman {query|--query|-Q} [OPTIONS]
 
-OPTIONS:
+Options:
     -s, --search <search>...    search locally installed packages for matching strings
     -i, --info <info>...        view package information
     -h, --help                  Print help information
@@ -548,10 +548,10 @@ fn flag_subcommand_long_short_normal_usage_string() {
 static FLAG_SUBCOMMAND_NO_SHORT_HELP: &str = "pacman-query 
 Query the package database.
 
-USAGE:
+Usage:
     pacman {query|--query} [OPTIONS]
 
-OPTIONS:
+Options:
     -s, --search <search>...    search locally installed packages for matching strings
     -i, --info <info>...        view package information
     -h, --help                  Print help information
@@ -601,10 +601,10 @@ fn flag_subcommand_long_normal_usage_string() {
 static FLAG_SUBCOMMAND_NO_LONG_HELP: &str = "pacman-query 
 Query the package database.
 
-USAGE:
+Usage:
     pacman {query|-Q} [OPTIONS]
 
-OPTIONS:
+Options:
     -s, --search <search>...    search locally installed packages for matching strings
     -i, --info <info>...        view package information
     -h, --help                  Print help information

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -6,7 +6,7 @@ const USE_FLAG_AS_ARGUMENT: &str =
 
 \tIf you tried to supply `--another-flag` as a value rather than a flag, use `-- --another-flag`
 
-USAGE:
+Usage:
     mycat [OPTIONS] [filename]
 
 For more information try --help
@@ -183,7 +183,7 @@ fn issue_2308_multiple_dashes() {
 
 	If you tried to supply `-----` as a value rather than a flag, use `-- -----`
 
-USAGE:
+Usage:
     test <arg>
 
 For more information try --help

--- a/tests/builder/groups.rs
+++ b/tests/builder/groups.rs
@@ -5,7 +5,7 @@ use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgGroup, Command, Id};
 static REQ_GROUP_USAGE: &str = "error: The following required arguments were not provided:
     <base|--delete>
 
-USAGE:
+Usage:
     clap-test <base|--delete>
 
 For more information try --help
@@ -14,7 +14,7 @@ For more information try --help
 static REQ_GROUP_CONFLICT_USAGE: &str =
     "error: The argument '--delete' cannot be used with '<base>'
 
-USAGE:
+Usage:
     clap-test <base|--delete>
 
 For more information try --help
@@ -23,7 +23,7 @@ For more information try --help
 static REQ_GROUP_CONFLICT_ONLY_OPTIONS: &str =
     "error: The argument '--delete' cannot be used with '--all'
 
-USAGE:
+Usage:
     clap-test <--all|--delete>
 
 For more information try --help
@@ -263,13 +263,13 @@ fn group_overrides_required() {
 fn group_usage_use_val_name() {
     static GROUP_USAGE_USE_VAL_NAME: &str = "prog 
 
-USAGE:
+Usage:
     prog <A>
 
-ARGS:
+Arguments:
     <A>    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ";
     let cmd = Command::new("prog")

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -78,7 +78,7 @@ fn help_multi_subcommand_error() {
 
     static EXPECTED: &str = "error: The subcommand 'foo' wasn't recognized
 
-USAGE:
+Usage:
     ctest subcmd multi [OPTIONS]
 
 For more information try --help
@@ -90,14 +90,14 @@ For more information try --help
 fn req_last_arg_usage() {
     static LAST_ARG_REQ_MULT: &str = "example 1.0
 
-USAGE:
+Usage:
     example <FIRST>... [--] <SECOND>...
 
-ARGS:
+Arguments:
     <FIRST>...     First
     <SECOND>...    Second
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -119,14 +119,14 @@ OPTIONS:
 fn args_with_last_usage() {
     static LAST_ARG_USAGE: &str = "flamegraph 0.1
 
-USAGE:
+Usage:
     flamegraph [OPTIONS] [BINFILE] [-- <ARGS>...]
 
-ARGS:
+Arguments:
     <BINFILE>    The path of the binary to be profiled. for a binary.
     <ARGS>...    Any arguments you wish to pass to the being profiled.
 
-OPTIONS:
+Options:
     -v, --verbose              Prints out more stuff.
     -t, --timeout <SECONDS>    Timeout in seconds.
     -f, --frequency <HERTZ>    The sampling frequency.
@@ -204,15 +204,15 @@ fn complex_help_output() {
 Kevin K. <kbknapp@gmail.com>
 tests clap library
 
-USAGE:
+Usage:
     clap-test [OPTIONS] [ARGS] [SUBCOMMAND]
 
-ARGS:
+Arguments:
     <positional>        tests positionals
     <positional2>       tests positionals with exclusions
     <positional3>...    tests specific values [possible values: vi, emacs]
 
-OPTIONS:
+Options:
     -o, --option <opt>...                    tests options
     -f, --flag...                            tests flags
     -F                                       tests flags with exclusions
@@ -227,7 +227,7 @@ OPTIONS:
     -h, --help                               Print help information
     -V, --version                            Print version information
 
-SUBCOMMANDS:
+Subcommands:
     subcmd    tests subcommands
     help      Print this message or the help of the given subcommand(s)
 ";
@@ -242,10 +242,10 @@ fn after_and_before_help_output() {
 clap-test v1.4.8
 tests clap library
 
-USAGE:
+Usage:
     clap-test
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -268,10 +268,10 @@ fn after_and_before_long_help_output() {
 clap-test v1.4.8
 tests clap library
 
-USAGE:
+Usage:
     clap-test
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -283,10 +283,10 @@ some text that comes after the help
 clap-test v1.4.8
 tests clap library
 
-USAGE:
+Usage:
     clap-test
 
-OPTIONS:
+Options:
     -h, --help
             Print help information
 
@@ -311,10 +311,10 @@ static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
 Kevin K. <kbknapp@gmail.com>
 tests subcommands
 
-USAGE:
+Usage:
     ctest subcmd multi [OPTIONS]
 
-OPTIONS:
+Options:
     -f, --flag                    tests flags
     -o, --option <scoption>...    tests options
     -h, --help                    Print help information
@@ -357,10 +357,10 @@ fn no_wrap_help() {
 fn no_wrap_default_help() {
     static DEFAULT_HELP: &str = "ctest 1.0
 
-USAGE:
+Usage:
     ctest
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -374,10 +374,10 @@ OPTIONS:
 fn wrapped_help() {
     static WRAPPED_HELP: &str = "test 
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -a, --all
             Also do versioning for private crates (will not be
             published)
@@ -430,10 +430,10 @@ OPTIONS:
 fn unwrapped_help() {
     static UNWRAPPED_HELP: &str = "test 
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -a, --all              Also do versioning for private crates
                            (will not be published)
         --exact            Specify inter dependency version numbers
@@ -478,10 +478,10 @@ OPTIONS:
 fn possible_value_wrapped_help() {
     static WRAPPED_HELP: &str = "test 
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --possible-values <possible_values>
             Possible values:
               - short_name:
@@ -545,13 +545,13 @@ fn complex_subcommand_help_output() {
 Kevin K. <kbknapp@gmail.com>
 tests subcommands
 
-USAGE:
+Usage:
     clap-test subcmd [OPTIONS] [--] [scpositional]
 
-ARGS:
+Arguments:
     <scpositional>    tests positionals
 
-OPTIONS:
+Options:
     -o, --option <scoption>...     tests options
     -f, --flag...                  tests flags
     -s, --subcmdarg <subcmdarg>    tests other args
@@ -567,10 +567,10 @@ OPTIONS:
 fn issue_626_unicode_cutoff() {
     static ISSUE_626_CUTOFF: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café is an
                          establishment which primarily serves hot
                          coffee, related coffee beverages (e.g., café
@@ -603,10 +603,10 @@ OPTIONS:
 
 static HIDE_POS_VALS: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -p, --pos <VAL>      Some vals [possible values: fast, slow]
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
     -h, --help           Print help information
@@ -671,10 +671,10 @@ fn hide_single_possible_val() {
 fn possible_vals_with_help() {
     static POS_VALS_HELP: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -p, --pos <VAL>
             Some vals
 
@@ -721,10 +721,10 @@ OPTIONS:
 fn issue_626_panic() {
     static ISSUE_626_PANIC: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe <FILE>
             La culture du café est très développée
             dans de nombreux pays à climat chaud
@@ -777,10 +777,10 @@ fn issue_626_variable_panic() {
 fn final_word_wrapping() {
     static FINAL_WORD_WRAPPING: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest
 
-OPTIONS:
+Options:
     -h, --help
             Print help
             information
@@ -797,10 +797,10 @@ OPTIONS:
 
 static WRAPPING_NEWLINE_CHARS: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [mode]
 
-ARGS:
+Arguments:
     <mode>    x, max, maximum   20 characters, contains
               symbols.
               l, long           Copy-friendly, 14
@@ -808,7 +808,7 @@ ARGS:
               m, med, medium    Copy-friendly, 8
               characters, contains symbols.
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -853,10 +853,10 @@ fn dont_wrap_urls() {
     const EXPECTED: &str = "\
 Example-update 
 
-USAGE:
+Usage:
     Example update [OPTIONS]
 
-OPTIONS:
+Options:
         --force-non-host
             Install toolchains
             that require an
@@ -872,10 +872,10 @@ OPTIONS:
 
 static OLD_NEWLINE_CHARS: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -m               Some help with some wrapping
                      (Defaults to something)
     -h, --help       Print help information
@@ -908,10 +908,10 @@ fn old_newline_variables() {
 fn issue_688_hide_pos_vals() {
     static ISSUE_688: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
         --filter <filter>    Sets the filter, or sampling method, to use for interpolation when resizing the particle
                              images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic,
                              Gaussian, Lanczos3]
@@ -961,14 +961,14 @@ fn issue_702_multiple_values() {
 foo
 bar
 
-USAGE:
+Usage:
     myapp [OPTIONS] [--] [ARGS]
 
-ARGS:
+Arguments:
     <arg1>       some option
     <arg2>...    some option
 
-OPTIONS:
+Options:
     -s, --some <some>         some option
     -o, --other <other>       some other option
     -l, --label <label>...    a label
@@ -1020,14 +1020,14 @@ something really really long, with
 multiple lines of text
 that should be displayed
 
-USAGE:
+Usage:
     myapp [arg1]
 
-ARGS:
+Arguments:
     <arg1>
             some option
 
-OPTIONS:
+Options:
     -h, --help
             Print help information
 
@@ -1048,13 +1048,13 @@ OPTIONS:
 
 static RIPGREP_USAGE: &str = "ripgrep 0.5
 
-USAGE:
+Usage:
     rg [OPTIONS] <pattern> [<path> ...]
     rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]
     rg [OPTIONS] --files [<path> ...]
     rg [OPTIONS] --type-list
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -1086,9 +1086,9 @@ fn ripgrep_usage_using_templates() {
             "\
 {bin} {version}
 
-USAGE:{usage}
+Usage:{usage}
 
-OPTIONS:
+Options:
 {options}",
         );
 
@@ -1099,19 +1099,19 @@ OPTIONS:
 fn sc_negates_reqs() {
     static SC_NEGATES_REQS: &str = "prog 1.0
 
-USAGE:
+Usage:
     prog --opt <FILE> [PATH]
     prog [PATH] <SUBCOMMAND>
 
-ARGS:
+Arguments:
     <PATH>    help
 
-OPTIONS:
+Options:
     -o, --opt <FILE>    tests options
     -h, --help          Print help information
     -V, --version       Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -1129,10 +1129,10 @@ SUBCOMMANDS:
 fn hide_args() {
     static HIDDEN_ARGS: &str = "prog 1.0
 
-USAGE:
+Usage:
     prog [OPTIONS]
 
-OPTIONS:
+Options:
     -f, --flag          testing flags
     -o, --opt <FILE>    tests options
     -h, --help          Print help information
@@ -1151,20 +1151,20 @@ OPTIONS:
 fn args_negate_sc() {
     static ARGS_NEGATE_SC: &str = "prog 1.0
 
-USAGE:
+Usage:
     prog [OPTIONS] [PATH]
     prog <SUBCOMMAND>
 
-ARGS:
+Arguments:
     <PATH>    help
 
-OPTIONS:
+Options:
     -f, --flag          testing flags
     -o, --opt <FILE>    tests options
     -h, --help          Print help information
     -V, --version       Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -1183,13 +1183,13 @@ SUBCOMMANDS:
 fn issue_1046_hide_scs() {
     static ISSUE_1046_HIDDEN_SCS: &str = "prog 1.0
 
-USAGE:
+Usage:
     prog [OPTIONS] [PATH]
 
-ARGS:
+Arguments:
     <PATH>    some
 
-OPTIONS:
+Options:
     -f, --flag          testing flags
     -o, --opt <FILE>    tests options
     -h, --help          Print help information
@@ -1214,10 +1214,10 @@ email <email@server.com>
 Show how the about text is not
 wrapped
 
-USAGE:
+Usage:
     ctest
 
-OPTIONS:
+Options:
     -h, --help
             Print help information
 
@@ -1236,10 +1236,10 @@ OPTIONS:
 
 static OVERRIDE_HELP_SHORT: &str = "test 0.1
 
-USAGE:
+Usage:
     test
 
-OPTIONS:
+Options:
     -H, --help       Print help information
     -V, --version    Print version information
 ";
@@ -1257,10 +1257,10 @@ fn override_help_short() {
 
 static OVERRIDE_HELP_LONG: &str = "test 0.1
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -h, --hell       Print help information
     -V, --version    Print version information
 ";
@@ -1278,10 +1278,10 @@ fn override_help_long() {
 
 static OVERRIDE_HELP_ABOUT: &str = "test 0.1
 
-USAGE:
+Usage:
     test
 
-OPTIONS:
+Options:
     -h, --help       Print custom help information
     -V, --version    Print version information
 ";
@@ -1332,15 +1332,15 @@ fn arg_long_conflict_with_help() {
 fn last_arg_mult_usage() {
     static LAST_ARG: &str = "last 0.1
 
-USAGE:
+Usage:
     last <TARGET> [CORPUS] [-- <ARGS>...]
 
-ARGS:
+Arguments:
     <TARGET>     some
     <CORPUS>     some
     <ARGS>...    some
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -1363,15 +1363,15 @@ OPTIONS:
 fn last_arg_mult_usage_req() {
     static LAST_ARG_REQ: &str = "last 0.1
 
-USAGE:
+Usage:
     last <TARGET> [CORPUS] -- <ARGS>...
 
-ARGS:
+Arguments:
     <TARGET>     some
     <CORPUS>     some
     <ARGS>...    some
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -1395,20 +1395,20 @@ OPTIONS:
 fn last_arg_mult_usage_req_with_sc() {
     static LAST_ARG_REQ_SC: &str = "last 0.1
 
-USAGE:
+Usage:
     last <TARGET> [CORPUS] -- <ARGS>...
     last <SUBCOMMAND>
 
-ARGS:
+Arguments:
     <TARGET>     some
     <CORPUS>     some
     <ARGS>...    some
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    some
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -1434,20 +1434,20 @@ SUBCOMMANDS:
 fn last_arg_mult_usage_with_sc() {
     static LAST_ARG_SC: &str = "last 0.1
 
-USAGE:
+Usage:
     last <TARGET> [CORPUS] [-- <ARGS>...]
     last <SUBCOMMAND>
 
-ARGS:
+Arguments:
     <TARGET>     some
     <CORPUS>     some
     <ARGS>...    some
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    some
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -1470,10 +1470,10 @@ SUBCOMMANDS:
 
 static HIDE_DEFAULT_VAL: &str = "default 0.1
 
-USAGE:
+Usage:
     default [OPTIONS]
 
-OPTIONS:
+Options:
         --arg <argument>    Pass an argument to the program. [default: default-argument]
     -h, --help              Print help information
     -V, --version           Print version information
@@ -1503,10 +1503,10 @@ fn hide_default_val() {
 fn escaped_whitespace_values() {
     static ESCAPED_DEFAULT_VAL: &str = "default 0.1
 
-USAGE:
+Usage:
     default [OPTIONS]
 
-OPTIONS:
+Options:
         --arg <argument>    Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
                             other]
     -h, --help              Print help information
@@ -1595,10 +1595,10 @@ fn issue_1052_require_delim_help() {
 Kevin K.
 tests stuff
 
-USAGE:
+Usage:
     test --fake <some> <val>
 
-OPTIONS:
+Options:
     -f, --fake <some> <val>    some help
     -h, --help                 Print help information
     -V, --version              Print version information
@@ -1625,10 +1625,10 @@ fn custom_headers_headers() {
 Will M.
 does stuff
 
-USAGE:
+Usage:
     test [OPTIONS] --fake <some> <val>
 
-OPTIONS:
+Options:
     -f, --fake <some> <val>    some help
     -h, --help                 Print help information
     -V, --version              Print version information
@@ -1666,10 +1666,10 @@ static MULTIPLE_CUSTOM_HELP_SECTIONS: &str = "blorp 1.4
 Will M.
 does stuff
 
-USAGE:
+Usage:
     test [OPTIONS] --fake <some> <val> --birthday-song <song> --birthday-song-volume <volume>
 
-OPTIONS:
+Options:
     -f, --fake <some> <val>    some help
         --style <style>        Choose musical style to play the song
     -s, --speed <SPEED>        How fast? [possible values: fast, slow]
@@ -1747,10 +1747,10 @@ static CUSTOM_HELP_SECTION_HIDDEN_ARGS: &str = "blorp 1.4
 Will M.
 does stuff
 
-USAGE:
+Usage:
     test [OPTIONS] --song <song> --song-volume <volume>
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -1799,10 +1799,10 @@ fn custom_help_headers_hide_args() {
 static ISSUE_897: &str = "ctest-foo 0.1
 Long about foo
 
-USAGE:
+Usage:
     ctest foo
 
-OPTIONS:
+Options:
     -h, --help
             Print help information
 
@@ -1824,10 +1824,10 @@ fn show_long_about_issue_897() {
 static ISSUE_897_SHORT: &str = "ctest-foo 0.1
 About foo
 
-USAGE:
+Usage:
     ctest foo
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -1847,13 +1847,13 @@ fn show_short_about_issue_897() {
 fn issue_1364_no_short_options() {
     static ISSUE_1364: &str = "demo 
 
-USAGE:
+Usage:
     demo [OPTIONS] [FILES]...
 
-ARGS:
+Arguments:
     <FILES>...    
 
-OPTIONS:
+Options:
     -f            
     -h, --help    Print help information
 ";
@@ -1881,14 +1881,14 @@ OPTIONS:
 fn issue_1487() {
 static ISSUE_1487: &str = "test 
 
-USAGE:
+Usage:
     ctest <arg1|arg2>
 
-ARGS:
+Arguments:
     <arg1>    
     <arg2>    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ";
 
@@ -2003,10 +2003,10 @@ fn help_required_and_no_args() {
 fn issue_1642_long_help_spacing() {
     static ISSUE_1642: &str = "prog 
 
-USAGE:
+Usage:
     prog [OPTIONS]
 
-OPTIONS:
+Options:
         --config
             The config file used by the myprog must be in JSON format
             with only valid keys and may not contain other nonsense
@@ -2033,7 +2033,7 @@ and on, so I'll stop now.",
 
 const AFTER_HELP_NO_ARGS: &str = "myapp 1.0
 
-USAGE:
+Usage:
     myapp
 
 This is after help.
@@ -2061,10 +2061,10 @@ fn help_subcmd_help() {
     static HELP_SUBCMD_HELP: &str = "myapp-help 
 Print this message or the help of the given subcommand(s)
 
-USAGE:
+Usage:
     myapp help [SUBCOMMAND]...
 
-ARGS:
+Arguments:
     [SUBCOMMAND]...    The subcommand whose help message to display
 ";
 
@@ -2079,10 +2079,10 @@ fn subcmd_help_subcmd_help() {
     static SUBCMD_HELP_SUBCMD_HELP: &str = "myapp-subcmd-help 
 Print this message or the help of the given subcommand(s)
 
-USAGE:
+Usage:
     myapp subcmd help [SUBCOMMAND]...
 
-ARGS:
+Arguments:
     [SUBCOMMAND]...    The subcommand whose help message to display
 ";
 
@@ -2101,10 +2101,10 @@ ARGS:
 fn option_usage_order() {
     static OPTION_USAGE_ORDER: &str = "order 
 
-USAGE:
+Usage:
     order [OPTIONS]
 
-OPTIONS:
+Options:
     -a                     
     -B                     
     -b                     
@@ -2136,13 +2136,13 @@ OPTIONS:
 fn prefer_about_over_long_about_in_subcommands_list() {
     static ABOUT_IN_SUBCOMMANDS_LIST: &str = "about-in-subcommands-list 
 
-USAGE:
+Usage:
     about-in-subcommands-list [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 
-SUBCOMMANDS:
+Subcommands:
     sub     short about sub
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -2165,14 +2165,14 @@ SUBCOMMANDS:
 fn issue_1794_usage() {
     static USAGE_WITH_GROUP: &str = "hello 
 
-USAGE:
+Usage:
     deno <pos1|--option1> [pos2]
 
-ARGS:
+Arguments:
     <pos1>    
     <pos2>    
 
-OPTIONS:
+Options:
         --option1    
     -h, --help       Print help information
 ";
@@ -2197,13 +2197,13 @@ OPTIONS:
 
 static CUSTOM_HEADING_POS: &str = "test 1.4
 
-USAGE:
+Usage:
     test [ARGS]
 
-ARGS:
+Arguments:
     <gear>    Which gear
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
@@ -2224,7 +2224,7 @@ fn custom_heading_pos() {
 
 static ONLY_CUSTOM_HEADING_OPTS_NO_ARGS: &str = "test 1.4
 
-USAGE:
+Usage:
     test [OPTIONS]
 
 NETWORKING:
@@ -2246,7 +2246,7 @@ fn only_custom_heading_opts_no_args() {
 
 static ONLY_CUSTOM_HEADING_POS_NO_ARGS: &str = "test 1.4
 
-USAGE:
+Usage:
     test [speed]
 
 NETWORKING:
@@ -2281,10 +2281,10 @@ fn issue_2508_number_of_values_with_single_value_name() {
         "my_app --help",
         "my_app 
 
-USAGE:
+Usage:
     my_app [OPTIONS]
 
-OPTIONS:
+Options:
         --some_arg <some_arg> <some_arg>    
         --some_arg_issue <ARG> <ARG>        
     -h, --help                              Print help information
@@ -2304,14 +2304,14 @@ fn missing_positional_final_required() {
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test [arg1] <arg2>
 
-ARGS:
+Arguments:
     <arg1>    
     <arg2>    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ",
         false,
@@ -2330,15 +2330,15 @@ fn missing_positional_final_multiple() {
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test [ARGS]
 
-ARGS:
+Arguments:
     <foo>       
     <bar>       
     <baz>...    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ",
         false,
@@ -2358,13 +2358,13 @@ fn positional_multiple_values_is_dotted() {
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test <foo>...
 
-ARGS:
+Arguments:
     <foo>...    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ",
         false,
@@ -2382,13 +2382,13 @@ OPTIONS:
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test <BAR>...
 
-ARGS:
+Arguments:
     <BAR>...    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ",
         false,
@@ -2409,13 +2409,13 @@ fn positional_multiple_occurrences_is_dotted() {
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test <foo>...
 
-ARGS:
+Arguments:
     <foo>...    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ",
         false,
@@ -2434,13 +2434,13 @@ OPTIONS:
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test <BAR>...
 
-ARGS:
+Arguments:
     <BAR>...    
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ",
         false,
@@ -2462,10 +2462,10 @@ fn too_few_value_names_is_dotted() {
         "test --help",
         "test 
 
-USAGE:
+Usage:
     test --foo <one> <two>...
 
-OPTIONS:
+Options:
         --foo <one> <two>...    
     -h, --help                  Print help information
 ",
@@ -2565,10 +2565,10 @@ fn subcommand_help_doesnt_have_useless_help_flag() {
         "example-help 
 Print this message or the help of the given subcommand(s)
 
-USAGE:
+Usage:
     example help [SUBCOMMAND]...
 
-ARGS:
+Arguments:
     [SUBCOMMAND]...    The subcommand whose help message to display
 ",
         false,
@@ -2608,10 +2608,10 @@ fn dont_propagate_version_to_help_subcommand() {
         "example-help 
 Print this message or the help of the given subcommand(s)
 
-USAGE:
+Usage:
     example help [SUBCOMMAND]...
 
-ARGS:
+Arguments:
     [SUBCOMMAND]...    The subcommand whose help message to display
 ",
         false,
@@ -2643,10 +2643,10 @@ fn parent_cmd_req_in_usage_with_help_flag() {
     static EXPECTED: &str = "parent-test 
 some
 
-USAGE:
+Usage:
     parent <TARGET> <ARGS> test
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ";
     let cmd = Command::new("parent")
@@ -2667,10 +2667,10 @@ fn parent_cmd_req_in_usage_with_help_subcommand() {
     static EXPECTED: &str = "parent-test 
 some
 
-USAGE:
+Usage:
     parent <TARGET> <ARGS> test
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ";
     let cmd = Command::new("parent")
@@ -2691,10 +2691,10 @@ fn parent_cmd_req_in_usage_with_render_help() {
     static EXPECTED: &str = "parent-test 
 some
 
-USAGE:
+Usage:
     parent <TARGET> <ARGS> test
 
-OPTIONS:
+Options:
     -h, --help    Print help information
 ";
     let mut cmd = Command::new("parent")

--- a/tests/builder/help_env.rs
+++ b/tests/builder/help_env.rs
@@ -8,10 +8,10 @@ use super::utils;
 
 static HIDE_ENV: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
     -h, --help           Print help information
     -V, --version        Print version information
@@ -19,10 +19,10 @@ OPTIONS:
 
 static SHOW_ENV: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -h, --help           Print help information
     -V, --version        Print version information
@@ -30,10 +30,10 @@ OPTIONS:
 
 static HIDE_ENV_VALS: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR]
     -h, --help           Print help information
     -V, --version        Print version information
@@ -41,10 +41,10 @@ OPTIONS:
 
 static SHOW_ENV_VALS: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -h, --help           Print help information
     -V, --version        Print version information
@@ -52,10 +52,10 @@ OPTIONS:
 
 static HIDE_ENV_FLAG: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe       A coffeehouse, coffee shop, or café.
     -h, --help       Print help information
     -V, --version    Print version information
@@ -63,10 +63,10 @@ OPTIONS:
 
 static SHOW_ENV_FLAG: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -h, --help       Print help information
     -V, --version    Print version information
@@ -74,10 +74,10 @@ OPTIONS:
 
 static HIDE_ENV_VALS_FLAG: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR]
     -h, --help       Print help information
     -V, --version    Print version information
@@ -85,10 +85,10 @@ OPTIONS:
 
 static SHOW_ENV_VALS_FLAG: &str = "ctest 0.1
 
-USAGE:
+Usage:
     ctest [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
     -h, --help       Print help information
     -V, --version    Print version information

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -6,10 +6,10 @@ static HIDDEN_ARGS: &str = "test 1.4
 Kevin K.
 tests stuff
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -F, --flag2           some other flag
         --option <opt>    some option
     -h, --help            Print help information
@@ -35,10 +35,10 @@ static HIDDEN_SHORT_ARGS: &str = "test 2.31.2
 Steve P.
 hides short args
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -v, --visible    This text should be visible
     -h, --help       Print help information
     -V, --version    Print version information
@@ -75,10 +75,10 @@ fn hide_short_args_long_help() {
 Steve P.
 hides short args
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --config
             Some help text describing the --config arg
 
@@ -117,10 +117,10 @@ static HIDDEN_LONG_ARGS: &str = "test 2.31.2
 Steve P.
 hides long args
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -v, --visible
             This text should be visible
 
@@ -158,10 +158,10 @@ static HIDDEN_LONG_ARGS_SHORT_HELP: &str = "test 2.31.2
 Steve P.
 hides long args
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -c, --config     Some help text describing the --config arg
     -v, --visible    This text should be visible
     -h, --help       Print help information
@@ -193,13 +193,13 @@ fn hide_long_args_short_help() {
 
 static HIDDEN_POS_ARGS: &str = "test 1.4
 
-USAGE:
+Usage:
     test [another]
 
-ARGS:
+Arguments:
     <another>    another pos
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -216,10 +216,10 @@ fn hide_pos_args() {
 
 static HIDDEN_SUBCMDS: &str = "test 1.4
 
-USAGE:
+Usage:
     test
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -235,7 +235,7 @@ fn hide_subcmds() {
 
 static HIDDEN_OPT_ARGS_ONLY: &str = "test 1.4
 
-USAGE:
+Usage:
     test
 
 After help
@@ -261,7 +261,7 @@ fn hide_opt_args_only() {
 
 static HIDDEN_POS_ARGS_ONLY: &str = "test 1.4
 
-USAGE:
+Usage:
     test
 
 After help
@@ -283,7 +283,7 @@ fn hide_pos_args_only() {
 
 static HIDDEN_SUBCMDS_ONLY: &str = "test 1.4
 
-USAGE:
+Usage:
     test
 
 After help

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -431,10 +431,10 @@ fn optional_value() {
     const HELP: &str = "\
 test 
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -p [<NUM>]        
     -h, --help        Print help information
 ";

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -10,7 +10,7 @@ static DYM: &str =
 
 \tIf you tried to supply `--optio` as a value rather than a flag, use `-- --optio`
 
-USAGE:
+Usage:
     clap-test --option <opt>...
 
 For more information try --help
@@ -24,7 +24,7 @@ static DYM_ISSUE_1073: &str =
 
 \tIf you tried to supply `--files-without-matches` as a value rather than a flag, use `-- --files-without-matches`
 
-USAGE:
+Usage:
     ripgrep-616 --files-without-match
 
 For more information try --help
@@ -50,7 +50,7 @@ fn require_equals_fail_message() {
     static NO_EQUALS: &str =
         "error: Equal sign is needed when assigning values to '--config=<cfg>'.
 
-USAGE:
+Usage:
     prog [OPTIONS]
 
 For more information try --help

--- a/tests/builder/positionals.rs
+++ b/tests/builder/positionals.rs
@@ -211,13 +211,13 @@ fn positional_hyphen_does_not_panic() {
 #[test]
 fn single_positional_usage_string() {
     let mut cmd = Command::new("test").arg(arg!([FILE] "some file"));
-    assert_eq!(cmd.render_usage(), "USAGE:\n    test [FILE]");
+    assert_eq!(cmd.render_usage(), "Usage:\n    test [FILE]");
 }
 
 #[test]
 fn single_positional_multiple_usage_string() {
     let mut cmd = Command::new("test").arg(arg!([FILE]... "some file"));
-    assert_eq!(cmd.render_usage(), "USAGE:\n    test [FILE]...");
+    assert_eq!(cmd.render_usage(), "Usage:\n    test [FILE]...");
 }
 
 #[test]
@@ -225,7 +225,7 @@ fn multiple_positional_usage_string() {
     let mut cmd = Command::new("test")
         .arg(arg!([FILE] "some file"))
         .arg(arg!([FILES]... "some file"));
-    assert_eq!(cmd.render_usage(), "USAGE:\n    test [ARGS]");
+    assert_eq!(cmd.render_usage(), "Usage:\n    test [ARGS]");
 }
 
 #[test]
@@ -233,13 +233,13 @@ fn multiple_positional_one_required_usage_string() {
     let mut cmd = Command::new("test")
         .arg(arg!(<FILE> "some file"))
         .arg(arg!([FILES]... "some file"));
-    assert_eq!(cmd.render_usage(), "USAGE:\n    test <FILE> [FILES]...");
+    assert_eq!(cmd.render_usage(), "Usage:\n    test <FILE> [FILES]...");
 }
 
 #[test]
 fn single_positional_required_usage_string() {
     let mut cmd = Command::new("test").arg(arg!(<FILE> "some file"));
-    assert_eq!(cmd.render_usage(), "USAGE:\n    test <FILE>");
+    assert_eq!(cmd.render_usage(), "Usage:\n    test <FILE>");
 }
 
 // This tests a programmer error and will only succeed with debug_assertions

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -6,7 +6,7 @@ use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgGroup, Command};
 static REQUIRE_EQUALS: &str = "error: The following required arguments were not provided:
     --opt=<FILE>
 
-USAGE:
+Usage:
     clap-test --opt=<FILE>
 
 For more information try --help
@@ -15,7 +15,7 @@ For more information try --help
 static REQUIRE_EQUALS_FILTERED: &str = "error: The following required arguments were not provided:
     --opt=<FILE>
 
-USAGE:
+Usage:
     clap-test --opt=<FILE> --foo=<FILE>
 
 For more information try --help
@@ -25,7 +25,7 @@ static REQUIRE_EQUALS_FILTERED_GROUP: &str =
     "error: The following required arguments were not provided:
     --opt=<FILE>
 
-USAGE:
+Usage:
     clap-test --opt=<FILE> --foo=<FILE> <--g1=<FILE>|--g2=<FILE>>
 
 For more information try --help
@@ -35,7 +35,7 @@ static MISSING_REQ: &str = "error: The following required arguments were not pro
     --long-option-2 <option2>
     <positional2>
 
-USAGE:
+Usage:
     clap-test --long-option-2 <option2> -F <positional2>
 
 For more information try --help
@@ -44,7 +44,7 @@ For more information try --help
 static COND_REQ_IN_USAGE: &str = "error: The following required arguments were not provided:
     --output <output>
 
-USAGE:
+Usage:
     test --target <target> --input <input> --output <output>
 
 For more information try --help
@@ -140,7 +140,7 @@ static POSITIONAL_REQ: &str = "error: The following required arguments were not 
     <flag>
     <opt>
 
-USAGE:
+Usage:
     clap-test <flag> <opt> [ARGS]
 
 For more information try --help
@@ -159,7 +159,7 @@ fn positional_required_with_requires_if_no_value() {
 static POSITIONAL_REQ_IF_NO_VAL: &str = "error: The following required arguments were not provided:
     <flag>
 
-USAGE:
+Usage:
     clap-test <flag> [ARGS]
 
 For more information try --help
@@ -180,7 +180,7 @@ static POSITIONAL_REQ_IF_VAL: &str = "error: The following required arguments we
     <foo>
     <opt>
 
-USAGE:
+Usage:
     clap-test <flag> <foo> <opt>
 
 For more information try --help
@@ -1030,7 +1030,7 @@ static ISSUE_1158: &str = "error: The following required arguments were not prov
     -y <Y>
     -z <Z>
 
-USAGE:
+Usage:
     example -x <X> -y <Y> -z <Z> <ID>
 
 For more information try --help
@@ -1066,7 +1066,7 @@ fn multiple_required_unless_usage_printing() {
     --a <a>
     --b <b>
 
-USAGE:
+Usage:
     test --c <c> --a <a> --b <b>
 
 For more information try --help
@@ -1434,7 +1434,7 @@ fn required_error_doesnt_duplicate() {
     const EXPECTED: &str = "\
 error: The argument '-b <b>' cannot be used with '-c <c>'
 
-USAGE:
+Usage:
     clap-test -b <b> <a>
 
 For more information try --help
@@ -1457,7 +1457,7 @@ fn required_require_with_group_shows_flag() {
 error: The following required arguments were not provided:
     --first
 
-USAGE:
+Usage:
     test --require-first <--first|--second>
 
 For more information try --help

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -4,28 +4,28 @@ use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 
 static VISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 
-USAGE:
+Usage:
     clap-test [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    Some help [aliases: dongle, done]
     help    Print this message or the help of the given subcommand(s)
 ";
 
 static INVISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 
-USAGE:
+Usage:
     clap-test [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    Some help
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -37,7 +37,7 @@ static DYM_SUBCMD: &str = "error: The subcommand 'subcm' wasn't recognized
 
 If you believe you received this message in error, try re-running with 'dym -- subcm'
 
-USAGE:
+Usage:
     dym [SUBCOMMAND]
 
 For more information try --help
@@ -50,7 +50,7 @@ static DYM_SUBCMD_AMBIGUOUS: &str = "error: The subcommand 'te' wasn't recognize
 
 If you believe you received this message in error, try re-running with 'dym -- te'
 
-USAGE:
+Usage:
     dym [SUBCOMMAND]
 
 For more information try --help
@@ -61,7 +61,7 @@ static SUBCMD_AFTER_DOUBLE_DASH: &str =
 
 \tIf you tried to supply `subcmd` as a subcommand, remove the '--' before it.
 
-USAGE:
+Usage:
     cmd [SUBCOMMAND]
 
 For more information try --help
@@ -183,7 +183,7 @@ fn subcmd_did_you_mean_output_arg() {
 
 \tIf you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
 
-USAGE:
+Usage:
     dym [SUBCOMMAND]
 
 For more information try --help
@@ -204,7 +204,7 @@ fn subcmd_did_you_mean_output_arg_false_positives() {
 
 \tIf you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
 
-USAGE:
+Usage:
     dym [SUBCOMMAND]
 
 For more information try --help
@@ -358,7 +358,7 @@ fn subcommand_placeholder_test() {
         .subcommand_value_name("TEST_PLACEHOLDER")
         .subcommand_help_heading("TEST_HEADER");
 
-    assert_eq!(&cmd.render_usage(), "USAGE:\n    myprog [TEST_PLACEHOLDER]");
+    assert_eq!(&cmd.render_usage(), "Usage:\n    myprog [TEST_PLACEHOLDER]");
 
     let mut help_text = Vec::new();
     cmd.write_help(&mut help_text)
@@ -440,7 +440,7 @@ fn subcommand_not_recognized() {
         "fake help",
         "error: The subcommand 'help' wasn't recognized
 
-USAGE:
+Usage:
     fake [SUBCOMMAND]
 
 For more information try --help
@@ -517,7 +517,7 @@ fn bad_multicall_command_error() {
     static HELLO_EXPECTED: &str = "\
 error: The subcommand 'world' wasn't recognized
 
-USAGE:
+Usage:
     <SUBCOMMAND>
 
 For more information try help
@@ -535,7 +535,7 @@ error: The subcommand 'baz' wasn't recognized
 
 If you believe you received this message in error, try re-running with ' -- baz'
 
-USAGE:
+Usage:
     <SUBCOMMAND>
 
 For more information try help
@@ -576,13 +576,13 @@ fn multicall_help_flag() {
     static EXPECTED: &str = "\
 foo-bar 1.0.0
 
-USAGE:
+Usage:
     foo bar [value]
 
-ARGS:
+Arguments:
     <value>    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -599,13 +599,13 @@ fn multicall_help_subcommand() {
     static EXPECTED: &str = "\
 foo-bar 1.0.0
 
-USAGE:
+Usage:
     foo bar [value]
 
-ARGS:
+Arguments:
     <value>    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";
@@ -622,13 +622,13 @@ fn multicall_render_help() {
     static EXPECTED: &str = "\
 foo-bar 1.0.0
 
-USAGE:
+Usage:
     foo bar [value]
 
-ARGS:
+Arguments:
     <value>    
 
-OPTIONS:
+Options:
     -h, --help       Print help information
     -V, --version    Print version information
 ";

--- a/tests/builder/template_help.rs
+++ b/tests/builder/template_help.rs
@@ -6,7 +6,7 @@ static EXAMPLE1_TMPL_S: &str = "{bin} {version}
 {author}
 {about}
 
-USAGE:
+Usage:
     {usage}
 
 {all-args}";
@@ -15,31 +15,31 @@ static EXAMPLE1_TMPS_F: &str = "{bin} {version}
 {author}
 {about}
 
-USAGE:
+Usage:
     {usage}
 
-OPTIONS:
+Options:
 {options}
-ARGS:
+Arguments:
 {positionals}
-SUBCOMMANDS:
+Subcommands:
 {subcommands}";
 
 static CUSTOM_TEMPL_HELP: &str = "MyApp 1.0
 Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
-USAGE:
+Usage:
     MyApp [OPTIONS] <output> [SUBCOMMAND]
 
-OPTIONS:
+Options:
     -c, --config <FILE>    Sets a custom config file
     -d...                  Turn debugging information on
     -h, --help             Print help information
     -V, --version          Print version information
-ARGS:
+Arguments:
     <output>    Sets an optional output file
-SUBCOMMANDS:
+Subcommands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -48,19 +48,19 @@ static SIMPLE_TEMPLATE: &str = "MyApp 1.0
 Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
-USAGE:
+Usage:
     MyApp [OPTIONS] <output> [SUBCOMMAND]
 
-ARGS:
+Arguments:
     <output>    Sets an optional output file
 
-OPTIONS:
+Options:
     -c, --config <FILE>    Sets a custom config file
     -d...                  Turn debugging information on
     -h, --help             Print help information
     -V, --version          Print version information
 
-SUBCOMMANDS:
+Subcommands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 ";

--- a/tests/derive/author_version_about.rs
+++ b/tests/derive/author_version_about.rs
@@ -23,7 +23,7 @@ fn no_author_version_about() {
     struct Opt {}
 
     let output = utils::get_long_help::<Opt>();
-    assert!(output.starts_with("foo \n\nUSAGE:"));
+    assert!(output.starts_with("foo \n\nUsage:"));
 }
 
 #[test]

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -59,7 +59,15 @@ fn empty_line_in_doc_comment_is_double_linefeed() {
     struct LoremIpsum {}
 
     let help = utils::get_long_help::<LoremIpsum>();
-    assert!(help.starts_with("lorem-ipsum \nFoo.\n\nBar\n\nUSAGE:"));
+    assert!(help.starts_with(
+        "\
+lorem-ipsum 
+Foo.
+
+Bar
+
+Usage:"
+    ));
 }
 
 #[test]

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -220,7 +220,7 @@ fn derive_generated_error_has_full_context() {
 
     let expected = r#"error: The following required argument was not provided: req_str
 
-USAGE:
+Usage:
     clap --req-str <REQ_STR>
     clap <SUBCOMMAND>
 
@@ -233,10 +233,10 @@ For more information try --help
 fn derive_order_next_order() {
     static HELP: &str = "test 1.2
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --flag-b                 first flag
         --option-b <OPTION_B>    first option
     -h, --help                   Print help information
@@ -289,10 +289,10 @@ OPTIONS:
 fn derive_order_next_order_flatten() {
     static HELP: &str = "test 1.2
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --flag-b                 first flag
         --option-b <OPTION_B>    first option
     -h, --help                   Print help information
@@ -345,10 +345,10 @@ OPTIONS:
 fn derive_order_no_next_order() {
     static HELP: &str = "test 1.2
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
         --flag-a                 first flag
         --flag-b                 second flag
     -h, --help                   Print help information
@@ -401,10 +401,10 @@ fn derive_possible_value_help() {
     static HELP: &str = "clap 
 Application help
 
-USAGE:
+Usage:
     clap <ARG>
 
-ARGS:
+Arguments:
     <ARG>
             Argument help
 
@@ -412,7 +412,7 @@ ARGS:
               - foo: Foo help
               - bar: Bar help
 
-OPTIONS:
+Options:
     -h, --help
             Print help information
 ";

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -303,10 +303,10 @@ mod arg {
         const HELP: &str = "\
 test 
 
-USAGE:
+Usage:
     test [OPTIONS]
 
-OPTIONS:
+Options:
     -p [<NUM>]        
     -h, --help        Print help information
 ";

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -5,15 +5,15 @@ stdout = ""
 stderr = """
 stdio-fixture 1.0
 
-USAGE:
+Usage:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
-OPTIONS:
+Options:
         --verbose    log
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     more    
     help    Print this message or the help of the given subcommand(s)
 """

--- a/tests/ui/error_stderr.toml
+++ b/tests/ui/error_stderr.toml
@@ -7,7 +7,7 @@ error: Found argument '--unknown-argument' which wasn't expected, or isn't valid
 
 \tIf you tried to supply `--unknown-argument` as a value rather than a flag, use `-- --unknown-argument`
 
-USAGE:
+Usage:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
 For more information try --help

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -4,15 +4,15 @@ status.code = 0
 stdout = """
 stdio-fixture 1.0
 
-USAGE:
+Usage:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
-OPTIONS:
+Options:
         --verbose    log
     -h, --help       Print help information
     -V, --version    Print version information
 
-SUBCOMMANDS:
+Subcommands:
     more    
     help    Print this message or the help of the given subcommand(s)
 """

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -4,10 +4,10 @@ status.code = 0
 stdout = """
 stdio-fixture 1.0
 
-USAGE:
+Usage:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
-OPTIONS:
+Options:
         --verbose
             more log
 
@@ -17,7 +17,7 @@ OPTIONS:
     -V, --version
             Print version information
 
-SUBCOMMANDS:
+Subcommands:
     more
             
     help

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -4,10 +4,10 @@ status.code = 0
 stdout = """
 stdio-fixture 1.0
 
-USAGE:
+Usage:
     stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
 
-OPTIONS:
+Options:
         --verbose
             more log
 
@@ -17,7 +17,7 @@ OPTIONS:
     -V, --version
             Print version information
 
-SUBCOMMANDS:
+Subcommands:
     more
             
     help


### PR DESCRIPTION
I see them fulfilling two roles
- A form of bolding
- As a callback to their placeholder in usage

However, it is a bit of an unpolished look and no other CLI seems to do
it.  This looks a bit more proefessional.  We have colored help for
formatting and I think the sections relation to usage will be clear
enough.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
