### PR TITLE
fix(complete): Fix zsh handling of multiple arguments

### DIFF
--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -449,7 +449,11 @@ fn write_opts_of(p: &Command, p_global: Option<&Command>) -> String {
         let help = escape_help(&o.get_help().unwrap_or_default().to_string());
         let conflicts = arg_conflicts(p, o, p_global);
 
-        let multiple = "*";
+        let multiple = if let ArgAction::Count | ArgAction::Append = o.get_action() {
+            "*"
+        } else {
+            ""
+        };
 
         let vn = match o.get_value_names() {
             None => " ".to_string(),
@@ -545,7 +549,11 @@ fn write_flags_of(p: &Command, p_global: Option<&Command>) -> String {
         let help = escape_help(&f.get_help().unwrap_or_default().to_string());
         let conflicts = arg_conflicts(p, &f, p_global);
 
-        let multiple = "*";
+        let multiple = if let ArgAction::Count | ArgAction::Append = f.get_action() {
+            "*"
+        } else {
+            ""
+        };
 
         if let Some(short) = f.get_short() {
             let s = format!(
@@ -620,14 +628,13 @@ fn write_positionals_of(p: &Command) -> String {
         debug!("write_positionals_of:iter: arg={}", arg.get_id());
 
         let num_args = arg.get_num_args().expect("built");
-        let cardinality =
-            if num_args != builder::ValueRange::EMPTY && num_args != builder::ValueRange::SINGLE {
-                "*:"
-            } else if !arg.is_required_set() {
-                ":"
-            } else {
-                ""
-            };
+        let cardinality = if num_args.max_values() > 1 {
+            "*:"
+        } else if !arg.is_required_set() {
+            ":"
+        } else {
+            ""
+        };
 
         let a = format!(
             "'{cardinality}:{name}{help}:{value_completion}' \\",

--- a/clap_complete/tests/snapshots/aliases.zsh
+++ b/clap_complete/tests/snapshots/aliases.zsh
@@ -15,18 +15,18 @@ _my-app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'*-o+[cmd option]: : ' \
-'*-O+[cmd option]: : ' \
-'*--option=[cmd option]: : ' \
-'*--opt=[cmd option]: : ' \
-'*-f[cmd flag]' \
-'*-F[cmd flag]' \
-'*--flag[cmd flag]' \
-'*--flg[cmd flag]' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-o+[cmd option]: : ' \
+'-O+[cmd option]: : ' \
+'--option=[cmd option]: : ' \
+'--opt=[cmd option]: : ' \
+'-f[cmd flag]' \
+'-F[cmd flag]' \
+'--flag[cmd flag]' \
+'--flg[cmd flag]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '::positional:' \
 && ret=0
 }

--- a/clap_complete/tests/snapshots/basic.zsh
+++ b/clap_complete/tests/snapshots/basic.zsh
@@ -15,10 +15,10 @@ _my-app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'*-c[]' \
-'(-c)*-v[]' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-c[]' \
+'(-c)-v[]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 ":: :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
@@ -31,9 +31,9 @@ _my-app() {
             (test)
 _arguments "${_arguments_options[@]}" \
 '*-d[]' \
-'*-c[]' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-c[]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 && ret=0
 ;;
 (help)

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -19,10 +19,10 @@ _my-app() {
 '*-C[some config file]' \
 '*--config[some config file]' \
 '*--conf[some config file]' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '::file -- some input file:_files' \
 '::choice:(first second)' \
 ":: :_my-app_commands" \
@@ -36,11 +36,11 @@ _my-app() {
         case $line[3] in
             (test)
 _arguments "${_arguments_options[@]}" \
-'*--case=[the case to test]: : ' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'--case=[the case to test]: : ' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (help)

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -15,16 +15,16 @@ _my-app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'*--single-quotes[Can be '\''always'\'', '\''auto'\'', or '\''never'\'']' \
-'*--double-quotes[Can be "always", "auto", or "never"]' \
-'*--backticks[For more information see `echo test`]' \
-'*--backslash[Avoid '\''\\n'\'']' \
-'*--brackets[List packages \[filter\]]' \
-'*--expansions[Execute the shell command with $SHELL]' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'--single-quotes[Can be '\''always'\'', '\''auto'\'', or '\''never'\'']' \
+'--double-quotes[Can be "always", "auto", or "never"]' \
+'--backticks[For more information see `echo test`]' \
+'--backslash[Avoid '\''\\n'\'']' \
+'--brackets[List packages \[filter\]]' \
+'--expansions[Execute the shell command with $SHELL]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 ":: :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
@@ -36,38 +36,38 @@ _my-app() {
         case $line[1] in
             (cmd-single-quotes)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 && ret=0
 ;;
 (cmd-double-quotes)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 && ret=0
 ;;
 (cmd-backticks)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 && ret=0
 ;;
 (cmd-backslash)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 && ret=0
 ;;
 (cmd-brackets)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 && ret=0
 ;;
 (cmd-expansions)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 && ret=0
 ;;
 (help)

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -19,10 +19,10 @@ _my-app() {
 '*-C[some config file]' \
 '*--config[some config file]' \
 '*--conf[some config file]' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '::file -- some input file:_files' \
 '::choice:(first second)' \
 ":: :_my-app_commands" \
@@ -36,37 +36,37 @@ _my-app() {
         case $line[3] in
             (test)
 _arguments "${_arguments_options[@]}" \
-'*--case=[the case to test]: : ' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'--case=[the case to test]: : ' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (some_cmd)
 _arguments "${_arguments_options[@]}" \
-'*--config=[the other case to test]: : ' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'--config=[the other case to test]: : ' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '*::path:' \
 && ret=0
 ;;
 (some-cmd-with-hyphens)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (some-hidden-cmd)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (help)

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -19,10 +19,10 @@ _my-app() {
 '*-C[some config file]' \
 '*--config[some config file]' \
 '*--conf[some config file]' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 '::file -- some input file:_files' \
 '::choice:(first second)' \
 ":: :_my-app_commands" \
@@ -36,19 +36,19 @@ _my-app() {
         case $line[3] in
             (test)
 _arguments "${_arguments_options[@]}" \
-'*--case=[the case to test]: : ' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'--case=[the case to test]: : ' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (some_cmd)
 _arguments "${_arguments_options[@]}" \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-h[Print help information]' \
+'--help[Print help information]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 ":: :_my-app__some_cmd_commands" \
 "*::: :->some_cmd" \
 && ret=0
@@ -61,12 +61,12 @@ _arguments "${_arguments_options[@]}" \
         case $line[1] in
             (sub_cmd)
 _arguments "${_arguments_options[@]}" \
-'*--config=[the other case to test]: :((Lest\ quotes,\ aren'\''t\ escaped.\:"help,with,comma"
+'--config=[the other case to test]: :((Lest\ quotes,\ aren'\''t\ escaped.\:"help,with,comma"
 Second\ to\ trigger\ display\ of\ options\:""))' \
-'*-h[Print help information (use `--help` for more detail)]' \
-'*--help[Print help information (use `--help` for more detail)]' \
-'*-V[Print version information]' \
-'*--version[Print version information]' \
+'-h[Print help information (use `--help` for more detail)]' \
+'--help[Print help information (use `--help` for more detail)]' \
+'-V[Print version information]' \
+'--version[Print version information]' \
 && ret=0
 ;;
 (help)

--- a/clap_complete/tests/snapshots/value_hint.zsh
+++ b/clap_complete/tests/snapshots/value_hint.zsh
@@ -15,28 +15,28 @@ _my-app() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" \
-'*--choice=[]: :(bash fish zsh)' \
-'*--unknown=[]: : ' \
-'*--other=[]: :( )' \
-'*-p+[]: :_files' \
-'*--path=[]: :_files' \
-'*-f+[]: :_files' \
-'*--file=[]: :_files' \
-'*-d+[]: :_files -/' \
-'*--dir=[]: :_files -/' \
-'*-e+[]: :_absolute_command_paths' \
-'*--exe=[]: :_absolute_command_paths' \
-'*--cmd-name=[]: :_command_names -e' \
-'*-c+[]: :_cmdstring' \
-'*--cmd=[]: :_cmdstring' \
-'*-u+[]: :_users' \
-'*--user=[]: :_users' \
-'*-H+[]: :_hosts' \
-'*--host=[]: :_hosts' \
-'*--url=[]: :_urls' \
-'*--email=[]: :_email_addresses' \
-'*-h[Print help information]' \
-'*--help[Print help information]' \
+'--choice=[]: :(bash fish zsh)' \
+'--unknown=[]: : ' \
+'--other=[]: :( )' \
+'-p+[]: :_files' \
+'--path=[]: :_files' \
+'-f+[]: :_files' \
+'--file=[]: :_files' \
+'-d+[]: :_files -/' \
+'--dir=[]: :_files -/' \
+'-e+[]: :_absolute_command_paths' \
+'--exe=[]: :_absolute_command_paths' \
+'--cmd-name=[]: :_command_names -e' \
+'-c+[]: :_cmdstring' \
+'--cmd=[]: :_cmdstring' \
+'-u+[]: :_users' \
+'--user=[]: :_users' \
+'-H+[]: :_hosts' \
+'--host=[]: :_hosts' \
+'--url=[]: :_urls' \
+'--email=[]: :_email_addresses' \
+'-h[Print help information]' \
+'--help[Print help information]' \
 '*::command_with_args:_cmdambivalent' \
 && ret=0
 }


### PR DESCRIPTION
In zsh completion rules, the `*` denotes whether a flag/argument is allowed multiple times or not. However, in clap 4.0.0, all flag/option rules are always marked with `*` even if it makes no sense to supply them multiple times, such as `--help`.

This regressed for flags/options in 6f03b4f948af4d862db3343a1fd8b48454404a2f, the logic for handling non-multiple arguments with zsh was simply thrown out. While the consequences of this are minor, it's discouraging to see logic discarded without an understanding of why it's there.

The printing of positional multiple args was also tweaked, `ValueRange::new(0..=1)` should not be treated as multiple values.
