### PR TITLE
docs: Add simple example of once_cell pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,11 @@ path = "examples/repl.rs"
 required-features = ["help"]
 
 [[example]]
+name = "singleton"
+path = "examples/singleton.rs"
+required-features = ["derive"]
+
+[[example]]
 name = "01_quick"
 path = "examples/tutorial_builder/01_quick.rs"
 required-features = ["cargo"]

--- a/examples/singleton.md
+++ b/examples/singleton.md
@@ -1,0 +1,11 @@
+`singleton` is a simple example of using [`once_cell`]. Use a global state for command line option is a common pattern for small application. You can use either derive or builder API.
+
+Clap doesn't recommend to use singleton, this example is only given for a Quick and Dirty (Q&D) bootstrap of small binary. Singleton pattern have caveats its make your code is less robust. A function that use global state is more difficult to test, you can't easily override options values for a specific test, you will have difficulty with cargo test ecosystem.
+
+```console
+$ singleton
+The answer is 42!
+
+```
+
+[`once_cell`]: https://docs.rs/once_cell/latest/once_cell/

--- a/examples/singleton.rs
+++ b/examples/singleton.rs
@@ -1,0 +1,16 @@
+use clap::Parser;
+
+use once_cell::sync::Lazy;
+
+#[derive(Parser, Debug)]
+#[command(author, version)]
+struct Args {
+    #[arg(short, long, default_value_t = 42)]
+    the_answer: u8,
+}
+
+static ARGS: Lazy<Args> = Lazy::new(Args::parse);
+
+fn main() {
+    println!("The answer is {}!", ARGS.the_answer)
+}


### PR DESCRIPTION
I noticed there was no "simple" global example, only one I found is https://github.com/clap-rs/clap/blob/master/clap_bench/benches/05_ripgrep.rs#L10 and that a benchmark.