### PR TITLE
fix: Permissions syntax

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,7 +10,8 @@ on:
       - '**/Cargo.lock'
   schedule:
   - cron: '3 3 3 * *'
-permissions: read
+permissions:
+  contents: read
 jobs:
   security_audit:
     permissions:


### PR DESCRIPTION
`permission: read` is invalid. There are three styles `permissions: {}`, `permissions: read-all` or
```yaml
permissions:
  contents: read
  ...
```