### PR TITLE
chore: Explain v4 migration for derive in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,29 @@ In particular, `num_args` (the replacement for `takes_value`) will default appro
 from the `ArgAction` and generally only needs to be set explicitly for the
 other `num_args` use cases.
 
+#### Migrating Derive
+- Rename `clap` to `command` or `arg`:
+Before
+```rust
+#[derive(Parser)]
+#[clap(about, version)]
+pub struct Args {
+    /// Path to config file.
+    #[clap(short, long)]
+    pub config: Option<String>,
+}
+```
+After:
+```rust
+#[derive(Parser)]
+#[command(about, version)]
+pub struct Args {
+    /// Path to config file.
+    #[arg(short, long)]
+    pub config: Option<String>,
+}
+```
+
 ### Breaking Changes
 
 Subtle changes (i.e. compiler won't catch):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,8 +172,9 @@ from the `ArgAction` and generally only needs to be set explicitly for the
 other `num_args` use cases.
 
 #### Migrating Derive
-- Rename `clap` to `command` or `arg`:
-Before
+- Rename `clap` to `command` or `arg`
+
+Before:
 ```rust
 #[derive(Parser)]
 #[clap(about, version)]


### PR DESCRIPTION
v4 changelog is not very clear on how to migrate for the derive users. I added a section that I had struggled with myself (had to look at the examples to figure it out)