### PR TITLE
revert(derive): Bald action/value_parser are deprecated, its good enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-
-## 5.0.0 - Upcoming
-
-### Breaking Changes
-
-- *(derive)* Removed `#[clap(value_parser)]` and `#[clap(action)]` defaulted attributes (its the default) (#3976)
-
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
@@ -230,6 +223,7 @@ Deprecated
 - `Command::allow_hyphen_values` in favor of `Arg::allow_hyphen_values` to make it clearer which arg it is meant to apply to (#4187)
 - `Command::allow_negative_numbers` in favor of `Arg::allow_negative_numbers` to make it clearer which arg it is meant to apply to (#4187)
 - *(derive)* `structopt` and `clap` attributes in favor of the more specific `command`, `arg`, and `value` to open the door for [more features](https://github.com/clap-rs/clap/issues/1807) and [clarify relationship to the builder](https://github.com/clap-rs/clap/discussions/4090) (#1807, #4180)
+- *(derive)* `#[clap(value_parser)]` and `#[clap(action)]` defaulted attributes (its the default) (#3976)
 
 ### Features
 

--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -93,9 +93,7 @@ impl Parse for ClapAttr {
             "default_values_os_t" => Some(MagicAttrName::DefaultValuesOsT),
             "long" => Some(MagicAttrName::Long),
             "short" => Some(MagicAttrName::Short),
-            #[cfg(not(feature = "unstable-v5"))]
             "value_parser" => Some(MagicAttrName::ValueParser),
-            #[cfg(not(feature = "unstable-v5"))]
             "action" => Some(MagicAttrName::Action),
             "env" => Some(MagicAttrName::Env),
             "flatten" => Some(MagicAttrName::Flatten),
@@ -150,9 +148,7 @@ impl Parse for ClapAttr {
 pub enum MagicAttrName {
     Short,
     Long,
-    #[cfg(not(feature = "unstable-v5"))]
     ValueParser,
-    #[cfg(not(feature = "unstable-v5"))]
     Action,
     Env,
     Flatten,

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -421,7 +421,6 @@ impl Item {
                     self.push_method(*attr.kind.get(), attr.name.clone(), self.name.clone().translate(*self.casing));
                 }
 
-                #[cfg(not(feature = "unstable-v5"))]
                 Some(MagicAttrName::ValueParser) if attr.value.is_none() => {
                     assert_attr_kind(attr, &[AttrKind::Arg]);
 
@@ -434,7 +433,6 @@ impl Item {
                     self.value_parser = Some(ValueParser::Implicit(attr.name.clone()));
                 }
 
-                #[cfg(not(feature = "unstable-v5"))]
                 Some(MagicAttrName::Action) if attr.value.is_none() => {
                     assert_attr_kind(attr, &[AttrKind::Arg]);
 
@@ -763,7 +761,6 @@ impl Item {
                 }
 
                 // Magic only for the default, otherwise just forward to the builder
-                #[cfg(not(feature = "unstable-v5"))]
                 Some(MagicAttrName::ValueParser) | Some(MagicAttrName::Action) => {
                     let expr = attr.value_or_abort();
                     self.push_method(*attr.kind.get(), attr.name.clone(), expr);
@@ -977,7 +974,6 @@ impl Item {
 #[derive(Clone)]
 enum ValueParser {
     Explicit(Method),
-    #[cfg(not(feature = "unstable-v5"))]
     Implicit(Ident),
 }
 
@@ -985,7 +981,6 @@ impl ValueParser {
     fn resolve(self, _inner_type: &Type) -> Method {
         match self {
             Self::Explicit(method) => method,
-            #[cfg(not(feature = "unstable-v5"))]
             Self::Implicit(ident) => default_value_parser(_inner_type, ident.span()),
         }
     }
@@ -993,7 +988,6 @@ impl ValueParser {
     fn span(&self) -> Span {
         match self {
             Self::Explicit(method) => method.name.span(),
-            #[cfg(not(feature = "unstable-v5"))]
             Self::Implicit(ident) => ident.span(),
         }
     }
@@ -1012,7 +1006,6 @@ fn default_value_parser(inner_type: &Type, span: Span) -> Method {
 #[derive(Clone)]
 pub enum Action {
     Explicit(Method),
-    #[cfg(not(feature = "unstable-v5"))]
     Implicit(Ident),
 }
 
@@ -1020,7 +1013,6 @@ impl Action {
     pub fn resolve(self, _field_type: &Type) -> Method {
         match self {
             Self::Explicit(method) => method,
-            #[cfg(not(feature = "unstable-v5"))]
             Self::Implicit(ident) => default_action(_field_type, ident.span()),
         }
     }
@@ -1028,7 +1020,6 @@ impl Action {
     pub fn span(&self) -> Span {
         match self {
             Self::Explicit(method) => method.name.span(),
-            #[cfg(not(feature = "unstable-v5"))]
             Self::Implicit(ident) => ident.span(),
         }
     }


### PR DESCRIPTION
When I removed these in v5, we didn't have a deprecation approach for the derive and I didn't want to forget.  Now we do have a deprecation approach and that is the reminder, so we don't need to carry around v5 changes.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
