### PR TITLE
perf: Drop use of Into::into for '?'

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -822,7 +822,7 @@ impl Command {
         let mut styled = StyledStr::new();
         let usage = Usage::new(self);
         write_help(&mut styled, self, &usage, false);
-        write!(w, "{}", styled)?;
+        ok!(write!(w, "{}", styled));
         w.flush()
     }
 
@@ -837,7 +837,7 @@ impl Command {
         let mut styled = StyledStr::new();
         let usage = Usage::new(self);
         write_help(&mut styled, self, &usage, true);
-        write!(w, "{}", styled)?;
+        ok!(write!(w, "{}", styled));
         w.flush()
     }
 
@@ -3896,7 +3896,7 @@ impl Command {
         }
         let is_multicall_set = self.is_multicall_set();
 
-        let sc = self.subcommands.iter_mut().find(|s| s.name == name)?;
+        let sc = some!(self.subcommands.iter_mut().find(|s| s.name == name));
 
         // Display subcommand name, short and long in usage
         let mut sc_names = String::new();

--- a/src/builder/range.rs
+++ b/src/builder/range.rs
@@ -172,10 +172,10 @@ impl From<std::ops::RangeToInclusive<usize>> for ValueRange {
 
 impl std::fmt::Display for ValueRange {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.start_inclusive.fmt(f)?;
+        ok!(self.start_inclusive.fmt(f));
         if !self.is_fixed() {
-            "..=".fmt(f)?;
-            self.end_inclusive.fmt(f)?;
+            ok!("..=".fmt(f));
+            ok!(self.end_inclusive.fmt(f));
         }
         Ok(())
     }

--- a/src/builder/styled_str.rs
+++ b/src/builder/styled_str.rs
@@ -223,9 +223,9 @@ impl StyledStr {
                 None => {}
             }
 
-            buffer.set_color(&color)?;
-            buffer.write_all(content.as_bytes())?;
-            buffer.reset()?;
+            ok!(buffer.set_color(&color));
+            ok!(buffer.write_all(content.as_bytes()));
+            ok!(buffer.reset());
         }
 
         Ok(())
@@ -291,7 +291,7 @@ fn cmp_key(c: (Option<Style>, &str)) -> (Option<usize>, &str) {
 impl std::fmt::Display for StyledStr {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         for (_, content) in self.iter() {
-            std::fmt::Display::fmt(content, f)?;
+            ok!(std::fmt::Display::fmt(content, f));
         }
 
         Ok(())
@@ -307,12 +307,13 @@ struct AnsiDisplay<'s> {
 impl std::fmt::Display for AnsiDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut buffer = termcolor::Buffer::ansi();
-        self.styled
+        ok!(self
+            .styled
             .write_colored(&mut buffer)
-            .map_err(|_| std::fmt::Error)?;
+            .map_err(|_| std::fmt::Error));
         let buffer = buffer.into_inner();
-        let buffer = String::from_utf8(buffer).map_err(|_| std::fmt::Error)?;
-        std::fmt::Display::fmt(&buffer, f)?;
+        let buffer = ok!(String::from_utf8(buffer).map_err(|_| std::fmt::Error));
+        ok!(std::fmt::Display::fmt(&buffer, f));
 
         Ok(())
     }

--- a/src/builder/value_parser.rs
+++ b/src/builder/value_parser.rs
@@ -569,7 +569,7 @@ where
         arg: Option<&crate::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<AnyValue, crate::Error> {
-        let value = TypedValueParser::parse_ref(self, cmd, arg, value)?;
+        let value = ok!(TypedValueParser::parse_ref(self, cmd, arg, value));
         Ok(AnyValue::new(value))
     }
 
@@ -579,7 +579,7 @@ where
         arg: Option<&crate::Arg>,
         value: std::ffi::OsString,
     ) -> Result<AnyValue, crate::Error> {
-        let value = TypedValueParser::parse(self, cmd, arg, value)?;
+        let value = ok!(TypedValueParser::parse(self, cmd, arg, value));
         Ok(AnyValue::new(value))
     }
 
