### PR TITLE
fix(help): Command::print_help should respect disable_colored_help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ _gated behind `unstable-v4`_
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- *(help)* `Command::print_help` now respects `Command::colored_help`
+
 ## [3.2.17] - 2022-08-12
 
 ### Fixes

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -744,7 +744,7 @@ impl<'help> App<'help> {
     /// [`io::stdout()`]: std::io::stdout()
     pub fn print_help(&mut self) -> io::Result<()> {
         self._build_self();
-        let color = self.get_color();
+        let color = self.color_help();
 
         let mut c = Colorizer::new(Stream::Stdout, color);
         let usage = Usage::new(self);
@@ -769,7 +769,7 @@ impl<'help> App<'help> {
     /// [`--help` (long)]: Arg::long_help()
     pub fn print_long_help(&mut self) -> io::Result<()> {
         self._build_self();
-        let color = self.get_color();
+        let color = self.color_help();
 
         let mut c = Colorizer::new(Stream::Stdout, color);
         let usage = Usage::new(self);


### PR DESCRIPTION
This is a backport of #4138