### PR TITLE
fix(derive): Apply doc comments for `#[command(subcommand)]`

### DIFF
--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -143,7 +143,7 @@ impl Item {
         let parsed_attrs = ClapAttr::parse_all(&variant.attrs);
         res.infer_kind(&parsed_attrs);
         res.push_attrs(&parsed_attrs);
-        if matches!(&*res.kind, Kind::Command(_)) {
+        if matches!(&*res.kind, Kind::Command(_) | Kind::Subcommand(_)) {
             res.push_doc_comment(&variant.attrs, "about", true);
         }
 
@@ -155,6 +155,9 @@ impl Item {
                         "methods are not allowed for flattened entry"
                     );
                 }
+
+                // ignore doc comments
+                res.doc_comment = vec![];
             }
 
             Kind::Subcommand(_)
@@ -228,6 +231,9 @@ impl Item {
                         "methods are not allowed for flattened entry"
                     );
                 }
+
+                // ignore doc comments
+                res.doc_comment = vec![];
             }
 
             Kind::Subcommand(_) => {

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -268,7 +268,7 @@ fn respect_subcommand_doc_comment() {
 Usage: cmd <COMMAND>
 
 Commands:
-  child  
+  child  For child
   help   Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -14,7 +14,7 @@
 
 use crate::utils;
 
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 
 #[test]
 fn doc_comments() {
@@ -247,4 +247,32 @@ fn doc_comment_about_handles_both_abouts() {
     // clap will fallback to `about` on `None`.  The main care about is not providing a `Sub` doc
     // comment.
     assert_eq!(cmd.get_long_about(), None);
+}
+
+#[test]
+fn respect_subcommand_doc_comment() {
+    #[derive(Parser, Debug)]
+    pub enum Cmd {
+        /// For child
+        #[command(subcommand)]
+        Child(Child),
+    }
+
+    #[derive(Subcommand, Debug)]
+    pub enum Child {
+        One,
+        Twp,
+    }
+
+    const OUTPUT: &str = "\
+Usage: cmd <COMMAND>
+
+Commands:
+  child  
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help information
+";
+    utils::assert_output::<Cmd>("cmd --help", OUTPUT, false);
 }


### PR DESCRIPTION
This was broken in 8a5a9ba931dd45a4976a5600eb24a91b202472f3.  I had
missed this case for parsing doc comments.