### PR TITLE
fix(help):Be dense on short next line help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,7 @@ Deprecated
 - *(help)* Trim extra whitespace to avoid artifacts from different uses of templates (#4132, #4156)
 - *(help)* Hint to the user the difference between `-h` / `--help` when applicable (#4132, #4159)
 - *(help)* Shorten help by eliding name/version/author (#4132, #4160)
+- *(help)* When short help is long enough to activate `next_line_help`, don't add blank lines (#4132, #4190)
 - *(version)* Use `Command::display_name` rather than `Command::bin_name` (#3966)
 - *(parser)* Always fill in `""` argument for external subcommands (#3263)
 - *(parser)* Short flags now have higher precedence than hyphen values with `Arg::allow_hyphen_values`, like `Command::allow_hyphen_values` (#4187)

--- a/examples/tutorial_builder/02_app_settings.md
+++ b/examples/tutorial_builder/02_app_settings.md
@@ -7,13 +7,10 @@ Usage: 02_app_settings[EXE] --two <VALUE> --one <VALUE>
 Options:
         --two <VALUE>
             
-
         --one <VALUE>
             
-
     -h, --help
             Print help information
-
     -V, --version
             Print version information
 

--- a/examples/tutorial_derive/02_app_settings.md
+++ b/examples/tutorial_derive/02_app_settings.md
@@ -7,13 +7,10 @@ Usage: 02_app_settings_derive[EXE] --two <TWO> --one <ONE>
 Options:
         --two <TWO>
             
-
         --one <ONE>
             
-
     -h, --help
             Print help information
-
     -V, --version
             Print version information
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -438,7 +438,7 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
         for (i, (_, arg)) in ord_v.iter().enumerate() {
             if i != 0 {
                 self.none("\n");
-                if next_line_help {
+                if next_line_help && self.use_long {
                     self.none("\n");
                 }
             }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -355,17 +355,13 @@ Options:
     -a, --all
             Also do versioning for private crates (will not be
             published)
-
         --exact
             Specify inter dependency version numbers exactly with
             `=`
-
         --no-git-commit
             Do not commit version changes
-
         --no-git-push
             Do not push generated commit and tags to git remote
-
     -h, --help
             Print help information
 ";
@@ -694,10 +690,8 @@ Options:
             les marchés d\'exportation. Le café est
             souvent une contribution majeure aux
             exportations des régions productrices.
-
     -h, --help
             Print help information
-
     -V, --version
             Print version information
 ";
@@ -743,7 +737,6 @@ Options:
     -h, --help
             Print help
             information
-
     -V, --version
             Print
             version
@@ -816,7 +809,6 @@ Options:
             that require an
             emulator. See
             https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-
     -h, --help
             Print help
             information
@@ -1168,7 +1160,6 @@ Usage: ctest
 Options:
     -h, --help
             Print help information
-
     -V, --version
             Print version
             information


### PR DESCRIPTION
If short help is too long for the terminal, clap will automatically switch to next line help.  As part of next line help for longs, we add a blank line between args.  This helps make the args clearer when dealing with multiple paragraphs.  However, its not as much needed for short and subcommands (always short), so now short matches subcommands.

This was inspired by #3300 and a part of #4132

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
