### PR TITLE
feat(parser): TypedValueParseer::map for adapting value parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- `TypedValueParser::map` to allow reusing existing value parsers for other purposes
+
 ## [3.2.20] - 2022-09-02
 
 ### Features

--- a/src/builder/value_parser.rs
+++ b/src/builder/value_parser.rs
@@ -637,6 +637,50 @@ pub trait TypedValueParser: Clone + Send + Sync + 'static {
     ) -> Option<Box<dyn Iterator<Item = crate::PossibleValue<'static>> + '_>> {
         None
     }
+
+    /// Adapt a `TypedValueParser` from one value to another
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use clap::Command;
+    /// # use clap::Arg;
+    /// # use clap::builder::TypedValueParser as _;
+    /// # use clap::builder::BoolishValueParser;
+    /// let cmd = Command::new("mycmd")
+    ///     .arg(
+    ///         Arg::new("flag")
+    ///             .long("flag")
+    ///             .action(clap::ArgAction::Set)
+    ///             .value_parser(
+    ///                 BoolishValueParser::new()
+    ///                 .map(|b| -> usize {
+    ///                     if b { 10 } else { 5 }
+    ///                 })
+    ///             )
+    ///     );
+    ///
+    /// let matches = cmd.clone().try_get_matches_from(["mycmd", "--flag=true", "--flag=true"]).unwrap();
+    /// assert!(matches.contains_id("flag"));
+    /// assert_eq!(
+    ///     matches.get_one::<usize>("flag").copied(),
+    ///     Some(10)
+    /// );
+    ///
+    /// let matches = cmd.try_get_matches_from(["mycmd", "--flag=false"]).unwrap();
+    /// assert!(matches.contains_id("flag"));
+    /// assert_eq!(
+    ///     matches.get_one::<usize>("flag").copied(),
+    ///     Some(5)
+    /// );
+    /// ```
+    fn map<T, F>(self, func: F) -> MapValueParser<Self, F>
+    where
+        T: Send + Sync + Clone,
+        F: Fn(Self::Value) -> T + Clone,
+    {
+        MapValueParser::new(self, func)
+    }
 }
 
 impl<F, T, E> TypedValueParser for F
@@ -1774,6 +1818,59 @@ impl TypedValueParser for NonEmptyStringValueParser {
 impl Default for NonEmptyStringValueParser {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Adapt a `TypedValueParser` from one value to another
+///
+/// See [`TypedValueParser::map`]
+#[derive(Clone, Debug)]
+pub struct MapValueParser<P, F> {
+    parser: P,
+    func: F,
+}
+
+impl<P, F> MapValueParser<P, F> {
+    fn new(parser: P, func: F) -> Self {
+        Self { parser, func }
+    }
+}
+
+impl<P, F, T> TypedValueParser for MapValueParser<P, F>
+where
+    P: TypedValueParser,
+    P::Value: Send + Sync + Clone,
+    F: Fn(P::Value) -> T + Clone + Send + Sync + 'static,
+    T: Send + Sync + Clone,
+{
+    type Value = T;
+
+    fn parse_ref(
+        &self,
+        cmd: &crate::Command,
+        arg: Option<&crate::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, crate::Error> {
+        let value = self.parser.parse_ref(cmd, arg, value)?;
+        let value = (self.func)(value);
+        Ok(value)
+    }
+
+    fn parse(
+        &self,
+        cmd: &crate::Command,
+        arg: Option<&crate::Arg>,
+        value: std::ffi::OsString,
+    ) -> Result<Self::Value, crate::Error> {
+        let value = self.parser.parse(cmd, arg, value)?;
+        let value = (self.func)(value);
+        Ok(value)
+    }
+
+    fn possible_values(
+        &self,
+    ) -> Option<Box<dyn Iterator<Item = crate::builder::PossibleValue<'static>> + '_>> {
+        self.parser.possible_values()
     }
 }
 


### PR DESCRIPTION
This is a partial backport of #4095.  This was written to allow mapping bools to other types but this will be useful for people using `PossibleValue` with non-string types to upgrade to value parsers.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
