### PR TITLE
feat(derive): add a 'prefix = ' attr for structs

### DIFF
--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -89,6 +89,7 @@ impl Parse for ClapAttr {
         let magic = match name_str.as_str() {
             "rename_all" => Some(MagicAttrName::RenameAll),
             "rename_all_env" => Some(MagicAttrName::RenameAllEnv),
+            "prefix" => Some(MagicAttrName::Prefix),
             "skip" => Some(MagicAttrName::Skip),
             "next_display_order" => Some(MagicAttrName::NextDisplayOrder),
             "next_help_heading" => Some(MagicAttrName::NextHelpHeading),
@@ -167,6 +168,7 @@ pub enum MagicAttrName {
     Version,
     RenameAllEnv,
     RenameAll,
+    Prefix,
     Skip,
     DefaultValueT,
     DefaultValuesT,

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -41,7 +41,7 @@ pub fn derive_args(input: &DeriveInput) -> TokenStream {
                 .named
                 .iter()
                 .map(|field| {
-                    let item = Item::from_args_field(field, item.casing(), item.env_casing());
+                    let item = Item::from_args_field(field, item.casing(), item.env_casing(), item.prefix());
                     (field, item)
                 })
                 .collect::<Vec<_>>();
@@ -57,7 +57,7 @@ pub fn derive_args(input: &DeriveInput) -> TokenStream {
             let fields = fields
                 .iter()
                 .map(|field| {
-                    let item = Item::from_args_field(field, item.casing(), item.env_casing());
+                    let item = Item::from_args_field(field, item.casing(), item.env_casing(), item.prefix());
                     (field, item)
                 })
                 .collect::<Vec<_>>();

--- a/clap_derive/src/derives/parser.rs
+++ b/clap_derive/src/derives/parser.rs
@@ -44,7 +44,7 @@ pub fn derive_parser(input: &DeriveInput) -> TokenStream {
                 .named
                 .iter()
                 .map(|field| {
-                    let item = Item::from_args_field(field, item.casing(), item.env_casing());
+                    let item = Item::from_args_field(field, item.casing(), item.env_casing(), item.prefix());
                     (field, item)
                 })
                 .collect::<Vec<_>>();
@@ -62,7 +62,7 @@ pub fn derive_parser(input: &DeriveInput) -> TokenStream {
             let fields = fields
                 .iter()
                 .map(|field| {
-                    let item = Item::from_args_field(field, item.casing(), item.env_casing());
+                    let item = Item::from_args_field(field, item.casing(), item.env_casing(), item.prefix());
                     (field, item)
                 })
                 .collect::<Vec<_>>();
@@ -78,7 +78,7 @@ pub fn derive_parser(input: &DeriveInput) -> TokenStream {
                 .iter()
                 .map(|variant| {
                     let item =
-                        Item::from_subcommand_variant(variant, item.casing(), item.env_casing());
+                        Item::from_subcommand_variant(variant, item.casing(), item.env_casing(), item.prefix());
                     (variant, item)
                 })
                 .collect::<Vec<_>>();

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -36,7 +36,7 @@ pub fn derive_subcommand(input: &DeriveInput) -> TokenStream {
                 .iter()
                 .map(|variant| {
                     let item =
-                        Item::from_subcommand_variant(variant, item.casing(), item.env_casing());
+                        Item::from_subcommand_variant(variant, item.casing(), item.env_casing(), item.prefix());
                     (variant, item)
                 })
                 .collect::<Vec<_>>();
@@ -268,7 +268,7 @@ fn gen_augment(
                                 .named
                                 .iter()
                                 .map(|field| {
-                                    let item = Item::from_args_field(field, item.casing(), item.env_casing());
+                                    let item = Item::from_args_field(field, item.casing(), item.env_casing(), item.prefix());
                                     (field, item)
                                 })
                                 .collect::<Vec<_>>();
@@ -476,7 +476,7 @@ fn gen_from_arg_matches(variants: &[(&Variant, Item)]) -> TokenStream {
                     .named
                     .iter()
                     .map(|field| {
-                        let item = Item::from_args_field(field, item.casing(), item.env_casing());
+                        let item = Item::from_args_field(field, item.casing(), item.env_casing(), item.prefix());
                         (field, item)
                     })
                     .collect::<Vec<_>>();
@@ -586,7 +586,7 @@ fn gen_update_from_arg_matches(variants: &[(&Variant, Item)]) -> TokenStream {
                     .named
                     .iter()
                     .map(|field| {
-                        let item = Item::from_args_field(field, item.casing(), item.env_casing());
+                        let item = Item::from_args_field(field, item.casing(), item.env_casing(), item.prefix());
                         (field, item)
                     })
                     .collect::<Vec<_>>();

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -31,7 +31,7 @@ pub fn derive_value_enum(input: &DeriveInput) -> TokenStream {
                 .iter()
                 .map(|variant| {
                     let item =
-                        Item::from_value_enum_variant(variant, item.casing(), item.env_casing());
+                        Item::from_value_enum_variant(variant, item.casing(), item.env_casing(), item.prefix());
                     (variant, item)
                 })
                 .collect::<Vec<_>>();

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -163,6 +163,12 @@
 //! - `rename_all_env = <string_literal>`: Override default field name case conversion for env variables for  [`Arg::env`][crate::Arg::env]
 //!   - When not present: `"SCREAMING_SNAKE_CASE"`
 //!   - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
+//! - `prefix = <string literal>`: Adds a prefix to the name of all args in the struct. This is useful when `flatten`ing into another struct.
+//!   - Long flags are prefixed like: `--prefix.arg-name`
+//!   - Env variables are prefixed like: `PREFIX.ARG_NAME`
+//!   - Short flags cannot be used in a struct with a prefix.
+//!   - Styles specified with `rename_all` and `rename_all_env` apply to the prefix as well.
+//!   - Does not apply to args explicitly given a name with `#[arg(long = "...")]`.
 //!
 //! And for [`Subcommand`][crate::Subcommand] variants:
 //! - `skip`: Ignore this variant

--- a/tests/derive/flatten_and_prefix.rs
+++ b/tests/derive/flatten_and_prefix.rs
@@ -1,0 +1,76 @@
+// Copyright 2022 Bill Fraser (@wfraser) <wfraser@codewise.org>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use clap::{Args, Parser};
+
+#[derive(Parser, Debug, PartialEq)]
+struct Main {
+    #[arg(short)]
+    s: String,
+
+    #[arg(long)]
+    some_string: String,
+
+    #[arg(long)]
+    same_name: String,
+
+    #[command(flatten)]
+    foo_args: Foo,
+
+    #[command(flatten)]
+    bar_args: Bar,
+}
+
+#[derive(Args, Debug, PartialEq)]
+#[command(prefix = "foo", next_help_heading = "Foo options")]
+struct Foo {
+    #[arg(long)]
+    some_param: String,
+
+    #[arg(long)]
+    same_name: String, // without prefix, would conflict with the one in Main
+}
+
+#[derive(Args, Debug, PartialEq)]
+#[command(prefix = "bar", rename_all = "pascal", next_help_heading = "Bar options")]
+struct Bar {
+    #[arg(long)]
+    another_param: String,
+
+    #[arg(long = "spaghetti")] // prefix does NOT get applied to this, nor does the rename_all.
+    weird_name: String,
+}
+
+#[test]
+fn test_all() {
+    let expected = Main {
+        s: "s-value".to_string(),
+        some_string: "some-string-value".to_string(),
+        same_name: "same-name-value".to_string(),
+        foo_args: Foo {
+            some_param: "foo-some-param-value".to_string(),
+            same_name: "foo-same-name-value".to_string(),
+        },
+        bar_args: Bar {
+            another_param: "bar-another-param-value".to_string(),
+            weird_name: "bar-weird-name-value".to_string(),
+        }
+    };
+
+    let result = Main::parse_from(&[
+        "test",
+        "-s", "s-value",
+        "--some-string", "some-string-value",
+        "--same-name", "same-name-value",
+        "--foo.some-param", "foo-some-param-value",
+        "--foo.same-name=foo-same-name-value",
+        "--Bar.AnotherParam", "bar-another-param-value",
+        "--spaghetti", "bar-weird-name-value",
+    ]);
+    assert_eq!(result, expected);
+}

--- a/tests/derive/main.rs
+++ b/tests/derive/main.rs
@@ -14,6 +14,7 @@ mod doc_comments_help;
 mod explicit_name_no_renaming;
 mod flags;
 mod flatten;
+mod flatten_and_prefix;
 mod generic;
 mod groups;
 mod help;


### PR DESCRIPTION
I took the code sample I wrote up in #3513 and rebased it onto the current master (at 4.0.0-rc.2). I'm currently using this feature in a large codebase and some folks on at least two other companies I've spoken to have found it useful as well.

Implementation notes: this works very similarly to `rename_all` and `rename_all_env` in that it takes effect in the `Name::translate()` method (and also in `Name::raw` to prevent collisions), and how it is propagated from parent struct down to child fields. It's nice that the entire implementation lives in clap_derive and needs no support from clap itself.

I've added a test which illustrates how it works. In real usage, the sub-structs would be defined in different modules or even in different crates; the whole point of this is to permit uniform re-use of a set of related options across several binaries in a large codebase.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
