### PR TITLE
fix(help): Make output more dense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,14 +69,14 @@ A fictional versioning CLI
 Usage: git <COMMAND>
 
 Commands:
-    clone    Clones repos
-    push     pushes things
-    add      adds things
-    stash
-    help     Print this message or the help of the given subcommand(s)
+  clone  Clones repos
+  push   pushes things
+  add    adds things
+  stash
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ```
 - name/version header was removed because we couldn't justify the space it occupied when
   - Usage already includes the name
@@ -85,6 +85,7 @@ Options:
 - Focus is put on the subcommands
 - Headings are now Title case
 - The more general term "command" is used rather than being explicit about being "subcommands"
+- The output is more dense with the expectation that it won't affect legibility but will allow more content
 - We've moved to a more neutral palette for highlighting elements (not highlighted above)
 
 In talking to users, we found some that liked clap's `man`-like experience.
@@ -260,6 +261,7 @@ Deprecated
 - *(help)* Hint to the user the difference between `-h` / `--help` when applicable (#4132, #4159)
 - *(help)* Shorten help by eliding name/version/author (#4132, #4160)
 - *(help)* When short help is long enough to activate `next_line_help`, don't add blank lines (#4132, #4190)
+- *(help)* Make help output more dense (reducing horizontal whitespace) (#4132, #4192)
 - *(version)* Use `Command::display_name` rather than `Command::bin_name` (#3966)
 - *(parser)* Always fill in `""` argument for external subcommands (#3263)
 - *(parser)* Short flags now have higher precedence than hyphen values with `Arg::allow_hyphen_values`, like `Command::allow_hyphen_values` (#4187)

--- a/examples/cargo-example-derive.md
+++ b/examples/cargo-example-derive.md
@@ -9,11 +9,11 @@ $ cargo-example-derive --help
 Usage: cargo <COMMAND>
 
 Commands:
-    example-derive    A simple to use, efficient, and full-featured Command Line Argument Parser
-    help              Print this message or the help of the given subcommand(s)
+  example-derive  A simple to use, efficient, and full-featured Command Line Argument Parser
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ cargo-example-derive example-derive --help
 A simple to use, efficient, and full-featured Command Line Argument Parser
@@ -21,9 +21,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: cargo example-derive [OPTIONS]
 
 Options:
-        --manifest-path <MANIFEST_PATH>    
-    -h, --help                             Print help information
-    -V, --version                          Print version information
+      --manifest-path <MANIFEST_PATH>  
+  -h, --help                           Print help information
+  -V, --version                        Print version information
 
 ```
 

--- a/examples/cargo-example.md
+++ b/examples/cargo-example.md
@@ -9,11 +9,11 @@ $ cargo-example --help
 Usage: cargo <COMMAND>
 
 Commands:
-    example    A simple to use, efficient, and full-featured Command Line Argument Parser
-    help       Print this message or the help of the given subcommand(s)
+  example  A simple to use, efficient, and full-featured Command Line Argument Parser
+  help     Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ cargo-example example --help
 A simple to use, efficient, and full-featured Command Line Argument Parser
@@ -21,9 +21,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: cargo example [OPTIONS]
 
 Options:
-        --manifest-path <PATH>    
-    -h, --help                    Print help information
-    -V, --version                 Print version information
+      --manifest-path <PATH>  
+  -h, --help                  Print help information
+  -V, --version               Print version information
 
 ```
 

--- a/examples/demo.md
+++ b/examples/demo.md
@@ -5,10 +5,10 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: demo[EXE] [OPTIONS] --name <NAME>
 
 Options:
-    -n, --name <NAME>      Name of the person to greet
-    -c, --count <COUNT>    Number of times to greet [default: 1]
-    -h, --help             Print help information
-    -V, --version          Print version information
+  -n, --name <NAME>    Name of the person to greet
+  -c, --count <COUNT>  Number of times to greet [default: 1]
+  -h, --help           Print help information
+  -V, --version        Print version information
 
 $ demo --name Me
 Hello Me!

--- a/examples/derive_ref/custom-bool.md
+++ b/examples/derive_ref/custom-bool.md
@@ -9,19 +9,19 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: custom-bool[EXE] [OPTIONS] --foo <FOO> <BOOM>
 
 Arguments:
-    <BOOM>    [possible values: true, false]
+  <BOOM>  [possible values: true, false]
 
 Options:
-        --foo <FOO>    [possible values: true, false]
-        --bar <BAR>    [default: false]
-    -h, --help         Print help information
-    -V, --version      Print version information
+      --foo <FOO>  [possible values: true, false]
+      --bar <BAR>  [default: false]
+  -h, --help       Print help information
+  -V, --version    Print version information
 
 $ custom-bool
 ? failed
 error: The following required arguments were not provided:
-    --foo <FOO>
-    <BOOM>
+  --foo <FOO>
+  <BOOM>
 
 Usage: custom-bool[EXE] --foo <FOO> <BOOM>
 

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -37,7 +37,7 @@ $ interop_augment_args --unknown
 ? failed
 error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
+  If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
 Usage: interop_augment_args[EXE] [OPTIONS]
 
@@ -74,7 +74,7 @@ $ interop_augment_subcommands derived --unknown
 ? failed
 error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
+  If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
 Usage: interop_augment_subcommands[EXE] derived [OPTIONS]
 
@@ -101,13 +101,13 @@ $ interop_hand_subcommand
 Usage: interop_hand_subcommand[EXE] [OPTIONS] <COMMAND>
 
 Commands:
-    add       
-    remove    
-    help      Print this message or the help of the given subcommand(s)
+  add     
+  remove  
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
-    -t, --top-level    
-    -h, --help         Print help information
+  -t, --top-level  
+  -h, --help       Print help information
 
 ```
 
@@ -146,7 +146,7 @@ $ interop_hand_subcommand add --unknown
 ? failed
 error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
+  If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
 Usage: interop_hand_subcommand[EXE] add [NAME]...
 
@@ -245,7 +245,7 @@ $ interop_flatten_hand_args --unknown
 ? failed
 error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
+  If you tried to supply `--unknown` as a value rather than a flag, use `-- --unknown`
 
 Usage: interop_flatten_hand_args[EXE] [OPTIONS]
 

--- a/examples/escaped-positional-derive.md
+++ b/examples/escaped-positional-derive.md
@@ -10,13 +10,13 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: escaped-positional-derive[EXE] [OPTIONS] [-- <SLOP>...]
 
 Arguments:
-    [SLOP]...    
+  [SLOP]...  
 
 Options:
-    -f               
-    -p <PEAR>        
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -f             
+  -p <PEAR>      
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 ```
 

--- a/examples/escaped-positional.md
+++ b/examples/escaped-positional.md
@@ -10,13 +10,13 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: escaped-positional[EXE] [OPTIONS] [-- <SLOP>...]
 
 Arguments:
-    [SLOP]...    
+  [SLOP]...  
 
 Options:
-    -f               
-    -p <PEAR>        
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -f             
+  -p <PEAR>      
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 ```
 

--- a/examples/find.md
+++ b/examples/find.md
@@ -7,17 +7,17 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: find[EXE] [OPTIONS] --name <NAME>
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 TESTS:
-        --empty          File is empty and is either a regular file or a directory
-        --name <NAME>    Base of file name (the path with the leading directories removed) matches
-                         shell pattern pattern
+      --empty        File is empty and is either a regular file or a directory
+      --name <NAME>  Base of file name (the path with the leading directories removed) matches shell
+                     pattern pattern
 
 OPERATORS:
