### PR TITLE
feat(parser): Provide convenience accessors for Actions

### DIFF
--- a/examples/derive_ref/augment_args.rs
+++ b/examples/derive_ref/augment_args.rs
@@ -12,13 +12,10 @@ fn main() {
     let cli = DerivedArgs::augment_args(cli);
 
     let matches = cli.get_matches();
-    println!(
-        "Value of built: {:?}",
-        *matches.get_one::<bool>("built").unwrap()
-    );
+    println!("Value of built: {:?}", matches.get_flag("built"));
     println!(
         "Value of derived via ArgMatches: {:?}",
-        *matches.get_one::<bool>("derived").unwrap()
+        matches.get_flag("derived")
     );
 
     // Since DerivedArgs implements FromArgMatches, we can extract it from the unstructured ArgMatches.

--- a/examples/derive_ref/flatten_hand_args.rs
+++ b/examples/derive_ref/flatten_hand_args.rs
@@ -15,8 +15,8 @@ impl FromArgMatches for CliArgs {
     }
     fn from_arg_matches_mut(matches: &mut ArgMatches) -> Result<Self, Error> {
         Ok(Self {
-            foo: *matches.get_one::<bool>("foo").expect("defaulted by clap"),
-            bar: *matches.get_one::<bool>("bar").expect("defaulted by clap"),
+            foo: matches.get_flag("foo"),
+            bar: matches.get_flag("bar"),
             quuz: matches.remove_one::<String>("quuz"),
         })
     }
@@ -25,8 +25,8 @@ impl FromArgMatches for CliArgs {
         self.update_from_arg_matches_mut(&mut matches)
     }
     fn update_from_arg_matches_mut(&mut self, matches: &mut ArgMatches) -> Result<(), Error> {
-        self.foo |= *matches.get_one::<bool>("foo").expect("defaulted by clap");
-        self.bar |= *matches.get_one::<bool>("bar").expect("defaulted by clap");
+        self.foo |= matches.get_flag("foo");
+        self.bar |= matches.get_flag("bar");
         if let Some(quuz) = matches.remove_one::<String>("quuz") {
             self.quuz = Some(quuz);
         }

--- a/examples/escaped-positional.rs
+++ b/examples/escaped-positional.rs
@@ -20,10 +20,7 @@ fn main() {
     // This is what will happen with `myprog -f -p=bob -- sloppy slop slop`...
 
     // -f used: true
-    println!(
-        "-f used: {:?}",
-        *matches.get_one::<bool>("eff").expect("defaulted by clap")
-    );
+    println!("-f used: {:?}", matches.get_flag("eff"));
     // -p's value: Some("bob")
     println!("-p's value: {:?}", matches.get_one::<String>("pea"));
     // 'slops' values: Some(["sloppy", "slop", "slop"])

--- a/examples/pacman.rs
+++ b/examples/pacman.rs
@@ -89,10 +89,7 @@ fn main() {
                 .collect();
             let values = packages.join(", ");
 
-            if *sync_matches
-                .get_one::<bool>("info")
-                .expect("defaulted by clap")
-            {
+            if sync_matches.get_flag("info") {
                 println!("Retrieving info for {}...", values);
             } else {
                 println!("Installing {}...", values);

--- a/examples/tutorial_builder/03_01_flag_bool.rs
+++ b/examples/tutorial_builder/03_01_flag_bool.rs
@@ -10,10 +10,5 @@ fn main() {
         )
         .get_matches();
 
-    println!(
-        "verbose: {:?}",
-        *matches
-            .get_one::<bool>("verbose")
-            .expect("defaulted by clap")
-    );
+    println!("verbose: {:?}", matches.get_flag("verbose"));
 }

--- a/examples/tutorial_builder/03_01_flag_count.rs
+++ b/examples/tutorial_builder/03_01_flag_count.rs
@@ -5,10 +5,5 @@ fn main() {
         .arg(arg!(-v - -verbose).action(ArgAction::Count))
         .get_matches();
 
-    println!(
-        "verbose: {:?}",
-        matches
-            .get_one::<u8>("verbose")
-            .expect("Count always defaulted")
-    );
+    println!("verbose: {:?}", matches.get_count("verbose"));
 }

--- a/examples/tutorial_builder/04_03_relations.rs
+++ b/examples/tutorial_builder/04_03_relations.rs
@@ -50,9 +50,9 @@ fn main() {
     } else {
         // Increment the one requested (in a real program, we'd reset the lower numbers)
         let (maj, min, pat) = (
-            *matches.get_one::<bool>("major").expect("defaulted by clap"),
-            *matches.get_one::<bool>("minor").expect("defaulted by clap"),
-            *matches.get_one::<bool>("patch").expect("defaulted by clap"),
+            matches.get_flag("major"),
+            matches.get_flag("minor"),
+            matches.get_flag("patch"),
         );
         match (maj, min, pat) {
             (true, _, _) => major += 1,

--- a/examples/tutorial_builder/04_04_custom.rs
+++ b/examples/tutorial_builder/04_04_custom.rs
@@ -34,10 +34,7 @@ fn main() {
 
     // See if --set-ver was used to set the version manually
     let version = if let Some(ver) = matches.get_one::<String>("set-ver") {
-        if *matches.get_one::<bool>("major").expect("defaulted by clap")
-            || *matches.get_one::<bool>("minor").expect("defaulted by clap")
-            || *matches.get_one::<bool>("patch").expect("defaulted by clap")
-        {
+        if matches.get_flag("major") || matches.get_flag("minor") || matches.get_flag("patch") {
             cmd.error(
                 ErrorKind::ArgumentConflict,
                 "Can't do relative and absolute version change",
@@ -48,9 +45,9 @@ fn main() {
     } else {
         // Increment the one requested (in a real program, we'd reset the lower numbers)
         let (maj, min, pat) = (
-            *matches.get_one::<bool>("major").expect("defaulted by clap"),
-            *matches.get_one::<bool>("minor").expect("defaulted by clap"),
-            *matches.get_one::<bool>("patch").expect("defaulted by clap"),
+            matches.get_flag("major"),
+            matches.get_flag("minor"),
+            matches.get_flag("patch"),
         );
         match (maj, min, pat) {
             (true, false, false) => major += 1,

--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -183,16 +183,16 @@ pub enum ArgAction {
     /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
-    ///     matches.get_one::<u8>("flag").copied(),
-    ///     Some(2)
+    ///     matches.get_count("flag"),
+    ///     2
     /// );
     ///
     /// let matches = cmd.try_get_matches_from(["mycmd"]).unwrap();
     /// assert!(matches.contains_id("flag"));
     /// assert_eq!(matches.occurrences_of("flag"), 0);
     /// assert_eq!(
-    ///     matches.get_one::<u8>("flag").copied(),
-    ///     Some(0)
+    ///     matches.get_count("flag"),
+    ///     0
     /// );
     /// ```
     Count,

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -119,6 +119,37 @@ impl ArgMatches {
         MatchesError::unwrap(&internal_id, self.try_get_one(id))
     }
 
+    /// Gets the value of a specific [`ArgAction::Count`][crate::ArgAction::Count] flag
+    ///
+    /// # Panic
+    ///
+    /// If the argument's action is not [`ArgAction::Count`][crate::ArgAction::Count]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .action(clap::ArgAction::Count)
+    ///     );
+    ///
+    /// let matches = cmd.clone().try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
+    /// assert_eq!(
+    ///     matches.get_count("flag"),
+    ///     2
+    /// );
+    /// ```
+    #[track_caller]
+    pub fn get_count(&self, id: &str) -> u8 {
+        *self
+            .get_one::<u8>(id)
+            .expect("ArgAction::Count is defaulted")
+    }
+
     /// Iterate over values of a specific option or positional argument.
     ///
     /// i.e. an argument that takes multiple values at runtime.

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -150,6 +150,38 @@ impl ArgMatches {
             .expect("ArgAction::Count is defaulted")
     }
 
+    /// Gets the value of a specific [`ArgAction::SetTrue`][crate::ArgAction::SetTrue] or [`ArgAction::SetFalse`][crate::ArgAction::SetFalse] flag
+    ///
+    /// # Panic
+    ///
+    /// If the argument's action is not [`ArgAction::SetTrue`][crate::ArgAction::SetTrue] or [`ArgAction::SetFalse`][crate::ArgAction::SetFalse]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .action(clap::ArgAction::SetTrue)
+    ///     );
+    ///
+    /// let matches = cmd.clone().try_get_matches_from(["mycmd", "--flag", "--flag"]).unwrap();
+    /// assert!(matches.contains_id("flag"));
+    /// assert_eq!(
+    ///     matches.get_flag("flag"),
+    ///     true
+    /// );
+    /// ```
+    #[track_caller]
+    pub fn get_flag(&self, id: &str) -> bool {
+        *self
+            .get_one::<bool>(id)
+            .expect("ArgAction::SetTrue / ArgAction::SetFalse is defaulted")
+    }
+
     /// Iterate over values of a specific option or positional argument.
     ///
     /// i.e. an argument that takes multiple values at runtime.


### PR DESCRIPTION
This is scoped specifically to Actions and not something we'll create for everything.  These actions have two unique properties: a fixed type and a default which makes more of a difference.

I know something like this already exists in cargo and probably elsewhere.  Seems probably worth while to make this easier.

This is a backport of #4169