### PR TITLE
fix(help): Consistently use `[]` for positionals

### DIFF
--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -4036,7 +4036,9 @@ impl Arg {
 
         debug_assert!(self.is_takes_value_set());
         for (n, val_name) in val_names.iter().enumerate() {
-            let arg_name = if self.is_positional() && num_vals.min_values() == 0 {
+            let arg_name = if self.is_positional()
+                && (num_vals.min_values() == 0 || !self.is_required_set())
+            {
                 format!("[{}]", val_name)
             } else {
                 format!("<{}>", val_name)
@@ -4372,6 +4374,14 @@ mod test {
         let mut p = Arg::new("pos").index(1).num_args(1..);
         p._build();
 
+        assert_eq!(p.to_string(), "[pos]...");
+    }
+
+    #[test]
+    fn positional_display_multiple_values_required() {
+        let mut p = Arg::new("pos").index(1).num_args(1..).required(true);
+        p._build();
+
         assert_eq!(p.to_string(), "<pos>...");
     }
 
@@ -4386,6 +4396,14 @@ mod test {
     #[test]
     fn positional_display_one_or_more_values() {
         let mut p = Arg::new("pos").index(1).num_args(1..);
+        p._build();
+
+        assert_eq!(p.to_string(), "[pos]...");
+    }
+
+    #[test]
+    fn positional_display_one_or_more_values_required() {
+        let mut p = Arg::new("pos").index(1).num_args(1..).required(true);
         p._build();
 
         assert_eq!(p.to_string(), "<pos>...");
@@ -4407,6 +4425,17 @@ mod test {
         let mut p = Arg::new("pos").index(1).action(ArgAction::Append);
         p._build();
 
+        assert_eq!(p.to_string(), "[pos]...");
+    }
+
+    #[test]
+    fn positional_display_multiple_occurrences_required() {
+        let mut p = Arg::new("pos")
+            .index(1)
+            .action(ArgAction::Append)
+            .required(true);
+        p._build();
+
         assert_eq!(p.to_string(), "<pos>...");
     }
 
@@ -4421,6 +4450,17 @@ mod test {
     #[test]
     fn positional_display_val_names() {
         let mut p = Arg::new("pos").index(1).value_names(["file1", "file2"]);
+        p._build();
+
+        assert_eq!(p.to_string(), "[file1] [file2]");
+    }
+
+    #[test]
+    fn positional_display_val_names_required() {
+        let mut p = Arg::new("pos")
+            .index(1)
+            .value_names(["file1", "file2"])
+            .required(true);
         p._build();
 
         assert_eq!(p.to_string(), "<file1> <file2>");

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -580,7 +580,7 @@ Usage:
     foo bar [value]
 
 Arguments:
-    <value>    
+    [value]    
 
 Options:
     -h, --help       Print help information
@@ -603,7 +603,7 @@ Usage:
     foo bar [value]
 
 Arguments:
-    <value>    
+    [value]    
 
 Options:
     -h, --help       Print help information
@@ -626,7 +626,7 @@ Usage:
     foo bar [value]
 
 Arguments:
-    <value>    
+    [value]    
 
 Options:
     -h, --help       Print help information


### PR DESCRIPTION
In the usaeg we use `[]` but in the arg list we use `<>`.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
