### PR TITLE
fix(clap): line wrap on strings that contain ascii control characters

### DIFF
--- a/src/output/textwrap/core.rs
+++ b/src/output/textwrap/core.rs
@@ -54,8 +54,20 @@
 #[inline(never)]
 pub(crate) fn display_width(text: &str) -> usize {
     let mut width = 0;
+
+    let mut control_sequence = false;
+    let control_terminate: char = 'm';
+
     for ch in text.chars() {
-        width += ch_width(ch);
+        if ch.is_ascii_control() {
+            control_sequence = true;
+        } else if control_sequence && ch == control_terminate {
+            control_sequence = false;
+        }
+
+        if !control_sequence {
+            width += ch_width(ch);
+        }
     }
     width
 }

--- a/src/output/textwrap/core.rs
+++ b/src/output/textwrap/core.rs
@@ -63,6 +63,7 @@ pub(crate) fn display_width(text: &str) -> usize {
             control_sequence = true;
         } else if control_sequence && ch == control_terminate {
             control_sequence = false;
+            continue;
         }
 
         if !control_sequence {


### PR DESCRIPTION
counting ascii control sequences leads to unpredictable line breaks on colorized inputs (e.g. syntax highlighted strings)

https://github.com/clap-rs/clap/issues/4360

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
