### PR TITLE
docs: Provide a better example for positional arg append

### DIFF
--- a/examples/tutorial_builder/03_03_positional_mult.md
+++ b/examples/tutorial_builder/03_03_positional_mult.md
@@ -12,9 +12,12 @@ Options:
   -V, --version  Print version information
 
 $ 03_03_positional_mult
-name: None
+names: []
 
 $ 03_03_positional_mult bob
-name: Some("bob")
+names: ["bob"]
+
+$ 03_03_positional_mult bob john
+names: ["bob", "john"]
 
 ```

--- a/examples/tutorial_builder/03_03_positional_mult.rs
+++ b/examples/tutorial_builder/03_03_positional_mult.rs
@@ -5,5 +5,11 @@ fn main() {
         .arg(Arg::new("name").action(ArgAction::Append))
         .get_matches();
 
-    println!("name: {:?}", matches.get_one::<String>("name"));
+    let args = matches
+        .get_many::<String>("name")
+        .unwrap_or_default()
+        .map(|v| v.as_str())
+        .collect::<Vec<_>>();
+
+    println!("names: {:?}", &args);
 }

--- a/examples/tutorial_derive/03_03_positional_mult.md
+++ b/examples/tutorial_derive/03_03_positional_mult.md
@@ -17,4 +17,7 @@ name: []
 $ 03_03_positional_mult_derive bob
 name: ["bob"]
 
+$ 03_03_positional_mult_derive bob john
+name: ["bob", "john"]
+
 ```


### PR DESCRIPTION
Right now the builder [tutorial example](https://docs.rs/clap/latest/clap/_tutorial/index.html#positionals) for positional append shows basically the same example as for the default 'Set' action.
Having an example where there are multiple arguments along with extracting logic provides a better explanation on how to use this API.