### PR TITLE
fix(error): Polish `--flag=bad-value` error

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -778,7 +778,7 @@ impl<'cmd> Parser<'cmd> {
                     "Parser::parse_long_arg({:?}): Got invalid literal `{:?}`",
                     long_arg, rest
                 );
-                let used: Vec<Id> = matcher
+                let mut used: Vec<Id> = matcher
                     .arg_ids()
                     .filter(|arg_id| {
                         matcher.check_explicit(arg_id, &crate::builder::ArgPredicate::IsPresent)
@@ -790,6 +790,7 @@ impl<'cmd> Parser<'cmd> {
                     })
                     .cloned()
                     .collect();
+                used.push(arg.get_id().clone());
 
                 Ok(ParseResult::UnneededAttachedValue {
                     rest: rest.to_str_lossy().into_owned(),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -183,7 +183,7 @@ impl<'cmd> Parser<'cmd> {
                                 self.cmd,
                                 rest,
                                 arg,
-                                Usage::new(self.cmd).create_usage_no_title(&used),
+                                Usage::new(self.cmd).create_usage_with_title(&used),
                             ));
                         }
                         ParseResult::MaybeHyphenValue => {

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -142,7 +142,7 @@ fn unexpected_value_error() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
 error: The value 'foo' was provided to '--a-flag' but it wasn't expecting any more values
 
-Usage: mycat [OPTIONS] [filename]
+Usage: mycat --a-flag [filename]
 
 For more information try '--help'
 ";

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -142,7 +142,7 @@ fn unexpected_value_error() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
 error: The value 'foo' was provided to '--a-flag' but it wasn't expecting any more values
 
-mycat [OPTIONS] [filename]
+Usage: mycat [OPTIONS] [filename]
 
 For more information try '--help'
 ";

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -138,6 +138,24 @@ fn multiple_flags_in_single() {
 
 #[test]
 #[cfg(feature = "error-context")]
+fn unexpected_value_error() {
+    const USE_FLAG_AS_ARGUMENT: &str = "\
+error: The value 'foo' was provided to '--a-flag' but it wasn't expecting any more values
+
+mycat [OPTIONS] [filename]
+
+For more information try '--help'
+";
+
+    let cmd = Command::new("mycat")
+        .arg(Arg::new("filename"))
+        .arg(Arg::new("a-flag").long("a-flag").action(ArgAction::SetTrue));
+
+    utils::assert_output(cmd, "mycat --a-flag=foo", USE_FLAG_AS_ARGUMENT, true);
+}
+
+#[test]
+#[cfg(feature = "error-context")]
 fn issue_1284_argument_in_flag_style() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
 error: Found argument '--another-flag' which wasn't expected, or isn't valid in this context


### PR DESCRIPTION
This error was untested and didn't fit the style of our other errors
```
error: The value 'value' was provided to '--flag' but it wasn't expecting any more values

example --other <path>...

For more information try '--help'
```
- It should show a usage type
- It should show the flag in the usage so people can scan more quickly for what is wrong

This supersedes #4268