### PR TITLE
docs: Describe the skip attribute for ValueEnums

### DIFF
--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -245,6 +245,7 @@
 //! - `rename_all = <string_literal>`: Override default field / variant name case conversion for [`PossibleValue::new`][crate::builder::PossibleValue]
 //!   - When not present: `"kebab-case"`
 //!   - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
+//! - `skip`: Ignore this variant
 //!
 //! ### Possible Value Attributes
 //!

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -245,7 +245,6 @@
 //! - `rename_all = <string_literal>`: Override default field / variant name case conversion for [`PossibleValue::new`][crate::builder::PossibleValue]
 //!   - When not present: `"kebab-case"`
 //!   - Available values: `"camelCase"`, `"kebab-case"`, `"PascalCase"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"lower"`, `"UPPER"`, `"verbatim"`
-//! - `skip`: Ignore this variant
 //!
 //! ### Possible Value Attributes
 //!
@@ -259,6 +258,7 @@
 //!   - When not present: case-converted field name is used
 //! - `help = <expr>`: [`PossibleValue::help`][crate::builder::PossibleValue::help]
 //!   - When not present: [Doc comment summary](#doc-comments)
+//! - `skip`: Ignore this variant
 //!
 //! ## Arg Types
 //!


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Documenting the `skip` attribute for the `ValueEnum` derive macro promptly, as it's not mentioned anywhere else.

Fixes #4327
