### PR TITLE
fix(help): Use Command in place of Subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - *(help)* Make `DeriveDisplayOrder` the default and removed the setting.  To sort help, set `next_display_order(None)` (#2808)
 - *(help)* Subcommand display order respects `Command::next_display_order` instead of `DeriveDisplayOrder` and using its own initial display order value (#2808)
 - *(help)* Help headings are now title cased, making any user-provided help headings inconsistent.  To get the old behavior, see `Command::help_template`, `Arg::help_heading`, and `Command::subcommand_help_heading`
+- *(help)* "Command" is used as the section heading for subcommands and `COMMAND` for the value name.  To get the old behavior, see  `Command::subcommand_help_heading` and `Arg::subcommand_value_name`
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)
 - *(derive)* Changed the default for arguments from `parse` to `value_parser`., removing `parse` support
 - *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp` (#3280)
@@ -96,6 +97,7 @@ Deprecated
 - *(help)* Do not include global args in `cmd help help` (#4131)
 - *(help)* Use `[positional]` in list when relevant (#4144)
 - *(help)* Show all `[positional]` in usage
+- *(help)* Polish up subcommands by referring to them as commands
 - *(version)* Use `Command::display_name` rather than `Command::bin_name`
 - *(parser)* Assert on unknown args when using external subcommands (#3703)
 - *(parser)* Always fill in `""` argument for external subcommands (#3263)

--- a/examples/cargo-example-derive.md
+++ b/examples/cargo-example-derive.md
@@ -9,9 +9,9 @@ $ cargo-example-derive --help
 cargo 
 
 Usage:
-    cargo <SUBCOMMAND>
+    cargo <COMMAND>
 
-Subcommands:
+Commands:
     example-derive    A simple to use, efficient, and full-featured Command Line Argument Parser
     help              Print this message or the help of the given subcommand(s)
 

--- a/examples/cargo-example.md
+++ b/examples/cargo-example.md
@@ -9,9 +9,9 @@ $ cargo-example --help
 cargo 
 
 Usage:
-    cargo <SUBCOMMAND>
+    cargo <COMMAND>
 
-Subcommands:
+Commands:
     example    A simple to use, efficient, and full-featured Command Line Argument Parser
     help       Print this message or the help of the given subcommand(s)
 

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -90,7 +90,7 @@ $ interop_augment_subcommands unknown
 error: Found argument 'unknown' which wasn't expected, or isn't valid in this context
 
 Usage:
-    interop_augment_subcommands[EXE] [SUBCOMMAND]
+    interop_augment_subcommands[EXE] [COMMAND]
 
 For more information try --help
 
@@ -104,9 +104,9 @@ $ interop_hand_subcommand
 clap 
 
 Usage:
-    interop_hand_subcommand[EXE] [OPTIONS] <SUBCOMMAND>
+    interop_hand_subcommand[EXE] [OPTIONS] <COMMAND>
 
-Subcommands:
+Commands:
     add       
     remove    
     help      Print this message or the help of the given subcommand(s)
@@ -199,7 +199,7 @@ $ interop_hand_subcommand unknown
 error: Found argument 'unknown' which wasn't expected, or isn't valid in this context
 
 Usage:
-    interop_hand_subcommand[EXE] [OPTIONS] <SUBCOMMAND>
+    interop_hand_subcommand[EXE] [OPTIONS] <COMMAND>
 
 For more information try --help
 

--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -10,9 +10,9 @@ git
 A fictional versioning CLI
 
 Usage:
-    git-derive[EXE] <SUBCOMMAND>
+    git-derive[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -27,9 +27,9 @@ git
 A fictional versioning CLI
 
 Usage:
-    git-derive[EXE] <SUBCOMMAND>
+    git-derive[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -82,9 +82,9 @@ git-stash
 
 Usage:
     git-derive[EXE] stash [OPTIONS]
-    git-derive[EXE] stash <SUBCOMMAND>
+    git-derive[EXE] stash <COMMAND>
 
-Subcommands:
+Commands:
     push     
     pop      
     apply    

--- a/examples/git.md
+++ b/examples/git.md
@@ -8,9 +8,9 @@ git
 A fictional versioning CLI
 
 Usage:
-    git[EXE] <SUBCOMMAND>
+    git[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -25,9 +25,9 @@ git
 A fictional versioning CLI
 
 Usage:
-    git[EXE] <SUBCOMMAND>
+    git[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     clone    Clones repos
     push     pushes things
     add      adds things
@@ -80,9 +80,9 @@ git-stash
 
 Usage:
     git[EXE] stash [OPTIONS]
-    git[EXE] stash <SUBCOMMAND>
+    git[EXE] stash <COMMAND>
 
-Subcommands:
+Commands:
     push     
     pop      
     apply    

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -40,9 +40,9 @@ Pacman Development Team
 package manager utility
 
 Usage:
-    pacman[EXE] <SUBCOMMAND>
+    pacman[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     query -Q --query    Query the package database.
     sync -S --sync      Synchronize packages.
     help                Print this message or the help of the given subcommand(s)

--- a/examples/tutorial_builder/01_quick.md
+++ b/examples/tutorial_builder/01_quick.md
@@ -4,9 +4,9 @@ clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
-    01_quick[EXE] [OPTIONS] [name] [SUBCOMMAND]
+    01_quick[EXE] [OPTIONS] [name] [COMMAND]
 
-Subcommands:
+Commands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 

--- a/examples/tutorial_builder/03_04_subcommands.md
+++ b/examples/tutorial_builder/03_04_subcommands.md
@@ -4,9 +4,9 @@ clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
-    03_04_subcommands[EXE] <SUBCOMMAND>
+    03_04_subcommands[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 
@@ -41,9 +41,9 @@ clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
-    03_04_subcommands[EXE] <SUBCOMMAND>
+    03_04_subcommands[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 

--- a/examples/tutorial_derive/01_quick.md
+++ b/examples/tutorial_derive/01_quick.md
@@ -4,9 +4,9 @@ clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
-    01_quick_derive[EXE] [OPTIONS] [NAME] [SUBCOMMAND]
+    01_quick_derive[EXE] [OPTIONS] [NAME] [COMMAND]
 
-Subcommands:
+Commands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 

--- a/examples/tutorial_derive/03_04_subcommands.md
+++ b/examples/tutorial_derive/03_04_subcommands.md
@@ -4,9 +4,9 @@ clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
-    03_04_subcommands_derive[EXE] <SUBCOMMAND>
+    03_04_subcommands_derive[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 
@@ -41,9 +41,9 @@ clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
-    03_04_subcommands_derive[EXE] <SUBCOMMAND>
+    03_04_subcommands_derive[EXE] <COMMAND>
 
-Subcommands:
+Commands:
     add     Adds files to myapp
     help    Print this message or the help of the given subcommand(s)
 

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -2588,7 +2588,7 @@ impl Command {
     /// Usage:
     ///     cust-ord [OPTIONS]
     ///
-    /// Subcommands:
+    /// Commands:
     ///     beta    I should be first!
     ///     alpha   Some help and text
     ///
@@ -3034,7 +3034,7 @@ impl Command {
 
     /// Sets the value name used for subcommands when printing usage and help.
     ///
-    /// By default, this is "SUBCOMMAND".
+    /// By default, this is "COMMAND".
     ///
     /// See also [`Command::subcommand_help_heading`]
     ///
@@ -3054,9 +3054,9 @@ impl Command {
     /// myprog
     ///
     /// Usage:
-    ///     myprog [SUBCOMMAND]
+    ///     myprog [COMMAND]
     ///
-    /// Subcommands:
+    /// Commands:
     ///     help    Print this message or the help of the given subcommand(s)
     ///     sub1
     ///
@@ -3088,7 +3088,7 @@ impl Command {
     ///     -h, --help       Print help information
     ///     -V, --version    Print version information
     ///
-    /// Subcommands:
+    /// Commands:
     ///     help    Print this message or the help of the given subcommand(s)
     ///     sub1
     /// ```
@@ -3100,7 +3100,7 @@ impl Command {
 
     /// Sets the help heading used for subcommands when printing usage and help.
     ///
-    /// By default, this is "Subcommands".
+    /// By default, this is "Commands".
     ///
     /// See also [`Command::subcommand_value_name`]
     ///
@@ -3120,13 +3120,13 @@ impl Command {
     /// myprog
     ///
     /// Usage:
-    ///     myprog [SUBCOMMAND]
+    ///     myprog [COMMAND]
     ///
     /// Options:
     ///     -h, --help       Print help information
     ///     -V, --version    Print version information
     ///
-    /// Subcommands:
+    /// Commands:
     ///     help    Print this message or the help of the given subcommand(s)
     ///     sub1
     /// ```
@@ -3148,7 +3148,7 @@ impl Command {
     /// myprog
     ///
     /// Usage:
-    ///     myprog [SUBCOMMAND]
+    ///     myprog [COMMAND]
     ///
     /// Options:
     ///     -h, --help       Print help information
@@ -4171,7 +4171,7 @@ impl Command {
                     Arg::new("subcommand")
                         .action(ArgAction::Append)
                         .num_args(..)
-                        .value_name("SUBCOMMAND")
+                        .value_name("COMMAND")
                         .help("The subcommand whose help message to display"),
                 )
             };

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -345,7 +345,7 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
                 self.none("\n\n");
             }
             first = false;
-            let default_help_heading = Str::from("Subcommands");
+            let default_help_heading = Str::from("Commands");
             self.header(
                 self.cmd
                     .get_subcommand_help_heading()

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -6,7 +6,7 @@ use crate::util::ChildGraph;
 use crate::util::FlatSet;
 use crate::util::Id;
 
-static DEFAULT_SUB_VALUE_NAME: &str = "SUBCOMMAND";
+static DEFAULT_SUB_VALUE_NAME: &str = "COMMAND";
 
 pub(crate) struct Usage<'cmd> {
     cmd: &'cmd Command,

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -7,7 +7,7 @@ use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 static ALLOW_EXT_SC: &str = "clap-test v1.4.8
 
 Usage:
-    clap-test [SUBCOMMAND]
+    clap-test [COMMAND]
 
 Options:
     -h, --help       Print help information

--- a/tests/builder/derive_order.rs
+++ b/tests/builder/derive_order.rs
@@ -269,9 +269,9 @@ fn subcommand_sorted_display_order() {
     static SUBCMD_ALPHA_ORDER: &str = "test 1
 
 Usage:
-    test [SUBCOMMAND]
+    test [COMMAND]
 
-Subcommands:
+Commands:
     a1      blah a1
     b1      blah b1
     help    Print this message or the help of the given subcommand(s)
@@ -306,9 +306,9 @@ fn subcommand_derived_display_order() {
     static SUBCMD_DECL_ORDER: &str = "test 1
 
 Usage:
-    test [SUBCOMMAND]
+    test [COMMAND]
 
-Subcommands:
+Commands:
     b1      blah b1
     a1      blah a1
     help    Print this message or the help of the given subcommand(s)

--- a/tests/builder/display_order.rs
+++ b/tests/builder/display_order.rs
@@ -12,9 +12,9 @@ fn very_large_display_order() {
         "test 
 
 Usage:
-    test [SUBCOMMAND]
+    test [COMMAND]
 
-Subcommands:
+Commands:
     help    Print this message or the help of the given subcommand(s)
     sub     
 

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -205,9 +205,9 @@ Kevin K. <kbknapp@gmail.com>
 tests clap library
 
 Usage:
-    clap-test [OPTIONS] [positional] [positional2] [positional3]... [SUBCOMMAND]
+    clap-test [OPTIONS] [positional] [positional2] [positional3]... [COMMAND]
 
-Subcommands:
+Commands:
     subcmd    tests subcommands
     help      Print this message or the help of the given subcommand(s)
 
@@ -1093,9 +1093,9 @@ fn sc_negates_reqs() {
 
 Usage:
     prog --opt <FILE> [PATH]
-    prog [PATH] <SUBCOMMAND>
+    prog [PATH] <COMMAND>
 
-Subcommands:
+Commands:
     test    
     help    Print this message or the help of the given subcommand(s)
 
@@ -1145,9 +1145,9 @@ fn args_negate_sc() {
 
 Usage:
     prog [OPTIONS] [PATH]
-    prog <SUBCOMMAND>
+    prog <COMMAND>
 
-Subcommands:
+Commands:
     test    
     help    Print this message or the help of the given subcommand(s)
 
@@ -1389,9 +1389,9 @@ fn last_arg_mult_usage_req_with_sc() {
 
 Usage:
     last <TARGET> [CORPUS] -- <ARGS>...
-    last [TARGET] [CORPUS] <SUBCOMMAND>
+    last [TARGET] [CORPUS] <COMMAND>
 
-Subcommands:
+Commands:
     test    some
     help    Print this message or the help of the given subcommand(s)
 
@@ -1428,9 +1428,9 @@ fn last_arg_mult_usage_with_sc() {
 
 Usage:
     last <TARGET> [CORPUS] [-- <ARGS>...]
-    last <SUBCOMMAND>
+    last <COMMAND>
 
-Subcommands:
+Commands:
     test    some
     help    Print this message or the help of the given subcommand(s)
 
@@ -2054,10 +2054,10 @@ fn help_subcmd_help() {
 Print this message or the help of the given subcommand(s)
 
 Usage:
-    myapp help [SUBCOMMAND]...
+    myapp help [COMMAND]...
 
 Arguments:
-    [SUBCOMMAND]...    The subcommand whose help message to display
+    [COMMAND]...    The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -2072,10 +2072,10 @@ fn subcmd_help_subcmd_help() {
 Print this message or the help of the given subcommand(s)
 
 Usage:
-    myapp subcmd help [SUBCOMMAND]...
+    myapp subcmd help [COMMAND]...
 
 Arguments:
-    [SUBCOMMAND]...    The subcommand whose help message to display
+    [COMMAND]...    The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -2094,9 +2094,9 @@ fn global_args_should_show_on_toplevel_help_message() {
     static HELP: &str = "myapp\x20
 
 Usage:
-    myapp [OPTIONS] [SUBCOMMAND]
+    myapp [OPTIONS] [COMMAND]
 
-Subcommands:
+Commands:
     subcmd\x20\x20\x20\x20
     help      Print this message or the help of the given subcommand(s)
 
@@ -2123,10 +2123,10 @@ fn global_args_should_not_show_on_help_message_for_help_help() {
 Print this message or the help of the given subcommand(s)
 
 Usage:
-    myapp help [SUBCOMMAND]...
+    myapp help [COMMAND]...
 
 Arguments:
-    [SUBCOMMAND]...    The subcommand whose help message to display
+    [COMMAND]...    The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -2146,9 +2146,9 @@ fn global_args_should_show_on_help_message_for_subcommand() {
     static HELP_SUBCMD: &str = "myapp-subcmd\x20
 
 Usage:
-    myapp subcmd [OPTIONS] [SUBCOMMAND]
+    myapp subcmd [OPTIONS] [COMMAND]
 
-Subcommands:
+Commands:
     multi\x20\x20\x20\x20
     help     Print this message or the help of the given subcommand(s)
 
@@ -2231,12 +2231,12 @@ Options:
 
 #[test]
 fn prefer_about_over_long_about_in_subcommands_list() {
-    static ABOUT_IN_SUBCOMMANDS_LIST: &str = "about-in-subcommands-list 
+    static ABOUT_IN_COMMANDS_LIST: &str = "about-in-subcommands-list 
 
 Usage:
-    about-in-subcommands-list [SUBCOMMAND]
+    about-in-subcommands-list [COMMAND]
 
-Subcommands:
+Commands:
     sub     short about sub
     help    Print this message or the help of the given subcommand(s)
 
@@ -2253,7 +2253,7 @@ Options:
     utils::assert_output(
         cmd,
         "about-in-subcommands-list --help",
-        ABOUT_IN_SUBCOMMANDS_LIST,
+        ABOUT_IN_COMMANDS_LIST,
         false,
     );
 }
@@ -2663,10 +2663,10 @@ fn subcommand_help_doesnt_have_useless_help_flag() {
 Print this message or the help of the given subcommand(s)
 
 Usage:
-    example help [SUBCOMMAND]...
+    example help [COMMAND]...
 
 Arguments:
-    [SUBCOMMAND]...    The subcommand whose help message to display
+    [COMMAND]...    The subcommand whose help message to display
 ",
         false,
     );
@@ -2706,10 +2706,10 @@ fn dont_propagate_version_to_help_subcommand() {
 Print this message or the help of the given subcommand(s)
 
 Usage:
-    example help [SUBCOMMAND]...
+    example help [COMMAND]...
 
 Arguments:
-    [SUBCOMMAND]...    The subcommand whose help message to display
+    [COMMAND]...    The subcommand whose help message to display
 ",
         false,
     );

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -5,9 +5,9 @@ use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 static VISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 
 Usage:
-    clap-test [SUBCOMMAND]
+    clap-test [COMMAND]
 
-Subcommands:
+Commands:
     test    Some help [aliases: dongle, done]
     help    Print this message or the help of the given subcommand(s)
 
@@ -19,9 +19,9 @@ Options:
 static INVISIBLE_ALIAS_HELP: &str = "clap-test 2.6
 
 Usage:
-    clap-test [SUBCOMMAND]
+    clap-test [COMMAND]
 
-Subcommands:
+Commands:
     test    Some help
     help    Print this message or the help of the given subcommand(s)
 
@@ -38,7 +38,7 @@ static DYM_SUBCMD: &str = "error: The subcommand 'subcm' wasn't recognized
 If you believe you received this message in error, try re-running with 'dym -- subcm'
 
 Usage:
-    dym [SUBCOMMAND]
+    dym [COMMAND]
 
 For more information try --help
 ";
@@ -51,7 +51,7 @@ static DYM_SUBCMD_AMBIGUOUS: &str = "error: The subcommand 'te' wasn't recognize
 If you believe you received this message in error, try re-running with 'dym -- te'
 
 Usage:
-    dym [SUBCOMMAND]
+    dym [COMMAND]
 
 For more information try --help
 ";
@@ -62,7 +62,7 @@ static SUBCMD_AFTER_DOUBLE_DASH: &str =
 \tIf you tried to supply `subcmd` as a subcommand, remove the '--' before it.
 
 Usage:
-    cmd [SUBCOMMAND]
+    cmd [COMMAND]
 
 For more information try --help
 ";
@@ -184,7 +184,7 @@ fn subcmd_did_you_mean_output_arg() {
 \tIf you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
 
 Usage:
-    dym [SUBCOMMAND]
+    dym [COMMAND]
 
 For more information try --help
 ";
@@ -205,7 +205,7 @@ fn subcmd_did_you_mean_output_arg_false_positives() {
 \tIf you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
 
 Usage:
-    dym [SUBCOMMAND]
+    dym [COMMAND]
 
 For more information try --help
 ";
@@ -441,7 +441,7 @@ fn subcommand_not_recognized() {
         "error: The subcommand 'help' wasn't recognized
 
 Usage:
-    fake [SUBCOMMAND]
+    fake [COMMAND]
 
 For more information try --help
 ",
@@ -518,7 +518,7 @@ fn bad_multicall_command_error() {
 error: The subcommand 'world' wasn't recognized
 
 Usage:
-    <SUBCOMMAND>
+    <COMMAND>
 
 For more information try help
 ";
@@ -536,7 +536,7 @@ error: The subcommand 'baz' wasn't recognized
 If you believe you received this message in error, try re-running with ' -- baz'
 
 Usage:
-    <SUBCOMMAND>
+    <COMMAND>
 
 For more information try help
 ";

--- a/tests/builder/template_help.rs
+++ b/tests/builder/template_help.rs
@@ -22,7 +22,7 @@ Options:
 {options}
 Arguments:
 {positionals}
-Subcommands:
+Commands:
 {subcommands}";
 
 static CUSTOM_TEMPL_HELP: &str = "MyApp 1.0
@@ -30,7 +30,7 @@ Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
 Usage:
-    MyApp [OPTIONS] <output> [SUBCOMMAND]
+    MyApp [OPTIONS] <output> [COMMAND]
 
 Options:
     -c, --config <FILE>    Sets a custom config file
@@ -39,7 +39,7 @@ Options:
     -V, --version          Print version information
 Arguments:
     <output>    Sets an optional output file
-Subcommands:
+Commands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 ";
@@ -49,9 +49,9 @@ Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
 Usage:
-    MyApp [OPTIONS] <output> [SUBCOMMAND]
+    MyApp [OPTIONS] <output> [COMMAND]
 
-Subcommands:
+Commands:
     test    does testing things
     help    Print this message or the help of the given subcommand(s)
 

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -222,7 +222,7 @@ fn derive_generated_error_has_full_context() {
 
 Usage:
     clap --req-str <REQ_STR>
-    clap <SUBCOMMAND>
+    clap <COMMAND>
 
 For more information try --help
 "#;

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -6,9 +6,9 @@ stderr = """
 stdio-fixture 1.0
 
 Usage:
-    stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
+    stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
-Subcommands:
+Commands:
     more    
     help    Print this message or the help of the given subcommand(s)
 

--- a/tests/ui/error_stderr.toml
+++ b/tests/ui/error_stderr.toml
@@ -8,7 +8,7 @@ error: Found argument '--unknown-argument' which wasn't expected, or isn't valid
 \tIf you tried to supply `--unknown-argument` as a value rather than a flag, use `-- --unknown-argument`
 
 Usage:
-    stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
+    stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
 For more information try --help
 """

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -5,9 +5,9 @@ stdout = """
 stdio-fixture 1.0
 
 Usage:
-    stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
+    stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
-Subcommands:
+Commands:
     more    
     help    Print this message or the help of the given subcommand(s)
 

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -5,9 +5,9 @@ stdout = """
 stdio-fixture 1.0
 
 Usage:
-    stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
+    stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
-Subcommands:
+Commands:
     more
             
     help

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -5,9 +5,9 @@ stdout = """
 stdio-fixture 1.0
 
 Usage:
-    stdio-fixture[EXE] [OPTIONS] [SUBCOMMAND]
+    stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
-Subcommands:
+Commands:
     more
             
     help


### PR DESCRIPTION
In switching to title case for help headings (#4123), it caused me to
look at "subcommand" in a fresh light.  I can't quite put my finger on
it but "Subcommand" looks a bit sloppy.  I also have recently been
surveying other CLIs and they just use "command" as well.

All of them are commands anyways, just some are children of others
(subcommands) while others are not (root or top-level commands, or just
command).  Context is good enough for clarifying subcommands from root
commands.

This is part of #4132

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
