### PR TITLE
Clarify that the "body" part of the doc comment on a `ValueEnum` is ignored

### DIFF
--- a/examples/tutorial_builder/04_01_enum.md
+++ b/examples/tutorial_builder/04_01_enum.md
@@ -5,10 +5,30 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_01_enum[EXE] <MODE>
 
 Arguments:
+  <MODE>
+          What mode to run the program in
+
+          Possible values:
+          - fast: Run swiftly
+          - slow: Crawl slowly but steadily
+
+Options:
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+  -V, --version
+          Print version information
+
+$ 04_01_enum -h
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+Usage: 04_01_enum[EXE] <MODE>
+
+Arguments:
   <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-  -h, --help     Print help information
+  -h, --help     Print help information (use `--help` for more detail)
   -V, --version  Print version information
 
 $ 04_01_enum fast

--- a/examples/tutorial_builder/04_01_enum.rs
+++ b/examples/tutorial_builder/04_01_enum.rs
@@ -14,8 +14,8 @@ impl ValueEnum for Mode {
 
     fn to_possible_value<'a>(&self) -> Option<PossibleValue> {
         Some(match self {
-            Mode::Fast => PossibleValue::new("fast"),
-            Mode::Slow => PossibleValue::new("slow"),
+            Mode::Fast => PossibleValue::new("fast").help("Run swiftly"),
+            Mode::Slow => PossibleValue::new("slow").help("Crawl slowly but steadily"),
         })
     }
 }

--- a/examples/tutorial_derive/04_01_enum.md
+++ b/examples/tutorial_derive/04_01_enum.md
@@ -5,10 +5,30 @@ A simple to use, efficient, and full-featured Command Line Argument Parser
 Usage: 04_01_enum_derive[EXE] <MODE>
 
 Arguments:
+  <MODE>
+          What mode to run the program in
+
+          Possible values:
+          - fast: Run swiftly
+          - slow: Crawl slowly but steadily
+
+Options:
+  -h, --help
+          Print help information (use `-h` for a summary)
+
+  -V, --version
+          Print version information
+
+$ 04_01_enum_derive -h
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+Usage: 04_01_enum_derive[EXE] <MODE>
+
+Arguments:
   <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-  -h, --help     Print help information
+  -h, --help     Print help information (use `--help` for more detail)
   -V, --version  Print version information
 
 $ 04_01_enum_derive fast

--- a/examples/tutorial_derive/04_01_enum.rs
+++ b/examples/tutorial_derive/04_01_enum.rs
@@ -10,7 +10,11 @@ struct Cli {
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum Mode {
+    /// Run swiftly
     Fast,
+    /// Crawl slowly but steadily
+    ///
+    /// This paragraph is ignored because there is no long help text for possible values.
     Slow,
 }
 

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -212,7 +212,7 @@ fn multiline_separates_default() {
 }
 
 #[test]
-fn argenum_multiline_doc_comment() {
+fn value_enum_multiline_doc_comment() {
     #[derive(ValueEnum, Clone)]
     enum LoremIpsum {
         /// Multiline

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -213,13 +213,25 @@ fn multiline_separates_default() {
 
 #[test]
 fn value_enum_multiline_doc_comment() {
-    #[derive(ValueEnum, Clone)]
+    #[derive(Parser, Debug)]
+    struct Command {
+        x: LoremIpsum,
+    }
+
+    #[derive(ValueEnum, Clone, PartialEq, Debug)]
     enum LoremIpsum {
-        /// Multiline
+        /// Doc comment summary
         ///
-        /// Doc comment
+        /// The doc comment body is ignored
         Bar,
     }
+
+    let help = utils::get_long_help::<Command>();
+
+    assert!(help.contains("Doc comment summary"));
+
+    // There is no long help text for possible values. The long help only contains the summary.
+    assert!(!help.contains("The doc comment body is ignored"));
 }
 
 #[test]


### PR DESCRIPTION
`PossibleValue` does not have a long help text and the "body" part of the doc comment on a `ValueEnum` is ignored.

Improve a test case and the example to clarify this behavior.