### PR TITLE
fix(help): Don't dim placeholders

### DIFF
--- a/src/builder/styled_str.rs
+++ b/src/builder/styled_str.rs
@@ -156,9 +156,7 @@ impl StyledStr {
                 Some(Style::Literal) => {
                     color.set_bold(true);
                 }
-                Some(Style::Placeholder) => {
-                    color.set_dimmed(true);
-                }
+                Some(Style::Placeholder) => {}
                 Some(Style::Good) => {
                     color.set_fg(Some(termcolor::Color::Green));
                 }


### PR DESCRIPTION
This came from feedback: https://rust-lang.zulipchat.com/#narrow/stream/220302-wg-cli/topic/Help.20changes.20in.20clap.20v4

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
