### PR TITLE
[Backport] Fix: Amend error message when deriving enums

### DIFF
--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -84,7 +84,7 @@ fn lits(
                 None
             } else {
                 if !matches!(variant.fields, Fields::Unit) {
-                    abort!(variant.span(), "`#[derive(ValueEnum)]` only supports non-unit variants, unless they are skipped");
+                    abort!(variant.span(), "`#[derive(ValueEnum)]` only supports unit variants. Non-unit variants must be skipped");
                 }
                 let fields = attrs.field_methods(false);
                 let name = attrs.cased_name();

--- a/tests/derive_ui/value_enum_non_unit.stderr
+++ b/tests/derive_ui/value_enum_non_unit.stderr
@@ -1,4 +1,4 @@
-error: `#[derive(ValueEnum)]` only supports non-unit variants, unless they are skipped
+error: `#[derive(ValueEnum)]` only supports unit variants. Non-unit variants must be skipped
  --> tests/derive_ui/value_enum_non_unit.rs:5:5
   |
 5 |     Foo(usize),


### PR DESCRIPTION
Backported from v4 (`master`). Original change: https://github.com/clap-rs/clap/pull/4118