### PR TITLE
fix(help): Always trim output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - *(help)* Subcommands are now listed before arguments.  To get the old behavior, see `Command::help_template`
 - *(help)* Help headings are now title cased, making any user-provided help headings inconsistent.  To get the old behavior, see `Command::help_template`, `Arg::help_heading`, and `Command::subcommand_help_heading`
 - *(help)* "Command" is used as the section heading for subcommands and `COMMAND` for the value name.  To get the old behavior, see  `Command::subcommand_help_heading` and `Arg::subcommand_value_name`
+- *(help)* Whitespace in help output is now trimmed to ensure consistency regardless of how well a template matches the users needs.
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)
 - *(derive)* Changed the default for arguments from `parse` to `value_parser`., removing `parse` support
 - *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp` (#3280)
@@ -99,6 +100,7 @@ Deprecated
 - *(help)* Use `[positional]` in list when relevant (#4144)
 - *(help)* Show all `[positional]` in usage
 - *(help)* Polish up subcommands by referring to them as commands
+- *(help)* Trim extra whitespace to avoid artifacts from different uses of templates
 - *(version)* Use `Command::display_name` rather than `Command::bin_name`
 - *(parser)* Assert on unknown args when using external subcommands (#3703)
 - *(parser)* Always fill in `""` argument for external subcommands (#3263)

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -106,6 +106,9 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
             self.write_templated_help(template);
         }
 
+        // Remove any extra lines caused by book keeping
+        self.writer.trim();
+        // Ensure there is still a trailing newline
         self.none("\n");
     }
 }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1627,7 +1627,7 @@ Options:
 
 NETWORKING:
     -n, --no-proxy    Do not use system proxy settings
-        --port        
+        --port
 ";
 
     let cmd = Command::new("blorp")
@@ -2853,7 +2853,7 @@ fn no_wrap_help() {
     let cmd = Command::new("ctest")
         .term_width(0)
         .override_help(MULTI_SC_HELP);
-    utils::assert_output(cmd, "ctest --help", &format!("{}\n", MULTI_SC_HELP), false);
+    utils::assert_output(cmd, "ctest --help", MULTI_SC_HELP, false);
 }
 
 #[test]


### PR DESCRIPTION
This ensures we don't end up with accidental leading or trailing
newlines due to help template variables not being used when a section is
empty.

This is prep for removing name/version from the default template and is
part of #4132

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
