### PR TITLE
refactor(error): Generalize how we report suggestions

### DIFF
--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -30,8 +30,6 @@ pub enum ContextKind {
     /// Trailing argument
     TrailingArg,
     /// Potential fix for the user
-    SuggestedTrailingArg,
-    /// Potential fix for the user
     Suggested,
     /// A usage string
     Usage,
@@ -56,7 +54,6 @@ impl ContextKind {
             Self::SuggestedArg => Some("Suggested Argument"),
             Self::SuggestedValue => Some("Suggested Value"),
             Self::TrailingArg => Some("Trailing Argument"),
-            Self::SuggestedTrailingArg => Some("Suggested Trailing Argument"),
             Self::Suggested => Some("Suggested"),
             Self::Usage => None,
             Self::Custom => None,

--- a/src/error/context.rs
+++ b/src/error/context.rs
@@ -31,6 +31,8 @@ pub enum ContextKind {
     TrailingArg,
     /// Potential fix for the user
     SuggestedTrailingArg,
+    /// Potential fix for the user
+    Suggested,
     /// A usage string
     Usage,
     /// An opaque message to the user
@@ -53,8 +55,9 @@ impl ContextKind {
             Self::SuggestedSubcommand => Some("Suggested Subcommand"),
             Self::SuggestedArg => Some("Suggested Argument"),
             Self::SuggestedValue => Some("Suggested Value"),
-            Self::SuggestedTrailingArg => Some("Suggested Trailing Argument"),
             Self::TrailingArg => Some("Trailing Argument"),
+            Self::SuggestedTrailingArg => Some("Suggested Trailing Argument"),
+            Self::Suggested => Some("Suggested"),
             Self::Usage => None,
             Self::Custom => None,
         }
@@ -82,6 +85,8 @@ pub enum ContextValue {
     Strings(Vec<String>),
     /// A single value
     StyledStr(crate::builder::StyledStr),
+    /// many value
+    StyledStrs(Vec<crate::builder::StyledStr>),
     /// A single value
     Number(isize),
 }
@@ -94,6 +99,15 @@ impl std::fmt::Display for ContextValue {
             Self::String(v) => v.fmt(f),
             Self::Strings(v) => v.join(", ").fmt(f),
             Self::StyledStr(v) => v.fmt(f),
+            Self::StyledStrs(v) => {
+                for (i, v) in v.iter().enumerate() {
+                    if i != 0 {
+                        ", ".fmt(f)?;
+                    }
+                    v.fmt(f)?;
+                }
+                Ok(())
+            }
             Self::Number(v) => v.fmt(f),
         }
     }

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -88,21 +88,6 @@ impl ErrorFormatter for RichFormatter {
             (_, _) => {}
         }
 
-        let invalid_arg = error.get(ContextKind::InvalidArg);
-        if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
-            let suggested_trailing_arg = error.get(ContextKind::SuggestedTrailingArg);
-            if suggested_trailing_arg == Some(&ContextValue::Bool(true)) {
-                styled.none("\n\n");
-                styled.none(TAB);
-                styled.none("If you tried to supply '");
-                styled.warning(invalid_arg);
-                styled.none("' as a value rather than a flag, use '");
-                styled.good("-- ");
-                styled.good(invalid_arg);
-                styled.none("'");
-            }
-        }
-
         let suggestions = error.get(ContextKind::Suggested);
         if let Some(ContextValue::StyledStrs(suggestions)) = suggestions {
             for suggestion in suggestions {

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -101,17 +101,6 @@ impl ErrorFormatter for RichFormatter {
                 styled.good(invalid_arg);
                 styled.none("'");
             }
-
-            let trailing_arg = error.get(ContextKind::TrailingArg);
-            if trailing_arg == Some(&ContextValue::Bool(true)) {
-                styled.none("\n\n");
-                styled.none(TAB);
-                styled.none("If you tried to supply '");
-                styled.warning(invalid_arg);
-                styled.none("' as a subcommand, remove the '");
-                styled.warning("--");
-                styled.none("' before it.");
-            }
         }
 
         let suggestions = error.get(ContextKind::Suggested);

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -114,15 +114,6 @@ impl ErrorFormatter for RichFormatter {
             }
         }
 
-        let suggestion = error.get(ContextKind::SuggestedCommand);
-        if let Some(ContextValue::String(suggestion)) = suggestion {
-            styled.none("\n\n");
-            styled.none(TAB);
-            styled.none("If you believe you received this message in error, try re-running with '");
-            styled.good(suggestion);
-            styled.none("'");
-        }
-
         let suggestions = error.get(ContextKind::Suggested);
         if let Some(ContextValue::StyledStrs(suggestions)) = suggestions {
             for suggestion in suggestions {

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -123,6 +123,15 @@ impl ErrorFormatter for RichFormatter {
             styled.none("'");
         }
 
+        let suggestions = error.get(ContextKind::Suggested);
+        if let Some(ContextValue::StyledStrs(suggestions)) = suggestions {
+            for suggestion in suggestions {
+                styled.none("\n\n");
+                styled.none(TAB);
+                styled.extend(suggestion.iter());
+            }
+        }
+
         let usage = error.get(ContextKind::Usage);
         if let Some(ContextValue::StyledStr(usage)) = usage {
             put_usage(&mut styled, usage.clone());

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -64,30 +64,18 @@ impl ErrorFormatter for RichFormatter {
             }
         }
 
+        if let Some(valid) = error.get(ContextKind::SuggestedSubcommand) {
+            styled.none("\n\n");
+            did_you_mean(&mut styled, valid);
+        }
+        if let Some(valid) = error.get(ContextKind::SuggestedArg) {
+            styled.none("\n\n");
+            did_you_mean(&mut styled, valid);
+        }
         if let Some(valid) = error.get(ContextKind::SuggestedValue) {
             styled.none("\n\n");
             did_you_mean(&mut styled, valid);
         }
-
-        let valid_sub = error.get(ContextKind::SuggestedSubcommand);
-        let valid_arg = error.get(ContextKind::SuggestedArg);
-        match (valid_sub, valid_arg) {
-            (Some(ContextValue::String(valid_sub)), Some(ContextValue::String(valid_arg))) => {
-                styled.none("\n\n");
-                styled.none(TAB);
-                styled.none("Did you mean to put '");
-                styled.good(valid_arg);
-                styled.none("' after the subcommand '");
-                styled.good(valid_sub);
-                styled.none("'?");
-            }
-            (Some(valid), None) | (None, Some(valid)) => {
-                styled.none("\n\n");
-                did_you_mean(&mut styled, valid);
-            }
-            (_, _) => {}
-        }
-
         let suggestions = error.get(ContextKind::Suggested);
         if let Some(ContextValue::StyledStrs(suggestions)) = suggestions {
             for suggestion in suggestions {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -426,11 +426,18 @@ impl<F: ErrorFormatter> Error<F> {
         name: String,
         usage: Option<StyledStr>,
     ) -> Self {
-        let suggestion = format!("{} -- {}", name, subcmd);
         let mut err = Self::new(ErrorKind::InvalidSubcommand).with_cmd(cmd);
 
         #[cfg(feature = "error-context")]
         {
+            let mut styled_suggestion = StyledStr::new();
+            styled_suggestion
+                .none("If you believe you received this message in error, try re-running with '");
+            styled_suggestion.good(name);
+            styled_suggestion.good(" -- ");
+            styled_suggestion.good(&subcmd);
+            styled_suggestion.none("'");
+
             err = err.extend_context_unchecked([
                 (ContextKind::InvalidSubcommand, ContextValue::String(subcmd)),
                 (
@@ -438,8 +445,8 @@ impl<F: ErrorFormatter> Error<F> {
                     ContextValue::Strings(did_you_mean),
                 ),
                 (
-                    ContextKind::SuggestedCommand,
-                    ContextValue::String(suggestion),
+                    ContextKind::Suggested,
+                    ContextValue::StyledStrs(vec![styled_suggestion]),
                 ),
             ]);
             if let Some(usage) = usage {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -672,14 +672,14 @@ impl<F: ErrorFormatter> Error<F> {
             }
             match did_you_mean {
                 Some((flag, Some(sub))) => {
-                    err = err.insert_context_unchecked(
-                        ContextKind::SuggestedSubcommand,
-                        ContextValue::String(sub),
-                    );
-                    err = err.insert_context_unchecked(
-                        ContextKind::SuggestedArg,
-                        ContextValue::String(format!("--{}", flag)),
-                    );
+                    let mut styled_suggestion = StyledStr::new();
+                    styled_suggestion.none("Did you mean to put '");
+                    styled_suggestion.good("--");
+                    styled_suggestion.good(flag);
+                    styled_suggestion.none("' after the subcommand '");
+                    styled_suggestion.good(sub);
+                    styled_suggestion.none("'?");
+                    suggestions.push(styled_suggestion);
                 }
                 Some((flag, None)) => {
                     err = err.insert_context_unchecked(

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -670,17 +670,24 @@ impl<F: ErrorFormatter> Error<F> {
                 err = err
                     .insert_context_unchecked(ContextKind::Usage, ContextValue::StyledStr(usage));
             }
-            if let Some((flag, sub)) = did_you_mean {
-                err = err.insert_context_unchecked(
-                    ContextKind::SuggestedArg,
-                    ContextValue::String(format!("--{}", flag)),
-                );
-                if let Some(sub) = sub {
+            match did_you_mean {
+                Some((flag, Some(sub))) => {
                     err = err.insert_context_unchecked(
                         ContextKind::SuggestedSubcommand,
                         ContextValue::String(sub),
                     );
+                    err = err.insert_context_unchecked(
+                        ContextKind::SuggestedArg,
+                        ContextValue::String(format!("--{}", flag)),
+                    );
                 }
+                Some((flag, None)) => {
+                    err = err.insert_context_unchecked(
+                        ContextKind::SuggestedArg,
+                        ContextValue::String(format!("--{}", flag)),
+                    );
+                }
+                None => {}
             }
             if !suggestions.is_empty() {
                 err = err.insert_context_unchecked(

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -652,6 +652,18 @@ impl<F: ErrorFormatter> Error<F> {
 
         #[cfg(feature = "error-context")]
         {
+            let mut suggestions = vec![];
+            if suggested_trailing_arg {
+                let mut styled_suggestion = StyledStr::new();
+                styled_suggestion.none("If you tried to supply '");
+                styled_suggestion.warning(&arg);
+                styled_suggestion.none("' as a value rather than a flag, use '");
+                styled_suggestion.good("-- ");
+                styled_suggestion.good(&arg);
+                styled_suggestion.none("'");
+                suggestions.push(styled_suggestion);
+            }
+
             err = err
                 .extend_context_unchecked([(ContextKind::InvalidArg, ContextValue::String(arg))]);
             if let Some(usage) = usage {
@@ -670,10 +682,10 @@ impl<F: ErrorFormatter> Error<F> {
                     );
                 }
             }
-            if suggested_trailing_arg {
+            if !suggestions.is_empty() {
                 err = err.insert_context_unchecked(
-                    ContextKind::SuggestedTrailingArg,
-                    ContextValue::Bool(true),
+                    ContextKind::Suggested,
+                    ContextValue::StyledStrs(suggestions),
                 );
             }
         }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -690,9 +690,19 @@ impl<F: ErrorFormatter> Error<F> {
 
         #[cfg(feature = "error-context")]
         {
+            let mut styled_suggestion = StyledStr::new();
+            styled_suggestion.none("If you tried to supply '");
+            styled_suggestion.warning(&arg);
+            styled_suggestion.none("' as a subcommand, remove the '");
+            styled_suggestion.warning("--");
+            styled_suggestion.none("' before it.");
+
             err = err.extend_context_unchecked([
                 (ContextKind::InvalidArg, ContextValue::String(arg)),
-                (ContextKind::TrailingArg, ContextValue::Bool(true)),
+                (
+                    ContextKind::Suggested,
+                    ContextValue::StyledStrs(vec![styled_suggestion]),
+                ),
             ]);
             if let Some(usage) = usage {
                 err = err


### PR DESCRIPTION
While `ContextKind` is useful for general information, it can't handle more nuanced suggestions, so we are falling back to a more general approach to suggestions.

This is a follow up to #4380 to make it API neutral.

Technically, there is a slight compatibility change here that only affects people who are doing custom formatted errors or manually generating errors.