### PR TITLE
docs: Update multiline usage override rules

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -1662,7 +1662,7 @@ impl Command {
     /// correctly by the default help formatter:
     ///
     /// - Do not indent the first usage line.
-    /// - Indent all subsequent usage lines with four spaces.
+    /// - Indent all subsequent usage lines with seven spaces.
     /// - The last line must not end with a newline.
     ///
     /// # Examples
@@ -1680,8 +1680,8 @@ impl Command {
     /// # use clap::{Command, Arg};
     /// Command::new("myprog")
     ///     .override_usage(
-    ///         "myapp -X [-a] [-b] <file>\n    \
-    ///          myapp -Y [-c] <file1> <file2>\n    \
+    ///         "myapp -X [-a] [-b] <file>\n       \
+    ///          myapp -Y [-c] <file1> <file2>\n       \
     ///          myapp -Z [-d|-e]"
     ///     )
     /// # ;


### PR DESCRIPTION
The styling of usage has changed in #4188 such that the usage string is on the same line as the "Usage:" title. Previously, the usage went on the line below the title. As such, the rules have changed for how to make a multiline usage format correctly.

These updated rules achieve the following output for the documented example:

    Usage: myapp -X [-a] [-b] <file>
           myapp -Y [-c] <file1> <file2>
           myapp -Z [-d|-e]

Relates-to: #4132

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
