### PR TITLE
fix(help): Clarify short vs long help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Deprecated
 - *(help)* Show all `[positional]` in usage
 - *(help)* Polish up subcommands by referring to them as commands
 - *(help)* Trim extra whitespace to avoid artifacts from different uses of templates
+- *(help)* Hint to the user the difference between `-h` / `--help` when applicable (#4159)
 - *(version)* Use `Command::display_name` rather than `Command::bin_name`
 - *(parser)* Assert on unknown args when using external subcommands (#3703)
 - *(parser)* Always fill in `""` argument for external subcommands (#3263)

--- a/clap_mangen/tests/snapshots/possible_values.bash.roff
+++ b/clap_mangen/tests/snapshots/possible_values.bash.roff
@@ -25,7 +25,7 @@ slow: use the slow method
 .RE
 .TP
 /fB/-h/fR, /fB/-/-help/fR
-Print help information
+Print help information (use `/-h` for a summary)
 .TP
 [/fIpositional_choice/fR]
 Pick the Position you want the command to run in

--- a/clap_mangen/tests/snapshots/value_env.bash.roff
+++ b/clap_mangen/tests/snapshots/value_env.bash.roff
@@ -15,4 +15,4 @@ May also be specified with the /fBCONFIG_FILE/fR environment variable.
 .RE
 .TP
 /fB/-h/fR, /fB/-/-help/fR
-Print help information
+Print help information (use `/-h` for a summary)

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -272,7 +272,7 @@ Usage:
     clap-test
 
 Options:
-    -h, --help       Print help information
+    -h, --help       Print help information (use `--help` for more detail)
     -V, --version    Print version information
 
 some text that comes after the help
@@ -288,7 +288,7 @@ Usage:
 
 Options:
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information
@@ -494,7 +494,7 @@ Options:
               - second: short help
 
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 ";
     let cmd = Command::new("test")
         .term_width(67)
@@ -678,7 +678,7 @@ Options:
             A coffeehouse, coffee shop, or café.
 
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information
@@ -1021,7 +1021,7 @@ Arguments:
 
 Options:
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information
@@ -1743,7 +1743,7 @@ Usage:
     test [OPTIONS] --song <song> --song-volume <volume>
 
 Options:
-    -h, --help       Print help information
+    -h, --help       Print help information (use `--help` for more detail)
     -V, --version    Print version information
 
 OVERRIDE SPECIAL:
@@ -1796,7 +1796,7 @@ Usage:
 
 Options:
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information
@@ -1820,7 +1820,7 @@ Usage:
     ctest foo
 
 Options:
-    -h, --help       Print help information
+    -h, --help       Print help information (use `--help` for more detail)
     -V, --version    Print version information
 ";
 
@@ -1847,7 +1847,7 @@ Arguments:
 
 Options:
     -f            
-    -h, --help    Print help information
+    -h, --help    Print help information (use `--help` for more detail)
 ";
 
     let cmd = Command::new("demo")
@@ -2006,7 +2006,7 @@ Options:
             and on, so I'll stop now.
 
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 ";
 
     let cmd = Command::new("prog").arg(

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -40,7 +40,7 @@ Usage:
 
 Options:
     -v, --visible    This text should be visible
-    -h, --help       Print help information
+    -h, --help       Print help information (use `--help` for more detail)
     -V, --version    Print version information
 ";
 
@@ -86,7 +86,7 @@ Options:
             This text should be visible
 
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information
@@ -125,7 +125,7 @@ Options:
             This text should be visible
 
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information
@@ -164,7 +164,7 @@ Usage:
 Options:
     -c, --config     Some help text describing the --config arg
     -v, --visible    This text should be visible
-    -h, --help       Print help information
+    -h, --help       Print help information (use `--help` for more detail)
     -V, --version    Print version information
 ";
 

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -414,7 +414,7 @@ Arguments:
 
 Options:
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 ";
 
     /// Application help

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -14,6 +14,6 @@ Commands:
 
 Options:
         --verbose    log
-    -h, --help       Print help information
+    -h, --help       Print help information (use `--help` for more detail)
     -V, --version    Print version information
 """

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -13,7 +13,7 @@ Commands:
 
 Options:
         --verbose    log
-    -h, --help       Print help information
+    -h, --help       Print help information (use `--help` for more detail)
     -V, --version    Print version information
 """
 stderr = ""

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -18,7 +18,7 @@ Options:
             more log
 
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -18,7 +18,7 @@ Options:
             more log
 
     -h, --help
-            Print help information
+            Print help information (use `-h` for a summary)
 
     -V, --version
             Print version information


### PR DESCRIPTION
In reviewing CLIs for #4132, I found some were providing helps on `-h`
vs `--help` and figured that could be built directly into clap.  I had
considered not making this hint automatic but I figured the overhead of
checking if long exists wouldn't be too bad.  The code exists (no binary
size increase) and just a simple iteration is probably not too slow
compared to everything else.

Fixes #1015

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
