### PR TITLE
fix(derive): Ensure clap/structopt attributes still work 

### DIFF
--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -1264,7 +1264,7 @@ fn assert_attr_kind(attr: &ClapAttr, possible_kind: &[AttrKind]) {
     if !possible_kind.contains(attr.kind.get()) {
         let options = possible_kind
             .iter()
-            .map(|k| format!("`#[{}({})]", k.as_str(), attr.name))
+            .map(|k| format!("`#[{}({})]`", k.as_str(), attr.name))
             .collect::<Vec<_>>();
         abort!(
             attr.name,

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -1261,7 +1261,9 @@ impl ToTokens for Deprecation {
 }
 
 fn assert_attr_kind(attr: &ClapAttr, possible_kind: &[AttrKind]) {
-    if !possible_kind.contains(attr.kind.get()) {
+    if *attr.kind.get() == AttrKind::Clap || *attr.kind.get() == AttrKind::StructOpt {
+        // deprecated
+    } else if !possible_kind.contains(attr.kind.get()) {
         let options = possible_kind
             .iter()
             .map(|k| format!("`#[{}({})]`", k.as_str(), attr.name))


### PR DESCRIPTION
The problem with updating all code to use non-deprecated APIs, there
aren't tests for the old way anymore.

Fixes #4274