### PR TITLE
fix(help): Remove name/version/author from help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - *(help)* Help headings are now title cased, making any user-provided help headings inconsistent.  To get the old behavior, see `Command::help_template`, `Arg::help_heading`, and `Command::subcommand_help_heading`
 - *(help)* "Command" is used as the section heading for subcommands and `COMMAND` for the value name.  To get the old behavior, see  `Command::subcommand_help_heading` and `Arg::subcommand_value_name`
 - *(help)* Whitespace in help output is now trimmed to ensure consistency regardless of how well a template matches the users needs.
+- *(help)* name/version/author are removed by default from help output.  To get the old behavior, see `Command::help_template`.
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)
 - *(derive)* Changed the default for arguments from `parse` to `value_parser`., removing `parse` support
 - *(derive)* `subcommand_required(true).arg_required_else_help(true)` is set instead of `SubcommandRequiredElseHelp` (#3280)
@@ -102,6 +103,7 @@ Deprecated
 - *(help)* Polish up subcommands by referring to them as commands
 - *(help)* Trim extra whitespace to avoid artifacts from different uses of templates
 - *(help)* Hint to the user the difference between `-h` / `--help` when applicable (#4159)
+- *(help)* Shorten help by eliding name/version/author
 - *(version)* Use `Command::display_name` rather than `Command::bin_name`
 - *(parser)* Assert on unknown args when using external subcommands (#3703)
 - *(parser)* Always fill in `""` argument for external subcommands (#3263)

--- a/examples/cargo-example-derive.md
+++ b/examples/cargo-example-derive.md
@@ -6,8 +6,6 @@ mimicking cargo's interface.
 The help looks like:
 ```console
 $ cargo-example-derive --help
-cargo 
-
 Usage:
     cargo <COMMAND>
 
@@ -19,7 +17,6 @@ Options:
     -h, --help    Print help information
 
 $ cargo-example-derive example-derive --help
-cargo-example-derive [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/cargo-example.md
+++ b/examples/cargo-example.md
@@ -6,8 +6,6 @@ mimicking cargo's interface.
 The help looks like:
 ```console
 $ cargo-example --help
-cargo 
-
 Usage:
     cargo <COMMAND>
 
@@ -19,7 +17,6 @@ Options:
     -h, --help    Print help information
 
 $ cargo-example example --help
-cargo-example [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/demo.md
+++ b/examples/demo.md
@@ -1,6 +1,5 @@
 ```console
 $ demo --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/derive_ref/custom-bool.md
+++ b/examples/derive_ref/custom-bool.md
@@ -4,7 +4,6 @@ Example of overriding the magic `bool` behavior
 
 ```console
 $ custom-bool --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -101,8 +101,6 @@ For more information try --help
 ```console
 $ interop_hand_subcommand
 ? failed
-clap 
-
 Usage:
     interop_hand_subcommand[EXE] [OPTIONS] <COMMAND>
 

--- a/examples/escaped-positional-derive.md
+++ b/examples/escaped-positional-derive.md
@@ -5,7 +5,6 @@ You can use `--` to escape further arguments.
 Let's see what this looks like in the help:
 ```console
 $ escaped-positional-derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/escaped-positional.md
+++ b/examples/escaped-positional.md
@@ -5,7 +5,6 @@ You can use `--` to escape further arguments.
 Let's see what this looks like in the help:
 ```console
 $ escaped-positional --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/find.md
+++ b/examples/find.md
@@ -2,7 +2,6 @@
 
 ```console
 $ find --help
-clap 4.0.0-alpha.0
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -6,7 +6,6 @@ Help:
 ```console
 $ git-derive
 ? failed
-git 
 A fictional versioning CLI
 
 Usage:
@@ -23,7 +22,6 @@ Options:
     -h, --help    Print help information
 
 $ git-derive help
-git 
 A fictional versioning CLI
 
 Usage:
@@ -40,7 +38,6 @@ Options:
     -h, --help    Print help information
 
 $ git-derive help add
-git-add 
 adds things
 
 Usage:
@@ -58,7 +55,6 @@ A basic argument:
 ```console
 $ git-derive add
 ? failed
-git-add 
 adds things
 
 Usage:
@@ -78,8 +74,6 @@ Adding ["Cargo.toml", "Cargo.lock"]
 Default subcommand:
 ```console
 $ git-derive stash -h
-git-stash 
-
 Usage:
     git-derive[EXE] stash [OPTIONS]
     git-derive[EXE] stash <COMMAND>
@@ -95,8 +89,6 @@ Options:
     -h, --help                 Print help information
 
 $ git-derive stash push -h
-git-stash-push 
-
 Usage:
     git-derive[EXE] stash push [OPTIONS]
 
@@ -105,8 +97,6 @@ Options:
     -h, --help                 Print help information
 
 $ git-derive stash pop -h
-git-stash-pop 
-
 Usage:
     git-derive[EXE] stash pop [STASH]
 

--- a/examples/git.md
+++ b/examples/git.md
@@ -4,7 +4,6 @@ Help:
 ```console
 $ git
 ? failed
-git 
 A fictional versioning CLI
 
 Usage:
@@ -21,7 +20,6 @@ Options:
     -h, --help    Print help information
 
 $ git help
-git 
 A fictional versioning CLI
 
 Usage:
@@ -38,7 +36,6 @@ Options:
     -h, --help    Print help information
 
 $ git help add
-git-add 
 adds things
 
 Usage:
@@ -56,7 +53,6 @@ A basic argument:
 ```console
 $ git add
 ? failed
-git-add 
 adds things
 
 Usage:
@@ -76,8 +72,6 @@ Adding ["Cargo.toml", "Cargo.lock"]
 Default subcommand:
 ```console
 $ git stash -h
-git-stash 
-
 Usage:
     git[EXE] stash [OPTIONS]
     git[EXE] stash <COMMAND>
@@ -93,8 +87,6 @@ Options:
     -h, --help                 Print help information
 
 $ git stash push -h
-git-stash-push 
-
 Usage:
     git[EXE] stash push [OPTIONS]
 
@@ -103,8 +95,6 @@ Options:
     -h, --help                 Print help information
 
 $ git stash pop -h
-git-stash-pop 
-
 Usage:
     git[EXE] stash pop [STASH]
 

--- a/examples/multicall-busybox.md
+++ b/examples/multicall-busybox.md
@@ -25,8 +25,6 @@ Though users must pass something:
 ```console
 $ busybox
 ? failed
-busybox 
-
 Usage:
     busybox [OPTIONS] [APPLET]
 

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -35,8 +35,6 @@ Searching for name...
 In the help, this looks like:
 ```console
 $ pacman -h
-pacman 5.2.1
-Pacman Development Team
 package manager utility
 
 Usage:
@@ -52,7 +50,6 @@ Options:
     -V, --version    Print version information
 
 $ pacman -S -h
-pacman-sync 
 Synchronize packages.
 
 Usage:

--- a/examples/tutorial_builder/01_quick.md
+++ b/examples/tutorial_builder/01_quick.md
@@ -1,6 +1,5 @@
 ```console
 $ 01_quick --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/02_app_settings.md
+++ b/examples/tutorial_builder/02_app_settings.md
@@ -1,6 +1,5 @@
 ```console
 $ 02_app_settings --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/02_apps.md
+++ b/examples/tutorial_builder/02_apps.md
@@ -1,7 +1,5 @@
 ```console
 $ 02_apps --help
-MyApp 1.0
-Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
 Usage:

--- a/examples/tutorial_builder/02_crate.md
+++ b/examples/tutorial_builder/02_crate.md
@@ -1,6 +1,5 @@
 ```console
 $ 02_crate --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_01_flag_bool.md
+++ b/examples/tutorial_builder/03_01_flag_bool.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_01_flag_bool --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_01_flag_count.md
+++ b/examples/tutorial_builder/03_01_flag_count.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_01_flag_count --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_02_option.md
+++ b/examples/tutorial_builder/03_02_option.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_02_option --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_02_option_mult.md
+++ b/examples/tutorial_builder/03_02_option_mult.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_02_option_mult --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_03_positional.md
+++ b/examples/tutorial_builder/03_03_positional.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_03_positional --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_03_positional_mult.md
+++ b/examples/tutorial_builder/03_03_positional_mult.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_03_positional_mult --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_04_subcommands.md
+++ b/examples/tutorial_builder/03_04_subcommands.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_04_subcommands help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
@@ -15,7 +14,6 @@ Options:
     -V, --version    Print version information
 
 $ 03_04_subcommands help add
-clap-add [..]
 Adds files to myapp
 
 Usage:
@@ -37,7 +35,6 @@ Because we set [`Command::arg_required_else_help`][crate::Command::arg_required_
 ```console
 $ 03_04_subcommands
 ? failed
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/03_05_default_values.md
+++ b/examples/tutorial_builder/03_05_default_values.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_05_default_values --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/04_01_enum.md
+++ b/examples/tutorial_builder/04_01_enum.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_01_enum --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/04_01_possible.md
+++ b/examples/tutorial_builder/04_01_possible.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_01_possible --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/04_02_parse.md
+++ b/examples/tutorial_builder/04_02_parse.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_02_parse --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/04_02_validate.md
+++ b/examples/tutorial_builder/04_02_validate.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_02_validate --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/04_03_relations.md
+++ b/examples/tutorial_builder/04_03_relations.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_03_relations --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_builder/04_04_custom.md
+++ b/examples/tutorial_builder/04_04_custom.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_04_custom --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/01_quick.md
+++ b/examples/tutorial_derive/01_quick.md
@@ -1,6 +1,5 @@
 ```console
 $ 01_quick_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/02_app_settings.md
+++ b/examples/tutorial_derive/02_app_settings.md
@@ -1,6 +1,5 @@
 ```console
 $ 02_app_settings_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/02_apps.md
+++ b/examples/tutorial_derive/02_apps.md
@@ -1,7 +1,5 @@
 ```console
 $ 02_apps_derive --help
-MyApp 1.0
-Kevin K. <kbknapp@gmail.com>
 Does awesome things
 
 Usage:

--- a/examples/tutorial_derive/02_crate.md
+++ b/examples/tutorial_derive/02_crate.md
@@ -1,6 +1,5 @@
 ```console
 $ 02_crate_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_01_flag_bool.md
+++ b/examples/tutorial_derive/03_01_flag_bool.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_01_flag_bool_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_01_flag_count.md
+++ b/examples/tutorial_derive/03_01_flag_count.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_01_flag_count_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_02_option.md
+++ b/examples/tutorial_derive/03_02_option.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_02_option_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_02_option_mult.md
+++ b/examples/tutorial_derive/03_02_option_mult.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_02_option_mult_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_03_positional.md
+++ b/examples/tutorial_derive/03_03_positional.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_03_positional_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_03_positional_mult.md
+++ b/examples/tutorial_derive/03_03_positional_mult.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_03_positional_mult_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_04_subcommands.md
+++ b/examples/tutorial_derive/03_04_subcommands.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_04_subcommands_derive help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:
@@ -15,7 +14,6 @@ Options:
     -V, --version    Print version information
 
 $ 03_04_subcommands_derive help add
-clap-add [..]
 Adds files to myapp
 
 Usage:
@@ -37,7 +35,6 @@ Because we used `command: Commands` instead of `command: Option<Commands>`:
 ```console
 $ 03_04_subcommands_derive
 ? failed
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/03_05_default_values.md
+++ b/examples/tutorial_derive/03_05_default_values.md
@@ -1,6 +1,5 @@
 ```console
 $ 03_05_default_values_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/04_01_enum.md
+++ b/examples/tutorial_derive/04_01_enum.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_01_enum_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/04_02_parse.md
+++ b/examples/tutorial_derive/04_02_parse.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_02_parse_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/04_02_validate.md
+++ b/examples/tutorial_derive/04_02_validate.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_02_validate_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/04_03_relations.md
+++ b/examples/tutorial_derive/04_03_relations.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_03_relations_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/tutorial_derive/04_04_custom.md
+++ b/examples/tutorial_derive/04_04_custom.md
@@ -1,6 +1,5 @@
 ```console
 $ 04_04_custom_derive --help
-clap [..]
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
 Usage:

--- a/examples/typed-derive.md
+++ b/examples/typed-derive.md
@@ -3,8 +3,6 @@
 Help:
 ```console
 $ typed-derive --help
-clap 
-
 Usage:
     typed-derive[EXE] [OPTIONS]
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -29,16 +29,14 @@ pub(crate) struct Help<'cmd, 'writer> {
 // Public Functions
 impl<'cmd, 'writer> Help<'cmd, 'writer> {
     const DEFAULT_TEMPLATE: &'static str = "\
-        {before-help}{name} {version}\n\
-        {author-with-newline}{about-with-newline}\n\
+        {before-help}{about-with-newline}\n\
         {usage-heading}\n    {usage}\n\
         \n\
         {all-args}{after-help}\
     ";
 
     const DEFAULT_NO_ARGS_TEMPLATE: &'static str = "\
-        {before-help}{name} {version}\n\
-        {author-with-newline}{about-with-newline}\n\
+        {before-help}{about-with-newline}\n\
         {usage-heading}\n    {usage}{after-help}\
     ";
 

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -4,8 +4,7 @@ use super::utils;
 
 use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 
-static ALLOW_EXT_SC: &str = "clap-test v1.4.8
-
+static ALLOW_EXT_SC: &str = "\
 Usage:
     clap-test [COMMAND]
 
@@ -14,8 +13,7 @@ Options:
     -V, --version    Print version information
 ";
 
-static DONT_COLLAPSE_ARGS: &str = "clap-test v1.4.8
-
+static DONT_COLLAPSE_ARGS: &str = "\
 Usage:
     clap-test [arg1] [arg2] [arg3]
 
@@ -125,8 +123,7 @@ fn arg_required_else_help_with_default() {
 
 #[test]
 fn arg_required_else_help_error_message() {
-    static ARG_REQUIRED_ELSE_HELP: &str = "test 1.0
-
+    static ARG_REQUIRED_ELSE_HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -284,8 +281,7 @@ fn no_bin_name() {
 
 #[test]
 fn skip_possible_values() {
-    static SKIP_POS_VALS: &str = "test 1.3
-Kevin K.
+    static SKIP_POS_VALS: &str = "\
 tests stuff
 
 Usage:
@@ -562,8 +558,7 @@ fn dont_collapse_args() {
 
 #[test]
 fn require_eq() {
-    static REQUIRE_EQUALS: &str = "clap-test v1.4.8
-
+    static REQUIRE_EQUALS: &str = "\
 Usage:
     clap-test --opt=<FILE>
 

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -190,7 +190,7 @@ fn alias_on_a_subcommand_option() {
 
 #[test]
 fn invisible_arg_aliases_help_output() {
-    static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+    static SC_INVISIBLE_ALIAS_HELP: &str = "\
 Some help
 
 Usage:
@@ -221,7 +221,7 @@ Options:
 
 #[test]
 fn visible_arg_aliases_help_output() {
-    static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+    static SC_VISIBLE_ALIAS_HELP: &str = "\
 Some help
 
 Usage:

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -157,7 +157,7 @@ fn short_alias_on_a_subcommand_option() {
 
 #[test]
 fn invisible_short_arg_aliases_help_output() {
-    static SC_INVISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+    static SC_INVISIBLE_ALIAS_HELP: &str = "\
 Some help
 
 Usage:
@@ -188,7 +188,7 @@ Options:
 
 #[test]
 fn visible_short_arg_aliases_help_output() {
-    static SC_VISIBLE_ALIAS_HELP: &str = "ct-test 1.2
+    static SC_VISIBLE_ALIAS_HELP: &str = "\
 Some help
 
 Usage:

--- a/tests/builder/cargo.rs
+++ b/tests/builder/cargo.rs
@@ -4,6 +4,8 @@ use clap::{
     crate_authors, crate_description, crate_name, crate_version, error::ErrorKind, Command,
 };
 
+use crate::utils;
+
 static DESCRIPTION_ONLY: &str = "prog 1
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
@@ -30,6 +32,7 @@ Options:
 fn crate_version() {
     let res = Command::new("prog")
         .version(crate_version!())
+        .help_template(utils::FULL_TEMPLATE)
         .try_get_matches_from(vec!["prog", "--version"]);
 
     assert!(res.is_err());
@@ -46,6 +49,7 @@ fn crate_description() {
     let res = Command::new("prog")
         .version("1")
         .about(crate_description!())
+        .help_template(utils::FULL_TEMPLATE)
         .try_get_matches_from(vec!["prog", "--help"]);
 
     assert!(res.is_err());
@@ -59,6 +63,7 @@ fn crate_authors() {
     let res = Command::new("prog")
         .version("1")
         .author(crate_authors!())
+        .help_template(utils::FULL_TEMPLATE)
         .try_get_matches_from(vec!["prog", "--help"]);
 
     assert!(res.is_err());
@@ -70,6 +75,7 @@ fn crate_authors() {
 #[test]
 fn crate_name() {
     let res = Command::new(crate_name!())
+        .help_template(utils::FULL_TEMPLATE)
         .version("3.0")
         .try_get_matches_from(vec!["clap", "--version"]);
 

--- a/tests/builder/command.rs
+++ b/tests/builder/command.rs
@@ -2,6 +2,8 @@
 
 use clap::{command, error::ErrorKind};
 
+use crate::utils;
+
 static EVERYTHING: &str = "clap {{version}}
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
@@ -15,7 +17,9 @@ Options:
 
 #[test]
 fn command() {
-    let res = command!().try_get_matches_from(vec!["clap", "--help"]);
+    let res = command!()
+        .help_template(utils::FULL_TEMPLATE)
+        .try_get_matches_from(vec!["clap", "--help"]);
 
     assert!(res.is_err());
     let err = res.unwrap_err();

--- a/tests/builder/derive_order.rs
+++ b/tests/builder/derive_order.rs
@@ -6,8 +6,7 @@ use clap::{Arg, ArgAction, Command};
 
 #[test]
 fn no_derive_order() {
-    static NO_DERIVE_ORDER: &str = "test 1.2
-
+    static NO_DERIVE_ORDER: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -47,8 +46,7 @@ Options:
 
 #[test]
 fn derive_order() {
-    static UNIFIED_HELP_AND_DERIVE: &str = "test 1.2
-
+    static UNIFIED_HELP_AND_DERIVE: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -85,8 +83,7 @@ Options:
 
 #[test]
 fn derive_order_next_order() {
-    static HELP: &str = "test 1.2
-
+    static HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -133,8 +130,7 @@ Options:
 
 #[test]
 fn derive_order_no_next_order() {
-    static HELP: &str = "test 1.2
-
+    static HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -180,8 +176,7 @@ Options:
 
 #[test]
 fn derive_order_subcommand_propagate() {
-    static UNIFIED_DERIVE_SC_PROP: &str = "test-sub 1.2
-
+    static UNIFIED_DERIVE_SC_PROP: &str = "\
 Usage:
     test sub [OPTIONS]
 
@@ -220,8 +215,7 @@ Options:
 
 #[test]
 fn derive_order_subcommand_propagate_with_explicit_display_order() {
-    static UNIFIED_DERIVE_SC_PROP_EXPLICIT_ORDER: &str = "test-sub 1.2
-
+    static UNIFIED_DERIVE_SC_PROP_EXPLICIT_ORDER: &str = "\
 Usage:
     test sub [OPTIONS]
 
@@ -266,8 +260,7 @@ Options:
 
 #[test]
 fn subcommand_sorted_display_order() {
-    static SUBCMD_ALPHA_ORDER: &str = "test 1
-
+    static SUBCMD_ALPHA_ORDER: &str = "\
 Usage:
     test [COMMAND]
 
@@ -303,8 +296,7 @@ Options:
 
 #[test]
 fn subcommand_derived_display_order() {
-    static SUBCMD_DECL_ORDER: &str = "test 1
-
+    static SUBCMD_DECL_ORDER: &str = "\
 Usage:
     test [COMMAND]
 

--- a/tests/builder/display_order.rs
+++ b/tests/builder/display_order.rs
@@ -9,8 +9,7 @@ fn very_large_display_order() {
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test [COMMAND]
 

--- a/tests/builder/double_require.rs
+++ b/tests/builder/double_require.rs
@@ -1,7 +1,6 @@
 use clap::{error::ErrorKind, Arg, ArgAction, Command};
 
-static HELP: &str = "prog 
-
+static HELP: &str = "\
 Usage:
     prog [OPTIONS]
 

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -89,8 +89,6 @@ fn null_prints_help() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::DisplayHelp;
     static MESSAGE: &str = "\
-test 
-
 Usage:
     test
 
@@ -110,8 +108,6 @@ fn raw_prints_help() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::DisplayHelp;
     static MESSAGE: &str = "\
-test 
-
 Usage:
     test
 

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -496,7 +496,7 @@ fn flag_subcommand_long_infer_exact_match() {
     assert_eq!(m.subcommand_name(), Some("test"));
 }
 
-static FLAG_SUBCOMMAND_HELP: &str = "pacman-query 
+static FLAG_SUBCOMMAND_HELP: &str = "\
 Query the package database.
 
 Usage:
@@ -545,7 +545,7 @@ fn flag_subcommand_long_short_normal_usage_string() {
     utils::assert_output(cmd, "pacman -Qh", FLAG_SUBCOMMAND_HELP, false);
 }
 
-static FLAG_SUBCOMMAND_NO_SHORT_HELP: &str = "pacman-query 
+static FLAG_SUBCOMMAND_NO_SHORT_HELP: &str = "\
 Query the package database.
 
 Usage:
@@ -598,7 +598,7 @@ fn flag_subcommand_long_normal_usage_string() {
     );
 }
 
-static FLAG_SUBCOMMAND_NO_LONG_HELP: &str = "pacman-query 
+static FLAG_SUBCOMMAND_NO_LONG_HELP: &str = "\
 Query the package database.
 
 Usage:

--- a/tests/builder/groups.rs
+++ b/tests/builder/groups.rs
@@ -261,8 +261,7 @@ fn group_overrides_required() {
 
 #[test]
 fn group_usage_use_val_name() {
-    static GROUP_USAGE_USE_VAL_NAME: &str = "prog 
-
+    static GROUP_USAGE_USE_VAL_NAME: &str = "\
 Usage:
     prog <A>
 

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -88,8 +88,7 @@ For more information try --help
 
 #[test]
 fn req_last_arg_usage() {
-    static LAST_ARG_REQ_MULT: &str = "example 1.0
-
+    static LAST_ARG_REQ_MULT: &str = "\
 Usage:
     example <FIRST>... -- <SECOND>...
 
@@ -117,8 +116,7 @@ Options:
 
 #[test]
 fn args_with_last_usage() {
-    static LAST_ARG_USAGE: &str = "flamegraph 0.1
-
+    static LAST_ARG_USAGE: &str = "\
 Usage:
     flamegraph [OPTIONS] [BINFILE] [-- <ARGS>...]
 
@@ -200,7 +198,8 @@ fn subcommand_help_rev() {
 
 #[test]
 fn complex_help_output() {
-    static HELP: &str = "clap-test v1.4.8
+    static HELP: &str = "\
+clap-test v1.4.8
 Kevin K. <kbknapp@gmail.com>
 tests clap library
 
@@ -239,7 +238,6 @@ Options:
 fn after_and_before_help_output() {
     static AFTER_HELP: &str = "some text that comes before the help
 
-clap-test v1.4.8
 tests clap library
 
 Usage:
@@ -265,7 +263,6 @@ some text that comes after the help
 fn after_and_before_long_help_output() {
     static AFTER_HELP: &str = "some text that comes before the help
 
-clap-test v1.4.8
 tests clap library
 
 Usage:
@@ -280,7 +277,6 @@ some text that comes after the help
 
     static AFTER_LONG_HELP: &str = "some longer text that comes before the help
 
-clap-test v1.4.8
 tests clap library
 
 Usage:
@@ -307,8 +303,7 @@ some longer text that comes after the help
     utils::assert_output(cmd, "clap-test -h", AFTER_HELP, false);
 }
 
-static MULTI_SC_HELP: &str = "ctest-subcmd-multi 0.1
-Kevin K. <kbknapp@gmail.com>
+static MULTI_SC_HELP: &str = "\
 tests subcommands
 
 Usage:
@@ -347,8 +342,7 @@ fn multi_level_sc_help() {
 
 #[test]
 fn no_wrap_default_help() {
-    static DEFAULT_HELP: &str = "ctest 1.0
-
+    static DEFAULT_HELP: &str = "\
 Usage:
     ctest
 
@@ -364,8 +358,7 @@ Options:
 #[test]
 #[cfg(feature = "wrap_help")]
 fn wrapped_help() {
-    static WRAPPED_HELP: &str = "test 
-
+    static WRAPPED_HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -420,8 +413,7 @@ Options:
 #[test]
 #[cfg(feature = "wrap_help")]
 fn unwrapped_help() {
-    static UNWRAPPED_HELP: &str = "test 
-
+    static UNWRAPPED_HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -468,8 +460,7 @@ Options:
 #[test]
 #[cfg(all(feature = "wrap_help"))]
 fn possible_value_wrapped_help() {
-    static WRAPPED_HELP: &str = "test 
-
+    static WRAPPED_HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -557,8 +548,7 @@ Options:
 
 #[test]
 fn issue_626_unicode_cutoff() {
-    static ISSUE_626_CUTOFF: &str = "ctest 0.1
-
+    static ISSUE_626_CUTOFF: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -593,8 +583,7 @@ Options:
     utils::assert_output(cmd, "ctest --help", ISSUE_626_CUTOFF, false);
 }
 
-static HIDE_POS_VALS: &str = "ctest 0.1
-
+static HIDE_POS_VALS: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -661,8 +650,7 @@ fn hide_single_possible_val() {
 
 #[test]
 fn possible_vals_with_help() {
-    static POS_VALS_HELP: &str = "ctest 0.1
-
+    static POS_VALS_HELP: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -711,8 +699,7 @@ Options:
 
 #[test]
 fn issue_626_panic() {
-    static ISSUE_626_PANIC: &str = "ctest 0.1
-
+    static ISSUE_626_PANIC: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -767,8 +754,7 @@ fn issue_626_variable_panic() {
 
 #[test]
 fn final_word_wrapping() {
-    static FINAL_WORD_WRAPPING: &str = "ctest 0.1
-
+    static FINAL_WORD_WRAPPING: &str = "\
 Usage:
     ctest
 
@@ -787,8 +773,7 @@ Options:
     utils::assert_output(cmd, "ctest --help", FINAL_WORD_WRAPPING, false);
 }
 
-static WRAPPING_NEWLINE_CHARS: &str = "ctest 0.1
-
+static WRAPPING_NEWLINE_CHARS: &str = "\
 Usage:
     ctest [mode]
 
@@ -843,8 +828,6 @@ fn dont_wrap_urls() {
     );
 
     const EXPECTED: &str = "\
-Example-update 
-
 Usage:
     Example update [OPTIONS]
 
@@ -862,8 +845,7 @@ Options:
     utils::assert_output(cmd, "Example update --help", EXPECTED, false);
 }
 
-static OLD_NEWLINE_CHARS: &str = "ctest 0.1
-
+static OLD_NEWLINE_CHARS: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -898,8 +880,7 @@ fn old_newline_variables() {
 
 #[test]
 fn issue_688_hide_pos_vals() {
-    static ISSUE_688: &str = "ctest 0.1
-
+    static ISSUE_688: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -949,8 +930,7 @@ Options:
 
 #[test]
 fn issue_702_multiple_values() {
-    static ISSUE_702: &str = "myapp 1.0
-foo
+    static ISSUE_702: &str = "\
 bar
 
 Usage:
@@ -1006,8 +986,7 @@ Options:
 
 #[test]
 fn long_about() {
-    static LONG_ABOUT: &str = "myapp 1.0
-foo
+    static LONG_ABOUT: &str = "\
 something really really long, with
 multiple lines of text
 that should be displayed
@@ -1038,8 +1017,9 @@ Options:
     utils::assert_output(cmd, "myapp --help", LONG_ABOUT, false);
 }
 
-static RIPGREP_USAGE: &str = "ripgrep 0.5
-
+#[test]
+fn ripgrep_usage() {
+    static RIPGREP_USAGE: &str = "\
 Usage:
     rg [OPTIONS] <pattern> [<path> ...]
     rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]
@@ -1051,8 +1031,6 @@ Options:
     -V, --version    Print version information
 ";
 
-#[test]
-fn ripgrep_usage() {
     let cmd = Command::new("ripgrep").version("0.5").override_usage(
         "rg [OPTIONS] <pattern> [<path> ...]
     rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]
@@ -1065,6 +1043,20 @@ fn ripgrep_usage() {
 
 #[test]
 fn ripgrep_usage_using_templates() {
+    static RIPGREP_USAGE: &str = "\
+ripgrep 0.5
+
+Usage:
+    rg [OPTIONS] <pattern> [<path> ...]
+    rg [OPTIONS] [-e PATTERN | -f FILE ]... [<path> ...]
+    rg [OPTIONS] --files [<path> ...]
+    rg [OPTIONS] --type-list
+
+Options:
+    -h, --help       Print help information
+    -V, --version    Print version information
+";
+
     let cmd = Command::new("ripgrep")
         .version("0.5")
         .override_usage(
@@ -1089,8 +1081,7 @@ Options:
 
 #[test]
 fn sc_negates_reqs() {
-    static SC_NEGATES_REQS: &str = "prog 1.0
-
+    static SC_NEGATES_REQS: &str = "\
 Usage:
     prog --opt <FILE> [PATH]
     prog [PATH] <COMMAND>
@@ -1119,8 +1110,7 @@ Options:
 
 #[test]
 fn hide_args() {
-    static HIDDEN_ARGS: &str = "prog 1.0
-
+    static HIDDEN_ARGS: &str = "\
 Usage:
     prog [OPTIONS]
 
@@ -1141,8 +1131,7 @@ Options:
 
 #[test]
 fn args_negate_sc() {
-    static ARGS_NEGATE_SC: &str = "prog 1.0
-
+    static ARGS_NEGATE_SC: &str = "\
 Usage:
     prog [OPTIONS] [PATH]
     prog <COMMAND>
@@ -1173,8 +1162,7 @@ Options:
 
 #[test]
 fn issue_1046_hide_scs() {
-    static ISSUE_1046_HIDDEN_SCS: &str = "prog 1.0
-
+    static ISSUE_1046_HIDDEN_SCS: &str = "\
 Usage:
     prog [OPTIONS] [PATH]
 
@@ -1222,12 +1210,12 @@ Options:
         .version("1.0")
         .author("Some Very Long Name and crazy long email <email@server.com>")
         .about("Show how the about text is not wrapped")
+        .help_template(utils::FULL_TEMPLATE)
         .term_width(35);
     utils::assert_output(cmd, "ctest --help", ISSUE_777, false);
 }
 
-static OVERRIDE_HELP_SHORT: &str = "test 0.1
-
+static OVERRIDE_HELP_SHORT: &str = "\
 Usage:
     test
 
@@ -1247,8 +1235,7 @@ fn override_help_short() {
     utils::assert_output(cmd, "test -H", OVERRIDE_HELP_SHORT, false);
 }
 
-static OVERRIDE_HELP_LONG: &str = "test 0.1
-
+static OVERRIDE_HELP_LONG: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -1268,8 +1255,7 @@ fn override_help_long() {
     utils::assert_output(cmd, "test -h", OVERRIDE_HELP_LONG, false);
 }
 
-static OVERRIDE_HELP_ABOUT: &str = "test 0.1
-
+static OVERRIDE_HELP_ABOUT: &str = "\
 Usage:
     test
 
@@ -1322,8 +1308,7 @@ fn arg_long_conflict_with_help() {
 
 #[test]
 fn last_arg_mult_usage() {
-    static LAST_ARG: &str = "last 0.1
-
+    static LAST_ARG: &str = "\
 Usage:
     last <TARGET> [CORPUS] [-- <ARGS>...]
 
@@ -1353,8 +1338,7 @@ Options:
 
 #[test]
 fn last_arg_mult_usage_req() {
-    static LAST_ARG_REQ: &str = "last 0.1
-
+    static LAST_ARG_REQ: &str = "\
 Usage:
     last <TARGET> [CORPUS] -- <ARGS>...
 
@@ -1385,8 +1369,7 @@ Options:
 
 #[test]
 fn last_arg_mult_usage_req_with_sc() {
-    static LAST_ARG_REQ_SC: &str = "last 0.1
-
+    static LAST_ARG_REQ_SC: &str = "\
 Usage:
     last <TARGET> [CORPUS] -- <ARGS>...
     last [TARGET] [CORPUS] <COMMAND>
@@ -1424,8 +1407,7 @@ Options:
 
 #[test]
 fn last_arg_mult_usage_with_sc() {
-    static LAST_ARG_SC: &str = "last 0.1
-
+    static LAST_ARG_SC: &str = "\
 Usage:
     last <TARGET> [CORPUS] [-- <ARGS>...]
     last <COMMAND>
@@ -1460,8 +1442,7 @@ Options:
     utils::assert_output(cmd, "last --help", LAST_ARG_SC, false);
 }
 
-static HIDE_DEFAULT_VAL: &str = "default 0.1
-
+static HIDE_DEFAULT_VAL: &str = "\
 Usage:
     default [OPTIONS]
 
@@ -1493,8 +1474,7 @@ fn hide_default_val() {
 
 #[test]
 fn escaped_whitespace_values() {
-    static ESCAPED_DEFAULT_VAL: &str = "default 0.1
-
+    static ESCAPED_DEFAULT_VAL: &str = "\
 Usage:
     default [OPTIONS]
 
@@ -1583,8 +1563,7 @@ fn prefer_user_subcmd_help_short_1112() {
 
 #[test]
 fn issue_1052_require_delim_help() {
-    static REQUIRE_DELIM_HELP: &str = "test 1.3
-Kevin K.
+    static REQUIRE_DELIM_HELP: &str = "\
 tests stuff
 
 Usage:
@@ -1613,8 +1592,7 @@ Options:
 
 #[test]
 fn custom_headers_headers() {
-    static CUSTOM_HELP_SECTION: &str = "blorp 1.4
-Will M.
+    static CUSTOM_HELP_SECTION: &str = "\
 does stuff
 
 Usage:
@@ -1654,8 +1632,7 @@ NETWORKING:
     utils::assert_output(cmd, "test --help", CUSTOM_HELP_SECTION, false);
 }
 
-static MULTIPLE_CUSTOM_HELP_SECTIONS: &str = "blorp 1.4
-Will M.
+static MULTIPLE_CUSTOM_HELP_SECTIONS: &str = "\
 does stuff
 
 Usage:
@@ -1735,8 +1712,7 @@ fn multiple_custom_help_headers() {
     utils::assert_output(cmd, "test --help", MULTIPLE_CUSTOM_HELP_SECTIONS, false);
 }
 
-static CUSTOM_HELP_SECTION_HIDDEN_ARGS: &str = "blorp 1.4
-Will M.
+static CUSTOM_HELP_SECTION_HIDDEN_ARGS: &str = "\
 does stuff
 
 Usage:
@@ -1788,7 +1764,7 @@ fn custom_help_headers_hide_args() {
     utils::assert_output(cmd, "test -h", CUSTOM_HELP_SECTION_HIDDEN_ARGS, false);
 }
 
-static ISSUE_897: &str = "ctest-foo 0.1
+static ISSUE_897: &str = "\
 Long about foo
 
 Usage:
@@ -1813,7 +1789,7 @@ fn show_long_about_issue_897() {
     utils::assert_output(cmd, "ctest foo --help", ISSUE_897, false);
 }
 
-static ISSUE_897_SHORT: &str = "ctest-foo 0.1
+static ISSUE_897_SHORT: &str = "\
 About foo
 
 Usage:
@@ -1837,8 +1813,7 @@ fn show_short_about_issue_897() {
 
 #[test]
 fn issue_1364_no_short_options() {
-    static ISSUE_1364: &str = "demo 
-
+    static ISSUE_1364: &str = "\
 Usage:
     demo [OPTIONS] [FILES]...
 
@@ -1871,8 +1846,7 @@ Options:
 #[rustfmt::skip]
 #[test]
 fn issue_1487() {
-static ISSUE_1487: &str = "test 
-
+static ISSUE_1487: &str = "\
 Usage:
     ctest <arg1|arg2>
 
@@ -1993,8 +1967,7 @@ fn help_required_and_no_args() {
 
 #[test]
 fn issue_1642_long_help_spacing() {
-    static ISSUE_1642: &str = "prog 
-
+    static ISSUE_1642: &str = "\
 Usage:
     prog [OPTIONS]
 
@@ -2023,8 +1996,7 @@ and on, so I'll stop now.",
     utils::assert_output(cmd, "prog --help", ISSUE_1642, false);
 }
 
-const AFTER_HELP_NO_ARGS: &str = "myapp 1.0
-
+const AFTER_HELP_NO_ARGS: &str = "\
 Usage:
     myapp
 
@@ -2050,7 +2022,7 @@ fn after_help_no_args() {
 
 #[test]
 fn help_subcmd_help() {
-    static HELP_SUBCMD_HELP: &str = "myapp-help 
+    static HELP_SUBCMD_HELP: &str = "\
 Print this message or the help of the given subcommand(s)
 
 Usage:
@@ -2068,7 +2040,7 @@ Arguments:
 
 #[test]
 fn subcmd_help_subcmd_help() {
-    static SUBCMD_HELP_SUBCMD_HELP: &str = "myapp-subcmd-help 
+    static SUBCMD_HELP_SUBCMD_HELP: &str = "\
 Print this message or the help of the given subcommand(s)
 
 Usage:
@@ -2091,8 +2063,7 @@ Arguments:
 
 #[test]
 fn global_args_should_show_on_toplevel_help_message() {
-    static HELP: &str = "myapp\x20
-
+    static HELP: &str = "\
 Usage:
     myapp [OPTIONS] [COMMAND]
 
@@ -2119,7 +2090,7 @@ Options:
 
 #[test]
 fn global_args_should_not_show_on_help_message_for_help_help() {
-    static HELP_HELP: &str = "myapp-help\x20
+    static HELP_HELP: &str = "\
 Print this message or the help of the given subcommand(s)
 
 Usage:
@@ -2143,8 +2114,7 @@ Arguments:
 
 #[test]
 fn global_args_should_show_on_help_message_for_subcommand() {
-    static HELP_SUBCMD: &str = "myapp-subcmd\x20
-
+    static HELP_SUBCMD: &str = "\
 Usage:
     myapp subcmd [OPTIONS] [COMMAND]
 
@@ -2171,8 +2141,7 @@ Options:
 
 #[test]
 fn global_args_should_show_on_help_message_for_nested_subcommand() {
-    static HELP_SUB_SUBCMD: &str = "myapp-subcmd-multi 1.0
-
+    static HELP_SUB_SUBCMD: &str = "\
 Usage:
     myapp subcmd multi [OPTIONS]
 
@@ -2196,8 +2165,7 @@ Options:
 
 #[test]
 fn option_usage_order() {
-    static OPTION_USAGE_ORDER: &str = "order 
-
+    static OPTION_USAGE_ORDER: &str = "\
 Usage:
     order [OPTIONS]
 
@@ -2231,8 +2199,7 @@ Options:
 
 #[test]
 fn prefer_about_over_long_about_in_subcommands_list() {
-    static ABOUT_IN_COMMANDS_LIST: &str = "about-in-subcommands-list 
-
+    static ABOUT_IN_COMMANDS_LIST: &str = "\
 Usage:
     about-in-subcommands-list [COMMAND]
 
@@ -2260,8 +2227,7 @@ Options:
 
 #[test]
 fn issue_1794_usage() {
-    static USAGE_WITH_GROUP: &str = "hello 
-
+    static USAGE_WITH_GROUP: &str = "\
 Usage:
     deno <pos1|--option1> [pos2]
 
@@ -2292,8 +2258,7 @@ Options:
     utils::assert_output(cmd, "deno --help", USAGE_WITH_GROUP, false);
 }
 
-static CUSTOM_HEADING_POS: &str = "test 1.4
-
+static CUSTOM_HEADING_POS: &str = "\
 Usage:
     test [gear] [speed]
 
@@ -2319,8 +2284,7 @@ fn custom_heading_pos() {
     utils::assert_output(cmd, "test --help", CUSTOM_HEADING_POS, false);
 }
 
-static ONLY_CUSTOM_HEADING_OPTS_NO_ARGS: &str = "test 1.4
-
+static ONLY_CUSTOM_HEADING_OPTS_NO_ARGS: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -2341,8 +2305,7 @@ fn only_custom_heading_opts_no_args() {
     utils::assert_output(cmd, "test --help", ONLY_CUSTOM_HEADING_OPTS_NO_ARGS, false);
 }
 
-static ONLY_CUSTOM_HEADING_POS_NO_ARGS: &str = "test 1.4
-
+static ONLY_CUSTOM_HEADING_POS_NO_ARGS: &str = "\
 Usage:
     test [speed]
 
@@ -2376,8 +2339,7 @@ fn issue_2508_number_of_values_with_single_value_name() {
     utils::assert_output(
         cmd,
         "my_app --help",
-        "my_app 
-
+        "\
 Usage:
     my_app [OPTIONS]
 
@@ -2399,8 +2361,7 @@ fn missing_positional_final_required() {
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test [arg1] <arg2>
 
@@ -2425,8 +2386,7 @@ fn missing_positional_final_multiple() {
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test [foo] [bar] [baz]...
 
@@ -2453,8 +2413,7 @@ fn positional_multiple_values_is_dotted() {
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test <foo>...
 
@@ -2477,8 +2436,7 @@ Options:
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test <BAR>...
 
@@ -2504,8 +2462,7 @@ fn positional_multiple_occurrences_is_dotted() {
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test <foo>...
 
@@ -2529,8 +2486,7 @@ Options:
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test <BAR>...
 
@@ -2557,8 +2513,7 @@ fn too_few_value_names_is_dotted() {
     utils::assert_output(
         cmd,
         "test --help",
-        "test 
-
+        "\
 Usage:
     test --foo <one> <two>...
 
@@ -2659,7 +2614,7 @@ fn subcommand_help_doesnt_have_useless_help_flag() {
     utils::assert_output(
         cmd,
         "example help help",
-        "example-help 
+        "\
 Print this message or the help of the given subcommand(s)
 
 Usage:
@@ -2702,7 +2657,7 @@ fn dont_propagate_version_to_help_subcommand() {
     utils::assert_output(
         cmd.clone(),
         "example help help",
-        "example-help 
+        "\
 Print this message or the help of the given subcommand(s)
 
 Usage:
@@ -2737,7 +2692,7 @@ fn help_without_short() {
 
 #[test]
 fn parent_cmd_req_in_usage_with_help_flag() {
-    static EXPECTED: &str = "parent-test 
+    static EXPECTED: &str = "\
 some
 
 Usage:
@@ -2761,7 +2716,7 @@ Options:
 
 #[test]
 fn parent_cmd_req_in_usage_with_help_subcommand() {
-    static EXPECTED: &str = "parent-test 
+    static EXPECTED: &str = "\
 some
 
 Usage:
@@ -2785,7 +2740,7 @@ Options:
 
 #[test]
 fn parent_cmd_req_in_usage_with_render_help() {
-    static EXPECTED: &str = "parent-test 
+    static EXPECTED: &str = "\
 some
 
 Usage:
@@ -2814,8 +2769,7 @@ Options:
 
 #[test]
 fn parent_cmd_req_ignored_when_negates_reqs() {
-    static MULTI_SC_HELP: &str = "ctest-subcmd 
-
+    static MULTI_SC_HELP: &str = "\
 Usage:
     ctest subcmd
 
@@ -2832,8 +2786,7 @@ Options:
 
 #[test]
 fn parent_cmd_req_ignored_when_conflicts() {
-    static MULTI_SC_HELP: &str = "ctest-subcmd 
-
+    static MULTI_SC_HELP: &str = "\
 Usage:
     ctest subcmd
 

--- a/tests/builder/help_env.rs
+++ b/tests/builder/help_env.rs
@@ -6,8 +6,7 @@ use clap::{Arg, ArgAction, Command};
 
 use super::utils;
 
-static HIDE_ENV: &str = "ctest 0.1
-
+static HIDE_ENV: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -17,8 +16,7 @@ Options:
     -V, --version        Print version information
 ";
 
-static SHOW_ENV: &str = "ctest 0.1
-
+static SHOW_ENV: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -28,8 +26,7 @@ Options:
     -V, --version        Print version information
 ";
 
-static HIDE_ENV_VALS: &str = "ctest 0.1
-
+static HIDE_ENV_VALS: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -39,8 +36,7 @@ Options:
     -V, --version        Print version information
 ";
 
-static SHOW_ENV_VALS: &str = "ctest 0.1
-
+static SHOW_ENV_VALS: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -50,8 +46,7 @@ Options:
     -V, --version        Print version information
 ";
 
-static HIDE_ENV_FLAG: &str = "ctest 0.1
-
+static HIDE_ENV_FLAG: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -61,8 +56,7 @@ Options:
     -V, --version    Print version information
 ";
 
-static SHOW_ENV_FLAG: &str = "ctest 0.1
-
+static SHOW_ENV_FLAG: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -72,8 +66,7 @@ Options:
     -V, --version    Print version information
 ";
 
-static HIDE_ENV_VALS_FLAG: &str = "ctest 0.1
-
+static HIDE_ENV_VALS_FLAG: &str = "\
 Usage:
     ctest [OPTIONS]
 
@@ -83,8 +76,7 @@ Options:
     -V, --version    Print version information
 ";
 
-static SHOW_ENV_VALS_FLAG: &str = "ctest 0.1
-
+static SHOW_ENV_VALS_FLAG: &str = "\
 Usage:
     ctest [OPTIONS]
 

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -2,8 +2,7 @@ use super::utils;
 
 use clap::{arg, Arg, ArgAction, Command};
 
-static HIDDEN_ARGS: &str = "test 1.4
-Kevin K.
+static HIDDEN_ARGS: &str = "\
 tests stuff
 
 Usage:
@@ -31,8 +30,7 @@ fn hide_args() {
     utils::assert_output(cmd, "test --help", HIDDEN_ARGS, false);
 }
 
-static HIDDEN_SHORT_ARGS: &str = "test 2.31.2
-Steve P.
+static HIDDEN_SHORT_ARGS: &str = "\
 hides short args
 
 Usage:
@@ -71,8 +69,7 @@ fn hide_short_args() {
 /// Ensure visible with opposite option
 #[test]
 fn hide_short_args_long_help() {
-    static HIDDEN_SHORT_ARGS_LONG_HELP: &str = "test 2.31.2
-Steve P.
+    static HIDDEN_SHORT_ARGS_LONG_HELP: &str = "\
 hides short args
 
 Usage:
@@ -113,8 +110,7 @@ Options:
     utils::assert_output(cmd, "test --help", HIDDEN_SHORT_ARGS_LONG_HELP, false);
 }
 
-static HIDDEN_LONG_ARGS: &str = "test 2.31.2
-Steve P.
+static HIDDEN_LONG_ARGS: &str = "\
 hides long args
 
 Usage:
@@ -154,8 +150,7 @@ fn hide_long_args() {
     utils::assert_output(cmd, "test --help", HIDDEN_LONG_ARGS, false);
 }
 
-static HIDDEN_LONG_ARGS_SHORT_HELP: &str = "test 2.31.2
-Steve P.
+static HIDDEN_LONG_ARGS_SHORT_HELP: &str = "\
 hides long args
 
 Usage:
@@ -191,8 +186,7 @@ fn hide_long_args_short_help() {
     utils::assert_output(cmd, "test -h", HIDDEN_LONG_ARGS_SHORT_HELP, false);
 }
 
-static HIDDEN_POS_ARGS: &str = "test 1.4
-
+static HIDDEN_POS_ARGS: &str = "\
 Usage:
     test [another]
 
@@ -214,8 +208,7 @@ fn hide_pos_args() {
     utils::assert_output(cmd, "test --help", HIDDEN_POS_ARGS, false);
 }
 
-static HIDDEN_SUBCMDS: &str = "test 1.4
-
+static HIDDEN_SUBCMDS: &str = "\
 Usage:
     test
 
@@ -233,8 +226,7 @@ fn hide_subcmds() {
     utils::assert_output(cmd, "test --help", HIDDEN_SUBCMDS, false);
 }
 
-static HIDDEN_OPT_ARGS_ONLY: &str = "test 1.4
-
+static HIDDEN_OPT_ARGS_ONLY: &str = "\
 Usage:
     test
 
@@ -259,8 +251,7 @@ fn hide_opt_args_only() {
     utils::assert_output(cmd, "test --help", HIDDEN_OPT_ARGS_ONLY, false);
 }
 
-static HIDDEN_POS_ARGS_ONLY: &str = "test 1.4
-
+static HIDDEN_POS_ARGS_ONLY: &str = "\
 Usage:
     test
 
@@ -281,8 +272,7 @@ fn hide_pos_args_only() {
     utils::assert_output(cmd, "test --help", HIDDEN_POS_ARGS_ONLY, false);
 }
 
-static HIDDEN_SUBCMDS_ONLY: &str = "test 1.4
-
+static HIDDEN_SUBCMDS_ONLY: &str = "\
 Usage:
     test
 

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -429,8 +429,6 @@ fn optional_value() {
     let mut help = Vec::new();
     cmd.write_help(&mut help).unwrap();
     const HELP: &str = "\
-test 
-
 Usage:
     test [OPTIONS]
 

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -2,8 +2,7 @@ use super::utils;
 
 use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 
-static VISIBLE_ALIAS_HELP: &str = "clap-test 2.6
-
+static VISIBLE_ALIAS_HELP: &str = "\
 Usage:
     clap-test [COMMAND]
 
@@ -16,8 +15,7 @@ Options:
     -V, --version    Print version information
 ";
 
-static INVISIBLE_ALIAS_HELP: &str = "clap-test 2.6
-
+static INVISIBLE_ALIAS_HELP: &str = "\
 Usage:
     clap-test [COMMAND]
 
@@ -574,8 +572,6 @@ fn cant_have_args_with_multicall() {
 #[test]
 fn multicall_help_flag() {
     static EXPECTED: &str = "\
-foo-bar 1.0.0
-
 Usage:
     foo bar [value]
 
@@ -597,8 +593,6 @@ Options:
 #[test]
 fn multicall_help_subcommand() {
     static EXPECTED: &str = "\
-foo-bar 1.0.0
-
 Usage:
     foo bar [value]
 
@@ -620,8 +614,6 @@ Options:
 #[test]
 fn multicall_render_help() {
     static EXPECTED: &str = "\
-foo-bar 1.0.0
-
 Usage:
     foo bar [value]
 

--- a/tests/builder/utils.rs
+++ b/tests/builder/utils.rs
@@ -5,6 +5,14 @@ use std::str;
 
 use clap::{arg, Arg, ArgAction, ArgGroup, Command};
 
+pub const FULL_TEMPLATE: &str = "\
+{before-help}{name} {version}
+{author-with-newline}{about-with-newline}
+{usage-heading}
+    {usage}
+
+{all-args}{after-help}";
+
 #[track_caller]
 pub fn assert_eq<S, S2>(expected: S, actual: S2)
 where
@@ -44,6 +52,7 @@ pub fn complex_app() -> Command {
         .version("v1.4.8")
         .about("tests clap library")
         .author("Kevin K. <kbknapp@gmail.com>")
+        .help_template(FULL_TEMPLATE)
         .arg(
             arg!(
                 -o --option <opt> "tests options"
@@ -97,6 +106,7 @@ pub fn complex_app() -> Command {
                 .about("tests subcommands")
                 .version("0.1")
                 .author("Kevin K. <kbknapp@gmail.com>")
+                .help_template(FULL_TEMPLATE)
                 .arg(
                     arg!(-o --option <scoption> "tests options")
                         .required(false)

--- a/tests/builder/version.rs
+++ b/tests/builder/version.rs
@@ -3,7 +3,7 @@ use clap::{error::ErrorKind, ArgAction, Command};
 use crate::utils;
 
 fn common() -> Command {
-    Command::new("foo")
+    Command::new("foo").help_template(utils::FULL_TEMPLATE)
 }
 
 fn with_version() -> Command {

--- a/tests/derive/author_version_about.rs
+++ b/tests/derive/author_version_about.rs
@@ -20,6 +20,7 @@ use clap::Parser;
 fn no_author_version_about() {
     #[derive(Parser, PartialEq, Debug)]
     #[clap(name = "foo")]
+    #[clap(help_template = utils::FULL_TEMPLATE)]
     struct Opt {}
 
     let output = utils::get_long_help::<Opt>();
@@ -30,6 +31,7 @@ fn no_author_version_about() {
 fn use_env() {
     #[derive(Parser, PartialEq, Debug)]
     #[clap(author, about, version)]
+    #[clap(help_template = utils::FULL_TEMPLATE)]
     struct Opt {}
 
     let output = utils::get_long_help::<Opt>();
@@ -44,6 +46,7 @@ fn explicit_version_not_str_lit() {
 
     #[derive(Parser)]
     #[clap(version = VERSION)]
+    #[clap(help_template = utils::FULL_TEMPLATE)]
     pub struct Opt {}
 
     let output = utils::get_long_help::<Opt>();

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -61,7 +61,6 @@ fn empty_line_in_doc_comment_is_double_linefeed() {
     let help = utils::get_long_help::<LoremIpsum>();
     assert!(help.starts_with(
         "\
-lorem-ipsum 
 Foo.
 
 Bar

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -231,8 +231,7 @@ For more information try --help
 
 #[test]
 fn derive_order_next_order() {
-    static HELP: &str = "test 1.2
-
+    static HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -287,8 +286,7 @@ Options:
 
 #[test]
 fn derive_order_next_order_flatten() {
-    static HELP: &str = "test 1.2
-
+    static HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -343,8 +341,7 @@ Options:
 
 #[test]
 fn derive_order_no_next_order() {
-    static HELP: &str = "test 1.2
-
+    static HELP: &str = "\
 Usage:
     test [OPTIONS]
 
@@ -398,7 +395,7 @@ Options:
 
 #[test]
 fn derive_possible_value_help() {
-    static HELP: &str = "clap 
+    static HELP: &str = "\
 Application help
 
 Usage:

--- a/tests/derive/issues.rs
+++ b/tests/derive/issues.rs
@@ -60,6 +60,7 @@ fn issue_324() {
 
     #[derive(Parser)]
     #[clap(version = my_version())]
+    #[clap(help_template = utils::FULL_TEMPLATE)]
     struct Opt {
         #[clap(subcommand)]
         _cmd: SubCommand,

--- a/tests/derive/utils.rs
+++ b/tests/derive/utils.rs
@@ -7,6 +7,14 @@
 
 use clap::CommandFactory;
 
+pub const FULL_TEMPLATE: &str = "\
+{before-help}{name} {version}
+{author-with-newline}{about-with-newline}
+{usage-heading}
+    {usage}
+
+{all-args}{after-help}";
+
 pub fn get_help<T: CommandFactory>() -> String {
     let mut output = Vec::new();
     <T as CommandFactory>::command()

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -301,8 +301,6 @@ mod arg {
         let mut help = Vec::new();
         cmd.write_help(&mut help).unwrap();
         const HELP: &str = "\
-test 
-
 Usage:
     test [OPTIONS]
 

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -3,8 +3,6 @@ args = []
 status.code = 2
 stdout = ""
 stderr = """
-stdio-fixture 1.0
-
 Usage:
     stdio-fixture[EXE] [OPTIONS] [COMMAND]
 

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -2,8 +2,6 @@ bin.name = "stdio-fixture"
 args = ["-h"]
 status.code = 0
 stdout = """
-stdio-fixture 1.0
-
 Usage:
     stdio-fixture[EXE] [OPTIONS] [COMMAND]
 

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -2,8 +2,6 @@ bin.name = "stdio-fixture"
 args = ["help"]
 status.code = 0
 stdout = """
-stdio-fixture 1.0
-
 Usage:
     stdio-fixture[EXE] [OPTIONS] [COMMAND]
 

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -2,8 +2,6 @@ bin.name = "stdio-fixture"
 args = ["--help"]
 status.code = 0
 stdout = """
-stdio-fixture 1.0
-
 Usage:
     stdio-fixture[EXE] [OPTIONS] [COMMAND]
 


### PR DESCRIPTION
This is to help shorten it and polish it by removing redundant
information.

This is a part of #4132

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
