### PR TITLE
fix(parser): Improve required error messages

### DIFF
--- a/examples/derive_ref/custom-bool.md
+++ b/examples/derive_ref/custom-bool.md
@@ -26,7 +26,7 @@ error: The following required arguments were not provided:
     <BOOM>
 
 Usage:
-    custom-bool[EXE] [OPTIONS] --foo <FOO> <BOOM>
+    custom-bool[EXE] --foo <FOO> <BOOM>
 
 For more information try --help
 

--- a/examples/tutorial_builder/04_03_relations.md
+++ b/examples/tutorial_builder/04_03_relations.md
@@ -25,7 +25,7 @@ error: The following required arguments were not provided:
     <--set-ver <VER>|--major|--minor|--patch>
 
 Usage:
-    04_03_relations[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
+    04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch>
 
 For more information try --help
 

--- a/examples/tutorial_derive/04_03_relations.md
+++ b/examples/tutorial_derive/04_03_relations.md
@@ -25,7 +25,7 @@ error: The following required arguments were not provided:
     <--set-ver <VER>|--major|--minor|--patch>
 
 Usage:
-    04_03_relations_derive[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
+    04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch>
 
 For more information try --help
 

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -396,30 +396,9 @@ impl<'cmd> Usage<'cmd> {
         );
 
         let mut required_groups_members = FlatSet::new();
-        let mut required_opts = FlatSet::new();
         let mut required_groups = FlatSet::new();
-        let mut required_positionals = FlatSet::new();
         for req in unrolled_reqs.iter().chain(incls.iter()) {
-            if let Some(arg) = self.cmd.find(req) {
-                let is_present = matcher
-                    .map(|m| m.check_explicit(req, &ArgPredicate::IsPresent))
-                    .unwrap_or(false);
-                debug!(
-                    "Usage::get_required_usage_from:iter:{:?} arg is_present={}",
-                    req, is_present
-                );
-                if !is_present {
-                    if arg.is_positional() {
-                        if incl_last || !arg.is_last_set() {
-                            required_positionals
-                                .insert((arg.index.unwrap(), arg.stylized(Some(true))));
-                        }
-                    } else {
-                        required_opts.insert(arg.stylized(Some(true)));
-                    }
-                }
-            } else {
-                debug_assert!(self.cmd.find_group(req).is_some());
+            if self.cmd.find_group(req).is_some() {
                 let group_members = self.cmd.unroll_args_in_group(req);
                 let is_present = matcher
                     .map(|m| {
@@ -442,6 +421,34 @@ impl<'cmd> Usage<'cmd> {
                             .map(|arg| arg.stylized(Some(true))),
                     );
                 }
+            } else {
+                debug_assert!(self.cmd.find(req).is_some());
+            }
+        }
+
+        let mut required_opts = FlatSet::new();
+        let mut required_positionals = FlatSet::new();
+        for req in unrolled_reqs.iter().chain(incls.iter()) {
+            if let Some(arg) = self.cmd.find(req) {
+                let is_present = matcher
+                    .map(|m| m.check_explicit(req, &ArgPredicate::IsPresent))
+                    .unwrap_or(false);
+                debug!(
+                    "Usage::get_required_usage_from:iter:{:?} arg is_present={}",
+                    req, is_present
+                );
+                if !is_present {
+                    if arg.is_positional() {
+                        if incl_last || !arg.is_last_set() {
+                            required_positionals
+                                .insert((arg.index.unwrap(), arg.stylized(Some(true))));
+                        }
+                    } else {
+                        required_opts.insert(arg.stylized(Some(true)));
+                    }
+                }
+            } else {
+                debug_assert!(self.cmd.find_group(req).is_some());
             }
         }
 

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -444,7 +444,7 @@ impl<'cmd> Usage<'cmd> {
 
                 let stylized = arg.stylized(Some(true));
                 if arg.is_positional() {
-                    if incl_last || !arg.is_last_set() {
+                    if !arg.is_last_set() || incl_last {
                         let index = arg.index.unwrap();
                         required_positionals.insert((index, stylized));
                     }

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -440,11 +440,17 @@ impl<'cmd> Usage<'cmd> {
                 if !is_present {
                     if arg.is_positional() {
                         if incl_last || !arg.is_last_set() {
-                            required_positionals
-                                .insert((arg.index.unwrap(), arg.stylized(Some(true))));
+                            let stylized = arg.stylized(Some(true));
+                            if !required_groups_members.contains(&stylized) {
+                                let index = arg.index.unwrap();
+                                required_positionals.insert((index, stylized));
+                            }
                         }
                     } else {
-                        required_opts.insert(arg.stylized(Some(true)));
+                        let stylized = arg.stylized(Some(true));
+                        if !required_groups_members.contains(&stylized) {
+                            required_opts.insert(stylized);
+                        }
                     }
                 }
             } else {
@@ -453,17 +459,11 @@ impl<'cmd> Usage<'cmd> {
         }
 
         let mut ret_val = Vec::new();
-
-        required_opts.retain(|arg| !required_groups_members.contains(arg));
         ret_val.extend(required_opts);
-
         ret_val.extend(required_groups);
-
         required_positionals.sort_by_key(|(ind, _)| *ind); // sort by index
         for (_, p) in required_positionals {
-            if !required_groups_members.contains(&p) {
-                ret_val.push(p);
-            }
+            ret_val.push(p);
         }
 
         debug!("Usage::get_required_usage_from: ret_val={:?}", ret_val);

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -414,12 +414,7 @@ impl<'cmd> Usage<'cmd> {
                 if !is_present {
                     let elem = self.cmd.format_group(req);
                     required_groups.insert(elem);
-                    required_groups_members.extend(
-                        group_members
-                            .iter()
-                            .flat_map(|id| self.cmd.find(id))
-                            .map(|arg| arg.stylized(Some(true))),
-                    );
+                    required_groups_members.extend(group_members);
                 }
             } else {
                 debug_assert!(self.cmd.find(req).is_some());
@@ -441,14 +436,14 @@ impl<'cmd> Usage<'cmd> {
                     if arg.is_positional() {
                         if incl_last || !arg.is_last_set() {
                             let stylized = arg.stylized(Some(true));
-                            if !required_groups_members.contains(&stylized) {
+                            if !required_groups_members.contains(arg.get_id()) {
                                 let index = arg.index.unwrap();
                                 required_positionals.insert((index, stylized));
                             }
                         }
                     } else {
                         let stylized = arg.stylized(Some(true));
-                        if !required_groups_members.contains(&stylized) {
+                        if !required_groups_members.contains(arg.get_id()) {
                             required_opts.insert(stylized);
                         }
                     }

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -411,11 +411,13 @@ impl<'cmd> Usage<'cmd> {
                     "Usage::get_required_usage_from:iter:{:?} group is_present={}",
                     req, is_present
                 );
-                if !is_present {
-                    let elem = self.cmd.format_group(req);
-                    required_groups.insert(elem);
-                    required_groups_members.extend(group_members);
+                if is_present {
+                    continue;
                 }
+
+                let elem = self.cmd.format_group(req);
+                required_groups.insert(elem);
+                required_groups_members.extend(group_members);
             } else {
                 debug_assert!(self.cmd.find(req).is_some());
             }
@@ -425,6 +427,10 @@ impl<'cmd> Usage<'cmd> {
         let mut required_positionals = FlatSet::new();
         for req in unrolled_reqs.iter().chain(incls.iter()) {
             if let Some(arg) = self.cmd.find(req) {
+                if required_groups_members.contains(arg.get_id()) {
+                    continue;
+                }
+
                 let is_present = matcher
                     .map(|m| m.check_explicit(req, &ArgPredicate::IsPresent))
                     .unwrap_or(false);
@@ -432,21 +438,18 @@ impl<'cmd> Usage<'cmd> {
                     "Usage::get_required_usage_from:iter:{:?} arg is_present={}",
                     req, is_present
                 );
-                if !is_present {
-                    if arg.is_positional() {
-                        if incl_last || !arg.is_last_set() {
-                            let stylized = arg.stylized(Some(true));
-                            if !required_groups_members.contains(arg.get_id()) {
-                                let index = arg.index.unwrap();
-                                required_positionals.insert((index, stylized));
-                            }
-                        }
-                    } else {
-                        let stylized = arg.stylized(Some(true));
-                        if !required_groups_members.contains(arg.get_id()) {
-                            required_opts.insert(stylized);
-                        }
+                if is_present {
+                    continue;
+                }
+
+                let stylized = arg.stylized(Some(true));
+                if arg.is_positional() {
+                    if incl_last || !arg.is_last_set() {
+                        let index = arg.index.unwrap();
+                        required_positionals.insert((index, stylized));
                     }
+                } else {
+                    required_opts.insert(stylized);
                 }
             } else {
                 debug_assert!(self.cmd.find_group(req).is_some());

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -365,7 +365,7 @@ impl<'cmd> Usage<'cmd> {
             &required_owned
         };
 
-        let mut unrolled_reqs = FlatSet::new();
+        let mut unrolled_reqs = Vec::new();
         for a in required.iter() {
             let is_relevant = |(val, req_arg): &(ArgPredicate, Id)| -> Option<Id> {
                 let required = match val {
@@ -384,11 +384,11 @@ impl<'cmd> Usage<'cmd> {
             for aa in self.cmd.unroll_arg_requires(is_relevant, a) {
                 // if we don't check for duplicates here this causes duplicate error messages
                 // see https://github.com/clap-rs/clap/issues/2770
-                unrolled_reqs.insert(aa);
+                unrolled_reqs.push(aa);
             }
             // always include the required arg itself. it will not be enumerated
             // by unroll_requirements_for_arg.
-            unrolled_reqs.insert(a.clone());
+            unrolled_reqs.push(a.clone());
         }
         debug!(
             "Usage::get_required_usage_from: unrolled_reqs={:?}",

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -314,11 +314,8 @@ impl<'cmd> Validator<'cmd> {
                 );
                 missing_required.push(a.get_id().clone());
             }
-        }
 
-        for a in self.cmd.get_arguments() {
             if (!a.r_unless.is_empty() || !a.r_unless_all.is_empty())
-                && !matcher.check_explicit(&a.id, &ArgPredicate::IsPresent)
                 && self.fails_arg_required_unless(a, matcher)
             {
                 debug!(

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -280,10 +280,12 @@ impl<'cmd> Validator<'cmd> {
 
         // Validate the conditionally required args
         for a in self.cmd.get_arguments() {
+            if matcher.check_explicit(&a.id, &ArgPredicate::IsPresent) {
+                continue;
+            }
+
             for (other, val) in &a.r_ifs {
-                if matcher.check_explicit(other, &ArgPredicate::Equals(val.into()))
-                    && !matcher.check_explicit(&a.id, &ArgPredicate::IsPresent)
-                {
+                if matcher.check_explicit(other, &ArgPredicate::Equals(val.into())) {
                     return self.missing_required_error(matcher, vec![a.id.clone()]);
                 }
             }
@@ -291,10 +293,7 @@ impl<'cmd> Validator<'cmd> {
             let match_all = a.r_ifs_all.iter().all(|(other, val)| {
                 matcher.check_explicit(other, &ArgPredicate::Equals(val.into()))
             });
-            if match_all
-                && !a.r_ifs_all.is_empty()
-                && !matcher.check_explicit(&a.id, &ArgPredicate::IsPresent)
-            {
+            if match_all && !a.r_ifs_all.is_empty() {
                 return self.missing_required_error(matcher, vec![a.id.clone()]);
             }
         }

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -289,11 +289,11 @@ impl<'cmd> Validator<'cmd> {
         }
 
         // Validate the conditionally required args
-        for a in self.cmd.get_arguments() {
-            if matcher.check_explicit(&a.id, &ArgPredicate::IsPresent) {
-                continue;
-            }
-
+        for a in self
+            .cmd
+            .get_arguments()
+            .filter(|a| !matcher.check_explicit(a.get_id(), &ArgPredicate::IsPresent))
+        {
             for (other, val) in &a.r_ifs {
                 if matcher.check_explicit(other, &ArgPredicate::Equals(val.into())) {
                     debug!(

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -299,16 +299,15 @@ impl<'cmd> Validator<'cmd> {
         }
 
         debug!("Validator::validate_required_unless");
-        let failed_args: Vec<_> = self
-            .cmd
-            .get_arguments()
-            .filter(|&a| {
-                (!a.r_unless.is_empty() || !a.r_unless_all.is_empty())
-                    && !matcher.check_explicit(&a.id, &ArgPredicate::IsPresent)
-                    && self.fails_arg_required_unless(a, matcher)
-            })
-            .map(|a| a.id.clone())
-            .collect();
+        let mut failed_args = Vec::new();
+        for a in self.cmd.get_arguments() {
+            if (!a.r_unless.is_empty() || !a.r_unless_all.is_empty())
+                && !matcher.check_explicit(&a.id, &ArgPredicate::IsPresent)
+                && self.fails_arg_required_unless(a, matcher)
+            {
+                failed_args.push(a.id.clone());
+            }
+        }
         if !failed_args.is_empty() {
             self.missing_required_error(matcher, failed_args)?;
         }

--- a/src/util/flat_map.rs
+++ b/src/util/flat_map.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::borrow::Borrow;
 
 /// Flat (Vec) backed map

--- a/src/util/flat_set.rs
+++ b/src/util/flat_set.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::borrow::Borrow;
 
 /// Flat (Vec) backed set

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -732,7 +732,7 @@ fn default_vals_donnot_show_in_smart_usage() {
     <input>
 
 Usage:
-    bug [OPTIONS] <input>
+    bug <input>
 
 For more information try --help
 ",

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -33,10 +33,11 @@ For more information try --help
 
 static MISSING_REQ: &str = "error: The following required arguments were not provided:
     --long-option-2 <option2>
+    <positional>
     <positional2>
 
 Usage:
-    clap-test --long-option-2 <option2> -F <positional2>
+    clap-test --long-option-2 <option2> -F <positional> <positional2>
 
 For more information try --help
 ";

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -141,7 +141,7 @@ static POSITIONAL_REQ: &str = "error: The following required arguments were not 
     <opt>
 
 Usage:
-    clap-test <flag> <opt> [ARGS]
+    clap-test <flag> <opt>
 
 For more information try --help
 ";
@@ -160,7 +160,7 @@ static POSITIONAL_REQ_IF_NO_VAL: &str = "error: The following required arguments
     <flag>
 
 Usage:
-    clap-test <flag> [ARGS]
+    clap-test <flag>
 
 For more information try --help
 ";


### PR DESCRIPTION
A lot of this came out of prep for more changes for #4132.

I do wonder if the other types of requires should be included in `self,.required` and should check for conflicts.

This dropped binary size by 3 KiB (#1365)