### PR TITLE
fix(derive): Replace clap attributes with command, arg, and value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Deprecated
 - `Arg::number_of_values` in favor of `Arg::num_args`
 - `default_value_os`, `default_values_os`, `default_value_if_os`, and `default_value_ifs_os` as the non `_os` variants now accept either a `str` or an `OsStr`
 - `Command::dont_collapse_args_in_usage` is now the default and is deprecated
+- *(derive)* `structopt` and `clap` attributes in favor of the more specific `command`, `arg`, and `value`
 
 ### Features
 

--- a/clap_complete/examples/completion-derive.rs
+++ b/clap_complete/examples/completion-derive.rs
@@ -19,41 +19,41 @@ use std::io;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug, PartialEq)]
-#[clap(
+#[command(
     name = "value_hints_derive",
     // Command::trailing_var_ar is required to use ValueHint::CommandWithArguments
     trailing_var_arg = true,
 )]
 struct Opt {
     /// If provided, outputs the completion file for given shell
-    #[clap(long = "generate", value_enum)]
+    #[arg(long = "generate", value_enum)]
     generator: Option<Shell>,
     // Showcasing all possible ValueHints:
-    #[clap(long, value_hint = ValueHint::Unknown)]
+    #[arg(long, value_hint = ValueHint::Unknown)]
     unknown: Option<String>,
-    #[clap(long, value_hint = ValueHint::Other)]
+    #[arg(long, value_hint = ValueHint::Other)]
     other: Option<String>,
-    #[clap(short, long, value_hint = ValueHint::AnyPath)]
+    #[arg(short, long, value_hint = ValueHint::AnyPath)]
     path: Option<PathBuf>,
-    #[clap(short, long, value_hint = ValueHint::FilePath)]
+    #[arg(short, long, value_hint = ValueHint::FilePath)]
     file: Option<PathBuf>,
-    #[clap(short, long, value_hint = ValueHint::DirPath)]
+    #[arg(short, long, value_hint = ValueHint::DirPath)]
     dir: Option<PathBuf>,
-    #[clap(short, long, value_hint = ValueHint::ExecutablePath)]
+    #[arg(short, long, value_hint = ValueHint::ExecutablePath)]
     exe: Option<PathBuf>,
-    #[clap(long, value_hint = ValueHint::CommandName)]
+    #[arg(long, value_hint = ValueHint::CommandName)]
     cmd_name: Option<OsString>,
-    #[clap(short, long, value_hint = ValueHint::CommandString)]
+    #[arg(short, long, value_hint = ValueHint::CommandString)]
     cmd: Option<String>,
-    #[clap(value_hint = ValueHint::CommandWithArguments)]
+    #[arg(value_hint = ValueHint::CommandWithArguments)]
     command_with_args: Vec<String>,
-    #[clap(short, long, value_hint = ValueHint::Username)]
+    #[arg(short, long, value_hint = ValueHint::Username)]
     user: Option<String>,
-    #[clap(short, long, value_hint = ValueHint::Hostname)]
+    #[arg(short, long, value_hint = ValueHint::Hostname)]
     host: Option<String>,
-    #[clap(long, value_hint = ValueHint::Url)]
+    #[arg(long, value_hint = ValueHint::Url)]
     url: Option<String>,
-    #[clap(long, value_hint = ValueHint::EmailAddress)]
+    #[arg(long, value_hint = ValueHint::EmailAddress)]
     email: Option<String>,
 }
 

--- a/clap_complete/src/dynamic.rs
+++ b/clap_complete/src/dynamic.rs
@@ -8,7 +8,7 @@ pub mod bash {
     use unicode_xid::UnicodeXID;
 
     #[derive(clap::Subcommand)]
-    #[clap(hide = true)]
+    #[command(hide = true)]
     #[allow(missing_docs)]
     #[derive(Clone, Debug)]
     pub enum CompleteCommand {
@@ -17,15 +17,15 @@ pub mod bash {
     }
 
     #[derive(clap::Args)]
-    #[clap(group = clap::ArgGroup::new("complete").multiple(true).conflicts_with("register"))]
+    #[command(group = clap::ArgGroup::new("complete").multiple(true).conflicts_with("register"))]
     #[allow(missing_docs)]
     #[derive(Clone, Debug)]
     pub struct CompleteArgs {
         /// Path to write completion-registration to
-        #[clap(long, required = true)]
+        #[arg(long, required = true)]
         register: Option<std::path::PathBuf>,
 
-        #[clap(
+        #[arg(
             long,
             required = true,
             value_name = "COMP_CWORD",
@@ -34,10 +34,10 @@ pub mod bash {
         )]
         index: Option<usize>,
 
-        #[clap(long, hide_short_help = true, group = "complete")]
+        #[arg(long, hide_short_help = true, group = "complete")]
         ifs: Option<String>,
 
-        #[clap(
+        #[arg(
             long = "type",
             required = true,
             hide_short_help = true,
@@ -45,10 +45,10 @@ pub mod bash {
         )]
         comp_type: Option<CompType>,
 
-        #[clap(long, hide_short_help = true, group = "complete")]
+        #[arg(long, hide_short_help = true, group = "complete")]
         space: bool,
 
-        #[clap(
+        #[arg(
             long,
             conflicts_with = "space",
             hide_short_help = true,
@@ -56,7 +56,7 @@ pub mod bash {
         )]
         no_space: bool,
 
-        #[clap(raw = true, hide_short_help = true, group = "complete")]
+        #[arg(raw = true, hide_short_help = true, group = "complete")]
         comp_words: Vec<OsString>,
     }
 

--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -32,6 +32,12 @@ impl ClapAttr {
                     Some(Sp::new(AttrKind::Clap, attr.path.span()))
                 } else if attr.path.is_ident("structopt") {
                     Some(Sp::new(AttrKind::StructOpt, attr.path.span()))
+                } else if attr.path.is_ident("command") {
+                    Some(Sp::new(AttrKind::Command, attr.path.span()))
+                } else if attr.path.is_ident("arg") {
+                    Some(Sp::new(AttrKind::Arg, attr.path.span()))
+                } else if attr.path.is_ident("value") {
+                    Some(Sp::new(AttrKind::Value, attr.path.span()))
                 } else {
                     None
                 };
