### PR TITLE
Update release diff links in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3616,7 +3616,9 @@ Minimum version of Rust is now v1.13.0 (Stable)
 * **arg**  allow lifetimes other than 'static in arguments ([9e8c1fb9](https://github.com/clap-rs/clap/commit/9e8c1fb9406f8448873ca58bab07fe905f1551e5))
 
 <!-- next-url -->
-[Unreleased]: https://github.com/clap-rs/clap/compare/v3.2.14...HEAD
+[Unreleased]: https://github.com/clap-rs/clap/compare/v3.2.18...HEAD
+[3.2.16]: https://github.com/clap-rs/clap/compare/v3.2.15...v3.2.16
+[3.2.15]: https://github.com/clap-rs/clap/compare/v3.2.14...v3.2.15
 [3.2.14]: https://github.com/clap-rs/clap/compare/v3.2.13...v3.2.14
 [3.2.13]: https://github.com/clap-rs/clap/compare/v3.2.12...v3.2.13
 [3.2.12]: https://github.com/clap-rs/clap/compare/v3.2.11...v3.2.12


### PR DESCRIPTION
Release notes for 3.2.17 and 3.2.18 are still missing though.
