### PR TITLE
feat(builder): implement into_resettable for more options

### DIFF
--- a/clap_derive/src/utils/doc_comments.rs
+++ b/clap_derive/src/utils/doc_comments.rs
@@ -63,7 +63,7 @@ pub fn process_doc_comment(lines: Vec<String>, name: &str, preprocess: bool) -> 
 
         vec![
             Method::new(short_name, quote!(#short)),
-            Method::new(long_name, quote!(None)),
+            Method::new(long_name, quote!(::clap::builder::Resettable::Reset)),
         ]
     }
 }

--- a/examples/cargo-example-derive.rs
+++ b/examples/cargo-example-derive.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)] // requires `derive` feature
 #[clap(name = "cargo")]
@@ -8,7 +8,7 @@ enum Cargo {
 }
 
 #[derive(clap::Args)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct ExampleDerive {
     #[clap(long)]
     manifest_path: Option<std::path::PathBuf>,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,8 +1,8 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 /// Simple program to greet a person
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Args {
     /// Name of the person to greet
     #[clap(short, long)]

--- a/examples/derive_ref/custom-bool.rs
+++ b/examples/derive_ref/custom-bool.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser, Debug, PartialEq)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Opt {
     // Default parser for `Set` is FromStr::from_str.
     // `impl FromStr for bool` parses `true` or `false` so this

--- a/examples/escaped-positional-derive.rs
+++ b/examples/escaped-positional-derive.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)] // requires `derive` feature
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     #[clap(short = 'f')]
     eff: bool,

--- a/examples/git-derive.rs
+++ b/examples/git-derive.rs
@@ -1,12 +1,12 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, builder::Resettable};
 
 /// A fictional versioning CLI
 #[derive(Debug, Parser)] // requires `derive` feature
 #[clap(name = "git")]
-#[clap(about = "A fictional versioning CLI", long_about = None)]
+#[clap(about = "A fictional versioning CLI", long_about = Resettable::Reset)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,

--- a/examples/tutorial_derive/01_quick.rs
+++ b/examples/tutorial_derive/01_quick.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     /// Optional name to operate on
     name: Option<String>,

--- a/examples/tutorial_derive/02_app_settings.rs
+++ b/examples/tutorial_derive/02_app_settings.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 #[clap(allow_negative_numbers = true)]
 struct Cli {
     #[clap(long)]

--- a/examples/tutorial_derive/02_apps.rs
+++ b/examples/tutorial_derive/02_apps.rs
@@ -1,10 +1,10 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
 #[clap(name = "MyApp")]
 #[clap(author = "Kevin K. <kbknapp@gmail.com>")]
 #[clap(version = "1.0")]
-#[clap(about = "Does awesome things", long_about = None)]
+#[clap(about = "Does awesome things", long_about = Resettable::Reset)]
 struct Cli {
     #[clap(long)]
     two: String,

--- a/examples/tutorial_derive/02_crate.rs
+++ b/examples/tutorial_derive/02_crate.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)] // Read from `Cargo.toml`
+#[clap(author, version, about, long_about = Resettable::Reset)] // Read from `Cargo.toml`
 struct Cli {
     #[clap(long)]
     two: String,

--- a/examples/tutorial_derive/03_01_flag_bool.rs
+++ b/examples/tutorial_derive/03_01_flag_bool.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     #[clap(short, long)]
     verbose: bool,

--- a/examples/tutorial_derive/03_01_flag_count.rs
+++ b/examples/tutorial_derive/03_01_flag_count.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{builder::Resettable::Reset, Parser};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Reset)]
 struct Cli {
     #[clap(short, long, action = clap::ArgAction::Count)]
     verbose: u8,

--- a/examples/tutorial_derive/03_02_option.rs
+++ b/examples/tutorial_derive/03_02_option.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     #[clap(short, long)]
     name: Option<String>,

--- a/examples/tutorial_derive/03_02_option_mult.rs
+++ b/examples/tutorial_derive/03_02_option_mult.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     #[clap(short, long)]
     name: Vec<String>,

--- a/examples/tutorial_derive/03_03_positional.rs
+++ b/examples/tutorial_derive/03_03_positional.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     name: Option<String>,
 }

--- a/examples/tutorial_derive/03_03_positional_mult.rs
+++ b/examples/tutorial_derive/03_03_positional_mult.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     name: Vec<String>,
 }

