### PR TITLE
feat(derive): Allow skipping the implicit ArgGroup 

### DIFF
--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -35,10 +35,7 @@ impl ClapAttr {
                 } else if attr.path.is_ident("command") {
                     Some(Sp::new(AttrKind::Command, attr.path.span()))
                 } else if attr.path.is_ident("group") {
-                    abort!(
-                        attr.path.span(),
-                        "`#[group()]` attributes are not supported yet"
-                    )
+                    Some(Sp::new(AttrKind::Group, attr.path.span()))
                 } else if attr.path.is_ident("arg") {
                     Some(Sp::new(AttrKind::Arg, attr.path.span()))
                 } else if attr.path.is_ident("value") {
@@ -202,6 +199,7 @@ pub enum AttrKind {
     Clap,
     StructOpt,
     Command,
+    Group,
     Arg,
     Value,
 }
@@ -212,6 +210,7 @@ impl AttrKind {
             Self::Clap => "clap",
             Self::StructOpt => "structopt",
             Self::Command => "command",
+            Self::Group => "group",
             Self::Arg => "arg",
             Self::Value => "value",
         }

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -315,11 +315,19 @@ pub fn gen_augment(
     let initial_app_methods = parent_item.initial_top_level_methods();
     let group_id = parent_item.ident().unraw().to_string();
     let final_app_methods = parent_item.final_top_level_methods();
+    let group_app_methods = if parent_item.skip_group() {
+        quote!()
+    } else {
+        quote!(
+            .group(clap::ArgGroup::new(#group_id).multiple(true))
+        )
+    };
     quote! {{
         #deprecations
         let #app_var = #app_var
             #initial_app_methods
-            .group(clap::ArgGroup::new(#group_id).multiple(true));
+            #group_app_methods
+            ;
         #( #args )*
         #app_var #final_app_methods
     }}

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -291,7 +291,7 @@ impl Item {
                         ),
                     });
                 }
-                AttrKind::Arg | AttrKind::Clap | AttrKind::StructOpt => {}
+                AttrKind::Group | AttrKind::Arg | AttrKind::Clap | AttrKind::StructOpt => {}
             }
             self.name = Name::Assigned(quote!(#arg));
         } else if name == "name" {
@@ -309,7 +309,11 @@ impl Item {
                         ),
                     });
                 }
-                AttrKind::Command | AttrKind::Value | AttrKind::Clap | AttrKind::StructOpt => {}
+                AttrKind::Group
+                | AttrKind::Command
+                | AttrKind::Value
+                | AttrKind::Clap
+                | AttrKind::StructOpt => {}
             }
             self.name = Name::Assigned(quote!(#arg));
         } else if name == "value_parser" {

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -4,6 +4,7 @@
 //! 2. [Attributes](#attributes)
 //!     1. [Terminology](#terminology)
 //!     2. [Command Attributes](#command-attributes)
+//!     2. [ArgGroup Attributes](#arggroup-attributes)
 //!     3. [Arg Attributes](#arg-attributes)
 //!     4. [ValueEnum Attributes](#valueenum-attributes)
 //!     5. [Possible Value Attributes](#possible-value-attributes)
@@ -28,6 +29,7 @@
 //! /// Doc comment
 //! #[derive(Parser)]
 //! #[command(CMD ATTRIBUTE)]
+//! #[group(GROUP ATTRIBUTE)]
 //! struct Cli {
 //!     /// Doc comment
 //!     #[arg(ARG ATTRIBUTE)]
@@ -46,6 +48,7 @@
 //! /// Doc comment
 //! #[derive(Args)]
 //! #[command(PARENT CMD ATTRIBUTE)]
+//! #[group(GROUP ATTRIBUTE)]
 //! struct Struct {
 //!     /// Doc comment
 //!     #[command(ARG ATTRIBUTE)]
@@ -172,6 +175,13 @@
 //!   [`Subcommand`][crate::Subcommand])
 //! - `external_subcommand`: [`Command::allow_external_subcommand(true)`][crate::Command::allow_external_subcommands]
 //!   - Variant must be either `Variant(Vec<String>)` or `Variant(Vec<OsString>)`
+//!
+//! ### ArgGroup Attributes
+//!
+//! These correspond to the [`ArgGroup`][crate::ArgGroup] which is implicitly created for each
+//! `Args` derive.
+//!
+//! At the moment, only `#[group(skip)]` is supported
 //!
 //! ### Arg Attributes
 //!

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -23,7 +23,6 @@ fn test_safely_nest_parser() {
 }
 
 #[test]
-#[should_panic = "'Compose' is already in use"]
 fn skip_group_avoids_duplicate_ids() {
     #[derive(Parser, Debug)]
     struct Opt {
@@ -34,6 +33,7 @@ fn skip_group_avoids_duplicate_ids() {
     }
 
     #[derive(clap::Args, Debug)]
+    #[group(skip)]
     pub struct Compose<L: clap::Args, R: clap::Args> {
         #[clap(flatten)]
         pub left: L,
@@ -42,6 +42,7 @@ fn skip_group_avoids_duplicate_ids() {
     }
 
     #[derive(clap::Args, Clone, Copy, Debug)]
+    #[group(skip)]
     pub struct Empty;
 
     use clap::CommandFactory;

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -21,3 +21,29 @@ fn test_safely_nest_parser() {
         Opt::try_parse_from(&["test", "--foo"]).unwrap()
     );
 }
+
+#[test]
+#[should_panic = "'Compose' is already in use"]
+fn skip_group_avoids_duplicate_ids() {
+    #[derive(Parser, Debug)]
+    struct Opt {
+        #[command(flatten)]
+        first: Compose<Empty, Empty>,
+        #[command(flatten)]
+        second: Compose<Empty, Empty>,
+    }
+
+    #[derive(clap::Args, Debug)]
+    pub struct Compose<L: clap::Args, R: clap::Args> {
+        #[clap(flatten)]
+        pub left: L,
+        #[clap(flatten)]
+        pub right: R,
+    }
+
+    #[derive(clap::Args, Clone, Copy, Debug)]
+    pub struct Empty;
+
+    use clap::CommandFactory;
+    Opt::command().debug_assert();
+}


### PR DESCRIPTION
This was prioritized to allow users to workaround problems when the
implicit `ArgGroup` is getting in the way.

Fixes #4279