@@ -694,18 +694,18 @@ where
         arg: Option<&crate::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, crate::Error> {
-        let value = value.to_str().ok_or_else(|| {
+        let value = ok!(value.to_str().ok_or_else(|| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
-        let value = (self)(value).map_err(|e| {
+        }));
+        let value = ok!((self)(value).map_err(|e| {
             let arg = arg
                 .map(|a| a.to_string())
                 .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(arg, value.to_owned(), e.into()).with_cmd(cmd)
-        })?;
+        }));
         Ok(value)
     }
 }
@@ -742,12 +742,12 @@ impl TypedValueParser for StringValueParser {
         _arg: Option<&crate::Arg>,
         value: std::ffi::OsString,
     ) -> Result<Self::Value, crate::Error> {
-        let value = value.into_string().map_err(|_| {
+        let value = ok!(value.into_string().map_err(|_| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
+        }));
         Ok(value)
     }
 }
@@ -939,7 +939,7 @@ impl<E: crate::ValueEnum + Clone + Send + Sync + 'static> TypedValueParser for E
                 .collect::<Vec<_>>()
         };
 
-        let value = value.to_str().ok_or_else(|| {
+        let value = ok!(value.to_str().ok_or_else(|| {
             crate::Error::invalid_value(
                 cmd,
                 value.to_string_lossy().into_owned(),
@@ -947,8 +947,8 @@ impl<E: crate::ValueEnum + Clone + Send + Sync + 'static> TypedValueParser for E
                 arg.map(ToString::to_string)
                     .unwrap_or_else(|| "...".to_owned()),
             )
-        })?;
-        let value = E::value_variants()
+        }));
+        let value = ok!(E::value_variants()
             .iter()
             .find(|v| {
                 v.to_possible_value()
@@ -963,7 +963,7 @@ impl<E: crate::ValueEnum + Clone + Send + Sync + 'static> TypedValueParser for E
                 arg.map(ToString::to_string)
                     .unwrap_or_else(|| "...".to_owned()),
             )
-            })?
+            }))
             .clone();
         Ok(value)
     }
@@ -1049,12 +1049,12 @@ impl TypedValueParser for PossibleValuesParser {
         arg: Option<&crate::Arg>,
         value: std::ffi::OsString,
     ) -> Result<String, crate::Error> {
-        let value = value.into_string().map_err(|_| {
+        let value = ok!(value.into_string().map_err(|_| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
+        }));
 
         let ignore_case = arg.map(|a| a.is_ignore_case_set()).unwrap_or(false);
         if self.0.iter().any(|v| v.matches(&value, ignore_case)) {
@@ -1233,13 +1233,13 @@ where
         arg: Option<&crate::Arg>,
         raw_value: &std::ffi::OsStr,
     ) -> Result<Self::Value, crate::Error> {
-        let value = raw_value.to_str().ok_or_else(|| {
+        let value = ok!(raw_value.to_str().ok_or_else(|| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
-        let value = value.parse::<i64>().map_err(|err| {
+        }));
+        let value = ok!(value.parse::<i64>().map_err(|err| {
             let arg = arg
                 .map(|a| a.to_string())
                 .unwrap_or_else(|| "...".to_owned());
@@ -1249,7 +1249,7 @@ where
                 err.into(),
             )
             .with_cmd(cmd)
-        })?;
+        }));
         if !self.bounds.contains(&value) {
             let arg = arg
                 .map(|a| a.to_string())
@@ -1263,7 +1263,7 @@ where
         }
 
         let value: Result<Self::Value, _> = value.try_into();
-        let value = value.map_err(|err| {
+        let value = ok!(value.map_err(|err| {
             let arg = arg
                 .map(|a| a.to_string())
                 .unwrap_or_else(|| "...".to_owned());
@@ -1273,7 +1273,7 @@ where
                 err.into(),
             )
             .with_cmd(cmd)
-        })?;
+        }));
 
         Ok(value)
     }
@@ -1431,13 +1431,13 @@ where
         arg: Option<&crate::Arg>,
         raw_value: &std::ffi::OsStr,
     ) -> Result<Self::Value, crate::Error> {
-        let value = raw_value.to_str().ok_or_else(|| {
+        let value = ok!(raw_value.to_str().ok_or_else(|| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
-        let value = value.parse::<u64>().map_err(|err| {
+        }));
+        let value = ok!(value.parse::<u64>().map_err(|err| {
             let arg = arg
                 .map(|a| a.to_string())
                 .unwrap_or_else(|| "...".to_owned());
@@ -1447,7 +1447,7 @@ where
                 err.into(),
             )
             .with_cmd(cmd)
-        })?;
+        }));
         if !self.bounds.contains(&value) {
             let arg = arg
                 .map(|a| a.to_string())
@@ -1461,7 +1461,7 @@ where
         }
 
         let value: Result<Self::Value, _> = value.try_into();
-        let value = value.map_err(|err| {
+        let value = ok!(value.map_err(|err| {
             let arg = arg
                 .map(|a| a.to_string())
                 .unwrap_or_else(|| "...".to_owned());
@@ -1471,7 +1471,7 @@ where
                 err.into(),
             )
             .with_cmd(cmd)
-        })?;
+        }));
 
         Ok(value)
     }
