### PR TITLE
clap_complete: print a better error message if bin_name is missing in a subcommand

### DIFF
--- a/clap_complete/src/generator/utils.rs
+++ b/clap_complete/src/generator/utils.rs
@@ -44,7 +44,9 @@ pub fn subcommands(p: &Command) -> Vec<(String, String)> {
     }
 
     for sc in p.get_subcommands() {
-        let sc_bin_name = sc.get_bin_name().unwrap();
+        let sc_bin_name = sc.get_bin_name().unwrap_or_else(|| {
+            panic!("bin_name must be specified in subcommand {}", sc.get_name())
+        });
 
         debug!(
             "subcommands:iter: name={}, bin_name={}",


### PR DESCRIPTION
I noticed that clap_complete panics on `unwrap()` when bin_name is not specified. This PR improves the error message so that users can see where the problem is

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