@@ -194,6 +200,9 @@ impl ToTokens for AttrValue {
 pub enum AttrKind {
     Clap,
     StructOpt,
+    Command,
+    Arg,
+    Value,
 }
 
 impl AttrKind {
@@ -201,6 +210,9 @@ impl AttrKind {
         match self {
             Self::Clap => "clap",
             Self::StructOpt => "structopt",
+            Self::Command => "command",
+            Self::Arg => "arg",
+            Self::Value => "value",
         }
     }
 }

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -204,7 +204,7 @@ pub fn gen_augment(
             Kind::Command(_)
             | Kind::Value(_)
             | Kind::Subcommand(_)
-            | Kind::Skip(_)
+            | Kind::Skip(_, _)
             | Kind::FromGlobal(_)
             | Kind::ExternalSubcommand => None,
             Kind::Flatten => {
@@ -384,7 +384,7 @@ pub fn gen_constructor(fields: &[(&Field, Item)]) -> TokenStream {
                 #field_name: clap::FromArgMatches::from_arg_matches_mut(#arg_matches)?
             },
 
-            Kind::Skip(val) => match val {
+            Kind::Skip(val, _) => match val {
                 None => quote_spanned!(kind.span()=> #field_name: Default::default()),
                 Some(val) => quote_spanned!(kind.span()=> #field_name: (#val).into()),
             },
@@ -463,7 +463,7 @@ pub fn gen_updater(fields: &[(&Field, Item)], use_self: bool) -> TokenStream {
                 }
             },
 
-            Kind::Skip(_) => quote!(),
+            Kind::Skip(_, _) => quote!(),
 
             Kind::Arg(ty) | Kind::FromGlobal(ty) => gen_parsers(item, ty, field_name, field, Some(&access)),
         }

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -137,7 +137,7 @@ fn gen_augment(
             let kind = item.kind();
 
             match &*kind {
-                Kind::Skip(_) => None,
+                Kind::Skip(_, _) => None,
 
                 Kind::ExternalSubcommand => {
                     let ty = match variant.fields {

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -78,7 +78,7 @@ fn lits(variants: &[(&Variant, Item)]) -> Vec<(TokenStream, Ident)> {
     variants
         .iter()
         .filter_map(|(variant, item)| {
-            if let Kind::Skip(_) = &*item.kind() {
+            if let Kind::Skip(_, _) = &*item.kind() {
                 None
             } else {
                 if !matches!(variant.fields, Fields::Unit) {

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -527,7 +527,7 @@ impl Item {
                         span: attr.name.span(),
                         id: "bare_value_parser",
                         version: "4.0.0",
-                        description: "`#[clap(value_parser)]` is now the default and is no longer needed`".to_owned(),
+                        description: "`#[arg(value_parser)]` is now the default and is no longer needed`".to_owned(),
                     });
                     self.value_parser = Some(ValueParser::Implicit(attr.name.clone()));
                 }
@@ -538,7 +538,7 @@ impl Item {
                         span: attr.name.span(),
                         id: "bare_action",
                         version: "4.0.0",
-                        description: "`#[clap(action)]` is now the default and is no longer needed`".to_owned(),
+                        description: "`#[arg(action)]` is now the default and is no longer needed`".to_owned(),
                     });
                     self.action = Some(Action::Implicit(attr.name.clone()));
                 }
@@ -584,7 +584,7 @@ impl Item {
                     } else {
                         abort!(
                             attr.name.clone(),
-                            "#[clap(default_value_t)] (without an argument) can be used \
+                            "#[arg(default_value_t)] (without an argument) can be used \
                             only on field level";
 
                             note = "see \
@@ -626,7 +626,7 @@ impl Item {
                     } else {
                         abort!(
                             attr.name.clone(),
-                            "#[clap(default_values_t)] (without an argument) can be used \
+                            "#[arg(default_values_t)] (without an argument) can be used \
                             only on field level";
 
                             note = "see \
@@ -638,7 +638,7 @@ impl Item {
                     if *container_type != Ty::Vec {
                         abort!(
                             attr.name.clone(),
-                            "#[clap(default_values_t)] can be used only on Vec types";
+                            "#[arg(default_values_t)] can be used only on Vec types";
 
                             note = "see \
                                 https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md#magic-attributes")
@@ -695,7 +695,7 @@ impl Item {
                     } else {
                         abort!(
                             attr.name.clone(),
-                            "#[clap(default_value_os_t)] (without an argument) can be used \
+                            "#[arg(default_value_os_t)] (without an argument) can be used \
                             only on field level";
 
                             note = "see \
@@ -737,7 +737,7 @@ impl Item {
                     } else {
                         abort!(
                             attr.name.clone(),
-                            "#[clap(default_values_os_t)] (without an argument) can be used \
+                            "#[arg(default_values_os_t)] (without an argument) can be used \
                             only on field level";
 
                             note = "see \
@@ -749,7 +749,7 @@ impl Item {
                     if *container_type != Ty::Vec {
                         abort!(
                             attr.name.clone(),
-                            "#[clap(default_values_os_t)] can be used only on Vec types";
+                            "#[arg(default_values_os_t)] can be used only on Vec types";
 
                             note = "see \
                                 https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md#magic-attributes")

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -481,8 +481,7 @@ impl Item {
             let actual_attr_kind = *attr.kind.get();
             let expected_attr_kind = self.kind.attr_kind();
             match (actual_attr_kind, expected_attr_kind) {
-                (AttrKind::Clap, _) => {}
-                (AttrKind::StructOpt, _) => {
+                (AttrKind::Clap, _) | (AttrKind::StructOpt, _) => {
                     self.deprecations.push(Deprecation::attribute(
                         "4.0.0",
                         actual_attr_kind,

--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -29,7 +29,7 @@ mod item;
 mod utils;
 
 /// Generates the `ValueEnum` impl.
-#[proc_macro_derive(ValueEnum, attributes(clap))]
+#[proc_macro_derive(ValueEnum, attributes(clap, value))]
 #[proc_macro_error]
 pub fn value_enum(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
@@ -42,7 +42,7 @@ pub fn value_enum(input: TokenStream) -> TokenStream {
 /// receiving an instance of `clap::ArgMatches` from conducting parsing, and then
 /// implementing a conversion code to instantiate an instance of the user
 /// context struct.
-#[proc_macro_derive(Parser, attributes(clap, structopt))]
+#[proc_macro_derive(Parser, attributes(clap, structopt, command, arg))]
 #[proc_macro_error]
 pub fn parser(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
@@ -50,7 +50,7 @@ pub fn parser(input: TokenStream) -> TokenStream {
 }
 
 /// Generates the `Subcommand` impl.
-#[proc_macro_derive(Subcommand, attributes(clap))]
+#[proc_macro_derive(Subcommand, attributes(clap, command, arg))]
 #[proc_macro_error]
 pub fn subcommand(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
@@ -58,7 +58,7 @@ pub fn subcommand(input: TokenStream) -> TokenStream {
 }
 
 /// Generates the `Args` impl.
-#[proc_macro_derive(Args, attributes(clap))]
+#[proc_macro_derive(Args, attributes(clap, command, arg))]
 #[proc_macro_error]
 pub fn args(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/examples/cargo-example-derive.rs
+++ b/examples/cargo-example-derive.rs
@@ -1,16 +1,16 @@
 use clap::Parser;
 
 #[derive(Parser)] // requires `derive` feature
-#[clap(name = "cargo")]
-#[clap(bin_name = "cargo")]
+#[command(name = "cargo")]
+#[command(bin_name = "cargo")]
 enum Cargo {
     ExampleDerive(ExampleDerive),
 }
 
 #[derive(clap::Args)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct ExampleDerive {
-    #[clap(long)]
+    #[arg(long)]
     manifest_path: Option<std::path::PathBuf>,
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,14 +2,14 @@ use clap::Parser;
 
 /// Simple program to greet a person
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Args {
     /// Name of the person to greet
-    #[clap(short, long)]
+    #[arg(short, long)]
     name: String,
 
     /// Number of times to greet
-    #[clap(short, long, default_value_t = 1)]
+    #[arg(short, long, default_value_t = 1)]
     count: u8,
 }
 

--- a/examples/derive_ref/augment_args.rs
+++ b/examples/derive_ref/augment_args.rs
@@ -2,7 +2,7 @@ use clap::{arg, Args, Command, FromArgMatches as _};
 
 #[derive(Args, Debug)]
 struct DerivedArgs {
-    #[clap(short, long)]
+    #[arg(short, long)]
     derived: bool,
 }
 

--- a/examples/derive_ref/augment_subcommands.rs
+++ b/examples/derive_ref/augment_subcommands.rs
@@ -3,7 +3,7 @@ use clap::{Command, FromArgMatches as _, Parser, Subcommand as _};
 #[derive(Parser, Debug)]
 enum Subcommands {
     Derived {
-        #[clap(short, long)]
+        #[arg(short, long)]
         derived_flag: bool,
     },
 }

--- a/examples/derive_ref/custom-bool.rs
+++ b/examples/derive_ref/custom-bool.rs
@@ -1,20 +1,20 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, PartialEq)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Opt {
     // Default parser for `Set` is FromStr::from_str.
     // `impl FromStr for bool` parses `true` or `false` so this
     // works as expected.
-    #[clap(long, action = clap::ArgAction::Set)]
+    #[arg(long, action = clap::ArgAction::Set)]
     foo: bool,
 
     // Of course, this could be done with an explicit parser function.
-    #[clap(long, action = clap::ArgAction::Set, value_parser = true_or_false, default_value_t)]
+    #[arg(long, action = clap::ArgAction::Set, value_parser = true_or_false, default_value_t)]
     bar: bool,
 
     // `bool` can be positional only with explicit `action` annotation
-    #[clap(action = clap::ArgAction::Set)]
+    #[arg(action = clap::ArgAction::Set)]
     boom: bool,
 }
 

--- a/examples/derive_ref/flatten_hand_args.rs
+++ b/examples/derive_ref/flatten_hand_args.rs
@@ -79,9 +79,9 @@ impl Args for CliArgs {
 
 #[derive(Parser, Debug)]
 struct Cli {
-    #[clap(short, long)]
+    #[arg(short, long)]
     top_level: bool,
-    #[clap(flatten)]
+    #[command(flatten)]
     more_args: CliArgs,
 }
 

--- a/examples/derive_ref/hand_subcommand.rs
+++ b/examples/derive_ref/hand_subcommand.rs
@@ -7,7 +7,7 @@ struct AddArgs {
 }
 #[derive(Parser, Debug)]
 struct RemoveArgs {
-    #[clap(short, long)]
+    #[arg(short, long)]
     force: bool,
     name: Vec<String>,
 }
@@ -67,7 +67,7 @@ impl Subcommand for CliSub {
 
 #[derive(Parser, Debug)]
 struct Cli {
-    #[clap(short, long)]
+    #[arg(short, long)]
     top_level: bool,
     #[clap(subcommand)]
     subcommand: CliSub,

--- a/examples/escaped-positional-derive.rs
+++ b/examples/escaped-positional-derive.rs
@@ -1,15 +1,15 @@
 use clap::Parser;
 
 #[derive(Parser)] // requires `derive` feature
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short = 'f')]
+    #[arg(short = 'f')]
     eff: bool,
 
-    #[clap(short = 'p', value_name = "PEAR")]
+    #[arg(short = 'p', value_name = "PEAR")]
     pea: Option<String>,
 
-    #[clap(last = true)]
+    #[arg(last = true)]
     slop: Vec<String>,
 }
 

--- a/examples/git-derive.rs
+++ b/examples/git-derive.rs
@@ -5,46 +5,46 @@ use clap::{Args, Parser, Subcommand};
 
 /// A fictional versioning CLI
 #[derive(Debug, Parser)] // requires `derive` feature
-#[clap(name = "git")]
-#[clap(about = "A fictional versioning CLI", long_about = None)]
+#[command(name = "git")]
+#[command(about = "A fictional versioning CLI", long_about = None)]
 struct Cli {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Commands,
 }
 
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Clones repos
-    #[clap(arg_required_else_help = true)]
+    #[command(arg_required_else_help = true)]
     Clone {
         /// The remote to clone
         remote: String,
     },
     /// pushes things
-    #[clap(arg_required_else_help = true)]
+    #[command(arg_required_else_help = true)]
     Push {
         /// The remote to target
         remote: String,
     },
     /// adds things
-    #[clap(arg_required_else_help = true)]
+    #[command(arg_required_else_help = true)]
     Add {
         /// Stuff to add
-        #[clap(required = true)]
+        #[arg(required = true)]
         path: Vec<PathBuf>,
     },
     Stash(Stash),
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     External(Vec<OsString>),
 }
 
 #[derive(Debug, Args)]
-#[clap(args_conflicts_with_subcommands = true)]
+#[command(args_conflicts_with_subcommands = true)]
 struct Stash {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<StashCommands>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     push: StashPush,
 }
 
@@ -57,7 +57,7 @@ enum StashCommands {
 
 #[derive(Debug, Args)]
 struct StashPush {
-    #[clap(short, long)]
+    #[arg(short, long)]
     message: Option<String>,
 }
 

--- a/examples/tutorial_derive/01_quick.rs
+++ b/examples/tutorial_derive/01_quick.rs
@@ -3,20 +3,20 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     /// Optional name to operate on
     name: Option<String>,
 
     /// Sets a custom config file
-    #[clap(short, long, value_name = "FILE")]
+    #[arg(short, long, value_name = "FILE")]
     config: Option<PathBuf>,
 
     /// Turn debugging information on
-    #[clap(short, long, action = clap::ArgAction::Count)]
+    #[arg(short, long, action = clap::ArgAction::Count)]
     debug: u8,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<Commands>,
 }
 
@@ -25,7 +25,7 @@ enum Commands {
     /// does testing things
     Test {
         /// lists test values
-        #[clap(short, long)]
+        #[arg(short, long)]
         list: bool,
     },
 }

--- a/examples/tutorial_derive/02_app_settings.rs
+++ b/examples/tutorial_derive/02_app_settings.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-#[clap(allow_negative_numbers = true)]
+#[command(author, version, about, long_about = None)]
+#[command(allow_negative_numbers = true)]
 struct Cli {
-    #[clap(long)]
+    #[arg(long)]
     two: String,
-    #[clap(long)]
+    #[arg(long)]
     one: String,
 }
 

--- a/examples/tutorial_derive/02_apps.rs
+++ b/examples/tutorial_derive/02_apps.rs
@@ -1,14 +1,14 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(name = "MyApp")]
-#[clap(author = "Kevin K. <kbknapp@gmail.com>")]
-#[clap(version = "1.0")]
-#[clap(about = "Does awesome things", long_about = None)]
+#[command(name = "MyApp")]
+#[command(author = "Kevin K. <kbknapp@gmail.com>")]
+#[command(version = "1.0")]
+#[command(about = "Does awesome things", long_about = None)]
 struct Cli {
-    #[clap(long)]
+    #[arg(long)]
     two: String,
-    #[clap(long)]
+    #[arg(long)]
     one: String,
 }
 

--- a/examples/tutorial_derive/02_crate.rs
+++ b/examples/tutorial_derive/02_crate.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)] // Read from `Cargo.toml`
+#[command(author, version, about, long_about = None)] // Read from `Cargo.toml`
 struct Cli {
-    #[clap(long)]
+    #[arg(long)]
     two: String,
-    #[clap(long)]
+    #[arg(long)]
     one: String,
 }
 

--- a/examples/tutorial_derive/03_01_flag_bool.rs
+++ b/examples/tutorial_derive/03_01_flag_bool.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 }
 

--- a/examples/tutorial_derive/03_01_flag_count.rs
+++ b/examples/tutorial_derive/03_01_flag_count.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long, action = clap::ArgAction::Count)]
+    #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 }
 

--- a/examples/tutorial_derive/03_02_option.rs
+++ b/examples/tutorial_derive/03_02_option.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long)]
+    #[arg(short, long)]
     name: Option<String>,
 }
 

--- a/examples/tutorial_derive/03_02_option_mult.rs
+++ b/examples/tutorial_derive/03_02_option_mult.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(short, long)]
+    #[arg(short, long)]
     name: Vec<String>,
 }
 

--- a/examples/tutorial_derive/03_03_positional.rs
+++ b/examples/tutorial_derive/03_03_positional.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     name: Option<String>,
 }

--- a/examples/tutorial_derive/03_03_positional_mult.rs
+++ b/examples/tutorial_derive/03_03_positional_mult.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     name: Vec<String>,
 }

--- a/examples/tutorial_derive/03_04_subcommands.md
+++ b/examples/tutorial_derive/03_04_subcommands.md
@@ -50,7 +50,7 @@ Options:
 
 ```
 
-Because we added `#[clap(propagate_version = true)]`:
+Because we added `#[command(propagate_version = true)]`:
 ```console
 $ 03_04_subcommands_derive --version
 clap [..]

--- a/examples/tutorial_derive/03_04_subcommands.rs
+++ b/examples/tutorial_derive/03_04_subcommands.rs
@@ -1,10 +1,10 @@
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-#[clap(propagate_version = true)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
 struct Cli {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Commands,
 }
 

--- a/examples/tutorial_derive/03_04_subcommands_alt.rs
+++ b/examples/tutorial_derive/03_04_subcommands_alt.rs
@@ -1,10 +1,10 @@
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-#[clap(propagate_version = true)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
 struct Cli {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Commands,
 }
 

--- a/examples/tutorial_derive/03_05_default_values.rs
+++ b/examples/tutorial_derive/03_05_default_values.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
-    #[clap(default_value_t = String::from("alice"))]
+    #[arg(default_value_t = String::from("alice"))]
     name: String,
 }
 

--- a/examples/tutorial_derive/04_01_enum.rs
+++ b/examples/tutorial_derive/04_01_enum.rs
@@ -1,10 +1,10 @@
 use clap::{Parser, ValueEnum};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     /// What mode to run the program in
-    #[clap(value_enum)]
+    #[arg(value_enum)]
     mode: Mode,
 }
 

--- a/examples/tutorial_derive/04_02_parse.rs
+++ b/examples/tutorial_derive/04_02_parse.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     /// Network port to use
-    #[clap(value_parser = clap::value_parser!(u16).range(1..))]
+    #[arg(value_parser = clap::value_parser!(u16).range(1..))]
     port: u16,
 }
 

--- a/examples/tutorial_derive/04_02_validate.rs
+++ b/examples/tutorial_derive/04_02_validate.rs
@@ -3,10 +3,10 @@ use std::ops::RangeInclusive;
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     /// Network port to use
-    #[clap(value_parser = port_in_range)]
+    #[arg(value_parser = port_in_range)]
     port: u16,
 }
 

--- a/examples/tutorial_derive/04_03_relations.rs
+++ b/examples/tutorial_derive/04_03_relations.rs
@@ -1,38 +1,38 @@
 use clap::{ArgGroup, Parser};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-#[clap(group(
+#[command(author, version, about, long_about = None)]
+#[command(group(
             ArgGroup::new("vers")
                 .required(true)
                 .args(["set_ver", "major", "minor", "patch"]),
         ))]
 struct Cli {
     /// set version manually
-    #[clap(long, value_name = "VER")]
+    #[arg(long, value_name = "VER")]
     set_ver: Option<String>,
 
     /// auto inc major
-    #[clap(long)]
+    #[arg(long)]
     major: bool,
 
     /// auto inc minor
-    #[clap(long)]
+    #[arg(long)]
     minor: bool,
 
     /// auto inc patch
-    #[clap(long)]
+    #[arg(long)]
     patch: bool,
 
     /// some regular input
-    #[clap(group = "input")]
+    #[arg(group = "input")]
     input_file: Option<String>,
 
     /// some special input argument
-    #[clap(long, group = "input")]
+    #[arg(long, group = "input")]
     spec_in: Option<String>,
 
-    #[clap(short, requires = "input")]
+    #[arg(short, requires = "input")]
     config: Option<String>,
 }
 

--- a/examples/tutorial_derive/04_04_custom.rs
+++ b/examples/tutorial_derive/04_04_custom.rs
@@ -2,32 +2,32 @@ use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     /// set version manually
-    #[clap(long, value_name = "VER")]
+    #[arg(long, value_name = "VER")]
     set_ver: Option<String>,
 
     /// auto inc major
-    #[clap(long)]
+    #[arg(long)]
     major: bool,
 
     /// auto inc minor
-    #[clap(long)]
+    #[arg(long)]
     minor: bool,
 
     /// auto inc patch
-    #[clap(long)]
+    #[arg(long)]
     patch: bool,
 
     /// some regular input
     input_file: Option<String>,
 
     /// some special input argument
-    #[clap(long)]
+    #[arg(long)]
     spec_in: Option<String>,
 
-    #[clap(short)]
+    #[arg(short)]
     config: Option<String>,
 }
 

--- a/examples/tutorial_derive/05_01_assert.rs
+++ b/examples/tutorial_derive/05_01_assert.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 struct Cli {
     /// Network port to use
     port: u16,

--- a/examples/typed-derive.rs
+++ b/examples/typed-derive.rs
@@ -4,23 +4,23 @@ use std::error::Error;
 #[derive(Parser, Debug)] // requires `derive` feature
 struct Args {
     /// Implicitly using `std::str::FromStr`
-    #[clap(short = 'O')]
+    #[arg(short = 'O')]
     optimization: Option<usize>,
 
     /// Allow invalid UTF-8 paths
-    #[clap(short = 'I', value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
+    #[arg(short = 'I', value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
     include: Option<std::path::PathBuf>,
 
     /// Handle IP addresses
-    #[clap(long)]
+    #[arg(long)]
     bind: Option<std::net::IpAddr>,
 
     /// Allow human-readable durations
-    #[clap(long)]
+    #[arg(long)]
     sleep: Option<humantime::Duration>,
 
     /// Hand-written parser for tuples
-    #[clap(short = 'D', value_parser = parse_key_val::<String, i32>)]
+    #[arg(short = 'D', value_parser = parse_key_val::<String, i32>)]
     defines: Vec<(String, i32)>,
 }
 

--- a/src/_derive/_tutorial.rs
+++ b/src/_derive/_tutorial.rs
@@ -49,7 +49,7 @@
 //!
 #![doc = include_str!("../../examples/tutorial_derive/02_apps.md")]
 //!
-//! You can use `#[clap(author, version, about)]` attribute defaults to fill these fields in from your `Cargo.toml` file.
+//! You can use `#[command(author, version, about)]` attribute defaults to fill these fields in from your `Cargo.toml` file.
 //!
 //! ```rust
 #![doc = include_str!("../../examples/tutorial_derive/02_crate.rs")]
@@ -88,9 +88,9 @@
 //! - They can be optional
 //! - Intent is clearer
 //!
-//! The `#[clap(short = 'n')]` and `#[clap(long = "name")]` attributes that define
+//! The `#[arg(short = 'n')]` and `#[arg(long = "name")]` attributes that define
 //! the flags are [`Arg`][crate::Args] methods that are derived from the field name when no value
-//! is specified (`#[clap(short)]` and `#[clap(long)]`).
+//! is specified (`#[arg(short)]` and `#[arg(long)]`).
 //!
 //! ```rust
 #![doc = include_str!("../../examples/tutorial_derive/03_02_option.rs")]
@@ -107,7 +107,7 @@
 //! ### Flags
 //!
 //! Flags can also be switches that can be on/off.  This is enabled via the
-//! `#[clap(action = ArgAction::SetTrue)]` attribute though this is implied when the field is a
+//! `#[arg(action = ArgAction::SetTrue)]` attribute though this is implied when the field is a
 //! `bool`.
 //!
 //! ```rust
@@ -126,7 +126,7 @@
 //!
 //! ### Subcommands
 //!
-//! Subcommands are derived with `#[derive(Subcommand)]` and be added via `#[clap(subcommand)]` attribute. Each
+//! Subcommands are derived with `#[derive(Subcommand)]` and be added via `#[command(subcommand)]` attribute. Each
 //! instance of a [Subcommand][crate::Subcommand] can have its own version, author(s), Args, and even its own
 //! subcommands.
 //!
@@ -145,7 +145,7 @@
 //!
 //! We've previously showed that arguments can be [`required`][crate::Arg::required] or optional.
 //! When optional, you work with a `Option` and can `unwrap_or`.  Alternatively, you can
-//! set `#[clap(default_value_t)]`.
+//! set `#[arg(default_value_t)]`.
 //!
 //! ```rust
 #![doc = include_str!("../../examples/tutorial_derive/03_05_default_values.rs")]

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -27,54 +27,54 @@
 //!
 //! /// Doc comment
 //! #[derive(Parser)]
-//! #[clap(APP ATTRIBUTE)]
+//! #[command(CMD ATTRIBUTE)]
 //! struct Cli {
 //!     /// Doc comment
-//!     #[clap(ARG ATTRIBUTE)]
+//!     #[arg(ARG ATTRIBUTE)]
 //!     field: UserType,
 //!
-//!     #[clap(value_enum, ARG ATTRIBUTE...)]
+//!     #[arg(value_enum, ARG ATTRIBUTE...)]
 //!     field: EnumValues,
 //!
-//!     #[clap(flatten)]
+//!     #[command(flatten)]
 //!     delegate: Struct,
 //!
-//!     #[clap(subcommand)]
+//!     #[command(subcommand)]
 //!     command: Command,
 //! }
 //!
 //! /// Doc comment
 //! #[derive(Args)]
-//! #[clap(PARENT APP ATTRIBUTE)]
+//! #[command(PARENT CMD ATTRIBUTE)]
 //! struct Struct {
 //!     /// Doc comment
-//!     #[clap(ARG ATTRIBUTE)]
+//!     #[command(ARG ATTRIBUTE)]
 //!     field: UserType,
 //! }
 //!
 //! /// Doc comment
 //! #[derive(Subcommand)]
-//! #[clap(PARENT APP ATTRIBUTE)]
+//! #[command(PARENT CMD ATTRIBUTE)]
 //! enum Command {
 //!     /// Doc comment
-//!     #[clap(APP ATTRIBUTE)]
+//!     #[command(CMD ATTRIBUTE)]
 //!     Variant1(Struct),
 //!
 //!     /// Doc comment
-//!     #[clap(APP ATTRIBUTE)]
+//!     #[command(CMD ATTRIBUTE)]
 //!     Variant2 {
 //!         /// Doc comment
-//!         #[clap(ARG ATTRIBUTE)]
+//!         #[arg(ARG ATTRIBUTE)]
 //!         field: UserType,
 //!     }
 //! }
 //!
 //! /// Doc comment
 //! #[derive(ValueEnum)]
-//! #[clap(VALUE ENUM ATTRIBUTE)]
+//! #[value(VALUE ENUM ATTRIBUTE)]
 //! enum EnumValues {
 //!     /// Doc comment
-//!     #[clap(POSSIBLE VALUE ATTRIBUTE)]
+//!     #[value(POSSIBLE VALUE ATTRIBUTE)]
 //!     Variant1,
 //! }
 //!
@@ -102,7 +102,7 @@
 //!
 //! Raw attributes come in two different syntaxes:
 //! ```rust,ignore
-//! #[clap(
+//! #[arg(
 //!     global = true, // name = arg form, neat for one-arg methods
 //!     required_if_eq("out", "file") // name(arg1, arg2, ...) form.
 //! )]
@@ -134,7 +134,7 @@
 //!
 //! **Raw attributes:**  Any [`Command` method][crate::Command] can also be used as an attribute,
 //! see [Terminology](#terminology) for syntax.
-//! - e.g. `#[clap(arg_required_else_help(true))]` would translate to `cmd.arg_required_else_help(true)`
+//! - e.g. `#[command(arg_required_else_help(true))]` would translate to `cmd.arg_required_else_help(true)`
 //!
 //! **Magic attributes:**
 //! - `name  = <expr>`: [`Command::name`][crate::Command::name]
@@ -149,7 +149,7 @@
 //!   - When not present: [Doc comment summary](#doc-comments)
 //!   - Without `<expr>`: [crate `description`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-description-field) ([`Parser`][crate::Parser] container)
 //!     - **TIP:** When a doc comment is also present, you most likely want to add
-//!       `#[clap(long_about = None)]` to clear the doc comment so only [`about`][crate::Command::about]
+//!       `#[arg(long_about = None)]` to clear the doc comment so only [`about`][crate::Command::about]
 //!       gets shown with both `-h` and `--help`.
 //! - `long_about = <expr>`: [`Command::long_about`][crate::Command::long_about]
 //!   - When not present: [Doc comment](#doc-comments) if there is a blank line, else nothing
@@ -178,7 +178,7 @@
 //! These correspond to a [`Arg`][crate::Arg].
 //!
 //! **Raw attributes:**  Any [`Arg` method][crate::Arg] can also be used as an attribute, see [Terminology](#terminology) for syntax.
-//! - e.g. `#[clap(max_values(3))]` would translate to `arg.max_values(3)`
+//! - e.g. `#[arg(max_values(3))]` would translate to `arg.max_values(3)`
 //!
 //! **Magic attributes**:
 //! - `id = <expr>`: [`Arg::id`][crate::Arg::id]
@@ -219,16 +219,16 @@
 //!   - Without `<expr>`: fills the field with `Default::default()`
 //! - `default_value = <str>`: [`Arg::default_value`][crate::Arg::default_value] and [`Arg::required(false)`][crate::Arg::required]
 //! - `default_value_t [= <expr>]`: [`Arg::default_value`][crate::Arg::default_value] and [`Arg::required(false)`][crate::Arg::required]
-//!   - Requires `std::fmt::Display` or `#[clap(value_enum)]`
+//!   - Requires `std::fmt::Display` or `#[arg(value_enum)]`
 //!   - Without `<expr>`, relies on `Default::default()`
 //! - `default_values_t = <expr>`: [`Arg::default_values`][crate::Arg::default_values] and [`Arg::required(false)`][crate::Arg::required]
-//!   - Requires field arg to be of type `Vec<T>` and `T` to implement `std::fmt::Display` or `#[clap(value_enum)]`
+//!   - Requires field arg to be of type `Vec<T>` and `T` to implement `std::fmt::Display` or `#[arg(value_enum)]`
 //!   - `<expr>` must implement `IntoIterator<T>`
 //! - `default_value_os_t [= <expr>]`: [`Arg::default_value_os`][crate::Arg::default_value_os] and [`Arg::required(false)`][crate::Arg::required]
-//!   - Requires `std::convert::Into<OsString>` or `#[clap(value_enum)]`
+//!   - Requires `std::convert::Into<OsString>` or `#[arg(value_enum)]`
 //!   - Without `<expr>`, relies on `Default::default()`
 //! - `default_values_os_t = <expr>`: [`Arg::default_values_os`][crate::Arg::default_values_os] and [`Arg::required(false)`][crate::Arg::required]
-//!   - Requires field arg to be of type `Vec<T>` and `T` to implement `std::convert::Into<OsString>` or `#[clap(value_enum)]`
+//!   - Requires field arg to be of type `Vec<T>` and `T` to implement `std::convert::Into<OsString>` or `#[arg(value_enum)]`
 //!   - `<expr>` must implement `IntoIterator<T>`
 //!
 //! ### ValueEnum Attributes
@@ -242,7 +242,7 @@
 //! These correspond to a [`PossibleValue`][crate::builder::PossibleValue].
 //!
 //! **Raw attributes:**  Any [`PossibleValue` method][crate::builder::PossibleValue] can also be used as an attribute, see [Terminology](#terminology) for syntax.
-//! - e.g. `#[clap(alias("foo"))]` would translate to `pv.alias("foo")`
+//! - e.g. `#[value(alias("foo"))]` would translate to `pv.alias("foo")`
 //!
 //! **Magic attributes**:
 //! - `name = <expr>`: [`PossibleValue::new`][crate::builder::PossibleValue::new]
@@ -282,9 +282,9 @@
 //! # use clap::Parser;
 //!
 //! #[derive(Parser)]
-//! #[clap(about = "I am a program and I work, just pass `-h`", long_about = None)]
+//! #[command(about = "I am a program and I work, just pass `-h`", long_about = None)]
 //! struct Foo {
-//!     #[clap(short, help = "Pass `-h` and you'll see me!")]
+//!     #[arg(short, help = "Pass `-h` and you'll see me!")]
 //!     bar: String,
 //! }
 //! ```
@@ -309,7 +309,7 @@
 //! If you really want to use the `Command::about/long_about` methods (you likely don't),
 //! use the `about` / `long_about` attributes to override the calls generated from
 //! the doc comment.  To clear `long_about`, you can use
-//! `#[clap(long_about = None)]`.
+//! `#[command(long_about = None)]`.
 //!
 //! **TIP:** Set `#![deny(missing_docs)]` to catch missing `--help` documentation at compile time.
 //!
@@ -329,7 +329,7 @@
 //!     /// I am artificial superintelligence. I won't rest
 //!     /// until I'll have destroyed humanity. Enjoy your
 //!     /// pathetic existence, you mere mortals.
-//!     #[clap(long, action)]
+//!     #[arg(long, action)]
 //!     kill_all_humans: bool,
 //! }
 //! ```
@@ -380,7 +380,7 @@
 //!
 //! ### Using derived arguments in a builder application
 //!
-//! When using the derive API, you can `#[clap(flatten)]` a struct deriving `Args` into a struct
+//! When using the derive API, you can `#[command(flatten)]` a struct deriving `Args` into a struct
 //! deriving `Args` or `Parser`. This example shows how you can augment a `Command` instance
 //! created using the builder API with `Args` created using the derive API.
 //!
@@ -398,7 +398,7 @@
 //!
 //! ### Using derived subcommands in a builder application
 //!
-//! When using the derive API, you can use `#[clap(subcommand)]` inside the struct to add
+//! When using the derive API, you can use `#[command(subcommand)]` inside the struct to add
 //! subcommands. The type of the field is usually an enum that derived `Parser`. However, you can
 //! also add the subcommands in that enum to a `Command` instance created with the builder API.
 //!
@@ -412,7 +412,7 @@
 //!
 //! ### Adding hand-implemented subcommands to a derived application
 //!
-//! When using the derive API, you can use `#[clap(subcommand)]` inside the struct to add
+//! When using the derive API, you can use `#[command(subcommand)]` inside the struct to add
 //! subcommands. The type of the field is usually an enum that derived `Parser`. However, you can
 //! also implement the `Subcommand` trait manually on this enum (or any other type) and it can
 //! still be used inside the struct created with the derive API. The implementation of the
@@ -423,7 +423,7 @@
 //! [`augment_subcommands`][crate::Subcommand::augment_subcommands] on an enum that derived
 //! `Parser`, whereas now we implement
 //! [`augment_subcommands`][crate::Subcommand::augment_subcommands] ourselves, but the derive API
-//! calls it automatically since we used the `#[clap(subcommand)]` attribute.
+//! calls it automatically since we used the `#[command(subcommand)]` attribute.
 //!
 //! For example:
 //! ```rust
@@ -432,7 +432,7 @@
 //!
 //! ### Flattening hand-implemented args into a derived application
 //!
-//! When using the derive API, you can use `#[clap(flatten)]` inside the struct to add arguments as
+//! When using the derive API, you can use `#[command(flatten)]` inside the struct to add arguments as
 //! if they were added directly to the containing struct. The type of the field is usually an
 //! struct that derived `Args`. However, you can also implement the `Args` trait manually on this
 //! struct (or any other type) and it can still be used inside the struct created with the derive
@@ -442,7 +442,7 @@
 //! Notice how in the previous example we used [`augment_args`][crate::Args::augment_args] on the
 //! struct that derived `Parser`, whereas now we implement
 //! [`augment_args`][crate::Args::augment_args] ourselves, but the derive API calls it
-//! automatically since we used the `#[clap(flatten)]` attribute.
+//! automatically since we used the `#[command(flatten)]` attribute.
 //!
 //! For example:
 //! ```rust

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -34,13 +34,13 @@ use std::ffi::OsString;
 #[cfg_attr(feature = "derive", doc = " ```")]
 /// /// My super CLI
 /// #[derive(clap::Parser)]
-/// #[clap(name = "demo")]
+/// #[command(name = "demo")]
 /// struct Context {
 ///     /// More verbose output
-///     #[clap(long)]
+///     #[arg(long)]
 ///     verbose: bool,
 ///     /// An optional name
-///     #[clap(short, long)]
+///     #[arg(short, long)]
 ///     name: Option<String>,
 /// }
 /// ```
@@ -257,7 +257,7 @@ pub trait FromArgMatches: Sized {
 ///
 /// Implementing this trait lets a parent container delegate argument parsing behavior to `Self`.
 /// with:
-/// - `#[clap(flatten)] args: ChildArgs`: Attribute can only be used with struct fields that impl
+/// - `#[command(flatten)] args: ChildArgs`: Attribute can only be used with struct fields that impl
 ///   `Args`.
 /// - `Variant(ChildArgs)`: No attribute is used with enum variants that impl `Args`.
 ///
@@ -271,13 +271,13 @@ pub trait FromArgMatches: Sized {
 #[cfg_attr(feature = "derive", doc = " ```")]
 /// #[derive(clap::Parser)]
 /// struct Args {
-///     #[clap(flatten)]
+///     #[command(flatten)]
 ///     logging: LogArgs,
 /// }
 ///
 /// #[derive(clap::Args)]
 /// struct LogArgs {
-///     #[clap(long, short = 'v', action = clap::ArgAction::Count)]
+///     #[arg(long, short = 'v', action = clap::ArgAction::Count)]
 ///     verbose: i8,
 /// }
 /// ```
@@ -288,7 +288,7 @@ pub trait Args: FromArgMatches + Sized {
     fn augment_args(cmd: Command) -> Command;
     /// Append to [`Command`] so it can update `self`.
     ///
-    /// This is used to implement `#[clap(flatten)]`
+    /// This is used to implement `#[command(flatten)]`
     ///
     /// See also [`CommandFactory`].
     fn augment_args_for_update(cmd: Command) -> Command;
@@ -298,9 +298,9 @@ pub trait Args: FromArgMatches + Sized {
 ///
 /// Implementing this trait lets a parent container delegate subcommand behavior to `Self`.
 /// with:
-/// - `#[clap(subcommand)] field: SubCmd`: Attribute can be used with either struct fields or enum
+/// - `#[command(subcommand)] field: SubCmd`: Attribute can be used with either struct fields or enum
 ///   variants that impl `Subcommand`.
-/// - `#[clap(flatten)] Variant(SubCmd)`: Attribute can only be used with enum variants that impl
+/// - `#[command(flatten)] Variant(SubCmd)`: Attribute can only be used with enum variants that impl
 ///   `Subcommand`.
 ///
 /// See the [derive reference](crate::_derive) for attributes and best practices.
@@ -313,7 +313,7 @@ pub trait Args: FromArgMatches + Sized {
 #[cfg_attr(feature = "derive", doc = " ```")]
 /// #[derive(clap::Parser)]
 /// struct Args {
-///     #[clap(subcommand)]
+///     #[command(subcommand)]
 ///     action: Action,
 /// }
 ///
@@ -330,7 +330,7 @@ pub trait Subcommand: FromArgMatches + Sized {
     fn augment_subcommands(cmd: Command) -> Command;
     /// Append to [`Command`] so it can update `self`.
     ///
-    /// This is used to implement `#[clap(flatten)]`
+    /// This is used to implement `#[command(flatten)]`
     ///
     /// See also [`CommandFactory`].
     fn augment_subcommands_for_update(cmd: Command) -> Command;
@@ -341,9 +341,9 @@ pub trait Subcommand: FromArgMatches + Sized {
 /// Parse arguments into enums.
 ///
 /// When deriving [`Parser`], a field whose type implements `ValueEnum` can have the attribute
-/// `#[clap(value_enum)]` which will
+/// `#[arg(value_enum)]` which will
 /// - Call [EnumValueParser`][crate::builder::EnumValueParser]`
-/// - Allowing using the `#[clap(default_value_t)]` attribute without implementing `Display`.
+/// - Allowing using the `#[arg(default_value_t)]` attribute without implementing `Display`.
 ///
 /// See the [derive reference](crate::_derive) for attributes and best practices.
 ///
@@ -355,7 +355,7 @@ pub trait Subcommand: FromArgMatches + Sized {
 #[cfg_attr(feature = "derive", doc = " ```")]
 /// #[derive(clap::Parser)]
 /// struct Args {
-///     #[clap(value_enum)]
+///     #[arg(value_enum)]
 ///     level: Level,
 /// }
 ///

--- a/tests/derive/app_name.rs
+++ b/tests/derive/app_name.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[test]
 fn app_name_in_short_help_from_struct() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     struct MyApp {}
 
     let mut help = Vec::new();
@@ -16,7 +16,7 @@ fn app_name_in_short_help_from_struct() {
 #[test]
 fn app_name_in_long_help_from_struct() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     struct MyApp {}
 
     let mut help = Vec::new();
@@ -29,7 +29,7 @@ fn app_name_in_long_help_from_struct() {
 #[test]
 fn app_name_in_short_help_from_enum() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     enum MyApp {}
 
     let mut help = Vec::new();
@@ -42,7 +42,7 @@ fn app_name_in_short_help_from_enum() {
 #[test]
 fn app_name_in_long_help_from_enum() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     enum MyApp {}
 
     let mut help = Vec::new();
@@ -55,7 +55,7 @@ fn app_name_in_long_help_from_enum() {
 #[test]
 fn app_name_in_short_version_from_struct() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     struct MyApp {}
 
     let version = MyApp::command().render_version();
@@ -66,7 +66,7 @@ fn app_name_in_short_version_from_struct() {
 #[test]
 fn app_name_in_long_version_from_struct() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     struct MyApp {}
 
     let version = MyApp::command().render_long_version();
@@ -77,7 +77,7 @@ fn app_name_in_long_version_from_struct() {
 #[test]
 fn app_name_in_short_version_from_enum() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     enum MyApp {}
 
     let version = MyApp::command().render_version();
@@ -88,7 +88,7 @@ fn app_name_in_short_version_from_enum() {
 #[test]
 fn app_name_in_long_version_from_enum() {
     #[derive(Parser)]
-    #[clap(name = "my-cmd")]
+    #[command(name = "my-cmd")]
     enum MyApp {}
 
     let version = MyApp::command().render_long_version();

--- a/tests/derive/arguments.rs
+++ b/tests/derive/arguments.rs
@@ -33,7 +33,7 @@ fn required_argument() {
 fn argument_with_default() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(default_value = "42")]
+        #[arg(default_value = "42")]
         arg: i32,
     }
     assert_eq!(
@@ -67,7 +67,7 @@ fn auto_value_name() {
 fn explicit_value_name() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_name = "BROWNIE_POINTS")]
+        #[arg(value_name = "BROWNIE_POINTS")]
         my_special_arg: i32,
     }
 

--- a/tests/derive/author_version_about.rs
+++ b/tests/derive/author_version_about.rs
@@ -19,8 +19,8 @@ use clap::Parser;
 #[test]
 fn no_author_version_about() {
     #[derive(Parser, PartialEq, Debug)]
-    #[clap(name = "foo")]
-    #[clap(help_template = utils::FULL_TEMPLATE)]
+    #[command(name = "foo")]
+    #[command(help_template = utils::FULL_TEMPLATE)]
     struct Opt {}
 
     let output = utils::get_long_help::<Opt>();
@@ -30,8 +30,8 @@ fn no_author_version_about() {
 #[test]
 fn use_env() {
     #[derive(Parser, PartialEq, Debug)]
-    #[clap(author, about, version)]
-    #[clap(help_template = utils::FULL_TEMPLATE)]
+    #[command(author, about, version)]
+    #[command(help_template = utils::FULL_TEMPLATE)]
     struct Opt {}
 
     let output = utils::get_long_help::<Opt>();
@@ -45,8 +45,8 @@ fn explicit_version_not_str_lit() {
     const VERSION: &str = "custom version";
 
     #[derive(Parser)]
-    #[clap(version = VERSION)]
-    #[clap(help_template = utils::FULL_TEMPLATE)]
+    #[command(version = VERSION)]
+    #[command(help_template = utils::FULL_TEMPLATE)]
     pub struct Opt {}
 
     let output = utils::get_long_help::<Opt>();

--- a/tests/derive/basic.rs
+++ b/tests/derive/basic.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 fn basic() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short = 'a', long = "arg")]
+        #[arg(short = 'a', long = "arg")]
         arg: i32,
     }
     assert_eq!(
@@ -31,7 +31,7 @@ fn basic() {
 fn update_basic() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short = 'a', long = "arg")]
+        #[arg(short = 'a', long = "arg")]
         single_value: i32,
     }
 

--- a/tests/derive/boxed.rs
+++ b/tests/derive/boxed.rs
@@ -2,14 +2,14 @@ use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser, PartialEq, Debug)]
 struct Opt {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     sub: Box<Sub>,
 }
 
 #[derive(Subcommand, PartialEq, Debug)]
 enum Sub {
     Flame {
-        #[clap(flatten)]
+        #[command(flatten)]
         arg: Box<Ext>,
     },
 }

--- a/tests/derive/custom_string_parsers.rs
+++ b/tests/derive/custom_string_parsers.rs
@@ -19,19 +19,19 @@ use std::path::PathBuf;
 
 #[derive(Parser, PartialEq, Debug)]
 struct PathOpt {
-    #[clap(short, long)]
+    #[arg(short, long)]
     path: PathBuf,
 
-    #[clap(short, default_value = "../")]
+    #[arg(short, default_value = "../")]
     default_path: PathBuf,
 
-    #[clap(short)]
+    #[arg(short)]
     vector_path: Vec<PathBuf>,
 
-    #[clap(short)]
+    #[arg(short)]
     option_path_1: Option<PathBuf>,
 
-    #[clap(short = 'q')]
+    #[arg(short = 'q')]
     option_path_2: Option<PathBuf>,
 }
 
@@ -63,7 +63,7 @@ fn parse_hex(input: &str) -> Result<u64, ParseIntError> {
 
 #[derive(Parser, PartialEq, Debug)]
 struct HexOpt {
-    #[clap(short, value_parser = parse_hex)]
+    #[arg(short, value_parser = parse_hex)]
     number: u64,
 }
 
@@ -102,7 +102,7 @@ fn custom_parser_2(_: &str) -> Result<&'static str, ErrCode> {
 
 #[derive(Parser, PartialEq, Debug)]
 struct NoOpOpt {
-    #[clap(short, value_parser = custom_parser_2)]
+    #[arg(short, value_parser = custom_parser_2)]
     b: &'static str,
 }
 
@@ -125,10 +125,10 @@ fn update_every_custom_parser() {
 
 #[derive(Parser, PartialEq, Debug)]
 struct DefaultedOpt {
-    #[clap(short)]
+    #[arg(short)]
     integer: u64,
 
-    #[clap(short)]
+    #[arg(short)]
     path: PathBuf,
 }
 

--- a/tests/derive/default_value.rs
+++ b/tests/derive/default_value.rs
@@ -8,7 +8,7 @@ use crate::utils;
 fn default_value() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(default_value = "3")]
+        #[arg(default_value = "3")]
         arg: i32,
     }
     assert_eq!(Opt { arg: 3 }, Opt::try_parse_from(&["test"]).unwrap());
@@ -22,7 +22,7 @@ fn default_value() {
 fn default_value_t() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(default_value_t = 3)]
+        #[arg(default_value_t = 3)]
         arg: i32,
     }
     assert_eq!(Opt { arg: 3 }, Opt::try_parse_from(&["test"]).unwrap());
@@ -36,7 +36,7 @@ fn default_value_t() {
 fn auto_default_value_t() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(default_value_t)]
+        #[arg(default_value_t)]
         arg: i32,
     }
     assert_eq!(Opt { arg: 0 }, Opt::try_parse_from(&["test"]).unwrap());
@@ -50,22 +50,22 @@ fn auto_default_value_t() {
 fn default_values_t() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(default_values_t = vec![1, 2, 3])]
+        #[arg(default_values_t = vec![1, 2, 3])]
         arg1: Vec<i32>,
 
-        #[clap(long, default_values_t = &[4, 5, 6])]
+        #[arg(long, default_values_t = &[4, 5, 6])]
         arg2: Vec<i32>,
 
-        #[clap(long, default_values_t = [7, 8, 9])]
+        #[arg(long, default_values_t = [7, 8, 9])]
         arg3: Vec<i32>,
 
-        #[clap(long, default_values_t = 10..=12)]
+        #[arg(long, default_values_t = 10..=12)]
         arg4: Vec<i32>,
 
-        #[clap(long, default_values_t = vec!["hello".to_string(), "world".to_string()])]
+        #[arg(long, default_values_t = vec!["hello".to_string(), "world".to_string()])]
         arg5: Vec<String>,
 
-        #[clap(long, default_values_t = &vec!["foo".to_string(), "bar".to_string()])]
+        #[arg(long, default_values_t = &vec!["foo".to_string(), "bar".to_string()])]
         arg6: Vec<String>,
     }
     assert_eq!(
@@ -110,7 +110,7 @@ fn default_values_t() {
 fn default_value_os_t() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(default_value_os_t = PathBuf::from("abc.def"))]
+        #[arg(default_value_os_t = PathBuf::from("abc.def"))]
         arg: PathBuf,
     }
     assert_eq!(
@@ -134,12 +134,12 @@ fn default_value_os_t() {
 fn default_values_os_t() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(
+        #[arg(
             default_values_os_t = vec![PathBuf::from("abc.def"), PathBuf::from("123.foo")]
         )]
         arg1: Vec<PathBuf>,
 
-        #[clap(
+        #[arg(
             long,
             default_values_os_t = &[PathBuf::from("bar.baz")]
         )]
@@ -170,7 +170,7 @@ fn detect_os_variant() {
 
     #[derive(clap::Parser)]
     pub struct Options {
-        #[clap(default_value_os = "123")]
+        #[arg(default_value_os = "123")]
         x: String,
     }
     Options::command().debug_assert();

--- a/tests/derive/deny_warnings.rs
+++ b/tests/derive/deny_warnings.rs
@@ -24,7 +24,7 @@ fn try_str(s: &str) -> Result<String, std::convert::Infallible> {
 fn warning_never_struct() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(value_parser = try_str, default_value_t)]
+        #[arg(value_parser = try_str, default_value_t)]
         s: String,
     }
     assert_eq!(
@@ -40,7 +40,7 @@ fn warning_never_enum() {
     #[derive(Parser, Debug, PartialEq)]
     enum Opt {
         Foo {
-            #[clap(value_parser = try_str, default_value_t)]
+            #[arg(value_parser = try_str, default_value_t)]
             s: String,
         },
     }

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -23,7 +23,7 @@ fn doc_comments() {
     struct LoremIpsum {
         /// Fooify a bar
         /// and a baz
-        #[clap(short, long)]
+        #[arg(short, long)]
         foo: bool,
     }
 
@@ -36,10 +36,10 @@ fn doc_comments() {
 fn help_is_better_than_comments() {
     /// Lorem ipsum
     #[derive(Parser, PartialEq, Debug)]
-    #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
+    #[command(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
         /// Fooify a bar
-        #[clap(short, long, help = "DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES")]
+        #[arg(short, long, help = "DO NOT PASS A BAR UNDER ANY CIRCUMSTANCES")]
         foo: bool,
     }
 
@@ -55,7 +55,7 @@ fn empty_line_in_doc_comment_is_double_linefeed() {
     ///
     /// Bar
     #[derive(Parser, PartialEq, Debug)]
-    #[clap(name = "lorem-ipsum")]
+    #[command(name = "lorem-ipsum")]
     struct LoremIpsum {}
 
     let help = utils::get_long_help::<LoremIpsum>();
@@ -73,16 +73,16 @@ Usage:"
 fn field_long_doc_comment_both_help_long_help() {
     /// Lorem ipsumclap
     #[derive(Parser, PartialEq, Debug)]
-    #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
+    #[command(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
         /// Dot is removed from multiline comments.
         ///
         /// Long help
-        #[clap(long)]
+        #[arg(long)]
         foo: bool,
 
         /// Dot is removed from one short comment.
-        #[clap(long)]
+        #[arg(long)]
         bar: bool,
     }
 
@@ -101,9 +101,9 @@ fn field_long_doc_comment_both_help_long_help() {
 fn top_long_doc_comment_both_help_long_help() {
     /// Lorem ipsumclap
     #[derive(Parser, Debug)]
-    #[clap(name = "lorem-ipsum", about = "Dolor sit amet")]
+    #[command(name = "lorem-ipsum", about = "Dolor sit amet")]
     struct LoremIpsum {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         foo: SubCommand,
     }
 
@@ -113,7 +113,7 @@ fn top_long_doc_comment_both_help_long_help() {
         ///
         /// Or something else
         Foo {
-            #[clap(help = "foo")]
+            #[arg(help = "foo")]
             bars: String,
         },
     }
@@ -146,9 +146,9 @@ fn verbatim_doc_comment() {
     ///      ( ()    ||
     ///       (      () ) )
     #[derive(Parser, Debug)]
-    #[clap(verbatim_doc_comment)]
+    #[command(verbatim_doc_comment)]
     struct SeeFigure1 {
-        #[clap(long)]
+        #[arg(long)]
         foo: bool,
     }
 
@@ -178,10 +178,10 @@ fn verbatim_doc_comment_field() {
     #[derive(Parser, Debug)]
     struct Command {
         /// This help ends in a period.
-        #[clap(long, verbatim_doc_comment)]
+        #[arg(long, verbatim_doc_comment)]
         foo: bool,
         /// This help does not end in a period.
-        #[clap(long)]
+        #[arg(long)]
         bar: bool,
     }
 
@@ -198,7 +198,7 @@ fn multiline_separates_default() {
         /// Multiline
         ///
         /// Doc comment
-        #[clap(long, default_value = "x")]
+        #[arg(long, default_value = "x")]
         x: String,
     }
 
@@ -227,7 +227,7 @@ fn doc_comment_about_handles_both_abouts() {
     /// Opts doc comment summary
     #[derive(Parser, Debug)]
     pub struct Opts {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         pub cmd: Sub,
     }
 

--- a/tests/derive/explicit_name_no_renaming.rs
+++ b/tests/derive/explicit_name_no_renaming.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 fn explicit_short_long_no_rename() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short = '.', long = ".foo")]
+        #[arg(short = '.', long = ".foo")]
         foo: String,
     }
 
@@ -27,7 +27,7 @@ fn explicit_short_long_no_rename() {
 fn explicit_name_no_rename() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(name = ".options")]
+        #[arg(name = ".options")]
         foo: String,
     }
 

--- a/tests/derive/flags.rs
+++ b/tests/derive/flags.rs
@@ -22,7 +22,7 @@ use clap::Parser;
 fn bool_type_is_flag() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
-        #[clap(short, long)]
+        #[arg(short, long)]
         alice: bool,
     }
 
@@ -58,9 +58,9 @@ fn non_bool_type_flag() {
 
     #[derive(Parser, Debug)]
     struct Opt {
-        #[clap(short, long, action = ArgAction::SetTrue, value_parser = BoolishValueParser::new().map(parse_from_flag))]
+        #[arg(short, long, action = ArgAction::SetTrue, value_parser = BoolishValueParser::new().map(parse_from_flag))]
         alice: usize,
-        #[clap(short, long, action = ArgAction::SetTrue, value_parser = BoolishValueParser::new().map(parse_from_flag))]
+        #[arg(short, long, action = ArgAction::SetTrue, value_parser = BoolishValueParser::new().map(parse_from_flag))]
         bob: usize,
     }
 
@@ -87,7 +87,7 @@ fn inferred_help() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
         /// Foo
-        #[clap(short, long)]
+        #[arg(short, long)]
         help: bool,
     }
 
@@ -108,7 +108,7 @@ fn inferred_version() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
         /// Foo
-        #[clap(short, long)]
+        #[arg(short, long)]
         version: bool,
     }
 
@@ -130,9 +130,9 @@ fn inferred_version() {
 fn count() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
-        #[clap(short, long, action = clap::ArgAction::Count)]
+        #[arg(short, long, action = clap::ArgAction::Count)]
         alice: u8,
-        #[clap(short, long, action = clap::ArgAction::Count)]
+        #[arg(short, long, action = clap::ArgAction::Count)]
         bob: u8,
     }
 
@@ -164,9 +164,9 @@ fn count() {
 fn mixed_type_flags() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
-        #[clap(short, long)]
+        #[arg(short, long)]
         alice: bool,
-        #[clap(short, long, action = clap::ArgAction::Count)]
+        #[arg(short, long, action = clap::ArgAction::Count)]
         bob: u8,
     }
 
@@ -247,7 +247,7 @@ fn ignore_qualified_bool_type() {
 fn override_implicit_action() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
-        #[clap(long, action = clap::ArgAction::Set)]
+        #[arg(long, action = clap::ArgAction::Set)]
         arg: bool,
     }
 
@@ -266,7 +266,7 @@ fn override_implicit_action() {
 fn override_implicit_from_flag_positional() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
-        #[clap(action = clap::ArgAction::Set)]
+        #[arg(action = clap::ArgAction::Set)]
         arg: bool,
     }
 

--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -25,7 +25,7 @@ fn flatten() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(flatten)]
+        #[command(flatten)]
         common: Common,
     }
     assert_eq!(
@@ -49,10 +49,10 @@ fn flatten_twice() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(flatten)]
+        #[command(flatten)]
         c1: Common,
         // Defines "arg" twice, so this should not work.
-        #[clap(flatten)]
+        #[command(flatten)]
         c2: Common,
     }
     Opt::try_parse_from(&["test", "42", "43"]).unwrap();
@@ -67,18 +67,18 @@ fn flatten_in_subcommand() {
 
     #[derive(Args, PartialEq, Debug)]
     struct Add {
-        #[clap(short)]
+        #[arg(short)]
         interactive: bool,
-        #[clap(flatten)]
+        #[command(flatten)]
         common: Common,
     }
 
     #[derive(Parser, PartialEq, Debug)]
     enum Opt {
         Fetch {
-            #[clap(short)]
+            #[arg(short)]
             all: bool,
-            #[clap(flatten)]
+            #[command(flatten)]
             common: Common,
         },
 
@@ -110,7 +110,7 @@ fn update_args_with_flatten() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(flatten)]
+        #[command(flatten)]
         common: Common,
     }
 
@@ -146,7 +146,7 @@ struct Command2 {
 
 #[derive(Parser, PartialEq, Debug)]
 enum Opt {
-    #[clap(flatten)]
+    #[command(flatten)]
     BaseCli(BaseCli),
     Command2(Command2),
 }
@@ -200,7 +200,7 @@ fn flatten_with_doc_comment() {
     struct Opt {
         /// The very important comment that clippy had me put here.
         /// It knows better.
-        #[clap(flatten)]
+        #[command(flatten)]
         common: Common,
     }
     assert_eq!(
@@ -216,18 +216,18 @@ fn flatten_with_doc_comment() {
 }
 
 #[test]
-fn docstrings_ordering_with_multiple_clap() {
+fn docstrings_ordering_with_multiple_command() {
     /// This is the docstring for Flattened
     #[derive(Args)]
     struct Flattened {
-        #[clap(long)]
+        #[arg(long)]
         foo: bool,
     }
 
     /// This is the docstring for Command
     #[derive(Parser)]
     struct Command {
-        #[clap(flatten)]
+        #[command(flatten)]
         flattened: Flattened,
     }
 
@@ -241,13 +241,13 @@ fn docstrings_ordering_with_multiple_clap_partial() {
     /// This is the docstring for Flattened
     #[derive(Args)]
     struct Flattened {
-        #[clap(long)]
+        #[arg(long)]
         foo: bool,
     }
 
     #[derive(Parser)]
     struct Command {
-        #[clap(flatten)]
+        #[command(flatten)]
         flattened: Flattened,
     }
 

--- a/tests/derive/generic.rs
+++ b/tests/derive/generic.rs
@@ -9,7 +9,7 @@ fn generic_struct_flatten() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Outer<T: Args> {
-        #[clap(flatten)]
+        #[command(flatten)]
         pub inner: T,
     }
 
@@ -33,7 +33,7 @@ fn generic_struct_flatten_w_where_clause() {
     where
         T: Args,
     {
-        #[clap(flatten)]
+        #[command(flatten)]
         pub inner: T,
     }
 
@@ -112,7 +112,7 @@ fn generic_wo_trait_bound() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt<T> {
         answer: isize,
-        #[clap(skip)]
+        #[arg(skip)]
         took: Option<T>,
     }
 

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -4,11 +4,11 @@ use clap::{ArgAction, Args, CommandFactory, Parser, Subcommand};
 fn arg_help_heading_applied() {
     #[derive(Debug, Clone, Parser)]
     struct CliOptions {
-        #[clap(long)]
-        #[clap(help_heading = Some("HEADING A"))]
+        #[arg(long)]
+        #[arg(help_heading = Some("HEADING A"))]
         should_be_in_section_a: u32,
 
-        #[clap(long)]
+        #[arg(long)]
         no_section: u32,
     }
 
@@ -30,13 +30,13 @@ fn arg_help_heading_applied() {
 #[test]
 fn app_help_heading_applied() {
     #[derive(Debug, Clone, Parser)]
-    #[clap(next_help_heading = "DEFAULT")]
+    #[command(next_help_heading = "DEFAULT")]
     struct CliOptions {
-        #[clap(long)]
-        #[clap(help_heading = Some("HEADING A"))]
+        #[arg(long)]
+        #[arg(help_heading = Some("HEADING A"))]
         should_be_in_section_a: u32,
 
-        #[clap(long)]
+        #[arg(long)]
         should_be_in_default_section: u32,
     }
 
@@ -65,41 +65,41 @@ fn app_help_heading_flattened() {
 
     #[derive(Debug, Clone, Parser)]
     struct CliOptions {
-        #[clap(flatten)]
+        #[command(flatten)]
         options_a: OptionsA,
 
-        #[clap(flatten)]
+        #[command(flatten)]
         options_b: OptionsB,
 
-        #[clap(subcommand)]
+        #[command(subcommand)]
         sub_a: SubA,
 
-        #[clap(long)]
+        #[arg(long)]
         should_be_in_default_section: u32,
     }
 
     #[derive(Debug, Clone, Args)]
-    #[clap(next_help_heading = "HEADING A")]
+    #[command(next_help_heading = "HEADING A")]
     struct OptionsA {
-        #[clap(long)]
+        #[arg(long)]
         should_be_in_section_a: u32,
     }
 
     #[derive(Debug, Clone, Args)]
-    #[clap(next_help_heading = "HEADING B")]
+    #[command(next_help_heading = "HEADING B")]
     struct OptionsB {
-        #[clap(long)]
+        #[arg(long)]
         should_be_in_section_b: u32,
     }
 
     #[derive(Debug, Clone, Subcommand)]
     enum SubA {
-        #[clap(flatten)]
+        #[command(flatten)]
         SubB(SubB),
-        #[clap(subcommand)]
+        #[command(subcommand)]
         SubC(SubC),
         SubAOne,
-        #[clap(next_help_heading = "SUB A")]
+        #[command(next_help_heading = "SUB A")]
         SubATwo {
             should_be_in_sub_a: u32,
         },
@@ -107,13 +107,13 @@ fn app_help_heading_flattened() {
 
     #[derive(Debug, Clone, Subcommand)]
     enum SubB {
-        #[clap(next_help_heading = "SUB B")]
+        #[command(next_help_heading = "SUB B")]
         SubBOne { should_be_in_sub_b: u32 },
     }
 
     #[derive(Debug, Clone, Subcommand)]
     enum SubC {
-        #[clap(next_help_heading = "SUB C")]
+        #[command(next_help_heading = "SUB C")]
         SubCOne { should_be_in_sub_c: u32 },
     }
 
@@ -167,14 +167,14 @@ fn app_help_heading_flattened() {
 fn flatten_field_with_help_heading() {
     #[derive(Debug, Clone, Parser)]
     struct CliOptions {
-        #[clap(flatten)]
-        #[clap(next_help_heading = "HEADING A")]
+        #[command(flatten)]
+        #[command(next_help_heading = "HEADING A")]
         options_a: OptionsA,
     }
 
     #[derive(Debug, Clone, Args)]
     struct OptionsA {
-        #[clap(long)]
+        #[arg(long)]
         should_be_in_section_a: u32,
     }
 
@@ -194,19 +194,19 @@ fn flatten_field_with_help_heading() {
 #[test]
 fn derive_generated_error_has_full_context() {
     #[derive(Debug, Parser)]
-    #[clap(subcommand_negates_reqs = true)]
+    #[command(subcommand_negates_reqs = true)]
     struct Opts {
-        #[clap(long)]
+        #[arg(long)]
         req_str: String,
 
-        #[clap(subcommand)]
+        #[command(subcommand)]
         cmd: Option<SubCommands>,
     }
 
     #[derive(Debug, Parser)]
     enum SubCommands {
         Sub {
-            #[clap(short, long, action = clap::ArgAction::Count)]
+            #[arg(short, long, action = clap::ArgAction::Count)]
             verbose: u8,
         },
     }
@@ -245,33 +245,33 @@ Options:
 ";
 
     #[derive(Parser, Debug)]
-    #[clap(name = "test", version = "1.2")]
+    #[command(name = "test", version = "1.2")]
     struct Args {
-        #[clap(flatten)]
+        #[command(flatten)]
         a: A,
-        #[clap(flatten)]
+        #[command(flatten)]
         b: B,
     }
 
     #[derive(Args, Debug)]
-    #[clap(next_display_order = 10000)]
+    #[command(next_display_order = 10000)]
     struct A {
         /// second flag
-        #[clap(long)]
+        #[arg(long)]
         flag_a: bool,
         /// second option
-        #[clap(long)]
+        #[arg(long)]
         option_a: Option<String>,
     }
 
     #[derive(Args, Debug)]
-    #[clap(next_display_order = 10)]
+    #[command(next_display_order = 10)]
     struct B {
         /// first flag
-        #[clap(long)]
+        #[arg(long)]
         flag_b: bool,
         /// first option
-        #[clap(long)]
+        #[arg(long)]
         option_b: Option<String>,
     }
 
@@ -300,33 +300,33 @@ Options:
 ";
 
     #[derive(Parser, Debug)]
-    #[clap(name = "test", version = "1.2")]
+    #[command(name = "test", version = "1.2")]
     struct Args {
-        #[clap(flatten)]
-        #[clap(next_display_order = 10000)]
+        #[command(flatten)]
+        #[command(next_display_order = 10000)]
         a: A,
-        #[clap(flatten)]
-        #[clap(next_display_order = 10)]
+        #[command(flatten)]
+        #[command(next_display_order = 10)]
         b: B,
     }
 
     #[derive(Args, Debug)]
     struct A {
         /// second flag
-        #[clap(long)]
+        #[arg(long)]
         flag_a: bool,
         /// second option
-        #[clap(long)]
+        #[arg(long)]
         option_a: Option<String>,
     }
 
     #[derive(Args, Debug)]
     struct B {
         /// first flag
-        #[clap(long)]
+        #[arg(long)]
         flag_b: bool,
         /// first option
-        #[clap(long)]
+        #[arg(long)]
         option_b: Option<String>,
     }
 
@@ -355,32 +355,32 @@ Options:
 ";
 
     #[derive(Parser, Debug)]
-    #[clap(name = "test", version = "1.2")]
-    #[clap(next_display_order = None)]
+    #[command(name = "test", version = "1.2")]
+    #[command(next_display_order = None)]
     struct Args {
-        #[clap(flatten)]
+        #[command(flatten)]
         a: A,
-        #[clap(flatten)]
+        #[command(flatten)]
         b: B,
     }
 
     #[derive(Args, Debug)]
     struct A {
         /// first flag
-        #[clap(long)]
+        #[arg(long)]
         flag_a: bool,
         /// first option
-        #[clap(long)]
+        #[arg(long)]
         option_a: Option<String>,
     }
 
     #[derive(Args, Debug)]
     struct B {
         /// second flag
-        #[clap(long)]
+        #[arg(long)]
         flag_b: bool,
         /// second option
-        #[clap(long)]
+        #[arg(long)]
         option_b: Option<String>,
     }
 
@@ -418,7 +418,7 @@ Options:
     #[derive(Parser, PartialEq, Debug)]
     struct Args {
         /// Argument help
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         arg: ArgChoice,
     }
 
@@ -442,9 +442,9 @@ Options:
 #[test]
 fn custom_help_flag() {
     #[derive(Debug, Clone, Parser)]
-    #[clap(disable_help_flag = true)]
+    #[command(disable_help_flag = true)]
     struct CliOptions {
-        #[clap(short = 'h', long = "verbose-help", action = ArgAction::Help)]
+        #[arg(short = 'h', long = "verbose-help", action = ArgAction::Help)]
         help: bool,
     }
 
@@ -456,9 +456,9 @@ fn custom_help_flag() {
 #[test]
 fn custom_version_flag() {
     #[derive(Debug, Clone, Parser)]
-    #[clap(disable_version_flag = true, version = "2.0.0")]
+    #[command(disable_version_flag = true, version = "2.0.0")]
     struct CliOptions {
-        #[clap(short = 'V', long = "verbose-version", action = ArgAction::Version)]
+        #[arg(short = 'V', long = "verbose-version", action = ArgAction::Version)]
         version: bool,
     }
 

--- a/tests/derive/issues.rs
+++ b/tests/derive/issues.rs
@@ -7,17 +7,17 @@ use clap::{ArgGroup, Args, Parser, Subcommand};
 #[test]
 fn issue_151_groups_within_subcommands() {
     #[derive(Args, Debug)]
-    #[clap(group = ArgGroup::new("verb").required(true).multiple(true))]
+    #[command(group = ArgGroup::new("verb").required(true).multiple(true))]
     struct Opt {
-        #[clap(long, group = "verb")]
+        #[arg(long, group = "verb")]
         foo: Option<String>,
-        #[clap(long, group = "verb")]
+        #[arg(long, group = "verb")]
         bar: Option<String>,
     }
 
     #[derive(Debug, Parser)]
     struct Cli {
-        #[clap(flatten)]
+        #[command(flatten)]
         a: Opt,
     }
 
@@ -31,17 +31,17 @@ fn issue_151_groups_within_subcommands() {
 #[test]
 fn issue_289() {
     #[derive(Parser)]
-    #[clap(infer_subcommands = true)]
+    #[command(infer_subcommands = true)]
     enum Args {
         SomeCommand {
-            #[clap(subcommand)]
+            #[command(subcommand)]
             sub: SubSubCommand,
         },
         AnotherCommand,
     }
 
     #[derive(Subcommand)]
-    #[clap(infer_subcommands = true)]
+    #[command(infer_subcommands = true)]
     enum SubSubCommand {
         TestCommand,
     }
@@ -59,10 +59,10 @@ fn issue_324() {
     }
 
     #[derive(Parser)]
-    #[clap(version = my_version())]
-    #[clap(help_template = utils::FULL_TEMPLATE)]
+    #[command(version = my_version())]
+    #[command(help_template = utils::FULL_TEMPLATE)]
     struct Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         _cmd: SubCommand,
     }
 
@@ -79,7 +79,7 @@ fn issue_324() {
 fn issue_418() {
     #[derive(Debug, Parser)]
     struct Opts {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         /// The command to run
         command: Command,
     }
@@ -87,13 +87,13 @@ fn issue_418() {
     #[derive(Debug, Subcommand)]
     enum Command {
         /// Reticulate the splines
-        #[clap(visible_alias = "ret")]
+        #[command(visible_alias = "ret")]
         Reticulate {
             /// How many splines
             num_splines: u8,
         },
         /// Frobnicate the rest
-        #[clap(visible_alias = "frob")]
+        #[command(visible_alias = "frob")]
         Frobnicate,
     }
 
@@ -123,7 +123,7 @@ fn issue_490() {
     #[derive(Parser, Debug)]
     struct Opt {
         opt_vec: Vec<u16>,
-        #[clap(long)]
+        #[arg(long)]
         opt_opt_vec: Option<Vec<u16>>,
     }
 

--- a/tests/derive/macros.rs
+++ b/tests/derive/macros.rs
@@ -22,7 +22,7 @@ fn use_option() {
         ($name:ident: $ty:ty) => {
             #[derive(Parser)]
             struct Outer {
-                #[clap(short, long)]
+                #[arg(short, long)]
                 #[allow(dead_code)]
                 $name: $ty,
             }
@@ -47,7 +47,7 @@ fn issue_447() {
     }
 
     Command! {GitCmd, [
-      #[clap(external_subcommand)]
+      #[command(external_subcommand)]
       Ext(Vec<String>)
     ]}
 }

--- a/tests/derive/naming.rs
+++ b/tests/derive/naming.rs
@@ -5,7 +5,7 @@ fn test_standalone_long_generates_kebab_case() {
     #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
-        #[clap(long)]
+        #[arg(long)]
         FOO_OPTION: bool,
     }
 
@@ -19,7 +19,7 @@ fn test_standalone_long_generates_kebab_case() {
 fn test_custom_long_overwrites_default_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(long = "foo")]
+        #[arg(long = "foo")]
         foo_option: bool,
     }
 
@@ -33,7 +33,7 @@ fn test_custom_long_overwrites_default_name() {
 fn test_standalone_long_uses_previous_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(name = "foo", long)]
+        #[arg(name = "foo", long)]
         foo_option: bool,
     }
 
@@ -47,7 +47,7 @@ fn test_standalone_long_uses_previous_defined_custom_name() {
 fn test_standalone_long_ignores_afterwards_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(long, name = "foo")]
+        #[arg(long, name = "foo")]
         foo_option: bool,
     }
 
@@ -61,7 +61,7 @@ fn test_standalone_long_ignores_afterwards_defined_custom_name() {
 fn test_standalone_long_uses_previous_defined_custom_id() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(id = "foo", long)]
+        #[arg(id = "foo", long)]
         foo_option: bool,
     }
 
@@ -75,7 +75,7 @@ fn test_standalone_long_uses_previous_defined_custom_id() {
 fn test_standalone_long_ignores_afterwards_defined_custom_id() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(long, id = "foo")]
+        #[arg(long, id = "foo")]
         foo_option: bool,
     }
 
@@ -90,7 +90,7 @@ fn test_standalone_short_generates_kebab_case() {
     #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         FOO_OPTION: bool,
     }
 
@@ -104,7 +104,7 @@ fn test_standalone_short_generates_kebab_case() {
 fn test_custom_short_overwrites_default_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short = 'o')]
+        #[arg(short = 'o')]
         foo_option: bool,
     }
 
@@ -118,7 +118,7 @@ fn test_custom_short_overwrites_default_name() {
 fn test_standalone_short_uses_previous_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(name = "option", short)]
+        #[arg(name = "option", short)]
         foo_option: bool,
     }
 
@@ -132,7 +132,7 @@ fn test_standalone_short_uses_previous_defined_custom_name() {
 fn test_standalone_short_ignores_afterwards_defined_custom_name() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short, name = "option")]
+        #[arg(short, name = "option")]
         foo_option: bool,
     }
 
@@ -146,7 +146,7 @@ fn test_standalone_short_ignores_afterwards_defined_custom_name() {
 fn test_standalone_short_uses_previous_defined_custom_id() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(id = "option", short)]
+        #[arg(id = "option", short)]
         foo_option: bool,
     }
 
@@ -160,7 +160,7 @@ fn test_standalone_short_uses_previous_defined_custom_id() {
 fn test_standalone_short_ignores_afterwards_defined_custom_id() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short, id = "option")]
+        #[arg(short, id = "option")]
         foo_option: bool,
     }
 
@@ -174,7 +174,7 @@ fn test_standalone_short_ignores_afterwards_defined_custom_id() {
 fn test_standalone_long_uses_previous_defined_casing() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "screaming_snake", long)]
+        #[arg(rename_all = "screaming_snake", long)]
         foo_option: bool,
     }
 
@@ -188,7 +188,7 @@ fn test_standalone_long_uses_previous_defined_casing() {
 fn test_standalone_short_uses_previous_defined_casing() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "screaming_snake", short)]
+        #[arg(rename_all = "screaming_snake", short)]
         foo_option: bool,
     }
 
@@ -203,7 +203,7 @@ fn test_standalone_long_works_with_verbatim_casing() {
     #[derive(Parser, Debug, PartialEq)]
     #[allow(non_snake_case)]
     struct Opt {
-        #[clap(rename_all = "verbatim", long)]
+        #[arg(rename_all = "verbatim", long)]
         _fOO_oPtiON: bool,
     }
 
@@ -217,7 +217,7 @@ fn test_standalone_long_works_with_verbatim_casing() {
 fn test_standalone_short_works_with_verbatim_casing() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "verbatim", short)]
+        #[arg(rename_all = "verbatim", short)]
         _foo: bool,
     }
 
@@ -230,9 +230,9 @@ fn test_standalone_short_works_with_verbatim_casing() {
 #[test]
 fn test_rename_all_is_propagated_from_struct_to_fields() {
     #[derive(Parser, Debug, PartialEq)]
-    #[clap(rename_all = "screaming_snake")]
+    #[command(rename_all = "screaming_snake")]
     struct Opt {
-        #[clap(long)]
+        #[arg(long)]
         foo: bool,
     }
 
@@ -245,15 +245,15 @@ fn test_rename_all_is_propagated_from_struct_to_fields() {
 #[test]
 fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
     #[derive(Parser, Debug, PartialEq)]
-    #[clap(rename_all = "screaming_snake")]
+    #[command(rename_all = "screaming_snake")]
     struct Opt {
-        #[clap(flatten)]
+        #[command(flatten)]
         foo: Foo,
     }
 
     #[derive(Parser, Debug, PartialEq)]
     struct Foo {
-        #[clap(long)]
+        #[arg(long)]
         foo: bool,
     }
 
@@ -269,7 +269,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
 fn test_lower_is_renamed() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "lower", long)]
+        #[arg(rename_all = "lower", long)]
         foo_option: bool,
     }
 
@@ -283,7 +283,7 @@ fn test_lower_is_renamed() {
 fn test_upper_is_renamed() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(rename_all = "upper", long)]
+        #[arg(rename_all = "upper", long)]
         foo_option: bool,
     }
 
@@ -322,16 +322,16 @@ fn test_multi_word_enum_variant_is_renamed() {
 #[test]
 fn test_rename_all_is_not_propagated_from_struct_into_subcommand() {
     #[derive(Parser, Debug, PartialEq)]
-    #[clap(rename_all = "screaming_snake")]
+    #[command(rename_all = "screaming_snake")]
     struct Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         foo: Foo,
     }
 
     #[derive(Parser, Debug, PartialEq)]
     enum Foo {
         Command {
-            #[clap(long)]
+            #[arg(long)]
             foo: bool,
         },
     }
@@ -347,11 +347,11 @@ fn test_rename_all_is_not_propagated_from_struct_into_subcommand() {
 #[test]
 fn test_rename_all_is_propagated_from_enum_to_variants() {
     #[derive(Parser, Debug, PartialEq)]
-    #[clap(rename_all = "screaming_snake")]
+    #[command(rename_all = "screaming_snake")]
     enum Opt {
         FirstVariant,
         SecondVariant {
-            #[clap(long)]
+            #[arg(long)]
             foo: String,
         },
     }
@@ -365,11 +365,11 @@ fn test_rename_all_is_propagated_from_enum_to_variants() {
 #[test]
 fn test_rename_all_is_propagated_from_enum_to_variant_fields() {
     #[derive(Parser, Debug, PartialEq)]
-    #[clap(rename_all = "screaming_snake")]
+    #[command(rename_all = "screaming_snake")]
     enum Opt {
         FirstVariant,
         SecondVariant {
-            #[clap(long)]
+            #[arg(long)]
             foo: String,
         },
     }
@@ -385,15 +385,15 @@ fn test_rename_all_is_propagated_from_enum_to_variant_fields() {
 #[test]
 fn test_rename_all_is_propagation_can_be_overridden() {
     #[derive(Parser, Debug, PartialEq)]
-    #[clap(rename_all = "screaming_snake")]
+    #[command(rename_all = "screaming_snake")]
     enum Opt {
-        #[clap(rename_all = "kebab_case")]
+        #[command(rename_all = "kebab_case")]
         FirstVariant {
-            #[clap(long)]
+            #[arg(long)]
             foo_option: bool,
         },
         SecondVariant {
-            #[clap(rename_all = "kebab_case", long)]
+            #[arg(rename_all = "kebab_case", long)]
             foo_option: bool,
         },
     }

--- a/tests/derive/nested_subcommands.rs
+++ b/tests/derive/nested_subcommands.rs
@@ -16,11 +16,11 @@ use clap::{Parser, Subcommand};
 
 #[derive(Parser, PartialEq, Debug)]
 struct Opt {
-    #[clap(short, long)]
+    #[arg(short, long)]
     force: bool,
-    #[clap(short, long, action = clap::ArgAction::Count)]
+    #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Sub,
 }
 
@@ -32,11 +32,11 @@ enum Sub {
 
 #[derive(Parser, PartialEq, Debug)]
 struct Opt2 {
-    #[clap(short, long)]
+    #[arg(short, long)]
     force: bool,
-    #[clap(short, long, action = clap::ArgAction::Count)]
+    #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Option<Sub>,
 }
 
@@ -109,9 +109,9 @@ fn test_badinput() {
 
 #[derive(Parser, PartialEq, Debug)]
 struct Opt3 {
-    #[clap(short, long)]
+    #[arg(short, long)]
     all: bool,
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Sub2,
 }
 
@@ -119,7 +119,7 @@ struct Opt3 {
 enum Sub2 {
     Foo {
         file: String,
-        #[clap(subcommand)]
+        #[command(subcommand)]
         cmd: Sub3,
     },
     Bar {},
@@ -148,11 +148,11 @@ fn test_subsubcommand() {
 #[derive(Parser, PartialEq, Debug)]
 enum SubSubCmdWithOption {
     Remote {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         cmd: Option<Remote>,
     },
     Stash {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         cmd: Stash,
     },
 }

--- a/tests/derive/non_literal_attributes.rs
+++ b/tests/derive/non_literal_attributes.rs
@@ -20,9 +20,9 @@ pub const DISPLAY_ORDER: usize = 2;
 
 // Check if the global settings compile
 #[derive(Parser, Debug, PartialEq, Eq)]
-#[clap(allow_hyphen_values = true)]
+#[command(allow_hyphen_values = true)]
 struct Opt {
-    #[clap(
+    #[arg(
         long = "x",
         display_order = DISPLAY_ORDER,
         next_line_help = true,
@@ -31,13 +31,13 @@ struct Opt {
     )]
     x: i32,
 
-    #[clap(short = 'l', long = "level", aliases = ["set-level", "lvl"])]
+    #[arg(short = 'l', long = "level", aliases = ["set-level", "lvl"])]
     level: String,
 
-    #[clap(long("values"))]
+    #[arg(long("values"))]
     values: Vec<i32>,
 
-    #[clap(name = "FILE", requires_if("FILE", "values"))]
+    #[arg(name = "FILE", requires_if("FILE", "values"))]
     files: Vec<String>,
 }
 
@@ -131,7 +131,7 @@ fn parse_hex(input: &str) -> Result<u64, ParseIntError> {
 
 #[derive(Parser, PartialEq, Debug)]
 struct HexOpt {
-    #[clap(short, value_parser = parse_hex)]
+    #[arg(short, value_parser = parse_hex)]
     number: u64,
 }
 

--- a/tests/derive/options.rs
+++ b/tests/derive/options.rs
@@ -22,7 +22,7 @@ use clap::{Parser, Subcommand};
 fn required_option() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short, long)]
+        #[arg(short, long)]
         arg: i32,
     }
     assert_eq!(
@@ -48,7 +48,7 @@ fn required_option() {
 fn option_with_default() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short, default_value = "42")]
+        #[arg(short, default_value = "42")]
         arg: i32,
     }
     assert_eq!(
@@ -66,7 +66,7 @@ fn option_with_default() {
 fn option_with_raw_default() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short, default_value = "42")]
+        #[arg(short, default_value = "42")]
         arg: i32,
     }
     assert_eq!(
@@ -148,7 +148,7 @@ fn option_vec_from_str() {
 
     #[derive(Debug, Parser, PartialEq)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         a: Option<Vec<A>>,
     }
 
@@ -163,7 +163,7 @@ fn option_vec_from_str() {
 fn option_type_is_optional() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         arg: Option<i32>,
     }
     assert_eq!(
@@ -180,19 +180,19 @@ fn option_type_is_optional() {
 #[test]
 fn required_with_option_type() {
     #[derive(Debug, PartialEq, Eq, Parser)]
-    #[clap(subcommand_negates_reqs = true)]
+    #[command(subcommand_negates_reqs = true)]
     struct Opt {
-        #[clap(required = true)]
+        #[arg(required = true)]
         req_str: Option<String>,
 
-        #[clap(subcommand)]
+        #[command(subcommand)]
         cmd: Option<SubCommands>,
     }
 
     #[derive(Debug, PartialEq, Eq, Subcommand)]
     enum SubCommands {
         ExSub {
-            #[clap(short, long, action = clap::ArgAction::Count)]
+            #[arg(short, long, action = clap::ArgAction::Count)]
             verbose: u8,
         },
     }
@@ -224,7 +224,7 @@ fn ignore_qualified_option_type() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_parser = parser)]
+        #[arg(value_parser = parser)]
         arg: ::std::option::Option<String>,
     }
 
@@ -240,7 +240,7 @@ fn ignore_qualified_option_type() {
 fn option_option_type_is_optional_value() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         #[allow(clippy::option_option)]
         arg: Option<Option<i32>>,
     }
@@ -267,7 +267,7 @@ fn option_option_type_is_optional_value() {
 fn option_option_type_help() {
     #[derive(Parser, Debug)]
     struct Opt {
-        #[clap(long, value_name = "val")]
+        #[arg(long, value_name = "val")]
         arg: Option<Option<i32>>,
     }
     let help = utils::get_help::<Opt>();
@@ -279,10 +279,10 @@ fn option_option_type_help() {
 fn two_option_option_types() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         arg: Option<Option<i32>>,
 
-        #[clap(long)]
+        #[arg(long)]
         field: Option<Option<String>>,
     }
     assert_eq!(
@@ -333,7 +333,7 @@ fn two_option_option_types() {
 fn vec_type_is_multiple_occurrences() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short, long)]
+        #[arg(short, long)]
         arg: Vec<i32>,
     }
     assert_eq!(
@@ -351,7 +351,7 @@ fn vec_type_is_multiple_occurrences() {
 fn vec_type_with_required() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short, long, required = true)]
+        #[arg(short, long, required = true)]
         arg: Vec<i32>,
     }
     assert_eq!(
@@ -369,7 +369,7 @@ fn vec_type_with_required() {
 fn vec_type_with_multiple_values_only() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short, long, num_args(1..))]
+        #[arg(short, long, num_args(1..))]
         arg: Vec<i32>,
     }
     assert_eq!(
@@ -391,7 +391,7 @@ fn ignore_qualified_vec_type() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_parser = parser)]
+        #[arg(value_parser = parser)]
         arg: ::std::vec::Vec<String>,
     }
 
@@ -407,7 +407,7 @@ fn ignore_qualified_vec_type() {
 fn option_vec_type() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         arg: Option<Vec<i32>>,
     }
     assert_eq!(
@@ -429,7 +429,7 @@ fn option_vec_type() {
 fn option_vec_type_structopt_behavior() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short, long, num_args(0..))]
+        #[arg(short, long, num_args(0..))]
         arg: Option<Vec<i32>>,
     }
     assert_eq!(
@@ -456,10 +456,10 @@ fn option_vec_type_structopt_behavior() {
 fn two_option_vec_types() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         arg: Option<Vec<i32>>,
 
-        #[clap(short)]
+        #[arg(short)]
         b: Option<Vec<i32>>,
     }
 
@@ -497,7 +497,7 @@ fn two_option_vec_types() {
 fn explicit_value_parser() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(long, value_parser = clap::value_parser!(i32))]
+        #[arg(long, value_parser = clap::value_parser!(i32))]
         arg: i32,
     }
     assert_eq!(
@@ -510,7 +510,7 @@ fn explicit_value_parser() {
 fn implicit_value_parser() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(long)]
+        #[arg(long)]
         arg: i32,
     }
     assert_eq!(

--- a/tests/derive/privacy.rs
+++ b/tests/derive/privacy.rs
@@ -17,7 +17,7 @@ mod options {
 
     #[derive(Debug, Parser)]
     pub struct Options {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         pub subcommand: super::subcommands::SubCommand,
     }
 }

--- a/tests/derive/raw_bool_literal.rs
+++ b/tests/derive/raw_bool_literal.rs
@@ -11,11 +11,11 @@ use clap::Parser;
 #[test]
 fn raw_bool_literal() {
     #[derive(Parser, Debug, PartialEq)]
-    #[clap(name = "raw_bool")]
+    #[command(name = "raw_bool")]
     struct Opt {
-        #[clap(raw(false))]
+        #[arg(raw(false))]
         a: String,
-        #[clap(raw(true))]
+        #[arg(raw(true))]
         b: String,
     }
 

--- a/tests/derive/raw_idents.rs
+++ b/tests/derive/raw_idents.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 fn raw_idents() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short, long)]
+        #[arg(short, long)]
         r#type: String,
     }
 

--- a/tests/derive/rename_all_env.rs
+++ b/tests/derive/rename_all_env.rs
@@ -7,9 +7,9 @@ use clap::Parser;
 #[test]
 fn it_works() {
     #[derive(Debug, PartialEq, Parser)]
-    #[clap(rename_all_env = "kebab")]
+    #[command(rename_all_env = "kebab")]
     struct BehaviorModel {
-        #[clap(env)]
+        #[arg(env)]
         be_nice: String,
     }
 
@@ -21,7 +21,7 @@ fn it_works() {
 fn default_is_screaming() {
     #[derive(Debug, PartialEq, Parser)]
     struct BehaviorModel {
-        #[clap(env)]
+        #[arg(env)]
         be_nice: String,
     }
 
@@ -32,12 +32,12 @@ fn default_is_screaming() {
 #[test]
 fn overridable() {
     #[derive(Debug, PartialEq, Parser)]
-    #[clap(rename_all_env = "kebab")]
+    #[command(rename_all_env = "kebab")]
     struct BehaviorModel {
-        #[clap(env)]
+        #[arg(env)]
         be_nice: String,
 
-        #[clap(rename_all_env = "pascal", env)]
+        #[arg(rename_all_env = "pascal", env)]
         be_aggressive: String,
     }
 

--- a/tests/derive/skip.rs
+++ b/tests/derive/skip.rs
@@ -12,9 +12,9 @@ use clap::Parser;
 fn skip_1() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         x: u32,
-        #[clap(skip)]
+        #[arg(skip)]
         s: u32,
     }
 
@@ -39,15 +39,15 @@ fn skip_1() {
 fn skip_2() {
     #[derive(Parser, Debug, PartialEq)]
     struct Opt {
-        #[clap(short)]
+        #[arg(short)]
         x: u32,
-        #[clap(skip)]
+        #[arg(skip)]
         ss: String,
-        #[clap(skip)]
+        #[arg(skip)]
         sn: u8,
 
         y: u32,
-        #[clap(skip)]
+        #[arg(skip)]
         sz: u16,
 
         t: u32,
@@ -83,11 +83,11 @@ fn skip_enum() {
 
     #[derive(Parser, Debug, PartialEq)]
     pub struct Opt {
-        #[clap(long, short)]
+        #[arg(long, short)]
         number: u32,
-        #[clap(skip)]
+        #[arg(skip)]
         k: Kind,
-        #[clap(skip)]
+        #[arg(skip)]
         v: Vec<u32>,
     }
 
@@ -105,19 +105,19 @@ fn skip_enum() {
 fn skip_help_doc_comments() {
     #[derive(Parser, Debug, PartialEq, Eq)]
     pub struct Opt {
-        #[clap(skip, help = "internal_stuff")]
+        #[arg(skip, help = "internal_stuff")]
         a: u32,
 
-        #[clap(skip, long_help = "internal_stuff\ndo not touch")]
+        #[arg(skip, long_help = "internal_stuff\ndo not touch")]
         b: u32,
 
         /// Not meant to be used by clap.
         ///
         /// I want a default here.
-        #[clap(skip)]
+        #[arg(skip)]
         c: u32,
 
-        #[clap(short)]
+        #[arg(short)]
         n: u32,
     }
 
@@ -136,13 +136,13 @@ fn skip_help_doc_comments() {
 fn skip_val() {
     #[derive(Parser, Debug, PartialEq, Eq)]
     pub struct Opt {
-        #[clap(long, short)]
+        #[arg(long, short)]
         number: u32,
 
-        #[clap(skip = "key")]
+        #[arg(skip = "key")]
         k: String,
 
-        #[clap(skip = vec![1, 2, 3])]
+        #[arg(skip = vec![1, 2, 3])]
         v: Vec<u32>,
     }
 

--- a/tests/derive/subcommands.rs
+++ b/tests/derive/subcommands.rs
@@ -20,19 +20,19 @@ use clap::{Args, Parser, Subcommand};
 enum Opt {
     /// Fetch stuff from GitHub
     Fetch {
-        #[clap(long)]
+        #[arg(long)]
         all: bool,
         /// Overwrite local branches.
-        #[clap(short, long)]
+        #[arg(short, long)]
         force: bool,
 
         repo: String,
     },
 
     Add {
-        #[clap(short, long)]
+        #[arg(short, long)]
         interactive: bool,
-        #[clap(short, long)]
+        #[arg(short, long)]
         verbose: bool,
     },
 }
@@ -122,7 +122,7 @@ fn test_null_commands() {
 }
 
 #[derive(Parser, PartialEq, Eq, Debug)]
-#[clap(about = "Not shown")]
+#[command(about = "Not shown")]
 struct Add {
     file: String,
 }
@@ -168,9 +168,9 @@ fn test_tuple_commands() {
 fn global_passed_down() {
     #[derive(Debug, PartialEq, Eq, Parser)]
     struct Opt {
-        #[clap(global = true, long)]
+        #[arg(global = true, long)]
         other: bool,
-        #[clap(subcommand)]
+        #[command(subcommand)]
         sub: Subcommands,
     }
 
@@ -182,7 +182,7 @@ fn global_passed_down() {
 
     #[derive(Debug, PartialEq, Eq, Args)]
     struct GlobalCmd {
-        #[clap(from_global)]
+        #[arg(from_global)]
         other: bool,
     }
 
@@ -207,7 +207,7 @@ fn global_passed_down() {
 fn external_subcommand() {
     #[derive(Debug, PartialEq, Eq, Parser)]
     struct Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         sub: Subcommands,
     }
 
@@ -215,7 +215,7 @@ fn external_subcommand() {
     enum Subcommands {
         Add,
         Remove,
-        #[clap(external_subcommand)]
+        #[command(external_subcommand)]
         Other(Vec<String>),
     }
 
@@ -249,13 +249,13 @@ fn external_subcommand_os_string() {
 
     #[derive(Debug, PartialEq, Eq, Parser)]
     struct Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         sub: Subcommands,
     }
 
     #[derive(Debug, PartialEq, Eq, Subcommand)]
     enum Subcommands {
-        #[clap(external_subcommand)]
+        #[command(external_subcommand)]
         Other(Vec<OsString>),
     }
 
@@ -273,13 +273,13 @@ fn external_subcommand_os_string() {
 fn external_subcommand_optional() {
     #[derive(Debug, PartialEq, Eq, Parser)]
     struct Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         sub: Option<Subcommands>,
     }
 
     #[derive(Debug, PartialEq, Eq, Subcommand)]
     enum Subcommands {
-        #[clap(external_subcommand)]
+        #[command(external_subcommand)]
         Other(Vec<String>),
     }
 
@@ -297,9 +297,9 @@ fn external_subcommand_optional() {
 fn enum_in_enum_subsubcommand() {
     #[derive(Parser, Debug, PartialEq, Eq)]
     pub enum Opt {
-        #[clap(alias = "l")]
+        #[command(alias = "l")]
         List,
-        #[clap(subcommand, alias = "d")]
+        #[command(subcommand, alias = "d")]
         Daemon(DaemonCommand),
     }
 
@@ -378,9 +378,9 @@ fn update_subcommands() {
 fn update_sub_subcommands() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     enum Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         Child1(Child1),
-        #[clap(subcommand)]
+        #[command(subcommand)]
         Child2(Child2),
     }
 
@@ -451,7 +451,7 @@ fn update_ext_subcommand() {
     enum Opt {
         Command1(Command1),
         Command2(Command2),
-        #[clap(external_subcommand)]
+        #[command(external_subcommand)]
         Ext(Vec<String>),
     }
 
@@ -503,13 +503,13 @@ fn subcommand_name_not_literal() {
 
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         subcmd: SubCmd,
     }
 
     #[derive(Subcommand, PartialEq, Eq, Debug)]
     enum SubCmd {
-        #[clap(name = get_name())]
+        #[command(name = get_name())]
         SubCmd1,
     }
 
@@ -520,7 +520,7 @@ fn subcommand_name_not_literal() {
 fn skip_subcommand() {
     #[derive(Debug, PartialEq, Eq, Parser)]
     struct Opt {
-        #[clap(subcommand)]
+        #[command(subcommand)]
         sub: Subcommands,
     }
 
@@ -530,7 +530,7 @@ fn skip_subcommand() {
         Remove,
 
         #[allow(dead_code)]
-        #[clap(skip)]
+        #[command(skip)]
         Skip,
     }
 
@@ -562,7 +562,7 @@ fn built_in_subcommand_escaped() {
         Install {
             arg: Option<String>,
         },
-        #[clap(external_subcommand)]
+        #[command(external_subcommand)]
         Custom(Vec<String>),
     }
 

--- a/tests/derive/type_alias_regressions.rs
+++ b/tests/derive/type_alias_regressions.rs
@@ -11,9 +11,9 @@ type Option<T> = std::option::Option<T>;
 #[derive(Parser)]
 pub struct Opts {
     another_string: String,
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Command,
-    #[clap(short, long, value_enum)]
+    #[arg(short, long, value_enum)]
     choice: ArgChoice,
 }
 

--- a/tests/derive/utf8.rs
+++ b/tests/derive/utf8.rs
@@ -12,7 +12,7 @@ struct Positional {
 
 #[derive(Parser, Debug, PartialEq, Eq)]
 struct Named {
-    #[clap(short, long)]
+    #[arg(short, long)]
     arg: String,
 }
 
@@ -82,7 +82,7 @@ struct PositionalOs {
 
 #[derive(Parser, Debug, PartialEq, Eq)]
 struct NamedOs {
-    #[clap(short, long)]
+    #[arg(short, long)]
     arg: OsString,
 }
 
@@ -171,7 +171,7 @@ fn invalid_utf8_option_long_equals() {
 
 #[derive(Debug, PartialEq, Parser)]
 enum External {
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     Other(Vec<String>),
 }
 
@@ -201,7 +201,7 @@ fn refuse_invalid_utf8_subcommand_args_with_allow_external_subcommands() {
 
 #[derive(Debug, PartialEq, Parser)]
 enum ExternalOs {
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     Other(Vec<OsString>),
 }
 

--- a/tests/derive/value_enum.rs
+++ b/tests/derive/value_enum.rs
@@ -19,7 +19,7 @@ fn basic() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         arg: ArgChoice,
     }
 
@@ -54,7 +54,7 @@ fn default_value() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, default_value_t)]
+        #[arg(value_enum, default_value_t)]
         arg: ArgChoice,
     }
 
@@ -88,10 +88,10 @@ fn vec_for_default_values_t() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, default_values_t = vec![ArgChoice::Foo, ArgChoice::Bar])]
+        #[arg(value_enum, default_values_t = vec![ArgChoice::Foo, ArgChoice::Bar])]
         arg1: Vec<ArgChoice>,
 
-        #[clap(
+        #[arg(
             long,
             value_enum,
             default_values_t = clap::ValueEnum::value_variants()
@@ -139,10 +139,10 @@ fn vec_for_default_values_os_t() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, default_values_os_t = vec![ArgChoice::Foo, ArgChoice::Bar])]
+        #[arg(value_enum, default_values_os_t = vec![ArgChoice::Foo, ArgChoice::Bar])]
         arg: Vec<ArgChoice>,
 
-        #[clap(
+        #[arg(
             long,
             value_enum,
             default_values_os_t = clap::ValueEnum::value_variants()
@@ -191,7 +191,7 @@ fn multi_word_is_renamed_kebab() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         arg: ArgChoice,
     }
 
@@ -214,13 +214,13 @@ fn multi_word_is_renamed_kebab() {
 fn variant_with_defined_casing() {
     #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
     enum ArgChoice {
-        #[clap(rename_all = "screaming_snake")]
+        #[value(rename_all = "screaming_snake")]
         FooBar,
     }
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         arg: ArgChoice,
     }
 
@@ -236,14 +236,14 @@ fn variant_with_defined_casing() {
 #[test]
 fn casing_is_propagated_from_parent() {
     #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
-    #[clap(rename_all = "screaming_snake")]
+    #[value(rename_all = "screaming_snake")]
     enum ArgChoice {
         FooBar,
     }
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         arg: ArgChoice,
     }
 
@@ -259,15 +259,15 @@ fn casing_is_propagated_from_parent() {
 #[test]
 fn casing_propagation_is_overridden() {
     #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
-    #[clap(rename_all = "screaming_snake")]
+    #[value(rename_all = "screaming_snake")]
     enum ArgChoice {
-        #[clap(rename_all = "camel")]
+        #[value(rename_all = "camel")]
         FooBar,
     }
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         arg: ArgChoice,
     }
 
@@ -290,7 +290,7 @@ fn ignore_case() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, ignore_case(true))]
+        #[arg(value_enum, ignore_case(true))]
         arg: ArgChoice,
     }
 
@@ -317,7 +317,7 @@ fn ignore_case_set_to_false() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, ignore_case(false))]
+        #[arg(value_enum, ignore_case(false))]
         arg: ArgChoice,
     }
 
@@ -334,13 +334,13 @@ fn ignore_case_set_to_false() {
 fn alias() {
     #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
     enum ArgChoice {
-        #[clap(alias = "TOTP")]
+        #[value(alias = "TOTP")]
         Totp,
     }
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, ignore_case(false))]
+        #[arg(value_enum, ignore_case(false))]
         arg: ArgChoice,
     }
 
@@ -362,13 +362,13 @@ fn alias() {
 fn multiple_alias() {
     #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
     enum ArgChoice {
-        #[clap(alias = "TOTP", alias = "t")]
+        #[value(alias = "TOTP", alias = "t")]
         Totp,
     }
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, ignore_case(false))]
+        #[arg(value_enum, ignore_case(false))]
         arg: ArgChoice,
     }
 
@@ -399,7 +399,7 @@ fn skip_variant() {
     enum ArgChoice {
         Foo,
         Bar,
-        #[clap(skip)]
+        #[value(skip)]
         Baz,
     }
 
@@ -430,7 +430,7 @@ fn skip_non_unit_variant() {
     enum ArgChoice {
         Foo,
         Bar,
-        #[clap(skip)]
+        #[value(skip)]
         Baz(usize),
     }
 
@@ -477,7 +477,7 @@ fn option_type() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum)]
+        #[arg(value_enum)]
         arg: Option<ArgChoice>,
     }
 
@@ -507,7 +507,7 @@ fn option_option_type() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, long)]
+        #[arg(value_enum, long)]
         arg: Option<Option<ArgChoice>>,
     }
 
@@ -541,7 +541,7 @@ fn vec_type() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, short, long)]
+        #[arg(value_enum, short, long)]
         arg: Vec<ArgChoice>,
     }
 
@@ -571,7 +571,7 @@ fn option_vec_type() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(value_enum, short, long)]
+        #[arg(value_enum, short, long)]
         arg: Option<Vec<ArgChoice>>,
     }
 
@@ -602,7 +602,7 @@ fn vec_type_default_value() {
 
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {
-        #[clap(
+        #[arg(
             value_enum,
             short,
             long,

--- a/tests/derive_ui/bool_value_enum.rs
+++ b/tests/derive_ui/bool_value_enum.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
-    #[clap(short, value_enum, default_value_t)]
+    #[arg(short, value_enum, default_value_t)]
     opts: bool,
 }
 

--- a/tests/derive_ui/bool_value_enum.stderr
+++ b/tests/derive_ui/bool_value_enum.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `bool: ValueEnum` is not satisfied
- --> tests/derive_ui/bool_value_enum.rs:6:31
+ --> tests/derive_ui/bool_value_enum.rs:6:30
   |
-6 |     #[clap(short, value_enum, default_value_t)]
-  |                               ^^^^^^^^^^^^^^^ the trait `ValueEnum` is not implemented for `bool`
+6 |     #[arg(short, value_enum, default_value_t)]
+  |                              ^^^^^^^^^^^^^^^ the trait `ValueEnum` is not implemented for `bool`

--- a/tests/derive_ui/clap_empty_attr.rs
+++ b/tests/derive_ui/clap_empty_attr.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap]
+#[command]
 struct Opt {}
 
 #[derive(Parser, Debug)]
 struct Opt1 {
-    #[clap = "short"]
+    #[arg = "short"]
     foo: u32,
 }
 

--- a/tests/derive_ui/clap_empty_attr.stderr
+++ b/tests/derive_ui/clap_empty_attr.stderr
@@ -1,11 +1,11 @@
-error: expected attribute arguments in parentheses: #[clap(...)]
- --> $DIR/clap_empty_attr.rs:4:1
+error: expected attribute arguments in parentheses: #[command(...)]
+ --> tests/derive_ui/clap_empty_attr.rs:4:1
   |
-4 | #[clap]
-  | ^^^^^^^
+4 | #[command]
+  | ^^^^^^^^^^
 
-error: expected parentheses: #[clap(...)]
- --> $DIR/clap_empty_attr.rs:9:12
+error: expected parentheses: #[arg(...)]
+ --> tests/derive_ui/clap_empty_attr.rs:9:11
   |
-9 |     #[clap = "short"]
-  |            ^
+9 |     #[arg = "short"]
+  |           ^

--- a/tests/derive_ui/default_value_t_invalid.rs
+++ b/tests/derive_ui/default_value_t_invalid.rs
@@ -9,9 +9,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
-    #[clap(default_value_t = -10)]
+    #[arg(default_value_t = -10)]
     value: u32,
 }
 

--- a/tests/derive_ui/default_value_t_invalid.stderr
+++ b/tests/derive_ui/default_value_t_invalid.stderr
@@ -1,7 +1,7 @@
 error[E0600]: cannot apply unary operator `-` to type `u32`
-  --> tests/derive_ui/default_value_t_invalid.rs:14:30
+  --> tests/derive_ui/default_value_t_invalid.rs:14:29
    |
-14 |     #[clap(default_value_t = -10)]
-   |                              ^^^ cannot apply unary operator `-`
+14 |     #[arg(default_value_t = -10)]
+   |                             ^^^ cannot apply unary operator `-`
    |
    = note: unsigned values cannot be negated

--- a/tests/derive_ui/default_values_t_invalid.rs
+++ b/tests/derive_ui/default_values_t_invalid.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
-    #[clap(default_values_t = [1, 2, 3])]
+    #[arg(default_values_t = [1, 2, 3])]
     value: u32,
 }
 

--- a/tests/derive_ui/default_values_t_invalid.stderr
+++ b/tests/derive_ui/default_values_t_invalid.stderr
@@ -1,8 +1,8 @@
-error: #[clap(default_values_t)] can be used only on Vec types
+error: #[arg(default_values_t)] can be used only on Vec types
 
          = note: see https://github.com/clap-rs/clap/blob/master/examples/derive_ref/README.md#magic-attributes
 
- --> tests/derive_ui/default_values_t_invalid.rs:6:12
+ --> tests/derive_ui/default_values_t_invalid.rs:6:11
   |
-6 |     #[clap(default_values_t = [1, 2, 3])]
-  |            ^^^^^^^^^^^^^^^^
+6 |     #[arg(default_values_t = [1, 2, 3])]
+  |           ^^^^^^^^^^^^^^^^

--- a/tests/derive_ui/enum_flatten.rs
+++ b/tests/derive_ui/enum_flatten.rs
@@ -9,9 +9,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 enum Opt {
-    #[clap(flatten)]
+    #[command(flatten)]
     Variant1,
 }
 

--- a/tests/derive_ui/enum_flatten.stderr
+++ b/tests/derive_ui/enum_flatten.stderr
@@ -1,6 +1,6 @@
 error: `flatten` is usable only with single-typed tuple variants
-  --> $DIR/enum_flatten.rs:14:5
+  --> tests/derive_ui/enum_flatten.rs:14:5
    |
-14 | /     #[clap(flatten)]
+14 | /     #[command(flatten)]
 15 | |     Variant1,
    | |____________^

--- a/tests/derive_ui/external_subcommand_misuse.rs
+++ b/tests/derive_ui/external_subcommand_misuse.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct Opt {
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     field: String,
 }
 

--- a/tests/derive_ui/external_subcommand_misuse.stderr
+++ b/tests/derive_ui/external_subcommand_misuse.stderr
@@ -1,5 +1,5 @@
 error: `external_subcommand` cannot be used with `arg`
- --> tests/derive_ui/external_subcommand_misuse.rs:5:12
+ --> tests/derive_ui/external_subcommand_misuse.rs:5:15
   |
-5 |     #[clap(external_subcommand)]
-  |            ^^^^^^^^^^^^^^^^^^^
+5 |     #[command(external_subcommand)]
+  |               ^^^^^^^^^^^^^^^^^^^

--- a/tests/derive_ui/external_subcommand_wrong_type.rs
+++ b/tests/derive_ui/external_subcommand_wrong_type.rs
@@ -3,19 +3,19 @@ use std::ffi::CString;
 
 #[derive(Parser, Debug)]
 enum Opt {
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     Other(Vec<CString>),
 }
 
 #[derive(Parser, Debug)]
 enum Opt2 {
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     Other(String),
 }
 
 #[derive(Parser, Debug)]
 enum Opt3 {
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     Other { a: String },
 }
 

--- a/tests/derive_ui/external_subcommand_wrong_type.stderr
+++ b/tests/derive_ui/external_subcommand_wrong_type.stderr
@@ -1,18 +1,18 @@
 error: The type must be either `Vec<String>` or `Vec<OsString>` to be used with `external_subcommand`.
- --> $DIR/external_subcommand_wrong_type.rs:7:11
+ --> tests/derive_ui/external_subcommand_wrong_type.rs:7:11
   |
 7 |     Other(Vec<CString>),
   |           ^^^
 
 error: The type must be either `Vec<String>` or `Vec<OsString>` to be used with `external_subcommand`.
-  --> $DIR/external_subcommand_wrong_type.rs:13:11
+  --> tests/derive_ui/external_subcommand_wrong_type.rs:13:11
    |
 13 |     Other(String),
    |           ^^^^^^
 
 error: The enum variant marked with `external_subcommand` must be a single-typed tuple, and the type must be either `Vec<String>` or `Vec<OsString>`.
-  --> $DIR/external_subcommand_wrong_type.rs:18:5
+  --> tests/derive_ui/external_subcommand_wrong_type.rs:18:5
    |
-18 | /     #[clap(external_subcommand)]
+18 | /     #[command(external_subcommand)]
 19 | |     Other { a: String },
    | |_______________________^

--- a/tests/derive_ui/flatten_and_methods.rs
+++ b/tests/derive_ui/flatten_and_methods.rs
@@ -10,16 +10,16 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct DaemonOpts {
-    #[clap(short)]
+    #[arg(short)]
     user: String,
-    #[clap(short)]
+    #[arg(short)]
     group: String,
 }
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
-    #[clap(short, flatten)]
+    #[command(short, flatten)]
     opts: DaemonOpts,
 }
 

--- a/tests/derive_ui/flatten_and_methods.stderr
+++ b/tests/derive_ui/flatten_and_methods.stderr
@@ -1,5 +1,5 @@
 error: methods are not allowed for flattened entry
-  --> $DIR/flatten_and_methods.rs:22:19
+  --> tests/derive_ui/flatten_and_methods.rs:22:22
    |
-22 |     #[clap(short, flatten)]
-   |                   ^^^^^^^
+22 |     #[command(short, flatten)]
+   |                      ^^^^^^^

--- a/tests/derive_ui/flatten_enum_in_struct.rs
+++ b/tests/derive_ui/flatten_enum_in_struct.rs
@@ -1,6 +1,6 @@
 #[derive(clap::Parser)]
 struct Opt {
-    #[clap(flatten)]
+    #[command(flatten)]
     sub: SubCmd,
 }
 

--- a/tests/derive_ui/flatten_enum_in_struct.stderr
+++ b/tests/derive_ui/flatten_enum_in_struct.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
- --> tests/derive_ui/flatten_enum_in_struct.rs:3:12
+ --> tests/derive_ui/flatten_enum_in_struct.rs:3:15
   |
-3 |     #[clap(flatten)]
-  |            ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+3 |     #[command(flatten)]
+  |               ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`

--- a/tests/derive_ui/flatten_struct_in_enum.rs
+++ b/tests/derive_ui/flatten_struct_in_enum.rs
@@ -1,6 +1,6 @@
 #[derive(clap::Parser)]
 enum Opt {
-    #[clap(flatten)]
+    #[command(flatten)]
     Sub(SubCmd),
 }
 

--- a/tests/derive_ui/multiple_external_subcommand.rs
+++ b/tests/derive_ui/multiple_external_subcommand.rs
@@ -2,16 +2,16 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct Opt {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Command,
 }
 
 #[derive(Parser, Debug)]
 enum Command {
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     Run(Vec<String>),
 
-    #[clap(external_subcommand)]
+    #[command(external_subcommand)]
     Other(Vec<String>),
 }
 

--- a/tests/derive_ui/multiple_external_subcommand.stderr
+++ b/tests/derive_ui/multiple_external_subcommand.stderr
@@ -1,5 +1,5 @@
 error: Only one variant can be marked with `external_subcommand`, this is the second
-  --> $DIR/multiple_external_subcommand.rs:14:12
+  --> tests/derive_ui/multiple_external_subcommand.rs:14:15
    |
-14 |     #[clap(external_subcommand)]
-   |            ^^^^^^^^^^^^^^^^^^^
+14 |     #[command(external_subcommand)]
+   |               ^^^^^^^^^^^^^^^^^^^

--- a/tests/derive_ui/non_existent_attr.rs
+++ b/tests/derive_ui/non_existent_attr.rs
@@ -9,9 +9,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
-    #[clap(short, non_existing_attribute = 1)]
+    #[arg(short, non_existing_attribute = 1)]
     debug: bool,
 }
 

--- a/tests/derive_ui/non_existent_attr.stderr
+++ b/tests/derive_ui/non_existent_attr.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `non_existing_attribute` found for struct `Arg` in the current scope
-  --> tests/derive_ui/non_existent_attr.rs:14:19
+  --> tests/derive_ui/non_existent_attr.rs:14:18
    |
-14 |     #[clap(short, non_existing_attribute = 1)]
-   |                   ^^^^^^^^^^^^^^^^^^^^^^ method not found in `Arg`
+14 |     #[arg(short, non_existing_attribute = 1)]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^ method not found in `Arg`

--- a/tests/derive_ui/opt_opt_nonpositional.rs
+++ b/tests/derive_ui/opt_opt_nonpositional.rs
@@ -9,7 +9,7 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
     n: Option<Option<u32>>,
 }

--- a/tests/derive_ui/opt_vec_nonpositional.rs
+++ b/tests/derive_ui/opt_vec_nonpositional.rs
@@ -9,7 +9,7 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
     n: Option<Vec<u32>>,
 }

--- a/tests/derive_ui/option_default_value.rs
+++ b/tests/derive_ui/option_default_value.rs
@@ -9,9 +9,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt {
-    #[clap(short, default_value = 1)]
+    #[arg(short, default_value = 1)]
     n: Option<u32>,
 }
 

--- a/tests/derive_ui/option_default_value.stderr
+++ b/tests/derive_ui/option_default_value.stderr
@@ -1,5 +1,5 @@
 error: default_value is meaningless for Option
-  --> $DIR/option_default_value.rs:14:19
+  --> tests/derive_ui/option_default_value.rs:14:18
    |
-14 |     #[clap(short, default_value = 1)]
-   |                   ^^^^^^^^^^^^^
+14 |     #[arg(short, default_value = 1)]
+   |                  ^^^^^^^^^^^^^

--- a/tests/derive_ui/rename_all_wrong_casing.rs
+++ b/tests/derive_ui/rename_all_wrong_casing.rs
@@ -9,9 +9,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic", rename_all = "fail")]
+#[command(name = "basic", rename_all = "fail")]
 struct Opt {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 }
 

--- a/tests/derive_ui/rename_all_wrong_casing.stderr
+++ b/tests/derive_ui/rename_all_wrong_casing.stderr
@@ -1,5 +1,5 @@
 error: unsupported casing: `fail`
-  --> $DIR/rename_all_wrong_casing.rs:12:37
+  --> tests/derive_ui/rename_all_wrong_casing.rs:12:40
    |
-12 | #[clap(name = "basic", rename_all = "fail")]
-   |                                     ^^^^^^
+12 | #[command(name = "basic", rename_all = "fail")]
+   |                                        ^^^^^^

--- a/tests/derive_ui/skip_flatten.rs
+++ b/tests/derive_ui/skip_flatten.rs
@@ -9,23 +9,23 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "make-cookie")]
+#[command(name = "make-cookie")]
 struct MakeCookie {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 
-    #[clap(skip, flatten)]
+    #[command(skip, flatten)]
     cmd: Command,
 }
 
 #[derive(Parser, Debug)]
 enum Command {
-    #[clap(name = "pound")]
+    #[command(name = "pound")]
     /// Pound acorns into flour for cookie dough.
     Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short)]
+        #[arg(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/skip_flatten.stderr
+++ b/tests/derive_ui/skip_flatten.stderr
@@ -1,5 +1,5 @@
 error: `flatten` cannot be used with `skip`
-  --> tests/derive_ui/skip_flatten.rs:17:18
+  --> tests/derive_ui/skip_flatten.rs:17:21
    |
-17 |     #[clap(skip, flatten)]
-   |                  ^^^^^^^
+17 |     #[command(skip, flatten)]
+   |                     ^^^^^^^

--- a/tests/derive_ui/skip_subcommand.rs
+++ b/tests/derive_ui/skip_subcommand.rs
@@ -9,23 +9,23 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "make-cookie")]
+#[command(name = "make-cookie")]
 struct MakeCookie {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 
-    #[clap(subcommand, skip)]
+    #[command(subcommand, skip)]
     cmd: Command,
 }
 
 #[derive(Parser, Debug)]
 enum Command {
-    #[clap(name = "pound")]
+    #[command(name = "pound")]
     /// Pound acorns into flour for cookie dough.
     Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short)]
+        #[arg(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/skip_subcommand.stderr
+++ b/tests/derive_ui/skip_subcommand.stderr
@@ -1,5 +1,5 @@
 error: `skip` cannot be used with `subcommand`
-  --> tests/derive_ui/skip_subcommand.rs:17:24
+  --> tests/derive_ui/skip_subcommand.rs:17:27
    |
-17 |     #[clap(subcommand, skip)]
-   |                        ^^^^
+17 |     #[command(subcommand, skip)]
+   |                           ^^^^

--- a/tests/derive_ui/skip_with_other_options.rs
+++ b/tests/derive_ui/skip_with_other_options.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "test")]
+#[command(name = "test")]
 pub struct Opt {
-    #[clap(long)]
+    #[arg(long)]
     a: u32,
-    #[clap(skip, long)]
+    #[arg(skip, long)]
     b: u32,
 }
 

--- a/tests/derive_ui/skip_with_other_options.stderr
+++ b/tests/derive_ui/skip_with_other_options.stderr
@@ -1,5 +1,5 @@
 error: methods are not allowed for skipped fields
- --> $DIR/skip_with_other_options.rs:8:12
+ --> tests/derive_ui/skip_with_other_options.rs:8:11
   |
-8 |     #[clap(skip, long)]
-  |            ^^^^
+8 |     #[arg(skip, long)]
+  |           ^^^^

--- a/tests/derive_ui/skip_without_default.rs
+++ b/tests/derive_ui/skip_without_default.rs
@@ -15,11 +15,11 @@ enum Kind {
 }
 
 #[derive(Parser, Debug)]
-#[clap(name = "test")]
+#[command(name = "test")]
 pub struct Opt {
-    #[clap(short)]
+    #[arg(short)]
     number: u32,
-    #[clap(skip)]
+    #[arg(skip)]
     k: Kind,
 }
 

--- a/tests/derive_ui/skip_without_default.stderr
+++ b/tests/derive_ui/skip_without_default.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Kind: Default` is not satisfied
-  --> tests/derive_ui/skip_without_default.rs:22:12
+  --> tests/derive_ui/skip_without_default.rs:22:11
    |
-22 |     #[clap(skip)]
-   |            ^^^^ the trait `Default` is not implemented for `Kind`
+22 |     #[arg(skip)]
+   |           ^^^^ the trait `Default` is not implemented for `Kind`

--- a/tests/derive_ui/struct_subcommand.rs
+++ b/tests/derive_ui/struct_subcommand.rs
@@ -9,9 +9,9 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic", subcommand)]
+#[command(name = "basic", subcommand)]
 struct Opt {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 }
 

--- a/tests/derive_ui/struct_subcommand.stderr
+++ b/tests/derive_ui/struct_subcommand.stderr
@@ -1,5 +1,5 @@
 error: `subcommand` cannot be used with `command`
-  --> tests/derive_ui/struct_subcommand.rs:12:24
+  --> tests/derive_ui/struct_subcommand.rs:12:27
    |
-12 | #[clap(name = "basic", subcommand)]
-   |                        ^^^^^^^^^^
+12 | #[command(name = "basic", subcommand)]
+   |                           ^^^^^^^^^^

--- a/tests/derive_ui/subcommand_and_flatten.rs
+++ b/tests/derive_ui/subcommand_and_flatten.rs
@@ -10,10 +10,10 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 
-    #[clap(subcommand, flatten)]
+    #[command(subcommand, flatten)]
     cmd: Command,
 }
 
@@ -23,7 +23,7 @@ enum Command {
     Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short)]
+        #[arg(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/subcommand_and_flatten.stderr
+++ b/tests/derive_ui/subcommand_and_flatten.stderr
@@ -1,5 +1,5 @@
 error: `flatten` cannot be used with `subcommand`
-  --> tests/derive_ui/subcommand_and_flatten.rs:16:24
+  --> tests/derive_ui/subcommand_and_flatten.rs:16:27
    |
-16 |     #[clap(subcommand, flatten)]
-   |                        ^^^^^^^
+16 |     #[command(subcommand, flatten)]
+   |                           ^^^^^^^

--- a/tests/derive_ui/subcommand_and_methods.rs
+++ b/tests/derive_ui/subcommand_and_methods.rs
@@ -10,10 +10,10 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 
-    #[clap(subcommand, long)]
+    #[command(subcommand, long)]
     cmd: Command,
 }
 
@@ -23,7 +23,7 @@ enum Command {
     Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short)]
+        #[arg(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/subcommand_and_methods.stderr
+++ b/tests/derive_ui/subcommand_and_methods.stderr
@@ -1,5 +1,5 @@
 error: methods in attributes are not allowed for subcommand
-  --> $DIR/subcommand_and_methods.rs:16:12
+  --> tests/derive_ui/subcommand_and_methods.rs:16:15
    |
-16 |     #[clap(subcommand, long)]
-   |            ^^^^^^^^^^
+16 |     #[command(subcommand, long)]
+   |               ^^^^^^^^^^

--- a/tests/derive_ui/subcommand_opt_opt.rs
+++ b/tests/derive_ui/subcommand_opt_opt.rs
@@ -10,10 +10,10 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Option<Option<Command>>,
 }
 
@@ -23,7 +23,7 @@ enum Command {
     Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short)]
+        #[arg(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/subcommand_opt_vec.rs
+++ b/tests/derive_ui/subcommand_opt_vec.rs
@@ -10,10 +10,10 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 struct MakeCookie {
-    #[clap(short)]
+    #[arg(short)]
     s: String,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     cmd: Option<Vec<Command>>,
 }
 
@@ -23,7 +23,7 @@ enum Command {
     Pound { acorns: u32 },
 
     Sparkle {
-        #[clap(short)]
+        #[arg(short)]
         color: String,
     },
 }

--- a/tests/derive_ui/tuple_struct.rs
+++ b/tests/derive_ui/tuple_struct.rs
@@ -9,7 +9,7 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[clap(name = "basic")]
+#[command(name = "basic")]
 struct Opt(u32);
 
 fn main() {


### PR DESCRIPTION
Example:
```rust
/// Simple program to greet a person
#[derive(Parser, Debug)]
#[command(author, version, about, long_about = None)]
struct Args {
    /// Name of the person to greet
    #[arg(short, long)]
    name: String,

    /// Number of times to greet
    #[arg(short, long, default_value_t = 1)]
    count: u8,
}
```

For the short term, this removes some of the magic so people have a better idea of how the derive connects to the builder API which is a continual problem (https://github.com/clap-rs/clap/discussions/4090) and makes it easier to document attributes generally.

Longer term, this is a step towards allowing command attributes on args/fields which will help with `next_help_heading`, etc.  See #1807