### PR TITLE
fix(parser): Allow defaults for Help/Version

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1274,7 +1274,6 @@ impl<'cmd> Parser<'cmd> {
                 Ok(ParseResult::ValuesDone)
             }
             ArgAction::Help => {
-                debug_assert_eq!(raw_vals, Vec::<OsString>::new());
                 let use_long = match ident {
                     Some(Identifier::Long) => true,
                     Some(Identifier::Short) => false,
@@ -1285,7 +1284,6 @@ impl<'cmd> Parser<'cmd> {
                 Err(self.help_err(use_long))
             }
             ArgAction::Version => {
-                debug_assert_eq!(raw_vals, Vec::<OsString>::new());
                 let use_long = match ident {
                     Some(Identifier::Long) => true,
                     Some(Identifier::Short) => false,


### PR DESCRIPTION
These didn't make sense for the builder but are helpful for the derive. The assert was assuming people wouldn't do this and to catch internal problems.

Fixes #4326

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