@@ -1622,12 +1622,12 @@ impl TypedValueParser for FalseyValueParser {
         _arg: Option<&crate::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, crate::Error> {
-        let value = value.to_str().ok_or_else(|| {
+        let value = ok!(value.to_str().ok_or_else(|| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
+        }));
         let value = if value.is_empty() {
             false
         } else {
@@ -1719,19 +1719,19 @@ impl TypedValueParser for BoolishValueParser {
         arg: Option<&crate::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, crate::Error> {
-        let value = value.to_str().ok_or_else(|| {
+        let value = ok!(value.to_str().ok_or_else(|| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
-        let value = crate::util::str_to_bool(value).ok_or_else(|| {
+        }));
+        let value = ok!(crate::util::str_to_bool(value).ok_or_else(|| {
             let arg = arg
                 .map(|a| a.to_string())
                 .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(arg, value.to_owned(), "value was not a boolean".into())
                 .with_cmd(cmd)
-        })?;
+        }));
         Ok(value)
     }
 
@@ -1808,12 +1808,12 @@ impl TypedValueParser for NonEmptyStringValueParser {
                     .unwrap_or_else(|| "...".to_owned()),
             ));
         }
-        let value = value.to_str().ok_or_else(|| {
+        let value = ok!(value.to_str().ok_or_else(|| {
             crate::Error::invalid_utf8(
                 cmd,
                 crate::output::Usage::new(cmd).create_usage_with_title(&[]),
             )
-        })?;
+        }));
         Ok(value.to_owned())
     }
 }
@@ -1860,7 +1860,7 @@ where
         arg: Option<&crate::Arg>,
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, crate::Error> {
-        let value = self.parser.parse_ref(cmd, arg, value)?;
+        let value = ok!(self.parser.parse_ref(cmd, arg, value));
         let value = (self.func)(value);
         Ok(value)
     }
@@ -1871,7 +1871,7 @@ where
         arg: Option<&crate::Arg>,
         value: std::ffi::OsString,
     ) -> Result<Self::Value, crate::Error> {
-        let value = self.parser.parse(cmd, arg, value)?;
+        let value = ok!(self.parser.parse(cmd, arg, value));
         let value = (self.func)(value);
         Ok(value)
     }

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -94,7 +94,7 @@ pub trait Parser: FromArgMatches + CommandFactory + Sized {
 
     /// Parse from `std::env::args_os()`, return Err on error.
     fn try_parse() -> Result<Self, Error> {
-        let mut matches = <Self as CommandFactory>::command().try_get_matches()?;
+        let mut matches = ok!(<Self as CommandFactory>::command().try_get_matches());
         <Self as FromArgMatches>::from_arg_matches_mut(&mut matches).map_err(format_error::<Self>)
     }
 
@@ -123,7 +123,7 @@ pub trait Parser: FromArgMatches + CommandFactory + Sized {
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        let mut matches = <Self as CommandFactory>::command().try_get_matches_from(itr)?;
+        let mut matches = ok!(<Self as CommandFactory>::command().try_get_matches_from(itr));
         <Self as FromArgMatches>::from_arg_matches_mut(&mut matches).map_err(format_error::<Self>)
     }
 
@@ -150,7 +150,7 @@ pub trait Parser: FromArgMatches + CommandFactory + Sized {
         T: Into<OsString> + Clone,
     {
         let mut matches =
-            <Self as CommandFactory>::command_for_update().try_get_matches_from(itr)?;
+            ok!(<Self as CommandFactory>::command_for_update().try_get_matches_from(itr));
         <Self as FromArgMatches>::update_from_arg_matches_mut(self, &mut matches)
             .map_err(format_error::<Self>)
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -694,11 +694,11 @@ impl<F: ErrorFormatter> error::Error for Error<F> {
 impl<F: ErrorFormatter> Display for Error<F> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         // Assuming `self.message` already has a trailing newline, from `try_help` or similar
-        write!(f, "{}", self.formatted())?;
+        ok!(write!(f, "{}", self.formatted()));
         if let Some(backtrace) = self.inner.backtrace.as_ref() {
-            writeln!(f)?;
-            writeln!(f, "Backtrace:")?;
-            writeln!(f, "{}", backtrace)?;
+            ok!(writeln!(f));
+            ok!(writeln!(f, "Backtrace:"));
+            ok!(writeln!(f, "{}", backtrace));
         }
         Ok(())
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -661,3 +661,15 @@ macro_rules! debug {
 macro_rules! debug {
     ($($arg:tt)*) => {};
 }
+
+macro_rules! ok {
+    ($expr:expr) => {
+        $expr?
+    };
+}
+
+macro_rules! some {
+    ($expr:expr) => {
+        $expr?
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -664,12 +664,22 @@ macro_rules! debug {
 
 macro_rules! ok {
     ($expr:expr) => {
-        $expr?
+        match $expr {
+            Ok(val) => val,
+            Err(err) => {
+                return Err(err);
+            }
+        }
     };
 }
 
 macro_rules! some {
     ($expr:expr) => {
-        $expr?
+        match $expr {
+            Some(val) => val,
+            None => {
+                return None;
+            }
+        }
     };
 }

--- a/src/output/fmt.rs
+++ b/src/output/fmt.rs
@@ -48,7 +48,7 @@ impl Colorizer {
         };
 
         let mut buffer = writer.buffer();
-        self.content.write_colored(&mut buffer)?;
+        ok!(self.content.write_colored(&mut buffer));
         writer.print(&buffer)
     }
 

--- a/src/output/help_template.rs
+++ b/src/output/help_template.rs
@@ -987,7 +987,9 @@ pub(crate) fn dimensions() -> (Option<usize>, Option<usize>) {
 
 #[cfg(feature = "wrap_help")]
 fn parse_env(var: &str) -> Option<usize> {
-    std::env::var_os(var)?.to_str()?.parse::<usize>().ok()
+    some!(some!(std::env::var_os(var)).to_str())
+        .parse::<usize>()
+        .ok()
 }
 
 fn should_show_arg(use_long: bool, arg: &Arg) -> bool {

--- a/src/output/usage.rs
+++ b/src/output/usage.rs
@@ -35,7 +35,7 @@ impl<'cmd> Usage<'cmd> {
     // any subcommands have been parsed (so as to give subcommands their own usage recursively)
     pub(crate) fn create_usage_with_title(&self, used: &[Id]) -> Option<StyledStr> {
         debug!("Usage::create_usage_with_title");
-        let usage = self.create_usage_no_title(used)?;
+        let usage = some!(self.create_usage_no_title(used));
 
         let mut styled = StyledStr::new();
         styled.header("Usage:");

--- a/src/parser/features/suggestions.rs
+++ b/src/parser/features/suggestions.rs
@@ -63,8 +63,8 @@ where
 
                 let subcommand_name = subcommand.get_name();
 
-                let candidate = did_you_mean(arg, longs).pop()?;
-                let score = remaining_args.iter().position(|x| subcommand_name == *x)?;
+                let candidate = some!(did_you_mean(arg, longs).pop());
+                let score = some!(remaining_args.iter().position(|x| subcommand_name == *x));
                 Some((score, (candidate, Some(subcommand_name.to_string()))))
             })
             .min_by_key(|(x, _)| *x)

--- a/src/parser/matches/any_value.rs
+++ b/src/parser/matches/any_value.rs
@@ -22,7 +22,7 @@ impl AnyValue {
     pub(crate) fn downcast_into<T: std::any::Any + Clone + Send + Sync>(self) -> Result<T, Self> {
         let id = self.id;
         let value =
-            std::sync::Arc::downcast::<T>(self.inner).map_err(|inner| Self { inner, id })?;
+            ok!(std::sync::Arc::downcast::<T>(self.inner).map_err(|inner| Self { inner, id }));
         let value = std::sync::Arc::try_unwrap(value).unwrap_or_else(|arc| (*arc).clone());
         Ok(value)
     }

--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -454,7 +454,7 @@ impl ArgMatches {
     #[cfg(feature = "unstable-grouped")]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn grouped_values_of(&self, id: &str) -> Option<GroupedValues> {
-        let arg = self.get_arg(id)?;
+        let arg = some!(self.get_arg(id));
         let v = GroupedValues {
             iter: arg.vals().map(|g| g.iter().map(unwrap_string).collect()),
             len: arg.vals().len(),
@@ -636,8 +636,8 @@ impl ArgMatches {
     /// [delimiter]: crate::Arg::value_delimiter()
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn index_of(&self, id: &str) -> Option<usize> {
-        let arg = self.get_arg(id)?;
-        let i = arg.get_index(0)?;
+        let arg = some!(self.get_arg(id));
+        let i = some!(arg.get_index(0));
         Some(i)
     }
 
@@ -718,7 +718,7 @@ impl ArgMatches {
     /// [delimiter]: Arg::value_delimiter()
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn indices_of(&self, id: &str) -> Option<Indices<'_>> {
-        let arg = self.get_arg(id)?;
+        let arg = some!(self.get_arg(id));
         let i = Indices {
             iter: arg.indices(),
             len: arg.num_vals(),
@@ -941,7 +941,7 @@ impl ArgMatches {
         &self,
         id: &str,
     ) -> Result<Option<&T>, MatchesError> {
-        let arg = self.try_get_arg_t::<T>(id)?;
+        let arg = ok!(self.try_get_arg_t::<T>(id));
         let value = match arg.and_then(|a| a.first()) {
             Some(value) => value,
             None => {
@@ -959,7 +959,7 @@ impl ArgMatches {
         &self,
         id: &str,
     ) -> Result<Option<ValuesRef<T>>, MatchesError> {
-        let arg = match self.try_get_arg_t::<T>(id)? {
+        let arg = match ok!(self.try_get_arg_t::<T>(id)) {
             Some(arg) => arg,
             None => return Ok(None),
         };
@@ -975,7 +975,7 @@ impl ArgMatches {
 
     /// Non-panicking version of [`ArgMatches::get_raw`]
     pub fn try_get_raw(&self, id: &str) -> Result<Option<RawValues<'_>>, MatchesError> {
-        let arg = match self.try_get_arg(id)? {
+        let arg = match ok!(self.try_get_arg(id)) {
             Some(arg) => arg,
             None => return Ok(None),
         };
@@ -993,7 +993,7 @@ impl ArgMatches {
         &mut self,
         id: &str,
     ) -> Result<Option<T>, MatchesError> {
-        match self.try_remove_arg_t::<T>(id)? {
+        match ok!(self.try_remove_arg_t::<T>(id)) {
             Some(values) => Ok(values
                 .into_vals_flatten()
                 // enforced by `try_get_arg_t`
@@ -1008,7 +1008,7 @@ impl ArgMatches {
         &mut self,
         id: &str,
     ) -> Result<Option<Values<T>>, MatchesError> {
-        let arg = match self.try_remove_arg_t::<T>(id)? {
+        let arg = match ok!(self.try_remove_arg_t::<T>(id)) {
             Some(arg) => arg,
             None => return Ok(None),
         };
@@ -1024,7 +1024,7 @@ impl ArgMatches {
 
     /// Non-panicking version of [`ArgMatches::contains_id`]
     pub fn try_contains_id(&self, id: &str) -> Result<bool, MatchesError> {
-        self.verify_arg(id)?;
+        ok!(self.verify_arg(id));
 
         let presence = self.args.contains_key(id);
         Ok(presence)
@@ -1035,7 +1035,7 @@ impl ArgMatches {
 impl ArgMatches {
     #[inline]
     fn try_get_arg(&self, arg: &str) -> Result<Option<&MatchedArg>, MatchesError> {
-        self.verify_arg(arg)?;
+        ok!(self.verify_arg(arg));
         Ok(self.args.get(arg))
     }
 
@@ -1044,13 +1044,13 @@ impl ArgMatches {
         &self,
         arg: &str,
     ) -> Result<Option<&MatchedArg>, MatchesError> {
-        let arg = match self.try_get_arg(arg)? {
+        let arg = match ok!(self.try_get_arg(arg)) {
             Some(arg) => arg,
             None => {
                 return Ok(None);
             }
         };
-        self.verify_arg_t::<T>(arg)?;
+        ok!(self.verify_arg_t::<T>(arg));
         Ok(Some(arg))
     }
 
@@ -1059,7 +1059,7 @@ impl ArgMatches {
         &mut self,
         arg: &str,
     ) -> Result<Option<MatchedArg>, MatchesError> {
-        self.verify_arg(arg)?;
+        ok!(self.verify_arg(arg));
         let (id, matched) = match self.args.remove_entry(arg) {
             Some((id, matched)) => (id, matched),
             None => {

--- a/src/parser/validator.rs
+++ b/src/parser/validator.rs
@@ -76,9 +76,9 @@ impl<'cmd> Validator<'cmd> {
             ));
         }
 
-        self.validate_conflicts(matcher, &mut conflicts)?;
+        ok!(self.validate_conflicts(matcher, &mut conflicts));
         if !(self.cmd.is_subcommand_negates_reqs_set() && has_subcmd) {
-            self.validate_required(matcher, &mut conflicts)?;
+            ok!(self.validate_required(matcher, &mut conflicts));
         }
 
         Ok(())
@@ -91,7 +91,7 @@ impl<'cmd> Validator<'cmd> {
     ) -> ClapResult<()> {
         debug!("Validator::validate_conflicts");
 
-        self.validate_exclusive(matcher)?;
+        ok!(self.validate_exclusive(matcher));
 
         for arg_id in matcher
             .arg_ids()
@@ -100,7 +100,7 @@ impl<'cmd> Validator<'cmd> {
         {
             debug!("Validator::validate_conflicts::iter: id={:?}", arg_id);
             let conflicts = conflicts.gather_conflicts(self.cmd, matcher, arg_id);
-            self.build_conflict_err(arg_id, &conflicts, matcher)?;
+            ok!(self.build_conflict_err(arg_id, &conflicts, matcher));
         }
 
         Ok(())
@@ -361,7 +361,7 @@ impl<'cmd> Validator<'cmd> {
         }
 
         if !missing_required.is_empty() {
-            self.missing_required_error(matcher, missing_required)?;
+            ok!(self.missing_required_error(matcher, missing_required));
         }
 
         Ok(())

--- a/src/util/flat_map.rs
+++ b/src/util/flat_map.rs
@@ -65,11 +65,11 @@ impl<K: PartialEq + Eq, V> FlatMap<K, V> {
         K: Borrow<Q>,
         Q: std::hash::Hash + Eq,
     {
-        let index = self
+        let index = some!(self
             .keys
             .iter()
             .enumerate()
-            .find_map(|(i, k)| (k.borrow() == key).then(|| i))?;
+            .find_map(|(i, k)| (k.borrow() == key).then(|| i)));
         let key = self.keys.remove(index);
         let value = self.values.remove(index);
         Some((key, value))


### PR DESCRIPTION
For binary size, this only dropped 0.2 KiB

For performance, before:
- parse_rustup_with_sc    time:   [7.9866 µs 8.0138 µs 8.0470 µs]
After:
- parse_rustup_with_sc    time:   [7.5387 µs 7.5722 µs 7.6157 µs]

For build-time, before
```console
$ hyperfine --warmup=1 --min-runs=5 "--prepare=cargo clean" "cargo build -F cargo --example cargo-example"
Benchmark 1: cargo build -F cargo --example cargo-example
  Time (mean ± σ):     16.988 s ±  1.190 s    [User: 68.178 s, System: 6.637 s]
  Range (min … max):   15.550 s … 18.277 s    5 runs
```
After:
```console
$ hyperfine --warmup=1 --min-runs=5 "--prepare=cargo clean" "cargo build -F cargo --example cargo-example"
Benchmark 1: cargo build -F cargo --example cargo-example
  Time (mean ± σ):     15.674 s ±  0.222 s    [User: 62.287 s, System: 4.608 s]
  Range (min … max):   15.426 s … 15.993 s    5 runs
```