### PR TITLE
fix(usage): Don't include irrelevant parent args

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -3837,7 +3837,8 @@ impl Command {
         use std::fmt::Write;
 
         let mut mid_string = String::from(" ");
-        if !self.is_subcommand_negates_reqs_set() {
+        if !self.is_subcommand_negates_reqs_set() && !self.is_args_conflicts_with_subcommands_set()
+        {
             let reqs = Usage::new(self).get_required_usage_from(&[], None, true); // maybe Some(m)
 
             for s in &reqs {
@@ -3921,7 +3922,9 @@ impl Command {
 
         if !self.is_set(AppSettings::BinNameBuilt) {
             let mut mid_string = String::from(" ");
-            if !self.is_subcommand_negates_reqs_set() {
+            if !self.is_subcommand_negates_reqs_set()
+                && !self.is_args_conflicts_with_subcommands_set()
+            {
                 let reqs = Usage::new(self).get_required_usage_from(&[], None, true); // maybe Some(m)
 
                 for s in &reqs {

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -346,14 +346,6 @@ fn multi_level_sc_help() {
 }
 
 #[test]
-fn no_wrap_help() {
-    let cmd = Command::new("ctest")
-        .term_width(0)
-        .override_help(MULTI_SC_HELP);
-    utils::assert_output(cmd, "ctest --help", &format!("{}\n", MULTI_SC_HELP), false);
-}
-
-#[test]
 fn no_wrap_default_help() {
     static DEFAULT_HELP: &str = "ctest 1.0
 
@@ -2818,6 +2810,50 @@ Options:
     let mut buf = Vec::new();
     subcmd.write_help(&mut buf).unwrap();
     utils::assert_eq(EXPECTED, String::from_utf8(buf).unwrap());
+}
+
+#[test]
+fn parent_cmd_req_ignored_when_negates_reqs() {
+    static MULTI_SC_HELP: &str = "ctest-subcmd 
+
+Usage:
+    ctest subcmd
+
+Options:
+    -h, --help    Print help information
+";
+
+    let cmd = Command::new("ctest")
+        .arg(arg!(<input>))
+        .subcommand_negates_reqs(true)
+        .subcommand(Command::new("subcmd"));
+    utils::assert_output(cmd, "ctest subcmd --help", MULTI_SC_HELP, false);
+}
+
+#[test]
+fn parent_cmd_req_ignored_when_conflicts() {
+    static MULTI_SC_HELP: &str = "ctest-subcmd 
+
+Usage:
+    ctest subcmd
+
+Options:
+    -h, --help    Print help information
+";
+
+    let cmd = Command::new("ctest")
+        .arg(arg!(<input>))
+        .args_conflicts_with_subcommands(true)
+        .subcommand(Command::new("subcmd"));
+    utils::assert_output(cmd, "ctest subcmd --help", MULTI_SC_HELP, false);
+}
+
+#[test]
+fn no_wrap_help() {
+    let cmd = Command::new("ctest")
+        .term_width(0)
+        .override_help(MULTI_SC_HELP);
+    utils::assert_output(cmd, "ctest --help", &format!("{}\n", MULTI_SC_HELP), false);
 }
 
 #[test]


### PR DESCRIPTION
This was identified in https://github.com/clap-rs/clap/discussions/4134

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
