### PR TITLE
doc(fix typo): no close bracket in example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ We try to focus our documentation on the [four types of
 documentation](https://documentation.divio.com/).  Examples fit into this by
 providing:
 - [Cookbook / How-To Guides](https://docs.rs/clap/latest/clap/_cookbook/index.html)
-- Tutorials ([derive](https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html), [builder](https://docs.rs/clap/latest/clap/_tutorial/index.html)
+- Tutorials ([derive](https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html), [builder](https://docs.rs/clap/latest/clap/_tutorial/index.html))
 
 This directory contains the source for the above.
 


### PR DESCRIPTION
> fix : Tutorials (derive, builder > Tutorials (derive, builder)

Fixes #4297


<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
