### PR TITLE
feat(derive): Implicitly populate groups from some structs

### DIFF
--- a/tests/derive/utils.rs
+++ b/tests/derive/utils.rs
@@ -53,3 +53,18 @@ pub fn get_subcommand_long_help<T: CommandFactory>(subcmd: &str) -> String {
 
     output
 }
+
+#[track_caller]
+pub fn assert_output<P: clap::Parser + std::fmt::Debug>(args: &str, expected: &str, stderr: bool) {
+    let res = P::try_parse_from(args.split(' ').collect::<Vec<_>>());
+    let err = res.unwrap_err();
+    let actual = err.render().to_string();
+    assert_eq!(
+        stderr,
+        err.use_stderr(),
+        "Should Use STDERR failed. Should be {} but is {}",
+        stderr,
+        err.use_stderr()
+    );
+    snapbox::assert_eq(expected, actual)
+}


### PR DESCRIPTION
This implements the basics for #3165, just missing
- `flatten` support (waiting on improved group support)
- `group` attributes

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
