### PR TITLE
feat(derive): Reserve behavior needed for implicit ArgGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@ Subtle changes (i.e. compiler won't catch):
 - *(env)* Parse `--help` and `--version` like any `ArgAction::SetTrue` flag (#3776)
 - *(derive)* Leave `Arg::id` as `verbatim` casing, requiring updating of string references to other args like in `conflicts_with` or `requires` (#3282)
 - *(derive)* Doc comments for `ValueEnum` variants will now show up in `--help` (#3312)
+- *(derive)* When deriving `Args`, and `ArgGroup` is created using the type's name, reserving it for future use (#2621, #4209)
 
 Easier to catch changes:
 

--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -34,6 +34,11 @@ impl ClapAttr {
                     Some(Sp::new(AttrKind::StructOpt, attr.path.span()))
                 } else if attr.path.is_ident("command") {
                     Some(Sp::new(AttrKind::Command, attr.path.span()))
+                } else if attr.path.is_ident("group") {
+                    abort!(
+                        attr.path.span(),
+                        "`#[group()]` attributes are not supported yet"
+                    )
                 } else if attr.path.is_ident("arg") {
                     Some(Sp::new(AttrKind::Arg, attr.path.span()))
                 } else if attr.path.is_ident("value") {

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -15,6 +15,7 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use proc_macro_error::{abort, abort_call_site};
 use quote::{format_ident, quote, quote_spanned};
+use syn::ext::IdentExt;
 use syn::{
     punctuated::Punctuated, spanned::Spanned, token::Comma, Data, DataStruct, DeriveInput, Field,
     Fields, Generics,
@@ -317,10 +318,13 @@ pub fn gen_augment(
         quote!()
     };
     let initial_app_methods = parent_item.initial_top_level_methods();
+    let group_id = parent_item.ident().unraw().to_string();
     let final_app_methods = parent_item.final_top_level_methods();
     quote! {{
         #deprecations
-        let #app_var = #app_var #initial_app_methods;
+        let #app_var = #app_var
+            #initial_app_methods
+            .group(clap::ArgGroup::new(#group_id).multiple(true));
         #( #args )*
         #app_var #final_app_methods
     }}

--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -50,7 +50,7 @@ pub fn parser(input: TokenStream) -> TokenStream {
 }
 
 /// Generates the `Subcommand` impl.
-#[proc_macro_derive(Subcommand, attributes(clap, command, arg))]
+#[proc_macro_derive(Subcommand, attributes(clap, command, arg, group))]
 #[proc_macro_error]
 pub fn subcommand(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);
@@ -58,7 +58,7 @@ pub fn subcommand(input: TokenStream) -> TokenStream {
 }
 
 /// Generates the `Args` impl.
-#[proc_macro_derive(Args, attributes(clap, command, arg))]
+#[proc_macro_derive(Args, attributes(clap, command, arg, group))]
 #[proc_macro_error]
 pub fn args(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -282,6 +282,10 @@ pub trait FromArgMatches: Sized {
 /// }
 /// ```
 pub trait Args: FromArgMatches + Sized {
+    /// Report the [`ArgGroup::id`][crate::ArgGroup::id] for this set of arguments
+    fn group_id() -> Option<crate::Id> {
+        None
+    }
     /// Append to [`Command`] so it can instantiate `Self`.
     ///
     /// See also [`CommandFactory`].

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+
+#[test]
+fn test_safely_nest_parser() {
+    #[derive(Parser, Debug, PartialEq)]
+    struct Opt {
+        #[command(flatten)]
+        foo: Foo,
+    }
+
+    #[derive(Parser, Debug, PartialEq)]
+    struct Foo {
+        #[arg(long)]
+        foo: bool,
+    }
+
+    assert_eq!(
+        Opt {
+            foo: Foo { foo: true }
+        },
+        Opt::try_parse_from(&["test", "--foo"]).unwrap()
+    );
+}

--- a/tests/derive/main.rs
+++ b/tests/derive/main.rs
@@ -13,6 +13,7 @@ mod explicit_name_no_renaming;
 mod flags;
 mod flatten;
 mod generic;
+mod groups;
 mod help;
 mod issues;
 mod macros;

--- a/tests/derive/naming.rs
+++ b/tests/derive/naming.rs
@@ -1,3 +1,4 @@
+use clap::Args;
 use clap::Parser;
 
 #[test]
@@ -251,7 +252,7 @@ fn test_rename_all_is_not_propagated_from_struct_into_flattened() {
         foo: Foo,
     }
 
-    #[derive(Parser, Debug, PartialEq)]
+    #[derive(Args, Debug, PartialEq)]
     struct Foo {
         #[arg(long)]
         foo: bool,


### PR DESCRIPTION
These are the building blocks for us to automatically create an `ArgGroup` when deriving `Args` on a struct.  This will make it easier to compose (write validation rules) particularly when the struct comes from a third party.

The next step will then be to support deriving `Args` on enums, see #2621