### PR TITLE
fix: missing lifetime specifier

### DIFF
--- a/examples/git.rs
+++ b/examples/git.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use clap::{arg, Command};
 
-fn cli() -> Command {
+fn cli() -> Command<'static> {
     Command::new("git")
         .about("A fictional versioning CLI")
         .subcommand_required(true)
@@ -37,7 +37,7 @@ fn cli() -> Command {
         )
 }
 
-fn push_args() -> Vec<clap::Arg> {
+fn push_args() -> Vec<clap::Arg<'static>> {
     vec![arg!(-m --message <MESSAGE>).required(false)]
 }
 


### PR DESCRIPTION
In this PR I fixed the missing lifetime specifier error by rustc

```cmd
error[E0106]: missing lifetime specifier
 --> src/main.rs:6:13
  |
6 | fn cli() -> Command {
  |             ^^^^^^^ expected named lifetime parameter
  |
  = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
help: consider using the `'static` lifetime
  |
6 | fn cli() -> Command<'static> {
  |             ~~~~~~~~~~~~~~~~

error[E0106]: missing lifetime specifier
  --> src/main.rs:40:29
   |
40 | fn push_args() -> Vec<clap::Arg> {
   |                             ^^^ expected named lifetime parameter
   |
   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
help: consider using the `'static` lifetime
   |
40 | fn push_args() -> Vec<clap::Arg<'static>> {
   |                             ~~~~~~~~~~~~

For more information about this error, try `rustc --explain E0106`.
error: could not compile `cli` due to 2 previous errors
```