### PR TITLE
fix(help): Command::print_help should respect disable_colored_help

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -717,7 +717,7 @@ impl Command {
     /// [`io::stdout()`]: std::io::stdout()
     pub fn print_help(&mut self) -> io::Result<()> {
         self._build_self();
-        let color = self.get_color();
+        let color = self.color_help();
 
         let mut styled = StyledStr::new();
         let usage = Usage::new(self);
@@ -744,7 +744,7 @@ impl Command {
     /// [`--help` (long)]: Arg::long_help()
     pub fn print_long_help(&mut self) -> io::Result<()> {
         self._build_self();
-        let color = self.get_color();
+        let color = self.color_help();
 
         let mut styled = StyledStr::new();
         let usage = Usage::new(self);


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