--- a/examples/tutorial_derive/03_04_subcommands.rs
+++ b/examples/tutorial_derive/03_04_subcommands.rs
@@ -1,7 +1,7 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 #[clap(propagate_version = true)]
 struct Cli {
     #[clap(subcommand)]

--- a/examples/tutorial_derive/03_04_subcommands_alt.rs
+++ b/examples/tutorial_derive/03_04_subcommands_alt.rs
@@ -1,7 +1,7 @@
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 #[clap(propagate_version = true)]
 struct Cli {
     #[clap(subcommand)]

--- a/examples/tutorial_derive/03_05_default_values.rs
+++ b/examples/tutorial_derive/03_05_default_values.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     #[clap(default_value_t = String::from("alice"))]
     name: String,

--- a/examples/tutorial_derive/04_01_enum.rs
+++ b/examples/tutorial_derive/04_01_enum.rs
@@ -1,7 +1,7 @@
-use clap::{Parser, ValueEnum};
+use clap::{Parser, ValueEnum, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     /// What mode to run the program in
     #[clap(value_enum)]

--- a/examples/tutorial_derive/04_02_parse.rs
+++ b/examples/tutorial_derive/04_02_parse.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     /// Network port to use
     #[clap(value_parser = clap::value_parser!(u16).range(1..))]

--- a/examples/tutorial_derive/04_02_validate.rs
+++ b/examples/tutorial_derive/04_02_validate.rs
@@ -1,9 +1,9 @@
 use std::ops::RangeInclusive;
 
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     /// Network port to use
     #[clap(value_parser = port_in_range)]

--- a/examples/tutorial_derive/04_03_relations.rs
+++ b/examples/tutorial_derive/04_03_relations.rs
@@ -1,7 +1,7 @@
-use clap::{ArgGroup, Parser};
+use clap::{ArgGroup, Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 #[clap(group(
             ArgGroup::new("vers")
                 .required(true)

--- a/examples/tutorial_derive/04_04_custom.rs
+++ b/examples/tutorial_derive/04_04_custom.rs
@@ -1,8 +1,9 @@
+use clap::builder::Resettable;
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     /// set version manually
     #[clap(long, value_name = "VER")]

--- a/examples/tutorial_derive/05_01_assert.rs
+++ b/examples/tutorial_derive/05_01_assert.rs
@@ -1,7 +1,7 @@
-use clap::Parser;
+use clap::{Parser, builder::Resettable};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = Resettable::Reset)]
 struct Cli {
     /// Network port to use
     port: u16,

--- a/src/builder/resettable.rs
+++ b/src/builder/resettable.rs
@@ -44,26 +44,8 @@ pub trait IntoResettable<T> {
     fn into_resettable(self) -> Resettable<T>;
 }
 
-impl IntoResettable<StyledStr> for Option<&'static str> {
-    fn into_resettable(self) -> Resettable<StyledStr> {
-        match self {
-            Some(s) => Resettable::Value(s.into()),
-            None => Resettable::Reset,
-        }
-    }
-}
-
 impl IntoResettable<OsStr> for Option<&'static str> {
     fn into_resettable(self) -> Resettable<OsStr> {
-        match self {
-            Some(s) => Resettable::Value(s.into()),
-            None => Resettable::Reset,
-        }
-    }
-}
-
-impl IntoResettable<Str> for Option<&'static str> {
-    fn into_resettable(self) -> Resettable<Str> {
         match self {
             Some(s) => Resettable::Value(s.into()),
             None => Resettable::Reset,
@@ -83,6 +65,12 @@ impl<I: Into<StyledStr>> IntoResettable<StyledStr> for I {
     }
 }
 
+impl<I: Into<StyledStr>> IntoResettable<StyledStr> for Option<I> {
+    fn into_resettable(self) -> Resettable<StyledStr> {
+        self.map(Into::into).into()
+    }
+}
+
 impl<I: Into<OsStr>> IntoResettable<OsStr> for I {
     fn into_resettable(self) -> Resettable<OsStr> {
         Resettable::Value(self.into())
@@ -92,6 +80,12 @@ impl<I: Into<OsStr>> IntoResettable<OsStr> for I {
 impl<I: Into<Str>> IntoResettable<Str> for I {
     fn into_resettable(self) -> Resettable<Str> {
         Resettable::Value(self.into())
+    }
+}
+
+impl<I: Into<Str>> IntoResettable<Str> for Option<I> {
+    fn into_resettable(self) -> Resettable<Str> {
+        self.map(Into::into).into()
     }
 }
 

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, builder::PossibleValue, error::ErrorKind, Arg, ArgAction, ArgGroup, Command};
+use clap::{arg, builder::{PossibleValue, Resettable}, error::ErrorKind, Arg, ArgAction, ArgGroup, Command};
 
 fn setup() -> Command {
     Command::new("test")
@@ -1685,12 +1685,12 @@ fn multiple_custom_help_headers() {
         .arg(
             arg!(--style <style> "Choose musical style to play the song")
                 .required(false)
-                .help_heading(None),
+                .help_heading(Resettable::Reset),
         )
         .arg(arg!(
             -v --"birthday-song-volume" <volume> "Change the volume of the birthday song"
         ))
-        .next_help_heading(None)
+        .next_help_heading(Resettable::Reset)
         .arg(
             Arg::new("server-addr")
                 .short('a')
@@ -1751,7 +1751,7 @@ fn custom_help_headers_hide_args() {
         .arg(arg!(
             -v --"song-volume" <volume> "Change the volume of the birthday song"
         ))
-        .next_help_heading(None)
+        .next_help_heading(Resettable::Reset)
         .arg(
             Arg::new("server-addr")
                 .short('a')


### PR DESCRIPTION
I noticed that currenlty only `Option<'static str>` implements `IntoResettable`.

The only reason I see would be that `Option::None` can infer its type that way. But this can be circumvented by using `Resettable::Reset` instead as I therefor updated all examples/tests/derivemacro to reflect that change.

The reason I implemented this change is to allow `Option<String>` as well.
