### PR TITLE
fix: Hide clap_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ default = [
   "error-context",
   "suggestions",
 ]
-debug = ["clap_derive/debug", "dep:backtrace"] # Enables debug messages
+debug = ["clap_derive?/debug", "dep:backtrace"] # Enables debug messages
 unstable-doc = ["derive", "cargo", "wrap_help", "env", "unicode", "string", "unstable-replace", "unstable-grouped"] # for docs.rs
 
 # Used in default
@@ -75,7 +75,7 @@ suggestions = ["dep:strsim", "error-context"]
 
 # Optional
 deprecated = ["clap_derive?/deprecated"] # Guided experience to prepare for next breaking release (at different stages of development, this may become default)
-derive = ["clap_derive", "dep:once_cell"]
+derive = ["dep:clap_derive", "dep:once_cell"]
 cargo = ["dep:once_cell"] # Disable if you're not using Cargo, enables Cargo-env-var-dependent macros
 wrap_help = ["help", "dep:terminal_size"]
 env = [] # Use environment variables during arg parsing


### PR DESCRIPTION
This was a bug that this wasn't done before and improves the `cargo add` behavior.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