-    -o, --or     expr2 is not evaluate if exp1 is true
-    -a, --and    Same as `expr1 expr1`
+  -o, --or   expr2 is not evaluate if exp1 is true
+  -a, --and  Same as `expr1 expr1`
 
 $ find --empty -o --name .keep
 [

--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -11,15 +11,15 @@ A fictional versioning CLI
 Usage: git-derive[EXE] <COMMAND>
 
 Commands:
-    clone    Clones repos
-    diff     Compare two commits
-    push     pushes things
-    add      adds things
-    stash    
-    help     Print this message or the help of the given subcommand(s)
+  clone  Clones repos
+  diff   Compare two commits
+  push   pushes things
+  add    adds things
+  stash  
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git-derive help
 A fictional versioning CLI
@@ -27,15 +27,15 @@ A fictional versioning CLI
 Usage: git-derive[EXE] <COMMAND>
 
 Commands:
-    clone    Clones repos
-    diff     Compare two commits
-    push     pushes things
-    add      adds things
-    stash    
-    help     Print this message or the help of the given subcommand(s)
+  clone  Clones repos
+  diff   Compare two commits
+  push   pushes things
+  add    adds things
+  stash  
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git-derive help add
 adds things
@@ -43,10 +43,10 @@ adds things
 Usage: git-derive[EXE] add <PATH>...
 
 Arguments:
-    <PATH>...    Stuff to add
+  <PATH>...  Stuff to add
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 ```
 
@@ -59,10 +59,10 @@ adds things
 Usage: git-derive[EXE] add <PATH>...
 
 Arguments:
-    <PATH>...    Stuff to add
+  <PATH>...  Stuff to add
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git-derive add Cargo.toml Cargo.lock
 Adding ["Cargo.toml", "Cargo.lock"]
@@ -76,30 +76,30 @@ Usage: git-derive[EXE] stash [OPTIONS]
        git-derive[EXE] stash <COMMAND>
 
 Commands:
-    push     
-    pop      
-    apply    
-    help     Print this message or the help of the given subcommand(s)
+  push   
+  pop    
+  apply  
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -m, --message <MESSAGE>    
-    -h, --help                 Print help information
+  -m, --message <MESSAGE>  
+  -h, --help               Print help information
 
 $ git-derive stash push -h
 Usage: git-derive[EXE] stash push [OPTIONS]
 
 Options:
-    -m, --message <MESSAGE>    
-    -h, --help                 Print help information
+  -m, --message <MESSAGE>  
+  -h, --help               Print help information
 
 $ git-derive stash pop -h
 Usage: git-derive[EXE] stash pop [STASH]
 
 Arguments:
-    [STASH]    
+  [STASH]  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git-derive stash -m "Prototype"
 Pushing StashPush { message: Some("Prototype") }
@@ -130,12 +130,12 @@ Compare two commits
 Usage: git-derive[EXE] diff [COMMIT] [COMMIT] [-- <PATH>]
 
 Arguments:
-    [COMMIT]    
-    [COMMIT]    
-    [PATH]      
+  [COMMIT]  
+  [COMMIT]  
+  [PATH]    
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git-derive diff
 Diffing stage..worktree 

--- a/examples/git.md
+++ b/examples/git.md
@@ -9,15 +9,15 @@ A fictional versioning CLI
 Usage: git[EXE] <COMMAND>
 
 Commands:
-    clone    Clones repos
-    diff     Compare two commits
-    push     pushes things
-    add      adds things
-    stash    
-    help     Print this message or the help of the given subcommand(s)
+  clone  Clones repos
+  diff   Compare two commits
+  push   pushes things
+  add    adds things
+  stash  
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git help
 A fictional versioning CLI
@@ -25,15 +25,15 @@ A fictional versioning CLI
 Usage: git[EXE] <COMMAND>
 
 Commands:
-    clone    Clones repos
-    diff     Compare two commits
-    push     pushes things
-    add      adds things
-    stash    
-    help     Print this message or the help of the given subcommand(s)
+  clone  Clones repos
+  diff   Compare two commits
+  push   pushes things
+  add    adds things
+  stash  
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git help add
 adds things
@@ -41,10 +41,10 @@ adds things
 Usage: git[EXE] add <PATH>...
 
 Arguments:
-    <PATH>...    Stuff to add
+  <PATH>...  Stuff to add
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 ```
 
@@ -57,10 +57,10 @@ adds things
 Usage: git[EXE] add <PATH>...
 
 Arguments:
-    <PATH>...    Stuff to add
+  <PATH>...  Stuff to add
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git add Cargo.toml Cargo.lock
 Adding ["Cargo.toml", "Cargo.lock"]
@@ -74,30 +74,30 @@ Usage: git[EXE] stash [OPTIONS]
        git[EXE] stash <COMMAND>
 
 Commands:
-    push     
-    pop      
-    apply    
-    help     Print this message or the help of the given subcommand(s)
+  push   
+  pop    
+  apply  
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -m, --message <MESSAGE>    
-    -h, --help                 Print help information
+  -m, --message <MESSAGE>  
+  -h, --help               Print help information
 
 $ git stash push -h
 Usage: git[EXE] stash push [OPTIONS]
 
 Options:
-    -m, --message <MESSAGE>    
-    -h, --help                 Print help information
+  -m, --message <MESSAGE>  
+  -h, --help               Print help information
 
 $ git stash pop -h
 Usage: git[EXE] stash pop [STASH]
 
 Arguments:
-    [STASH]    
+  [STASH]  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git stash -m "Prototype"
 Pushing Some("Prototype")
@@ -128,12 +128,12 @@ Compare two commits
 Usage: git[EXE] diff [COMMIT] [COMMIT] [-- <PATH>]
 
 Arguments:
-    [COMMIT]    
-    [COMMIT]    
-    [PATH]      
+  [COMMIT]  
+  [COMMIT]  
+  [PATH]    
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 
 $ git diff
 Diffing stage..worktree 

--- a/examples/multicall-busybox.md
+++ b/examples/multicall-busybox.md
@@ -28,12 +28,12 @@ $ busybox
 Usage: busybox [OPTIONS] [APPLET]
 
 APPLETS:
-    true     does nothing successfully
-    false    does nothing unsuccessfully
-    help     Print this message or the help of the given subcommand(s)
+  true   does nothing successfully
+  false  does nothing unsuccessfully
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-        --install <install>    Install hardlinks for all subcommands in path
-    -h, --help                 Print help information
+      --install <install>  Install hardlinks for all subcommands in path
+  -h, --help               Print help information
 
 ```

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -40,13 +40,13 @@ package manager utility
 Usage: pacman[EXE] <COMMAND>
 
 Commands:
-    query -Q --query    Query the package database.
-    sync -S --sync      Synchronize packages.
-    help                Print this message or the help of the given subcommand(s)
+  query -Q --query  Query the package database.
+  sync -S --sync    Synchronize packages.
+  help              Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ pacman -S -h
 Synchronize packages.
@@ -54,12 +54,12 @@ Synchronize packages.
 Usage: pacman[EXE] {sync|--sync|-S} [OPTIONS] [package]...
 
 Arguments:
-    [package]...    packages
+  [package]...  packages
 
 Options:
-    -s, --search <search>...    search remote repositories for matching strings
-    -i, --info                  view package information
-    -h, --help                  Print help information
+  -s, --search <search>...  search remote repositories for matching strings
+  -i, --info                view package information
+  -h, --help                Print help information
 
 ```
 

--- a/examples/tutorial_builder/01_quick.md
+++ b/examples/tutorial_builder/01_quick.md
@@ -5,17 +5,17 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 01_quick[EXE] [OPTIONS] [name] [COMMAND]
 
 Commands:
-    test    does testing things
-    help    Print this message or the help of the given subcommand(s)
+  test  does testing things
+  help  Print this message or the help of the given subcommand(s)
 
 Arguments:
-    [name]    Optional name to operate on
+  [name]  Optional name to operate on
 
 Options:
-    -c, --config <FILE>    Sets a custom config file
-    -d, --debug...         Turn debugging information on
-    -h, --help             Print help information
-    -V, --version          Print version information
+  -c, --config <FILE>  Sets a custom config file
+  -d, --debug...       Turn debugging information on
+  -h, --help           Print help information
+  -V, --version        Print version information
 
 ```
 

--- a/examples/tutorial_builder/02_app_settings.md
+++ b/examples/tutorial_builder/02_app_settings.md
@@ -5,13 +5,13 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 02_app_settings[EXE] --two <VALUE> --one <VALUE>
 
 Options:
-        --two <VALUE>
-            
-        --one <VALUE>
-            
-    -h, --help
-            Print help information
-    -V, --version
-            Print version information
+      --two <VALUE>
+          
+      --one <VALUE>
+          
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
 
 ```

--- a/examples/tutorial_builder/02_apps.md
+++ b/examples/tutorial_builder/02_apps.md
@@ -5,10 +5,10 @@ Does awesome things
 Usage: 02_apps[EXE] --two <VALUE> --one <VALUE>
 
 Options:
-        --two <VALUE>    
-        --one <VALUE>    
-    -h, --help           Print help information
-    -V, --version        Print version information
+      --two <VALUE>  
+      --one <VALUE>  
+  -h, --help         Print help information
+  -V, --version      Print version information
 
 $ 02_apps --version
 MyApp 1.0

--- a/examples/tutorial_builder/02_crate.md
+++ b/examples/tutorial_builder/02_crate.md
@@ -5,10 +5,10 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 02_crate[EXE] --two <VALUE> --one <VALUE>
 
 Options:
-        --two <VALUE>    
-        --one <VALUE>    
-    -h, --help           Print help information
-    -V, --version        Print version information
+      --two <VALUE>  
+      --one <VALUE>  
+  -h, --help         Print help information
+  -V, --version      Print version information
 
 $ 02_crate --version
 clap [..]

--- a/examples/tutorial_builder/03_01_flag_bool.md
+++ b/examples/tutorial_builder/03_01_flag_bool.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_01_flag_bool[EXE] [OPTIONS]
 
 Options:
-    -v, --verbose    
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -v, --verbose  
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_01_flag_bool
 verbose: false

--- a/examples/tutorial_builder/03_01_flag_count.md
+++ b/examples/tutorial_builder/03_01_flag_count.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_01_flag_count[EXE] [OPTIONS]
 
 Options:
-    -v, --verbose...    
-    -h, --help          Print help information
-    -V, --version       Print version information
+  -v, --verbose...  
+  -h, --help        Print help information
+  -V, --version     Print version information
 
 $ 03_01_flag_count
 verbose: 0

--- a/examples/tutorial_builder/03_02_option.md
+++ b/examples/tutorial_builder/03_02_option.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_02_option[EXE] [OPTIONS]
 
 Options:
-    -n, --name <name>    
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -n, --name <name>  
+  -h, --help         Print help information
+  -V, --version      Print version information
 
 $ 03_02_option
 name: None

--- a/examples/tutorial_builder/03_02_option_mult.md
+++ b/examples/tutorial_builder/03_02_option_mult.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_02_option_mult[EXE] [OPTIONS]
 
 Options:
-    -n, --name <name>    
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -n, --name <name>  
+  -h, --help         Print help information
+  -V, --version      Print version information
 
 $ 03_02_option_mult
 name: None

--- a/examples/tutorial_builder/03_03_positional.md
+++ b/examples/tutorial_builder/03_03_positional.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_03_positional[EXE] [name]
 
 Arguments:
-    [name]    
+  [name]  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_03_positional
 name: None

--- a/examples/tutorial_builder/03_03_positional_mult.md
+++ b/examples/tutorial_builder/03_03_positional_mult.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_03_positional_mult[EXE] [name]...
 
 Arguments:
-    [name]...    
+  [name]...  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_03_positional_mult
 name: None

--- a/examples/tutorial_builder/03_04_subcommands.md
+++ b/examples/tutorial_builder/03_04_subcommands.md
@@ -5,12 +5,12 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_04_subcommands[EXE] <COMMAND>
 
 Commands:
-    add     Adds files to myapp
-    help    Print this message or the help of the given subcommand(s)
+  add   Adds files to myapp
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_04_subcommands help add
 Adds files to myapp
@@ -18,11 +18,11 @@ Adds files to myapp
 Usage: 03_04_subcommands[EXE] add [NAME]
 
 Arguments:
-    [NAME]    
+  [NAME]  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_04_subcommands add bob
 'myapp add' was used, name is: Some("bob")
@@ -38,12 +38,12 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_04_subcommands[EXE] <COMMAND>
 
 Commands:
-    add     Adds files to myapp
-    help    Print this message or the help of the given subcommand(s)
+  add   Adds files to myapp
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 ```
 

--- a/examples/tutorial_builder/03_05_default_values.md
+++ b/examples/tutorial_builder/03_05_default_values.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_05_default_values[EXE] [NAME]
 
 Arguments:
-    [NAME]    [default: alice]
+  [NAME]  [default: alice]
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_05_default_values
 name: "alice"

--- a/examples/tutorial_builder/04_01_enum.md
+++ b/examples/tutorial_builder/04_01_enum.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_01_enum[EXE] <MODE>
 
 Arguments:
-    <MODE>    What mode to run the program in [possible values: fast, slow]
+  <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 04_01_enum fast
 Hare
@@ -20,7 +20,7 @@ Tortoise
 $ 04_01_enum medium
 ? failed
 error: "medium" isn't a valid value for '<MODE>'
-    [possible values: fast, slow]
+  [possible values: fast, slow]
 
 For more information try --help
 

--- a/examples/tutorial_builder/04_01_possible.md
+++ b/examples/tutorial_builder/04_01_possible.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_01_possible[EXE] <MODE>
 
 Arguments:
-    <MODE>    What mode to run the program in [possible values: fast, slow]
+  <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 04_01_possible fast
 Hare
@@ -20,7 +20,7 @@ Tortoise
 $ 04_01_possible medium
 ? failed
 error: "medium" isn't a valid value for '<MODE>'
-    [possible values: fast, slow]
+  [possible values: fast, slow]
 
 For more information try --help
 

--- a/examples/tutorial_builder/04_02_parse.md
+++ b/examples/tutorial_builder/04_02_parse.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_02_parse[EXE] <PORT>
 
 Arguments:
-    <PORT>    Network port to use
+  <PORT>  Network port to use
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 04_02_parse 22
 PORT = 22

--- a/examples/tutorial_builder/04_02_validate.md
+++ b/examples/tutorial_builder/04_02_validate.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_02_validate[EXE] <PORT>
 
 Arguments:
-    <PORT>    Network port to use
+  <PORT>  Network port to use
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 04_02_validate 22
 PORT = 22

--- a/examples/tutorial_builder/04_03_relations.md
+++ b/examples/tutorial_builder/04_03_relations.md
@@ -5,22 +5,22 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_03_relations[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
 Arguments:
-    [INPUT_FILE]    some regular input
+  [INPUT_FILE]  some regular input
 
 Options:
-        --set-ver <VER>        set version manually
-        --major                auto inc major
-        --minor                auto inc minor
-        --patch                auto inc patch
-        --spec-in <SPEC_IN>    some special input argument
-    -c <CONFIG>                
-    -h, --help                 Print help information
-    -V, --version              Print version information
+      --set-ver <VER>      set version manually
+      --major              auto inc major
+      --minor              auto inc minor
+      --patch              auto inc patch
+      --spec-in <SPEC_IN>  some special input argument
+  -c <CONFIG>              
+  -h, --help               Print help information
+  -V, --version            Print version information
 
 $ 04_03_relations
 ? failed
 error: The following required arguments were not provided:
-    <--set-ver <VER>|--major|--minor|--patch>
+  <--set-ver <VER>|--major|--minor|--patch>
 
 Usage: 04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
@@ -40,7 +40,7 @@ For more information try --help
 $ 04_03_relations --major -c config.toml
 ? failed
 error: The following required arguments were not provided:
-    <INPUT_FILE|--spec-in <SPEC_IN>>
+  <INPUT_FILE|--spec-in <SPEC_IN>>
 
 Usage: 04_03_relations[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>
 

--- a/examples/tutorial_builder/04_04_custom.md
+++ b/examples/tutorial_builder/04_04_custom.md
@@ -5,17 +5,17 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
 Arguments:
-    [INPUT_FILE]    some regular input
+  [INPUT_FILE]  some regular input
 
 Options:
-        --set-ver <VER>        set version manually
-        --major                auto inc major
-        --minor                auto inc minor
-        --patch                auto inc patch
-        --spec-in <SPEC_IN>    some special input argument
-    -c <CONFIG>                
-    -h, --help                 Print help information
-    -V, --version              Print version information
+      --set-ver <VER>      set version manually
+      --major              auto inc major
+      --minor              auto inc minor
+      --patch              auto inc patch
+      --spec-in <SPEC_IN>  some special input argument
+  -c <CONFIG>              
+  -h, --help               Print help information
+  -V, --version            Print version information
 
 $ 04_04_custom
 ? failed

--- a/examples/tutorial_derive/01_quick.md
+++ b/examples/tutorial_derive/01_quick.md
@@ -5,17 +5,17 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 01_quick_derive[EXE] [OPTIONS] [NAME] [COMMAND]
 
 Commands:
-    test    does testing things
-    help    Print this message or the help of the given subcommand(s)
+  test  does testing things
+  help  Print this message or the help of the given subcommand(s)
 
 Arguments:
-    [NAME]    Optional name to operate on
+  [NAME]  Optional name to operate on
 
 Options:
-    -c, --config <FILE>    Sets a custom config file
-    -d, --debug...         Turn debugging information on
-    -h, --help             Print help information
-    -V, --version          Print version information
+  -c, --config <FILE>  Sets a custom config file
+  -d, --debug...       Turn debugging information on
+  -h, --help           Print help information
+  -V, --version        Print version information
 
 ```
 

--- a/examples/tutorial_derive/02_app_settings.md
+++ b/examples/tutorial_derive/02_app_settings.md
@@ -5,13 +5,13 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 02_app_settings_derive[EXE] --two <TWO> --one <ONE>
 
 Options:
-        --two <TWO>
-            
-        --one <ONE>
-            
-    -h, --help
-            Print help information
-    -V, --version
-            Print version information
+      --two <TWO>
+          
+      --one <ONE>
+          
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
 
 ```

--- a/examples/tutorial_derive/02_apps.md
+++ b/examples/tutorial_derive/02_apps.md
@@ -5,10 +5,10 @@ Does awesome things
 Usage: 02_apps_derive[EXE] --two <TWO> --one <ONE>
 
 Options:
-        --two <TWO>    
-        --one <ONE>    
-    -h, --help         Print help information
-    -V, --version      Print version information
+      --two <TWO>  
+      --one <ONE>  
+  -h, --help       Print help information
+  -V, --version    Print version information
 
 $ 02_apps_derive --version
 MyApp 1.0

--- a/examples/tutorial_derive/02_crate.md
+++ b/examples/tutorial_derive/02_crate.md
@@ -5,10 +5,10 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 02_crate_derive[EXE] --two <TWO> --one <ONE>
 
 Options:
-        --two <TWO>    
-        --one <ONE>    
-    -h, --help         Print help information
-    -V, --version      Print version information
+      --two <TWO>  
+      --one <ONE>  
+  -h, --help       Print help information
+  -V, --version    Print version information
 
 $ 02_crate_derive --version
 clap [..]

--- a/examples/tutorial_derive/03_01_flag_bool.md
+++ b/examples/tutorial_derive/03_01_flag_bool.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_01_flag_bool_derive[EXE] [OPTIONS]
 
 Options:
-    -v, --verbose    
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -v, --verbose  
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_01_flag_bool_derive
 verbose: false

--- a/examples/tutorial_derive/03_01_flag_count.md
+++ b/examples/tutorial_derive/03_01_flag_count.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_01_flag_count_derive[EXE] [OPTIONS]
 
 Options:
-    -v, --verbose...    
-    -h, --help          Print help information
-    -V, --version       Print version information
+  -v, --verbose...  
+  -h, --help        Print help information
+  -V, --version     Print version information
 
 $ 03_01_flag_count_derive
 verbose: 0

--- a/examples/tutorial_derive/03_02_option.md
+++ b/examples/tutorial_derive/03_02_option.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_02_option_derive[EXE] [OPTIONS]
 
 Options:
-    -n, --name <NAME>    
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -n, --name <NAME>  
+  -h, --help         Print help information
+  -V, --version      Print version information
 
 $ 03_02_option_derive
 name: None

--- a/examples/tutorial_derive/03_02_option_mult.md
+++ b/examples/tutorial_derive/03_02_option_mult.md
@@ -5,9 +5,9 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_02_option_mult_derive[EXE] [OPTIONS]
 
 Options:
-    -n, --name <NAME>    
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -n, --name <NAME>  
+  -h, --help         Print help information
+  -V, --version      Print version information
 
 $ 03_02_option_mult_derive
 name: []

--- a/examples/tutorial_derive/03_03_positional.md
+++ b/examples/tutorial_derive/03_03_positional.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_03_positional_derive[EXE] [NAME]
 
 Arguments:
-    [NAME]    
+  [NAME]  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_03_positional_derive
 name: None

--- a/examples/tutorial_derive/03_03_positional_mult.md
+++ b/examples/tutorial_derive/03_03_positional_mult.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_03_positional_mult_derive[EXE] [NAME]...
 
 Arguments:
-    [NAME]...    
+  [NAME]...  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_03_positional_mult_derive
 name: []

--- a/examples/tutorial_derive/03_04_subcommands.md
+++ b/examples/tutorial_derive/03_04_subcommands.md
@@ -5,12 +5,12 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_04_subcommands_derive[EXE] <COMMAND>
 
 Commands:
-    add     Adds files to myapp
-    help    Print this message or the help of the given subcommand(s)
+  add   Adds files to myapp
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_04_subcommands_derive help add
 Adds files to myapp
@@ -18,11 +18,11 @@ Adds files to myapp
 Usage: 03_04_subcommands_derive[EXE] add [NAME]
 
 Arguments:
-    [NAME]    
+  [NAME]  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_04_subcommands_derive add bob
 'myapp add' was used, name is: Some("bob")
@@ -38,12 +38,12 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_04_subcommands_derive[EXE] <COMMAND>
 
 Commands:
-    add     Adds files to myapp
-    help    Print this message or the help of the given subcommand(s)
+  add   Adds files to myapp
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 ```
 

--- a/examples/tutorial_derive/03_05_default_values.md
+++ b/examples/tutorial_derive/03_05_default_values.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 03_05_default_values_derive[EXE] [NAME]
 
 Arguments:
-    [NAME]    [default: alice]
+  [NAME]  [default: alice]
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 03_05_default_values_derive
 name: "alice"

--- a/examples/tutorial_derive/04_01_enum.md
+++ b/examples/tutorial_derive/04_01_enum.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_01_enum_derive[EXE] <MODE>
 
 Arguments:
-    <MODE>    What mode to run the program in [possible values: fast, slow]
+  <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 04_01_enum_derive fast
 Hare
@@ -20,7 +20,7 @@ Tortoise
 $ 04_01_enum_derive medium
 ? failed
 error: "medium" isn't a valid value for '<MODE>'
-    [possible values: fast, slow]
+  [possible values: fast, slow]
 
 For more information try --help
 

--- a/examples/tutorial_derive/04_02_parse.md
+++ b/examples/tutorial_derive/04_02_parse.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_02_parse_derive[EXE] <PORT>
 
 Arguments:
-    <PORT>    Network port to use
+  <PORT>  Network port to use
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 04_02_parse_derive 22
 PORT = 22

--- a/examples/tutorial_derive/04_02_validate.md
+++ b/examples/tutorial_derive/04_02_validate.md
@@ -5,11 +5,11 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_02_validate_derive[EXE] <PORT>
 
 Arguments:
-    <PORT>    Network port to use
+  <PORT>  Network port to use
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 $ 04_02_validate_derive 22
 PORT = 22

--- a/examples/tutorial_derive/04_03_relations.md
+++ b/examples/tutorial_derive/04_03_relations.md
@@ -5,22 +5,22 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_03_relations_derive[EXE] [OPTIONS] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
 Arguments:
-    [INPUT_FILE]    some regular input
+  [INPUT_FILE]  some regular input
 
 Options:
-        --set-ver <VER>        set version manually
-        --major                auto inc major
-        --minor                auto inc minor
-        --patch                auto inc patch
-        --spec-in <SPEC_IN>    some special input argument
-    -c <CONFIG>                
-    -h, --help                 Print help information
-    -V, --version              Print version information
+      --set-ver <VER>      set version manually
+      --major              auto inc major
+      --minor              auto inc minor
+      --patch              auto inc patch
+      --spec-in <SPEC_IN>  some special input argument
+  -c <CONFIG>              
+  -h, --help               Print help information
+  -V, --version            Print version information
 
 $ 04_03_relations_derive
 ? failed
 error: The following required arguments were not provided:
-    <--set-ver <VER>|--major|--minor|--patch>
+  <--set-ver <VER>|--major|--minor|--patch>
 
 Usage: 04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
@@ -40,7 +40,7 @@ For more information try --help
 $ 04_03_relations_derive --major -c config.toml
 ? failed
 error: The following required arguments were not provided:
-    <INPUT_FILE|--spec-in <SPEC_IN>>
+  <INPUT_FILE|--spec-in <SPEC_IN>>
 
 Usage: 04_03_relations_derive[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>
 

--- a/examples/tutorial_derive/04_04_custom.md
+++ b/examples/tutorial_derive/04_04_custom.md
@@ -5,17 +5,17 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_04_custom_derive[EXE] [OPTIONS] [INPUT_FILE]
 
 Arguments:
-    [INPUT_FILE]    some regular input
+  [INPUT_FILE]  some regular input
 
 Options:
-        --set-ver <VER>        set version manually
-        --major                auto inc major
-        --minor                auto inc minor
-        --patch                auto inc patch
-        --spec-in <SPEC_IN>    some special input argument
-    -c <CONFIG>                
-    -h, --help                 Print help information
-    -V, --version              Print version information
+      --set-ver <VER>      set version manually
+      --major              auto inc major
+      --minor              auto inc minor
+      --patch              auto inc patch
+      --spec-in <SPEC_IN>  some special input argument
+  -c <CONFIG>              
+  -h, --help               Print help information
+  -V, --version            Print version information
 
 $ 04_04_custom_derive
 ? failed

--- a/examples/typed-derive.md
+++ b/examples/typed-derive.md
@@ -6,12 +6,12 @@ $ typed-derive --help
 Usage: typed-derive[EXE] [OPTIONS]
 
 Options:
-    -O <OPTIMIZATION>        Implicitly using `std::str::FromStr`
-    -I <DIR>                 Allow invalid UTF-8 paths
-        --bind <BIND>        Handle IP addresses
-        --sleep <SLEEP>      Allow human-readable durations
-    -D <DEFINES>             Hand-written parser for tuples
-    -h, --help               Print help information
+  -O <OPTIMIZATION>      Implicitly using `std::str::FromStr`
+  -I <DIR>               Allow invalid UTF-8 paths
+      --bind <BIND>      Handle IP addresses
+      --sleep <SLEEP>    Allow human-readable durations
+  -D <DEFINES>           Hand-written parser for tuples
+  -h, --help             Print help information
 
 ```
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -547,11 +547,13 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
         // Is help on next line, if so then indent
         if next_line_help {
             debug!("Help::help: Next Line...{:?}", next_line_help);
-            self.none(format!("\n{}{}{}", TAB, TAB, TAB));
+            self.none("\n");
+            self.none(TAB);
+            self.none(NEXT_LINE_INDENT);
         }
 
         let trailing_indent = if next_line_help {
-            TAB_WIDTH * 3
+            TAB.len() + NEXT_LINE_INDENT.len()
         } else if let Some(true) = arg.map(|a| a.is_positional()) {
             longest + TAB_WIDTH * 2
         } else {
@@ -560,7 +562,7 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
         let trailing_indent = self.get_spaces(trailing_indent);
 
         let spaces = if next_line_help {
-            TAB_WIDTH * 3
+            TAB.len() + NEXT_LINE_INDENT.len()
         } else {
             longest + TAB_WIDTH * 3
         };
@@ -931,6 +933,8 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
         }
     }
 }
+
+const NEXT_LINE_INDENT: &str = "        ";
 
 type ArgSortKey = fn(arg: &Arg) -> (usize, String);
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -552,20 +552,16 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
             self.none(NEXT_LINE_INDENT);
         }
 
-        let trailing_indent = if next_line_help {
+        let spaces = if next_line_help {
             TAB.len() + NEXT_LINE_INDENT.len()
         } else if let Some(true) = arg.map(|a| a.is_positional()) {
             longest + TAB_WIDTH * 2
         } else {
             longest + TAB_WIDTH * 3
         };
+        let trailing_indent = spaces; // Don't indent any further than the first line is indented
         let trailing_indent = self.get_spaces(trailing_indent);
 
-        let spaces = if next_line_help {
-            TAB.len() + NEXT_LINE_INDENT.len()
-        } else {
-            longest + TAB_WIDTH * 3
-        };
         let mut help = about.clone();
         help.replace_newline();
         if !spec_vals.is_empty() {
@@ -590,7 +586,6 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
         help.indent("", &trailing_indent);
         let help_is_empty = help.is_empty();
         self.writer.extend(help.into_iter());
-
         if let Some(arg) = arg {
             const DASH_SPACE: usize = "- ".len();
             const COLON_SPACE: usize = ": ".len();

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -476,7 +476,7 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
         if let Some(s) = arg.get_short() {
             self.literal(format!("-{}", s));
         } else if arg.get_long().is_some() {
-            self.none(TAB)
+            self.none("    ");
         }
     }
 

--- a/src/output/help.rs
+++ b/src/output/help.rs
@@ -557,7 +557,7 @@ impl<'cmd, 'writer> Help<'cmd, 'writer> {
         } else if let Some(true) = arg.map(|a| a.is_positional()) {
             longest + TAB_WIDTH * 2
         } else {
-            longest + TAB_WIDTH * 3
+            longest + TAB_WIDTH * 2 + 4 // See `fn short` for the 4
         };
         let trailing_indent = spaces; // Don't indent any further than the first line is indented
         let trailing_indent = self.get_spaces(trailing_indent);

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -9,5 +9,5 @@ pub(crate) use self::textwrap::core::display_width;
 pub(crate) use self::textwrap::wrap;
 pub(crate) use self::usage::Usage;
 
-pub(crate) const TAB: &str = "    ";
+pub(crate) const TAB: &str = "  ";
 pub(crate) const TAB_WIDTH: usize = TAB.len();

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -8,21 +8,21 @@ static ALLOW_EXT_SC: &str = "\
 Usage: clap-test [COMMAND]
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 static DONT_COLLAPSE_ARGS: &str = "\
 Usage: clap-test [arg1] [arg2] [arg3]
 
 Arguments:
-    [arg1]    some
-    [arg2]    some
-    [arg3]    some
+  [arg1]  some
+  [arg2]  some
+  [arg3]  some
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -125,9 +125,9 @@ fn arg_required_else_help_error_message() {
 Usage: test [OPTIONS]
 
 Options:
-    -i, --info       Provides more info
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -i, --info     Provides more info
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("test")
@@ -284,12 +284,12 @@ tests stuff
 Usage: test [OPTIONS] [arg1]
 
 Arguments:
-    [arg1]    some pos arg
+  [arg1]  some pos arg
 
 Options:
-    -o, --opt <opt>    some option
-    -h, --help         Print help information
-    -V, --version      Print version information
+  -o, --opt <opt>  some option
+  -h, --help       Print help information
+  -V, --version    Print version information
 ";
 
     let cmd = Command::new("test")
@@ -624,9 +624,9 @@ fn require_eq() {
 Usage: clap-test --opt=<FILE>
 
 Options:
-    -o, --opt=<FILE>    some
-    -h, --help          Print help information
-    -V, --version       Print version information
+  -o, --opt=<FILE>  some
+  -h, --help        Print help information
+  -V, --version     Print version information
 ";
 
     let cmd = Command::new("clap-test").version("v1.4.8").arg(

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -196,10 +196,10 @@ Some help
 Usage: ct test [OPTIONS]
 
 Options:
-    -o, --opt <opt>    
-    -f, --flag         
-    -h, --help         Print help information
-    -V, --version      Print version information
+  -o, --opt <opt>  
+  -f, --flag       
+  -h, --help       Print help information
+  -V, --version    Print version information
 ";
 
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(
@@ -226,10 +226,10 @@ Some help
 Usage: ct test [OPTIONS]
 
 Options:
-    -o, --opt <opt>    [aliases: visible]
-    -f, --flag         [aliases: v_flg, flag2, flg3]
-    -h, --help         Print help information
-    -V, --version      Print version information
+  -o, --opt <opt>  [aliases: visible]
+  -f, --flag       [aliases: v_flg, flag2, flg3]
+  -h, --help       Print help information
+  -V, --version    Print version information
 ";
 
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -163,10 +163,10 @@ Some help
 Usage: ct test [OPTIONS]
 
 Options:
-    -o, --opt <opt>    
-    -f, --flag         
-    -h, --help         Print help information
-    -V, --version      Print version information
+  -o, --opt <opt>  
+  -f, --flag       
+  -h, --help       Print help information
+  -V, --version    Print version information
 ";
 
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(
@@ -193,10 +193,10 @@ Some help
 Usage: ct test [OPTIONS]
 
 Options:
-    -o, --opt <opt>    [short aliases: v]
-    -f, --flag         [aliases: flag1] [short aliases: a, b, 🦆]
-    -h, --help         Print help information
-    -V, --version      Print version information
+  -o, --opt <opt>  [short aliases: v]
+  -f, --flag       [aliases: flag1] [short aliases: a, b, 🦆]
+  -h, --help       Print help information
+  -V, --version    Print version information
 ";
 
     let cmd = Command::new("ct").author("Salim Afiune").subcommand(

--- a/tests/builder/cargo.rs
+++ b/tests/builder/cargo.rs
@@ -12,8 +12,8 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: prog
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 static AUTHORS_ONLY: &str = "prog 1
@@ -22,8 +22,8 @@ static AUTHORS_ONLY: &str = "prog 1
 Usage: prog
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]

--- a/tests/builder/command.rs
+++ b/tests/builder/command.rs
@@ -10,8 +10,8 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: clap
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -290,7 +290,8 @@ fn get_arg_conflicts_with_group() {
 
 #[test]
 fn conflict_output() {
-    static CONFLICT_ERR: &str = "error: The argument '--flag...' cannot be used with '-F'
+    static CONFLICT_ERR: &str = "\
+error: The argument '--flag...' cannot be used with '-F'
 
 Usage: clap-test --flag... --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -307,7 +308,8 @@ For more information try --help
 
 #[test]
 fn conflict_output_rev() {
-    static CONFLICT_ERR_REV: &str = "error: The argument '-F' cannot be used with '--flag...'
+    static CONFLICT_ERR_REV: &str = "\
+error: The argument '-F' cannot be used with '--flag...'
 
 Usage: clap-test -F --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -324,7 +326,8 @@ For more information try --help
 
 #[test]
 fn conflict_output_with_required() {
-    static CONFLICT_ERR: &str = "error: The argument '--flag...' cannot be used with '-F'
+    static CONFLICT_ERR: &str = "\
+error: The argument '--flag...' cannot be used with '-F'
 
 Usage: clap-test --flag... --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -341,7 +344,8 @@ For more information try --help
 
 #[test]
 fn conflict_output_rev_with_required() {
-    static CONFLICT_ERR_REV: &str = "error: The argument '-F' cannot be used with '--flag...'
+    static CONFLICT_ERR_REV: &str = "\
+error: The argument '-F' cannot be used with '--flag...'
 
 Usage: clap-test -F --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -358,9 +362,10 @@ For more information try --help
 
 #[test]
 fn conflict_output_three_conflicting() {
-    static CONFLICT_ERR_THREE: &str = "error: The argument '--one' cannot be used with:
-    --two
-    --three
+    static CONFLICT_ERR_THREE: &str = "\
+error: The argument '--one' cannot be used with:
+  --two
+  --three
 
 Usage: three_conflicting_arguments --one
 

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -728,8 +728,9 @@ fn default_vals_donnot_show_in_smart_usage() {
     utils::assert_output(
         cmd,
         "bug",
-        "error: The following required arguments were not provided:
-    <input>
+        "\
+error: The following required arguments were not provided:
+  <input>
 
 Usage: bug <input>
 

--- a/tests/builder/derive_order.rs
+++ b/tests/builder/derive_order.rs
@@ -10,12 +10,12 @@ fn no_derive_order() {
 Usage: test [OPTIONS]
 
 Options:
-        --flag_a                 second flag
-        --flag_b                 first flag
-    -h, --help                   Print help information
-        --option_a <option_a>    second option
-        --option_b <option_b>    first option
-    -V, --version                Print version information
+      --flag_a               second flag
+      --flag_b               first flag
+  -h, --help                 Print help information
+      --option_a <option_a>  second option
+      --option_b <option_b>  first option
+  -V, --version              Print version information
 ";
 
     let cmd = Command::new("test")
@@ -49,12 +49,12 @@ fn derive_order() {
 Usage: test [OPTIONS]
 
 Options:
-        --flag_b                 first flag
-        --option_b <option_b>    first option
-        --flag_a                 second flag
-        --option_a <option_a>    second option
-    -h, --help                   Print help information
-    -V, --version                Print version information
+      --flag_b               first flag
+      --option_b <option_b>  first option
+      --flag_a               second flag
+      --option_a <option_a>  second option
+  -h, --help                 Print help information
+  -V, --version              Print version information
 ";
 
     let cmd = Command::new("test").version("1.2").args(&[
@@ -85,12 +85,12 @@ fn derive_order_next_order() {
 Usage: test [OPTIONS]
 
 Options:
-        --flag_b                 first flag
-        --option_b <option_b>    first option
-    -h, --help                   Print help information
-    -V, --version                Print version information
-        --flag_a                 second flag
-        --option_a <option_a>    second option
+      --flag_b               first flag
+      --option_b <option_b>  first option
+  -h, --help                 Print help information
+  -V, --version              Print version information
+      --flag_a               second flag
+      --option_a <option_a>  second option
 ";
 
     let cmd = Command::new("test")
@@ -131,12 +131,12 @@ fn derive_order_no_next_order() {
 Usage: test [OPTIONS]
 
 Options:
-        --flag_a                 first flag
-        --flag_b                 second flag
-    -h, --help                   Print help information
-        --option_a <option_a>    first option
-        --option_b <option_b>    second option
-    -V, --version                Print version information
+      --flag_a               first flag
+      --flag_b               second flag
+  -h, --help                 Print help information
+      --option_a <option_a>  first option
+      --option_b <option_b>  second option
+  -V, --version              Print version information
 ";
 
     let cmd = Command::new("test")
@@ -176,12 +176,12 @@ fn derive_order_subcommand_propagate() {
 Usage: test sub [OPTIONS]
 
 Options:
-        --flag_b                 first flag
-        --option_b <option_b>    first option
-        --flag_a                 second flag
-        --option_a <option_a>    second option
-    -h, --help                   Print help information
-    -V, --version                Print version information
+      --flag_b               first flag
+      --option_b <option_b>  first option
+      --flag_a               second flag
+      --option_a <option_a>  second option
+  -h, --help                 Print help information
+  -V, --version              Print version information
 ";
 
     let cmd = Command::new("test").subcommand(
@@ -214,12 +214,12 @@ fn derive_order_subcommand_propagate_with_explicit_display_order() {
 Usage: test sub [OPTIONS]
 
 Options:
-        --flag_a                 second flag
-        --flag_b                 first flag
-        --option_b <option_b>    first option
-        --option_a <option_a>    second option
-    -h, --help                   Print help information
-    -V, --version                Print version information
+      --flag_a               second flag
+      --flag_b               first flag
+      --option_b <option_b>  first option
+      --option_a <option_a>  second option
+  -h, --help                 Print help information
+  -V, --version              Print version information
 ";
 
     let cmd = Command::new("test").subcommand(
@@ -258,13 +258,13 @@ fn subcommand_sorted_display_order() {
 Usage: test [COMMAND]
 
 Commands:
-    a1      blah a1
-    b1      blah b1
-    help    Print this message or the help of the given subcommand(s)
+  a1    blah a1
+  b1    blah b1
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let app_subcmd_alpha_order = Command::new("test")
@@ -293,13 +293,13 @@ fn subcommand_derived_display_order() {
 Usage: test [COMMAND]
 
 Commands:
-    b1      blah b1
-    a1      blah a1
-    help    Print this message or the help of the given subcommand(s)
+  b1    blah b1
+  a1    blah a1
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let app_subcmd_decl_order = Command::new("test").version("1").subcommands(vec![

--- a/tests/builder/display_order.rs
+++ b/tests/builder/display_order.rs
@@ -13,11 +13,11 @@ fn very_large_display_order() {
 Usage: test [COMMAND]
 
 Commands:
-    help    Print this message or the help of the given subcommand(s)
-    sub     
+  help  Print this message or the help of the given subcommand(s)
+  sub   
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ",
         false,
     );

--- a/tests/builder/double_require.rs
+++ b/tests/builder/double_require.rs
@@ -4,22 +4,24 @@ static HELP: &str = "\
 Usage: prog [OPTIONS]
 
 Options:
-    -a            
-    -b            
-    -c            
-    -h, --help    Print help information
+  -a          
+  -b          
+  -c          
+  -h, --help  Print help information
 ";
 
-static ONLY_B_ERROR: &str = "error: The following required arguments were not provided:
-    -c
+static ONLY_B_ERROR: &str = "\
+error: The following required arguments were not provided:
+  -c
 
 Usage: prog -b -c
 
 For more information try --help
 ";
 
-static ONLY_C_ERROR: &str = "error: The following required arguments were not provided:
-    -b
+static ONLY_C_ERROR: &str = "\
+error: The following required arguments were not provided:
+  -b
 
 Usage: prog -c -b
 

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -91,7 +91,7 @@ fn null_prints_help() {
 Usage: test
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     assert_error(err, expected_kind, MESSAGE, false);
 }
@@ -109,7 +109,7 @@ fn raw_prints_help() {
 Usage: test
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     assert_error(err, expected_kind, MESSAGE, false);
 }

--- a/tests/builder/flag_subcommands.rs
+++ b/tests/builder/flag_subcommands.rs
@@ -502,9 +502,9 @@ Query the package database.
 Usage: pacman {query|--query|-Q} [OPTIONS]
 
 Options:
-    -s, --search <search>...    search locally installed packages for matching strings
-    -i, --info <info>...        view package information
-    -h, --help                  Print help information
+  -s, --search <search>...  search locally installed packages for matching strings
+  -i, --info <info>...      view package information
+  -h, --help                Print help information
 ";
 
 #[test]
@@ -550,9 +550,9 @@ Query the package database.
 Usage: pacman {query|--query} [OPTIONS]
 
 Options:
-    -s, --search <search>...    search locally installed packages for matching strings
-    -i, --info <info>...        view package information
-    -h, --help                  Print help information
+  -s, --search <search>...  search locally installed packages for matching strings
+  -i, --info <info>...      view package information
+  -h, --help                Print help information
 ";
 
 #[test]
@@ -602,9 +602,9 @@ Query the package database.
 Usage: pacman {query|-Q} [OPTIONS]
 
 Options:
-    -s, --search <search>...    search locally installed packages for matching strings
-    -i, --info <info>...        view package information
-    -h, --help                  Print help information
+  -s, --search <search>...  search locally installed packages for matching strings
+  -i, --info <info>...      view package information
+  -h, --help                Print help information
 ";
 
 #[test]

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -1,10 +1,10 @@
 use super::utils;
 use clap::{arg, Arg, ArgAction, Command};
 
-const USE_FLAG_AS_ARGUMENT: &str =
-    "error: Found argument '--another-flag' which wasn't expected, or isn't valid in this context
+const USE_FLAG_AS_ARGUMENT: &str = "\
+error: Found argument '--another-flag' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `--another-flag` as a value rather than a flag, use `-- --another-flag`
+  If you tried to supply `--another-flag` as a value rather than a flag, use `-- --another-flag`
 
 Usage: mycat [OPTIONS] [filename]
 
@@ -177,10 +177,10 @@ fn issue_1284_argument_in_flag_style() {
 
 #[test]
 fn issue_2308_multiple_dashes() {
-    static MULTIPLE_DASHES: &str =
-        "error: Found argument '-----' which wasn't expected, or isn't valid in this context
+    static MULTIPLE_DASHES: &str = "\
+error: Found argument '-----' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `-----` as a value rather than a flag, use `-- -----`
+  If you tried to supply `-----` as a value rather than a flag, use `-- -----`
 
 Usage: test <arg>
 

--- a/tests/builder/groups.rs
+++ b/tests/builder/groups.rs
@@ -3,23 +3,23 @@ use super::utils;
 use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgGroup, Command, Id};
 
 static REQ_GROUP_USAGE: &str = "error: The following required arguments were not provided:
-    <base|--delete>
+  <base|--delete>
 
 Usage: clap-test <base|--delete>
 
 For more information try --help
 ";
 
-static REQ_GROUP_CONFLICT_USAGE: &str =
-    "error: The argument '--delete' cannot be used with '[base]'
+static REQ_GROUP_CONFLICT_USAGE: &str = "\
+error: The argument '--delete' cannot be used with '[base]'
 
 Usage: clap-test <base|--delete>
 
 For more information try --help
 ";
 
-static REQ_GROUP_CONFLICT_ONLY_OPTIONS: &str =
-    "error: The argument '--delete' cannot be used with '--all'
+static REQ_GROUP_CONFLICT_ONLY_OPTIONS: &str = "\
+error: The argument '--delete' cannot be used with '--all'
 
 Usage: clap-test <--all|--delete>
 
@@ -262,10 +262,10 @@ fn group_usage_use_val_name() {
 Usage: prog <A>
 
 Arguments:
-    [A]    
+  [A]  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     let cmd = Command::new("prog")
         .arg(Arg::new("a").value_name("A"))

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -755,8 +755,8 @@ Arguments:
               symbols.
               l, long           Copy-friendly, 14
               characters, contains symbols.
-              m, med, medium    Copy-friendly, 8
-              characters, contains symbols.
+              m, med, medium    Copy-friendly, 8 characters,
+              contains symbols.
 
 Options:
     -h, --help       Print help information

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -91,12 +91,12 @@ fn req_last_arg_usage() {
 Usage: example <FIRST>... -- <SECOND>...
 
 Arguments:
-    <FIRST>...     First
-    <SECOND>...    Second
+  <FIRST>...   First
+  <SECOND>...  Second
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("example")
@@ -118,15 +118,15 @@ fn args_with_last_usage() {
 Usage: flamegraph [OPTIONS] [BINFILE] [-- <ARGS>...]
 
 Arguments:
-    [BINFILE]    The path of the binary to be profiled. for a binary.
-    [ARGS]...    Any arguments you wish to pass to the being profiled.
+  [BINFILE]  The path of the binary to be profiled. for a binary.
+  [ARGS]...  Any arguments you wish to pass to the being profiled.
 
 Options:
-    -v, --verbose              Prints out more stuff.
-    -t, --timeout <SECONDS>    Timeout in seconds.
-    -f, --frequency <HERTZ>    The sampling frequency.
-    -h, --help                 Print help information
-    -V, --version              Print version information
+  -v, --verbose            Prints out more stuff.
+  -t, --timeout <SECONDS>  Timeout in seconds.
+  -f, --frequency <HERTZ>  The sampling frequency.
+  -h, --help               Print help information
+  -V, --version            Print version information
 ";
 
     let cmd = Command::new("flamegraph")
@@ -202,28 +202,28 @@ tests clap library
 Usage: clap-test [OPTIONS] [positional] [positional2] [positional3]... [COMMAND]
 
 Commands:
-    subcmd    tests subcommands
-    help      Print this message or the help of the given subcommand(s)
+  subcmd  tests subcommands
+  help    Print this message or the help of the given subcommand(s)
 
 Arguments:
-    [positional]        tests positionals
-    [positional2]       tests positionals with exclusions
-    [positional3]...    tests specific values [possible values: vi, emacs]
+  [positional]      tests positionals
+  [positional2]     tests positionals with exclusions
+  [positional3]...  tests specific values [possible values: vi, emacs]
 
 Options:
-    -o, --option <opt>...                    tests options
-    -f, --flag...                            tests flags
-    -F                                       tests flags with exclusions
-        --long-option-2 <option2>            tests long options with exclusions
-    -O, --option3 <option3>                  specific vals [possible values: fast, slow]
-        --multvals <one> <two>               Tests multiple values, not mult occs
-        --multvalsmo <one> <two>             Tests multiple values, and mult occs
-        --minvals2 <minvals> <minvals>...    Tests 2 min vals
-        --maxvals3 <maxvals>...              Tests 3 max vals
-        --optvaleq[=<optval>]                Tests optional value, require = sign
-        --optvalnoeq [<optval>]              Tests optional value
-    -h, --help                               Print help information
-    -V, --version                            Print version information
+  -o, --option <opt>...                  tests options
+  -f, --flag...                          tests flags
+  -F                                     tests flags with exclusions
+      --long-option-2 <option2>          tests long options with exclusions
+  -O, --option3 <option3>                specific vals [possible values: fast, slow]
+      --multvals <one> <two>             Tests multiple values, not mult occs
+      --multvalsmo <one> <two>           Tests multiple values, and mult occs
+      --minvals2 <minvals> <minvals>...  Tests 2 min vals
+      --maxvals3 <maxvals>...            Tests 3 max vals
+      --optvaleq[=<optval>]              Tests optional value, require = sign
+      --optvalnoeq [<optval>]            Tests optional value
+  -h, --help                             Print help information
+  -V, --version                          Print version information
 ";
 
     utils::assert_output(utils::complex_app(), "clap-test --help", HELP, false);
@@ -238,8 +238,8 @@ tests clap library
 Usage: clap-test
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 some text that comes after the help
 ";
@@ -262,8 +262,8 @@ tests clap library
 Usage: clap-test
 
 Options:
-    -h, --help       Print help information (use `--help` for more detail)
-    -V, --version    Print version information
+  -h, --help     Print help information (use `--help` for more detail)
+  -V, --version  Print version information
 
 some text that comes after the help
 ";
@@ -275,11 +275,11 @@ tests clap library
 Usage: clap-test
 
 Options:
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 
 some longer text that comes after the help
 ";
@@ -301,10 +301,10 @@ tests subcommands
 Usage: ctest subcmd multi [OPTIONS]
 
 Options:
-    -f, --flag                    tests flags
-    -o, --option <scoption>...    tests options
-    -h, --help                    Print help information
-    -V, --version                 Print version information
+  -f, --flag                  tests flags
+  -o, --option <scoption>...  tests options
+  -h, --help                  Print help information
+  -V, --version               Print version information
 ";
 
 #[test]
@@ -337,8 +337,8 @@ fn no_wrap_default_help() {
 Usage: ctest
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("ctest").version("1.0").term_width(0);
@@ -352,18 +352,17 @@ fn wrapped_help() {
 Usage: test [OPTIONS]
 
 Options:
-    -a, --all
-            Also do versioning for private crates (will not be
-            published)
-        --exact
-            Specify inter dependency version numbers exactly with
-            `=`
-        --no-git-commit
-            Do not commit version changes
-        --no-git-push
-            Do not push generated commit and tags to git remote
-    -h, --help
-            Print help information
+  -a, --all
+          Also do versioning for private crates (will not be
+          published)
+      --exact
+          Specify inter dependency version numbers exactly with `=`
+      --no-git-commit
+          Do not commit version changes
+      --no-git-push
+          Do not push generated commit and tags to git remote
+  -h, --help
+          Print help information
 ";
     let cmd = Command::new("test")
         .term_width(67)
@@ -402,14 +401,14 @@ fn unwrapped_help() {
 Usage: test [OPTIONS]
 
 Options:
-    -a, --all              Also do versioning for private crates
-                           (will not be published)
-        --exact            Specify inter dependency version numbers
-                           exactly with `=`
-        --no-git-commit    Do not commit version changes
-        --no-git-push      Do not push generated commit and tags to
-                           git remote
-    -h, --help             Print help information
+  -a, --all            Also do versioning for private crates (will
+                       not be published)
+      --exact          Specify inter dependency version numbers
+                       exactly with `=`
+      --no-git-commit  Do not commit version changes
+      --no-git-push    Do not push generated commit and tags to git
+                       remote
+  -h, --help           Print help information
 ";
     let cmd = Command::new("test")
         .term_width(68)
@@ -448,27 +447,27 @@ fn possible_value_wrapped_help() {
 Usage: test [OPTIONS]
 
 Options:
-        --possible-values <possible_values>
-            Possible values:
-              - short_name:
-                Long enough help message, barely warrant wrapping
-              - second:
-                Short help gets handled the same
+      --possible-values <possible_values>
+          Possible values:
+          - short_name:
+            Long enough help message, barely warrant wrapping
+          - second:
+            Short help gets handled the same
 
-        --possible-values-with-new-line <possible_values_with_new_line>
-            Possible values:
-              - long enough name to trigger new line:
-                Really long enough help message to clearly warrant
-                wrapping believe me
-              - second
+      --possible-values-with-new-line <possible_values_with_new_line>
+          Possible values:
+          - long enough name to trigger new line:
+            Really long enough help message to clearly warrant
+            wrapping believe me
+          - second
 
-        --possible-values-without-new-line <possible_values_without_new_line>
-            Possible values:
-              - name:   Short enough help message with no wrapping
-              - second: short help
+      --possible-values-without-new-line <possible_values_without_new_line>
+          Possible values:
+          - name:   Short enough help message with no wrapping
+          - second: short help
 
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 ";
     let cmd = Command::new("test")
         .term_width(67)
@@ -514,14 +513,14 @@ tests subcommands
 Usage: clap-test subcmd [OPTIONS] [scpositional]
 
 Arguments:
-    [scpositional]    tests positionals
+  [scpositional]  tests positionals
 
 Options:
-    -o, --option <scoption>...     tests options
-    -f, --flag...                  tests flags
-    -s, --subcmdarg <subcmdarg>    tests other args
-    -h, --help                     Print help information
-    -V, --version                  Print version information
+  -o, --option <scoption>...   tests options
+  -f, --flag...                tests flags
+  -s, --subcmdarg <subcmdarg>  tests other args
+  -h, --help                   Print help information
+  -V, --version                Print version information
 ";
 
     let a = utils::complex_app();
@@ -534,16 +533,16 @@ fn issue_626_unicode_cutoff() {
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café is an
-                         establishment which primarily serves hot
-                         coffee, related coffee beverages (e.g., café
-                         latte, cappuccino, espresso), tea, and other
-                         hot beverages. Some coffeehouses also serve
-                         cold beverages such as iced coffee and iced
-                         tea. Many cafés also serve some type of food,
-                         such as light snacks, muffins, or pastries.
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -c, --cafe <FILE>  A coffeehouse, coffee shop, or café is an
+                     establishment which primarily serves hot coffee,
+                     related coffee beverages (e.g., café latte,
+                     cappuccino, espresso), tea, and other hot
+                     beverages. Some coffeehouses also serve cold
+                     beverages such as iced coffee and iced tea. Many
+                     cafés also serve some type of food, such as light
+                     snacks, muffins, or pastries.
+  -h, --help         Print help information
+  -V, --version      Print version information
 ";
 
     let cmd = Command::new("ctest").version("0.1").term_width(70).arg(
@@ -553,11 +552,11 @@ Options:
             .value_name("FILE")
             .help(
                 "A coffeehouse, coffee shop, or café is an establishment \
-                 which primarily serves hot coffee, related coffee beverages \
-                 (e.g., café latte, cappuccino, espresso), tea, and other hot \
-                 beverages. Some coffeehouses also serve cold beverages such as \
-                 iced coffee and iced tea. Many cafés also serve some type of \
-                 food, such as light snacks, muffins, or pastries.",
+             which primarily serves hot coffee, related coffee beverages \
+             (e.g., café latte, cappuccino, espresso), tea, and other hot \
+             beverages. Some coffeehouses also serve cold beverages such as \
+             iced coffee and iced tea. Many cafés also serve some type of \
+             food, such as light snacks, muffins, or pastries.",
             )
             .action(ArgAction::Set),
     );
@@ -568,10 +567,10 @@ static HIDE_POS_VALS: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -p, --pos <VAL>      Some vals [possible values: fast, slow]
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -p, --pos <VAL>    Some vals [possible values: fast, slow]
+  -c, --cafe <FILE>  A coffeehouse, coffee shop, or café.
+  -h, --help         Print help information
+  -V, --version      Print version information
 ";
 
 #[test]
@@ -634,21 +633,21 @@ fn possible_vals_with_help() {
 Usage: ctest [OPTIONS]
 
 Options:
-    -p, --pos <VAL>
-            Some vals
+  -p, --pos <VAL>
+          Some vals
 
-            Possible values:
-              - fast
-              - slow: not as fast
+          Possible values:
+          - fast
+          - slow: not as fast
 
-    -c, --cafe <FILE>
-            A coffeehouse, coffee shop, or café.
+  -c, --cafe <FILE>
+          A coffeehouse, coffee shop, or café.
 
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 ";
     let app = Command::new("ctest")
         .version("0.1")
@@ -682,18 +681,18 @@ fn issue_626_panic() {
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe <FILE>
-            La culture du café est très développée
-            dans de nombreux pays à climat chaud
-            d\'Amérique, d\'Afrique et d\'Asie, dans
-            des plantations qui sont cultivées pour
-            les marchés d\'exportation. Le café est
-            souvent une contribution majeure aux
-            exportations des régions productrices.
-    -h, --help
-            Print help information
-    -V, --version
-            Print version information
+  -c, --cafe <FILE>
+          La culture du café est très développée
+          dans de nombreux pays à climat chaud
+          d\'Amérique, d\'Afrique et d\'Asie, dans des
+          plantations qui sont cultivées pour les
+          marchés d\'exportation. Le café est souvent
+          une contribution majeure aux exportations
+          des régions productrices.
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
 ";
 
     let cmd = Command::new("ctest")
@@ -734,13 +733,12 @@ fn final_word_wrapping() {
 Usage: ctest
 
 Options:
-    -h, --help
-            Print help
-            information
-    -V, --version
-            Print
-            version
-            information
+  -h, --help
+          Print help
+          information
+  -V, --version
+          Print version
+          information
 ";
 
     let cmd = Command::new("ctest").version("0.1").term_width(24);
@@ -751,16 +749,15 @@ static WRAPPING_NEWLINE_CHARS: &str = "\
 Usage: ctest [mode]
 
 Arguments:
-    [mode]    x, max, maximum   20 characters, contains
-              symbols.
-              l, long           Copy-friendly, 14
-              characters, contains symbols.
-              m, med, medium    Copy-friendly, 8 characters,
-              contains symbols.
+  [mode]  x, max, maximum   20 characters, contains symbols.
+          l, long           Copy-friendly, 14 characters,
+          contains symbols.
+          m, med, medium    Copy-friendly, 8 characters,
+          contains symbols.
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -804,14 +801,14 @@ fn dont_wrap_urls() {
 Usage: Example update [OPTIONS]
 
 Options:
-        --force-non-host
-            Install toolchains
-            that require an
-            emulator. See
-            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-    -h, --help
-            Print help
-            information
+      --force-non-host
+          Install toolchains
+          that require an
+          emulator. See
+          https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+  -h, --help
+          Print help
+          information
 ";
     utils::assert_output(cmd, "Example update --help", EXPECTED, false);
 }
@@ -820,10 +817,10 @@ static OLD_NEWLINE_CHARS: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -m               Some help with some wrapping
-                     (Defaults to something)
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -m             Some help with some wrapping
+                 (Defaults to something)
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -854,44 +851,44 @@ fn issue_688_hide_pos_vals() {
 Usage: ctest [OPTIONS]
 
 Options:
-        --filter <filter>    Sets the filter, or sampling method, to use for interpolation when resizing the particle
-                             images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic,
-                             Gaussian, Lanczos3]
-    -h, --help               Print help information
-    -V, --version            Print version information
+      --filter <filter>  Sets the filter, or sampling method, to use for interpolation when resizing the particle
+                         images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian,
+                         Lanczos3]
+  -h, --help             Print help information
+  -V, --version          Print version information
 ";
 
     let filter_values = ["Nearest", "Linear", "Cubic", "Gaussian", "Lanczos3"];
 
     let app1 = Command::new("ctest")
-            .version("0.1")
+        .version("0.1")
 			.term_width(120)
 			.hide_possible_values(true)
 			.arg(Arg::new("filter")
 				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
-                images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
+            images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
 				.long("filter")
 				.value_parser(filter_values)
 				.action(ArgAction::Set));
     utils::assert_output(app1, "ctest --help", ISSUE_688, false);
 
     let app2 = Command::new("ctest")
-            .version("0.1")
+        .version("0.1")
 			.term_width(120)
 			.arg(Arg::new("filter")
 				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
-                images. The default is Linear (Bilinear).")
+            images. The default is Linear (Bilinear).")
 				.long("filter")
 				.value_parser(filter_values)
 				.action(ArgAction::Set));
     utils::assert_output(app2, "ctest --help", ISSUE_688, false);
 
     let app3 = Command::new("ctest")
-            .version("0.1")
+        .version("0.1")
 			.term_width(120)
 			.arg(Arg::new("filter")
 				.help("Sets the filter, or sampling method, to use for interpolation when resizing the particle \
-                images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
+            images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian, Lanczos3]")
 				.long("filter")
 				.action(ArgAction::Set));
     utils::assert_output(app3, "ctest --help", ISSUE_688, false);
@@ -905,15 +902,15 @@ bar
 Usage: myapp [OPTIONS] [arg1] [arg2]...
 
 Arguments:
-    [arg1]       some option
-    [arg2]...    some option
+  [arg1]     some option
+  [arg2]...  some option
 
 Options:
-    -s, --some <some>         some option
-    -o, --other <other>       some other option
-    -l, --label <label>...    a label
-    -h, --help                Print help information
-    -V, --version             Print version information
+  -s, --some <some>       some option
+  -o, --other <other>     some other option
+  -l, --label <label>...  a label
+  -h, --help              Print help information
+  -V, --version           Print version information
 ";
 
     let cmd = Command::new("myapp")
@@ -962,15 +959,15 @@ that should be displayed
 Usage: myapp [arg1]
 
 Arguments:
-    [arg1]
-            some option
+  [arg1]
+          some option
 
 Options:
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 ";
 
     let cmd = Command::new("myapp")
@@ -993,8 +990,8 @@ Usage: rg [OPTIONS] <pattern> [<path> ...]
        rg [OPTIONS] --type-list
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("ripgrep").version("0.5").override_usage(
@@ -1018,8 +1015,8 @@ Usage: rg [OPTIONS] <pattern> [<path> ...]
        rg [OPTIONS] --type-list
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("ripgrep")
@@ -1051,16 +1048,16 @@ Usage: prog --opt <FILE> [PATH]
        prog [PATH] <COMMAND>
 
 Commands:
-    test    
-    help    Print this message or the help of the given subcommand(s)
+  test  
+  help  Print this message or the help of the given subcommand(s)
 
 Arguments:
-    [PATH]    help
+  [PATH]  help
 
 Options:
-    -o, --opt <FILE>    tests options
-    -h, --help          Print help information
-    -V, --version       Print version information
+  -o, --opt <FILE>  tests options
+  -h, --help        Print help information
+  -V, --version     Print version information
 ";
 
     let cmd = Command::new("prog")
@@ -1078,10 +1075,10 @@ fn hide_args() {
 Usage: prog [OPTIONS]
 
 Options:
-    -f, --flag          testing flags
-    -o, --opt <FILE>    tests options
-    -h, --help          Print help information
-    -V, --version       Print version information
+  -f, --flag        testing flags
+  -o, --opt <FILE>  tests options
+  -h, --help        Print help information
+  -V, --version     Print version information
 ";
 
     let cmd = Command::new("prog")
@@ -1099,17 +1096,17 @@ Usage: prog [OPTIONS] [PATH]
        prog <COMMAND>
 
 Commands:
-    test    
-    help    Print this message or the help of the given subcommand(s)
+  test  
+  help  Print this message or the help of the given subcommand(s)
 
 Arguments:
-    [PATH]    help
+  [PATH]  help
 
 Options:
-    -f, --flag          testing flags
-    -o, --opt <FILE>    tests options
-    -h, --help          Print help information
-    -V, --version       Print version information
+  -f, --flag        testing flags
+  -o, --opt <FILE>  tests options
+  -h, --help        Print help information
+  -V, --version     Print version information
 ";
 
     let cmd = Command::new("prog")
@@ -1128,13 +1125,13 @@ fn issue_1046_hide_scs() {
 Usage: prog [OPTIONS] [PATH]
 
 Arguments:
-    [PATH]    some
+  [PATH]  some
 
 Options:
-    -f, --flag          testing flags
-    -o, --opt <FILE>    tests options
-    -h, --help          Print help information
-    -V, --version       Print version information
+  -f, --flag        testing flags
+  -o, --opt <FILE>  tests options
+  -h, --help        Print help information
+  -V, --version     Print version information
 ";
 
     let cmd = Command::new("prog")
@@ -1158,11 +1155,10 @@ wrapped
 Usage: ctest
 
 Options:
-    -h, --help
-            Print help information
-    -V, --version
-            Print version
-            information
+  -h, --help
+          Print help information
+  -V, --version
+          Print version information
 ";
 
     let cmd = Command::new("A cmd with a crazy very long long long name hahaha")
@@ -1178,8 +1174,8 @@ static OVERRIDE_HELP_SHORT: &str = "\
 Usage: test
 
 Options:
-    -H, --help       Print help information
-    -V, --version    Print version information
+  -H, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -1197,8 +1193,8 @@ static OVERRIDE_HELP_LONG: &str = "\
 Usage: test [OPTIONS]
 
 Options:
-    -h, --hell       Print help information
-    -V, --version    Print version information
+  -h, --hell     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -1216,8 +1212,8 @@ static OVERRIDE_HELP_ABOUT: &str = "\
 Usage: test
 
 Options:
-    -h, --help       Print custom help information
-    -V, --version    Print version information
+  -h, --help     Print custom help information
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -1268,13 +1264,13 @@ fn last_arg_mult_usage() {
 Usage: last <TARGET> [CORPUS] [-- <ARGS>...]
 
 Arguments:
-    <TARGET>     some
-    [CORPUS]     some
-    [ARGS]...    some
+  <TARGET>   some
+  [CORPUS]   some
+  [ARGS]...  some
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("last")
@@ -1297,13 +1293,13 @@ fn last_arg_mult_usage_req() {
 Usage: last <TARGET> [CORPUS] -- <ARGS>...
 
 Arguments:
-    <TARGET>     some
-    [CORPUS]     some
-    <ARGS>...    some
+  <TARGET>   some
+  [CORPUS]   some
+  <ARGS>...  some
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("last")
@@ -1328,17 +1324,17 @@ Usage: last <TARGET> [CORPUS] -- <ARGS>...
        last [TARGET] [CORPUS] <COMMAND>
 
 Commands:
-    test    some
-    help    Print this message or the help of the given subcommand(s)
+  test  some
+  help  Print this message or the help of the given subcommand(s)
 
 Arguments:
-    <TARGET>     some
-    [CORPUS]     some
-    <ARGS>...    some
+  <TARGET>   some
+  [CORPUS]   some
+  <ARGS>...  some
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("last")
@@ -1365,17 +1361,17 @@ Usage: last <TARGET> [CORPUS] [-- <ARGS>...]
        last <COMMAND>
 
 Commands:
-    test    some
-    help    Print this message or the help of the given subcommand(s)
+  test  some
+  help  Print this message or the help of the given subcommand(s)
 
 Arguments:
-    <TARGET>     some
-    [CORPUS]     some
-    [ARGS]...    some
+  <TARGET>   some
+  [CORPUS]   some
+  [ARGS]...  some
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
     let cmd = Command::new("last")
@@ -1398,9 +1394,9 @@ static HIDE_DEFAULT_VAL: &str = "\
 Usage: default [OPTIONS]
 
 Options:
-        --arg <argument>    Pass an argument to the program. [default: default-argument]
-    -h, --help              Print help information
-    -V, --version           Print version information
+      --arg <argument>  Pass an argument to the program. [default: default-argument]
+  -h, --help            Print help information
+  -V, --version         Print version information
 ";
 
 #[test]
@@ -1429,10 +1425,10 @@ fn escaped_whitespace_values() {
 Usage: default [OPTIONS]
 
 Options:
-        --arg <argument>    Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
-                            other]
-    -h, --help              Print help information
-    -V, --version           Print version information
+      --arg <argument>  Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
+                        other]
+  -h, --help            Print help information
+  -V, --version         Print version information
 ";
 
     let app1 = Command::new("default").version("0.1").term_width(120).arg(
@@ -1519,9 +1515,9 @@ tests stuff
 Usage: test --fake <some> <val>
 
 Options:
-    -f, --fake <some> <val>    some help
-    -h, --help                 Print help information
-    -V, --version              Print version information
+  -f, --fake <some> <val>  some help
+  -h, --help               Print help information
+  -V, --version            Print version information
 ";
 
     let cmd = Command::new("test")
@@ -1547,13 +1543,13 @@ does stuff
 Usage: test [OPTIONS] --fake <some> <val>
 
 Options:
-    -f, --fake <some> <val>    some help
-    -h, --help                 Print help information
-    -V, --version              Print version information
+  -f, --fake <some> <val>  some help
+  -h, --help               Print help information
+  -V, --version            Print version information
 
 NETWORKING:
-    -n, --no-proxy    Do not use system proxy settings
-        --port
+  -n, --no-proxy  Do not use system proxy settings
+      --port
 ";
 
     let cmd = Command::new("blorp")
@@ -1586,21 +1582,21 @@ does stuff
 Usage: test [OPTIONS] --fake <some> <val> --birthday-song <song> --birthday-song-volume <volume>
 
 Options:
-    -f, --fake <some> <val>    some help
-        --style <style>        Choose musical style to play the song
-    -s, --speed <SPEED>        How fast? [possible values: fast, slow]
-    -h, --help                 Print help information
-    -V, --version              Print version information
+  -f, --fake <some> <val>  some help
+      --style <style>      Choose musical style to play the song
+  -s, --speed <SPEED>      How fast? [possible values: fast, slow]
+  -h, --help               Print help information
+  -V, --version            Print version information
 
 NETWORKING:
-    -n, --no-proxy       Do not use system proxy settings
-    -a, --server-addr    Set server address
+  -n, --no-proxy     Do not use system proxy settings
+  -a, --server-addr  Set server address
 
 OVERRIDE SPECIAL:
-    -b, --birthday-song <song>    Change which song is played for birthdays
+  -b, --birthday-song <song>  Change which song is played for birthdays
 
 SPECIAL:
-    -v, --birthday-song-volume <volume>    Change the volume of the birthday song
+  -v, --birthday-song-volume <volume>  Change the volume of the birthday song
 ";
 
 #[test]
@@ -1665,14 +1661,14 @@ does stuff
 Usage: test [OPTIONS] --song <song> --song-volume <volume>
 
 Options:
-    -h, --help       Print help information (use `--help` for more detail)
-    -V, --version    Print version information
+  -h, --help     Print help information (use `--help` for more detail)
+  -V, --version  Print version information
 
 OVERRIDE SPECIAL:
-    -b, --song <song>    Change which song is played for birthdays
+  -b, --song <song>  Change which song is played for birthdays
 
 SPECIAL:
-    -v, --song-volume <volume>    Change the volume of the birthday song
+  -v, --song-volume <volume>  Change the volume of the birthday song
 ";
 
 #[test]
@@ -1716,11 +1712,11 @@ Long about foo
 Usage: ctest foo
 
 Options:
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 ";
 
 #[test]
@@ -1740,8 +1736,8 @@ About foo
 Usage: ctest foo
 
 Options:
-    -h, --help       Print help information (use `--help` for more detail)
-    -V, --version    Print version information
+  -h, --help     Print help information (use `--help` for more detail)
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -1761,11 +1757,11 @@ fn issue_1364_no_short_options() {
 Usage: demo [OPTIONS] [FILES]...
 
 Arguments:
-    [FILES]...    
+  [FILES]...  
 
 Options:
-    -f            
-    -h, --help    Print help information (use `--help` for more detail)
+  -f          
+  -h, --help  Print help information (use `--help` for more detail)
 ";
 
     let cmd = Command::new("demo")
@@ -1793,21 +1789,21 @@ static ISSUE_1487: &str = "\
 Usage: ctest <arg1|arg2>
 
 Arguments:
-    [arg1]    
-    [arg2]    
+  [arg1]  
+  [arg2]  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
 
     let cmd = Command::new("test")
-        .arg(Arg::new("arg1")
-            .group("group1"))
-        .arg(Arg::new("arg2")
-            .group("group1"))
-        .group(ArgGroup::new("group1")
-            .args(["arg1", "arg2"])
-            .required(true));
+    .arg(Arg::new("arg1")
+        .group("group1"))
+    .arg(Arg::new("arg2")
+        .group("group1"))
+    .group(ArgGroup::new("group1")
+        .args(["arg1", "arg2"])
+        .required(true));
     utils::assert_output(cmd, "ctest -h", ISSUE_1487, false);
 }
 
@@ -1913,14 +1909,14 @@ fn issue_1642_long_help_spacing() {
 Usage: prog [OPTIONS]
 
 Options:
-        --config
-            The config file used by the myprog must be in JSON format
-            with only valid keys and may not contain other nonsense
-            that cannot be read by this program. Obviously I'm going on
-            and on, so I'll stop now.
+      --config
+          The config file used by the myprog must be in JSON format
+          with only valid keys and may not contain other nonsense
+          that cannot be read by this program. Obviously I'm going on
+          and on, so I'll stop now.
 
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 ";
 
     let cmd = Command::new("prog").arg(
@@ -1968,7 +1964,7 @@ Print this message or the help of the given subcommand(s)
 Usage: myapp help [COMMAND]...
 
 Arguments:
-    [COMMAND]...    The subcommand whose help message to display
+  [COMMAND]...  The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -1985,7 +1981,7 @@ Print this message or the help of the given subcommand(s)
 Usage: myapp subcmd help [COMMAND]...
 
 Arguments:
-    [COMMAND]...    The subcommand whose help message to display
+  [COMMAND]...  The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -2005,12 +2001,12 @@ fn global_args_should_show_on_toplevel_help_message() {
 Usage: myapp [OPTIONS] [COMMAND]
 
 Commands:
-    subcmd\x20\x20\x20\x20
-    help      Print this message or the help of the given subcommand(s)
+  subcmd\x20\x20
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
-    -g, --some-global <someglobal>\x20\x20\x20\x20
-    -h, --help                        Print help information
+  -g, --some-global <someglobal>\x20\x20
+  -h, --help                      Print help information
 ";
 
     let cmd = Command::new("myapp")
@@ -2033,7 +2029,7 @@ Print this message or the help of the given subcommand(s)
 Usage: myapp help [COMMAND]...
 
 Arguments:
-    [COMMAND]...    The subcommand whose help message to display
+  [COMMAND]...  The subcommand whose help message to display
 ";
 
     let cmd = Command::new("myapp")
@@ -2054,12 +2050,12 @@ fn global_args_should_show_on_help_message_for_subcommand() {
 Usage: myapp subcmd [OPTIONS] [COMMAND]
 
 Commands:
-    multi\x20\x20\x20\x20
-    help     Print this message or the help of the given subcommand(s)
+  multi\x20\x20
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
-    -g, --some-global <someglobal>\x20\x20\x20\x20
-    -h, --help                        Print help information
+  -g, --some-global <someglobal>\x20\x20
+  -h, --help                      Print help information
 ";
 
     let cmd = Command::new("myapp")
@@ -2080,9 +2076,9 @@ fn global_args_should_show_on_help_message_for_nested_subcommand() {
 Usage: myapp subcmd multi [OPTIONS]
 
 Options:
-    -g, --some-global <someglobal>\x20\x20\x20\x20
-    -h, --help                        Print help information
-    -V, --version                     Print version information
+  -g, --some-global <someglobal>\x20\x20
+  -h, --help                      Print help information
+  -V, --version                   Print version information
 ";
 
     let cmd = Command::new("myapp")
@@ -2103,14 +2099,14 @@ fn option_usage_order() {
 Usage: order [OPTIONS]
 
 Options:
-    -a                     
-    -B                     
-    -b                     
-    -s                     
-        --select_file      
-        --select_folder    
-    -x                     
-    -h, --help             Print help information
+  -a                   
+  -B                   
+  -b                   
+  -s                   
+      --select_file    
+      --select_folder  
+  -x                   
+  -h, --help           Print help information
 ";
 
     let cmd = Command::new("order").args([
@@ -2136,11 +2132,11 @@ fn prefer_about_over_long_about_in_subcommands_list() {
 Usage: about-in-subcommands-list [COMMAND]
 
 Commands:
-    sub     short about sub
-    help    Print this message or the help of the given subcommand(s)
+  sub   short about sub
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
 
     let cmd = Command::new("about-in-subcommands-list").subcommand(
@@ -2163,12 +2159,12 @@ fn issue_1794_usage() {
 Usage: deno <pos1|--option1> [pos2]
 
 Arguments:
-    [pos1]    
-    [pos2]    
+  [pos1]  
+  [pos2]  
 
 Options:
-        --option1    
-    -h, --help       Print help information
+      --option1  
+  -h, --help     Print help information
 ";
 
     let cmd = clap::Command::new("hello")
@@ -2193,14 +2189,14 @@ static CUSTOM_HEADING_POS: &str = "\
 Usage: test [gear] [speed]
 
 Arguments:
-    [gear]    Which gear
+  [gear]  Which gear
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 
 NETWORKING:
-    [speed]    How fast
+  [speed]  How fast
 ";
 
 #[test]
@@ -2218,7 +2214,7 @@ static ONLY_CUSTOM_HEADING_OPTS_NO_ARGS: &str = "\
 Usage: test [OPTIONS]
 
 NETWORKING:
-    -s, --speed <SPEED>    How fast
+  -s, --speed <SPEED>  How fast
 ";
 
 #[test]
@@ -2238,7 +2234,7 @@ static ONLY_CUSTOM_HEADING_POS_NO_ARGS: &str = "\
 Usage: test [speed]
 
 NETWORKING:
-    [speed]    How fast
+  [speed]  How fast
 ";
 
 #[test]
@@ -2271,9 +2267,9 @@ fn issue_2508_number_of_values_with_single_value_name() {
 Usage: my_app [OPTIONS]
 
 Options:
-        --some_arg <some_arg> <some_arg>    
-        --some_arg_issue <ARG> <ARG>        
-    -h, --help                              Print help information
+      --some_arg <some_arg> <some_arg>  
+      --some_arg_issue <ARG> <ARG>      
+  -h, --help                            Print help information
 ",
         false,
     );
@@ -2292,11 +2288,11 @@ fn missing_positional_final_required() {
 Usage: test [arg1] <arg2>
 
 Arguments:
-    [arg1]    
-    <arg2>    
+  [arg1]  
+  <arg2>  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ",
         false,
     );
@@ -2316,12 +2312,12 @@ fn missing_positional_final_multiple() {
 Usage: test [foo] [bar] [baz]...
 
 Arguments:
-    [foo]       
-    [bar]       
-    [baz]...    
+  [foo]     
+  [bar]     
+  [baz]...  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ",
         false,
     );
@@ -2342,10 +2338,10 @@ fn positional_multiple_values_is_dotted() {
 Usage: test <foo>...
 
 Arguments:
-    <foo>...    
+  <foo>...  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ",
         false,
     );
@@ -2364,10 +2360,10 @@ Options:
 Usage: test <BAR>...
 
 Arguments:
-    <BAR>...    
+  <BAR>...  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ",
         false,
     );
@@ -2389,10 +2385,10 @@ fn positional_multiple_occurrences_is_dotted() {
 Usage: test <foo>...
 
 Arguments:
-    <foo>...    
+  <foo>...  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ",
         false,
     );
@@ -2412,10 +2408,10 @@ Options:
 Usage: test <BAR>...
 
 Arguments:
-    <BAR>...    
+  <BAR>...  
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ",
         false,
     );
@@ -2438,8 +2434,8 @@ fn too_few_value_names_is_dotted() {
 Usage: test --foo <one> <two>...
 
 Options:
-        --foo <one> <two>...    
-    -h, --help                  Print help information
+      --foo <one> <two>...  
+  -h, --help                Print help information
 ",
         false,
     );
@@ -2540,7 +2536,7 @@ Print this message or the help of the given subcommand(s)
 Usage: example help [COMMAND]...
 
 Arguments:
-    [COMMAND]...    The subcommand whose help message to display
+  [COMMAND]...  The subcommand whose help message to display
 ",
         false,
     );
@@ -2582,7 +2578,7 @@ Print this message or the help of the given subcommand(s)
 Usage: example help [COMMAND]...
 
 Arguments:
-    [COMMAND]...    The subcommand whose help message to display
+  [COMMAND]...  The subcommand whose help message to display
 ",
         false,
     );
@@ -2616,7 +2612,7 @@ some
 Usage: parent <TARGET> <ARGS> test
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     let cmd = Command::new("parent")
         .version("0.1")
@@ -2639,7 +2635,7 @@ some
 Usage: parent <TARGET> <ARGS> test
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     let cmd = Command::new("parent")
         .version("0.1")
@@ -2662,7 +2658,7 @@ some
 Usage: parent <TARGET> <ARGS> test
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     let mut cmd = Command::new("parent")
         .version("0.1")
@@ -2688,7 +2684,7 @@ fn parent_cmd_req_ignored_when_negates_reqs() {
 Usage: ctest subcmd
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
 
     let cmd = Command::new("ctest")
@@ -2704,7 +2700,7 @@ fn parent_cmd_req_ignored_when_conflicts() {
 Usage: ctest subcmd
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
 
     let cmd = Command::new("ctest")

--- a/tests/builder/help_env.rs
+++ b/tests/builder/help_env.rs
@@ -10,72 +10,72 @@ static HIDE_ENV: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café.
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -c, --cafe <FILE>  A coffeehouse, coffee shop, or café.
+  -h, --help         Print help information
+  -V, --version      Print version information
 ";
 
 static SHOW_ENV: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -c, --cafe <FILE>  A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
+  -h, --help         Print help information
+  -V, --version      Print version information
 ";
 
 static HIDE_ENV_VALS: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR]
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -c, --cafe <FILE>  A coffeehouse, coffee shop, or café. [env: ENVVAR]
+  -h, --help         Print help information
+  -V, --version      Print version information
 ";
 
 static SHOW_ENV_VALS: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe <FILE>    A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
-    -h, --help           Print help information
-    -V, --version        Print version information
+  -c, --cafe <FILE>  A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
+  -h, --help         Print help information
+  -V, --version      Print version information
 ";
 
 static HIDE_ENV_FLAG: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe       A coffeehouse, coffee shop, or café.
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -c, --cafe     A coffeehouse, coffee shop, or café.
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 static SHOW_ENV_FLAG: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -c, --cafe     A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 static HIDE_ENV_VALS_FLAG: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR]
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -c, --cafe     A coffeehouse, coffee shop, or café. [env: ENVVAR]
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 static SHOW_ENV_VALS_FLAG: &str = "\
 Usage: ctest [OPTIONS]
 
 Options:
-    -c, --cafe       A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -c, --cafe     A coffeehouse, coffee shop, or café. [env: ENVVAR=MYVAL]
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -8,10 +8,10 @@ tests stuff
 Usage: test [OPTIONS]
 
 Options:
-    -F, --flag2           some other flag
-        --option <opt>    some option
-    -h, --help            Print help information
-    -V, --version         Print version information
+  -F, --flag2         some other flag
+      --option <opt>  some option
+  -h, --help          Print help information
+  -V, --version       Print version information
 ";
 
 #[test]
@@ -35,9 +35,9 @@ hides short args
 Usage: test [OPTIONS]
 
 Options:
-    -v, --visible    This text should be visible
-    -h, --help       Print help information (use `--help` for more detail)
-    -V, --version    Print version information
+  -v, --visible  This text should be visible
+  -h, --help     Print help information (use `--help` for more detail)
+  -V, --version  Print version information
 ";
 
 /// Ensure hide with short option
@@ -73,17 +73,17 @@ hides short args
 Usage: test [OPTIONS]
 
 Options:
-    -c, --config
-            Some help text describing the --config arg
+  -c, --config
+          Some help text describing the --config arg
 
-    -v, --visible
-            This text should be visible
+  -v, --visible
+          This text should be visible
 
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 ";
 
     let cmd = Command::new("test")
@@ -113,14 +113,14 @@ hides long args
 Usage: test [OPTIONS]
 
 Options:
-    -v, --visible
-            This text should be visible
+  -v, --visible
+          This text should be visible
 
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 ";
 
 #[test]
@@ -152,10 +152,10 @@ hides long args
 Usage: test [OPTIONS]
 
 Options:
-    -c, --config     Some help text describing the --config arg
-    -v, --visible    This text should be visible
-    -h, --help       Print help information (use `--help` for more detail)
-    -V, --version    Print version information
+  -c, --config   Some help text describing the --config arg
+  -v, --visible  This text should be visible
+  -h, --help     Print help information (use `--help` for more detail)
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -185,11 +185,11 @@ static HIDDEN_POS_ARGS: &str = "\
 Usage: test [another]
 
 Arguments:
-    [another]    another pos
+  [another]  another pos
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]
@@ -206,8 +206,8 @@ static HIDDEN_SUBCMDS: &str = "\
 Usage: test
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[test]

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -432,8 +432,8 @@ fn optional_value() {
 Usage: test [OPTIONS]
 
 Options:
-    -p [<NUM>]        
-    -h, --help        Print help information
+  -p [<NUM>]      
+  -h, --help      Print help information
 ";
     snapbox::assert_eq(HELP, help);
 }

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -3,12 +3,12 @@ use super::utils;
 use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgMatches, Command};
 
 #[cfg(feature = "suggestions")]
-static DYM: &str =
-    "error: Found argument '--optio' which wasn't expected, or isn't valid in this context
+static DYM: &str = "\
+error: Found argument '--optio' which wasn't expected, or isn't valid in this context
 
-    Did you mean '--option'?
+  Did you mean '--option'?
 
-    If you tried to supply `--optio` as a value rather than a flag, use `-- --optio`
+  If you tried to supply `--optio` as a value rather than a flag, use `-- --optio`
 
 Usage: clap-test --option <opt>... [positional] [positional2] [positional3]...
 
@@ -16,12 +16,12 @@ For more information try --help
 ";
 
 #[cfg(feature = "suggestions")]
-static DYM_ISSUE_1073: &str =
-    "error: Found argument '--files-without-matches' which wasn't expected, or isn't valid in this context
+static DYM_ISSUE_1073: &str = "\
+error: Found argument '--files-without-matches' which wasn't expected, or isn't valid in this context
 
-    Did you mean '--files-without-match'?
+  Did you mean '--files-without-match'?
 
-    If you tried to supply `--files-without-matches` as a value rather than a flag, use `-- --files-without-matches`
+  If you tried to supply `--files-without-matches` as a value rather than a flag, use `-- --files-without-matches`
 
 Usage: ripgrep-616 --files-without-match
 

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -3,33 +3,37 @@ use super::utils;
 use clap::{builder::PossibleValue, error::ErrorKind, Arg, ArgAction, Command};
 
 #[cfg(feature = "suggestions")]
-static PV_ERROR: &str = "error: \"slo\" isn't a valid value for '-O <option>'
-    [possible values: slow, fast, \"ludicrous speed\"]
+static PV_ERROR: &str = "\
+error: \"slo\" isn't a valid value for '-O <option>'
+  [possible values: slow, fast, \"ludicrous speed\"]
 
-    Did you mean \"slow\"?
+  Did you mean \"slow\"?
 
 For more information try --help
 ";
 
 #[cfg(not(feature = "suggestions"))]
-static PV_ERROR: &str = "error: \"slo\" isn't a valid value for '-O <option>'
-    [possible values: slow, fast, \"ludicrous speed\"]
+static PV_ERROR: &str = "\
+error: \"slo\" isn't a valid value for '-O <option>'
+  [possible values: slow, fast, \"ludicrous speed\"]
 
 For more information try --help
 ";
 
 #[cfg(feature = "suggestions")]
-static PV_ERROR_ESCAPED: &str = "error: \"ludicrous\" isn't a valid value for '-O <option>'
-    [possible values: slow, fast, \"ludicrous speed\"]
+static PV_ERROR_ESCAPED: &str = "\
+error: \"ludicrous\" isn't a valid value for '-O <option>'
+  [possible values: slow, fast, \"ludicrous speed\"]
 
-    Did you mean \"ludicrous speed\"?
+  Did you mean \"ludicrous speed\"?
 
 For more information try --help
 ";
 
 #[cfg(not(feature = "suggestions"))]
-static PV_ERROR_ESCAPED: &str = "error: \"ludicrous\" isn't a valid value for '-O <option>'
-    [possible values: slow, fast, \"ludicrous speed\"]
+static PV_ERROR_ESCAPED: &str = "\
+error: \"ludicrous\" isn't a valid value for '-O <option>'
+  [possible values: slow, fast, \"ludicrous speed\"]
 
 For more information try --help
 ";
@@ -293,9 +297,9 @@ fn missing_possible_value_error() {
     );
 }
 
-static MISSING_PV_ERROR: &str =
-    "error: The argument '-O <option>' requires a value but none was supplied
-    [possible values: slow, fast, \"ludicrous speed\"]
+static MISSING_PV_ERROR: &str = "\
+error: The argument '-O <option>' requires a value but none was supplied
+  [possible values: slow, fast, \"ludicrous speed\"]
 
 For more information try --help
 ";

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -3,43 +3,47 @@ use super::utils;
 use clap::builder::ArgPredicate;
 use clap::{arg, error::ErrorKind, Arg, ArgAction, ArgGroup, Command};
 
-static REQUIRE_EQUALS: &str = "error: The following required arguments were not provided:
-    --opt=<FILE>
+static REQUIRE_EQUALS: &str = "\
+error: The following required arguments were not provided:
+  --opt=<FILE>
 
 Usage: clap-test --opt=<FILE>
 
 For more information try --help
 ";
 
-static REQUIRE_EQUALS_FILTERED: &str = "error: The following required arguments were not provided:
-    --opt=<FILE>
+static REQUIRE_EQUALS_FILTERED: &str = "\
+error: The following required arguments were not provided:
+  --opt=<FILE>
 
 Usage: clap-test --opt=<FILE> --foo=<FILE>
 
 For more information try --help
 ";
 
-static REQUIRE_EQUALS_FILTERED_GROUP: &str =
-    "error: The following required arguments were not provided:
-    --opt=<FILE>
+static REQUIRE_EQUALS_FILTERED_GROUP: &str = "\
+error: The following required arguments were not provided:
+  --opt=<FILE>
 
 Usage: clap-test --opt=<FILE> --foo=<FILE> <--g1=<FILE>|--g2=<FILE>>
 
 For more information try --help
 ";
 
-static MISSING_REQ: &str = "error: The following required arguments were not provided:
-    --long-option-2 <option2>
-    <positional>
-    <positional2>
+static MISSING_REQ: &str = "\
+error: The following required arguments were not provided:
+  --long-option-2 <option2>
+  <positional>
+  <positional2>
 
 Usage: clap-test --long-option-2 <option2> -F <positional> <positional2> [positional3]...
 
 For more information try --help
 ";
 
-static COND_REQ_IN_USAGE: &str = "error: The following required arguments were not provided:
-    --output <output>
+static COND_REQ_IN_USAGE: &str = "\
+error: The following required arguments were not provided:
+  --output <output>
 
 Usage: test --target <target> --input <input> --output <output>
 
@@ -132,9 +136,10 @@ fn positional_required_with_requires() {
     utils::assert_output(cmd, "clap-test", POSITIONAL_REQ, true);
 }
 
-static POSITIONAL_REQ: &str = "error: The following required arguments were not provided:
-    <flag>
-    <opt>
+static POSITIONAL_REQ: &str = "\
+error: The following required arguments were not provided:
+  <flag>
+  <opt>
 
 Usage: clap-test <flag> <opt> [bar]
 
@@ -151,8 +156,9 @@ fn positional_required_with_requires_if_no_value() {
     utils::assert_output(cmd, "clap-test", POSITIONAL_REQ_IF_NO_VAL, true);
 }
 
-static POSITIONAL_REQ_IF_NO_VAL: &str = "error: The following required arguments were not provided:
-    <flag>
+static POSITIONAL_REQ_IF_NO_VAL: &str = "\
+error: The following required arguments were not provided:
+  <flag>
 
 Usage: clap-test <flag> [opt] [bar]
 
@@ -170,9 +176,10 @@ fn positional_required_with_requires_if_value() {
     utils::assert_output(cmd, "clap-test val", POSITIONAL_REQ_IF_VAL, true);
 }
 
-static POSITIONAL_REQ_IF_VAL: &str = "error: The following required arguments were not provided:
-    <foo>
-    <opt>
+static POSITIONAL_REQ_IF_VAL: &str = "\
+error: The following required arguments were not provided:
+  <foo>
+  <opt>
 
 Usage: clap-test <flag> <foo> <opt> [bar]
 
@@ -1018,10 +1025,11 @@ fn require_eq_filtered_group() {
     );
 }
 
-static ISSUE_1158: &str = "error: The following required arguments were not provided:
-    -x <X>
-    -y <Y>
-    -z <Z>
+static ISSUE_1158: &str = "\
+error: The following required arguments were not provided:
+  -x <X>
+  -y <Y>
+  -z <Z>
 
 Usage: example -x <X> -y <Y> -z <Z> <ID>
 
@@ -1053,10 +1061,10 @@ fn issue_1158_app() -> Command {
 
 #[test]
 fn multiple_required_unless_usage_printing() {
-    static MULTIPLE_REQUIRED_UNLESS_USAGE: &str =
-        "error: The following required arguments were not provided:
-    --a <a>
-    --b <b>
+    static MULTIPLE_REQUIRED_UNLESS_USAGE: &str = "\
+error: The following required arguments were not provided:
+  --a <a>
+  --b <b>
 
 Usage: test --c <c> --a <a> --b <b>
 
@@ -1445,7 +1453,7 @@ fn required_require_with_group_shows_flag() {
         );
     const EXPECTED: &str = "\
 error: The following required arguments were not provided:
-    --first
+  --first
 
 Usage: test --require-first <--first|--second>
 

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -6,30 +6,31 @@ static VISIBLE_ALIAS_HELP: &str = "\
 Usage: clap-test [COMMAND]
 
 Commands:
-    test    Some help [aliases: dongle, done]
-    help    Print this message or the help of the given subcommand(s)
+  test  Some help [aliases: dongle, done]
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 static INVISIBLE_ALIAS_HELP: &str = "\
 Usage: clap-test [COMMAND]
 
 Commands:
-    test    Some help
-    help    Print this message or the help of the given subcommand(s)
+  test  Some help
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
 
 #[cfg(feature = "suggestions")]
-static DYM_SUBCMD: &str = "error: The subcommand 'subcm' wasn't recognized
+static DYM_SUBCMD: &str = "\
+error: The subcommand 'subcm' wasn't recognized
 
-    Did you mean 'subcmd'?
+  Did you mean 'subcmd'?
 
 If you believe you received this message in error, try re-running with 'dym -- subcm'
 
@@ -39,9 +40,10 @@ For more information try --help
 ";
 
 #[cfg(feature = "suggestions")]
-static DYM_SUBCMD_AMBIGUOUS: &str = "error: The subcommand 'te' wasn't recognized
+static DYM_SUBCMD_AMBIGUOUS: &str = "\
+error: The subcommand 'te' wasn't recognized
 
-    Did you mean 'test' or 'temp'?
+  Did you mean 'test' or 'temp'?
 
 If you believe you received this message in error, try re-running with 'dym -- te'
 
@@ -50,10 +52,10 @@ Usage: dym [COMMAND]
 For more information try --help
 ";
 
-static SUBCMD_AFTER_DOUBLE_DASH: &str =
-    "error: Found argument 'subcmd' which wasn't expected, or isn't valid in this context
+static SUBCMD_AFTER_DOUBLE_DASH: &str = "\
+error: Found argument 'subcmd' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `subcmd` as a subcommand, remove the '--' before it.
+  If you tried to supply `subcmd` as a subcommand, remove the '--' before it.
 
 Usage: cmd [COMMAND]
 
@@ -169,12 +171,12 @@ fn subcmd_did_you_mean_output_ambiguous() {
 #[test]
 #[cfg(feature = "suggestions")]
 fn subcmd_did_you_mean_output_arg() {
-    static EXPECTED: &str =
-        "error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
+    static EXPECTED: &str = "\
+error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
 
-    Did you mean to put '--subcmdarg' after the subcommand 'subcmd'?
+  Did you mean to put '--subcmdarg' after the subcommand 'subcmd'?
 
-    If you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
+  If you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
 
 Usage: dym [COMMAND]
 
@@ -191,10 +193,10 @@ For more information try --help
 #[test]
 #[cfg(feature = "suggestions")]
 fn subcmd_did_you_mean_output_arg_false_positives() {
-    static EXPECTED: &str =
-        "error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
+    static EXPECTED: &str = "\
+error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
+  If you tried to supply `--subcmarg` as a value rather than a flag, use `-- --subcmarg`
 
 Usage: dym [COMMAND]
 
@@ -520,7 +522,7 @@ For more information try help
         static BAZ_EXPECTED: &str = "\
 error: The subcommand 'baz' wasn't recognized
 
-    Did you mean 'bar'?
+  Did you mean 'bar'?
 
 If you believe you received this message in error, try re-running with ' -- baz'
 
@@ -565,11 +567,11 @@ fn multicall_help_flag() {
 Usage: foo bar [value]
 
 Arguments:
-    [value]    
+  [value]  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = Command::new("repl")
         .version("1.0.0")
@@ -585,11 +587,11 @@ fn multicall_help_subcommand() {
 Usage: foo bar [value]
 
 Arguments:
-    [value]    
+  [value]  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = Command::new("repl")
         .version("1.0.0")
@@ -605,11 +607,11 @@ fn multicall_render_help() {
 Usage: foo bar [value]
 
 Arguments:
-    [value]    
+  [value]  
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let mut cmd = Command::new("repl")
         .version("1.0.0")

--- a/tests/builder/template_help.rs
+++ b/tests/builder/template_help.rs
@@ -30,15 +30,15 @@ Does awesome things
 Usage: MyApp [OPTIONS] <output> [COMMAND]
 
 Options:
-    -c, --config <FILE>    Sets a custom config file
-    -d...                  Turn debugging information on
-    -h, --help             Print help information
-    -V, --version          Print version information
+  -c, --config <FILE>  Sets a custom config file
+  -d...                Turn debugging information on
+  -h, --help           Print help information
+  -V, --version        Print version information
 Arguments:
-    <output>    Sets an optional output file
+  <output>  Sets an optional output file
 Commands:
-    test    does testing things
-    help    Print this message or the help of the given subcommand(s)
+  test  does testing things
+  help  Print this message or the help of the given subcommand(s)
 ";
 
 static SIMPLE_TEMPLATE: &str = "MyApp 1.0
@@ -48,17 +48,17 @@ Does awesome things
 Usage: MyApp [OPTIONS] <output> [COMMAND]
 
 Commands:
-    test    does testing things
-    help    Print this message or the help of the given subcommand(s)
+  test  does testing things
+  help  Print this message or the help of the given subcommand(s)
 
 Arguments:
-    <output>    Sets an optional output file
+  <output>  Sets an optional output file
 
 Options:
-    -c, --config <FILE>    Sets a custom config file
-    -d...                  Turn debugging information on
-    -h, --help             Print help information
-    -V, --version          Print version information
+  -c, --config <FILE>  Sets a custom config file
+  -d...                Turn debugging information on
+  -h, --help           Print help information
+  -V, --version        Print version information
 ";
 
 #[test]

--- a/tests/builder/version.rs
+++ b/tests/builder/version.rs
@@ -108,7 +108,7 @@ foo
 Usage: foo
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     let cmd = common();
     utils::assert_output(cmd, "foo -h", EXPECTED, false);
@@ -122,7 +122,7 @@ foo
 Usage: foo
 
 Options:
-    -h, --help    Print help information
+  -h, --help  Print help information
 ";
     let cmd = common();
     utils::assert_output(cmd, "foo --help", EXPECTED, false);
@@ -136,8 +136,8 @@ foo 3.0
 Usage: foo
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = with_version();
     utils::assert_output(cmd, "foo -h", EXPECTED, false);
@@ -151,8 +151,8 @@ foo 3.0
 Usage: foo
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = with_version();
     utils::assert_output(cmd, "foo --help", EXPECTED, false);
@@ -166,8 +166,8 @@ foo 3.0 (abcdefg)
 Usage: foo
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = with_long_version();
     utils::assert_output(cmd, "foo -h", EXPECTED, false);
@@ -181,8 +181,8 @@ foo 3.0 (abcdefg)
 Usage: foo
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = with_long_version();
     utils::assert_output(cmd, "foo --help", EXPECTED, false);
@@ -196,8 +196,8 @@ foo 3.0
 Usage: foo
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = with_both();
     utils::assert_output(cmd, "foo -h", EXPECTED, false);
@@ -211,8 +211,8 @@ foo 3.0
 Usage: foo
 
 Options:
-    -h, --help       Print help information
-    -V, --version    Print version information
+  -h, --help     Print help information
+  -V, --version  Print version information
 ";
     let cmd = with_both();
     utils::assert_output(cmd, "foo --help", EXPECTED, false);

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -234,12 +234,12 @@ fn derive_order_next_order() {
 Usage: test [OPTIONS]
 
 Options:
-        --flag-b                 first flag
-        --option-b <OPTION_B>    first option
-    -h, --help                   Print help information
-    -V, --version                Print version information
-        --flag-a                 second flag
-        --option-a <OPTION_A>    second option
+      --flag-b               first flag
+      --option-b <OPTION_B>  first option
+  -h, --help                 Print help information
+  -V, --version              Print version information
+      --flag-a               second flag
+      --option-a <OPTION_A>  second option
 ";
 
     #[derive(Parser, Debug)]
@@ -288,12 +288,12 @@ fn derive_order_next_order_flatten() {
 Usage: test [OPTIONS]
 
 Options:
-        --flag-b                 first flag
-        --option-b <OPTION_B>    first option
-    -h, --help                   Print help information
-    -V, --version                Print version information
-        --flag-a                 second flag
-        --option-a <OPTION_A>    second option
+      --flag-b               first flag
+      --option-b <OPTION_B>  first option
+  -h, --help                 Print help information
+  -V, --version              Print version information
+      --flag-a               second flag
+      --option-a <OPTION_A>  second option
 ";
 
     #[derive(Parser, Debug)]
@@ -342,12 +342,12 @@ fn derive_order_no_next_order() {
 Usage: test [OPTIONS]
 
 Options:
-        --flag-a                 first flag
-        --flag-b                 second flag
-    -h, --help                   Print help information
-        --option-a <OPTION_A>    first option
-        --option-b <OPTION_B>    second option
-    -V, --version                Print version information
+      --flag-a               first flag
+      --flag-b               second flag
+  -h, --help                 Print help information
+      --option-a <OPTION_A>  first option
+      --option-b <OPTION_B>  second option
+  -V, --version              Print version information
 ";
 
     #[derive(Parser, Debug)]
@@ -397,16 +397,16 @@ Application help
 Usage: clap <ARG>
 
 Arguments:
-    <ARG>
-            Argument help
+  <ARG>
+          Argument help
 
-            Possible values:
-              - foo: Foo help
-              - bar: Bar help
+          Possible values:
+          - foo: Foo help
+          - bar: Bar help
 
 Options:
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 ";
 
     /// Application help

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -304,8 +304,8 @@ mod arg {
 Usage: test [OPTIONS]
 
 Options:
-    -p [<NUM>]        
-    -h, --help        Print help information
+  -p [<NUM>]      
+  -h, --help      Print help information
 ";
         snapbox::assert_eq(HELP, help);
     }

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -6,11 +6,11 @@ stderr = """
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
 Commands:
-    more    
-    help    Print this message or the help of the given subcommand(s)
+  more  
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-        --verbose    log
-    -h, --help       Print help information (use `--help` for more detail)
-    -V, --version    Print version information
+      --verbose  log
+  -h, --help     Print help information (use `--help` for more detail)
+  -V, --version  Print version information
 """

--- a/tests/ui/error_stderr.toml
+++ b/tests/ui/error_stderr.toml
@@ -5,7 +5,7 @@ stdout = ""
 stderr = """
 error: Found argument '--unknown-argument' which wasn't expected, or isn't valid in this context
 
-    If you tried to supply `--unknown-argument` as a value rather than a flag, use `-- --unknown-argument`
+  If you tried to supply `--unknown-argument` as a value rather than a flag, use `-- --unknown-argument`
 
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -5,12 +5,12 @@ stdout = """
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
 Commands:
-    more    
-    help    Print this message or the help of the given subcommand(s)
+  more  
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
-        --verbose    log
-    -h, --help       Print help information (use `--help` for more detail)
-    -V, --version    Print version information
+      --verbose  log
+  -h, --help     Print help information (use `--help` for more detail)
+  -V, --version  Print version information
 """
 stderr = ""

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -5,19 +5,19 @@ stdout = """
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
 Commands:
-    more
-            
-    help
-            Print this message or the help of the given subcommand(s)
+  more
+          
+  help
+          Print this message or the help of the given subcommand(s)
 
 Options:
-        --verbose
-            more log
+      --verbose
+          more log
 
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 """
 stderr = ""

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -5,19 +5,19 @@ stdout = """
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
 Commands:
-    more
-            
-    help
-            Print this message or the help of the given subcommand(s)
+  more
+          
+  help
+          Print this message or the help of the given subcommand(s)
 
 Options:
-        --verbose
-            more log
+      --verbose
+          more log
 
-    -h, --help
-            Print help information (use `-h` for a summary)
+  -h, --help
+          Print help information (use `-h` for a summary)
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version information
 """
 stderr = ""


### PR DESCRIPTION
In looking at other help output, I noticed that they use two spaces, in
place of clap's 4, and it doesn't suffer from legibility.  If it
doesn't make the output worse, let's go ahead and make it as dense so we
fit more content on the screen.

This is a part of #4132