### PR TITLE
fix(parser) No usage for unneeded attached value

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -177,14 +177,9 @@ impl<'cmd> Parser<'cmd> {
                                 .collect();
                             return Err(self.did_you_mean_error(&arg, matcher, &remaining_args));
                         }
-                        ParseResult::UnneededAttachedValue { rest, used, arg } => {
+                        ParseResult::UnneededAttachedValue { rest, used: _, arg } => {
                             let _ = self.resolve_pending(matcher);
-                            return Err(ClapError::too_many_values(
-                                self.cmd,
-                                rest,
-                                arg,
-                                Usage::new(self.cmd).create_usage_no_title(&used),
-                            ));
+                            return Err(ClapError::too_many_values(self.cmd, rest, arg, None));
                         }
                         ParseResult::MaybeHyphenValue => {
                             // Maybe a hyphen value, do nothing.


### PR DESCRIPTION
When a value is attached to an option that does not need a value (as in "--flag=value"), the error message included a usage line. However, that usage line, which could be generic generated usage, "smart" usage based off the user-provided command line, or the user-overridden usage. None of these forms of usage provide helpful information for this class of error. The crux of the problem is explained clearly in the error message's first line.

For example, this:

    error: The value 'value' was provided to '--flag' but it wasn't expecting any more values

    example --other <path>...

    For more information try '--help'

Becomes this:

    error: The value 'value' was provided to '--flag' but it wasn't expecting any more values

    For more information try '--help'

N.B. a motivating factor is that the "no-title" usage in this error message, in addition to being not super useful, was necessarily formatted incorrectly with a user-overridden, multi-line usage string. For example:

    error: The value 'value' was provided to '--flag' but it wasn't expecting any more values

    example -X <path>...
           example -Y [OPTIONS]
           example -Z [OPTIONS] [path]

    For more information try '--help'

Removing usage from this error message side-steps the usage formatting issue.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
