### PR TITLE
fix(help): Shorten `--help` short help to shorten short help

### DIFF
--- a/clap_complete/tests/snapshots/sub_subcommands.elvish
+++ b/clap_complete/tests/snapshots/sub_subcommands.elvish
@@ -47,8 +47,8 @@ set edit:completion:arg-completer[my-app] = {|@words|
         }
         &'my-app;some_cmd;sub_cmd'= {
             cand --config 'the other case to test'
-            cand -h 'Print help information (use `--help` for more detail)'
-            cand --help 'Print help information (use `--help` for more detail)'
+            cand -h 'Print help information (use ''--help'' for more detail)'
+            cand --help 'Print help information (use ''--help'' for more detail)'
             cand -V 'Print version information'
             cand --version 'Print version information'
         }

--- a/clap_complete/tests/snapshots/sub_subcommands.elvish
+++ b/clap_complete/tests/snapshots/sub_subcommands.elvish
@@ -47,8 +47,8 @@ set edit:completion:arg-completer[my-app] = {|@words|
         }
         &'my-app;some_cmd;sub_cmd'= {
             cand --config 'the other case to test'
-            cand -h 'Print help information (use ''--help'' for more detail)'
-            cand --help 'Print help information (use ''--help'' for more detail)'
+            cand -h 'Print help (''--help'' for more)'
+            cand --help 'Print help (''--help'' for more)'
             cand -V 'Print version information'
             cand --version 'Print version information'
         }

--- a/clap_complete/tests/snapshots/sub_subcommands.fish
+++ b/clap_complete/tests/snapshots/sub_subcommands.fish
@@ -12,7 +12,7 @@ complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.	help\,with\,comma,Second to trigger display of options	}"
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help information (use \'--help\' for more detail)'
+complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help (\'--help\' for more)'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version information'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/clap_complete/tests/snapshots/sub_subcommands.fish
+++ b/clap_complete/tests/snapshots/sub_subcommands.fish
@@ -12,7 +12,7 @@ complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.	help\,with\,comma,Second to trigger display of options	}"
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help information (use `--help` for more detail)'
+complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help information (use \'--help\' for more detail)'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version information'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/clap_complete/tests/snapshots/sub_subcommands.ps1
+++ b/clap_complete/tests/snapshots/sub_subcommands.ps1
@@ -53,8 +53,8 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
         'my-app;some_cmd;sub_cmd' {
             [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'the other case to test')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information (use `--help` for more detail)')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information (use `--help` for more detail)')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information (use ''--help'' for more detail)')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information (use ''--help'' for more detail)')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break

--- a/clap_complete/tests/snapshots/sub_subcommands.ps1
+++ b/clap_complete/tests/snapshots/sub_subcommands.ps1
@@ -53,8 +53,8 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
         'my-app;some_cmd;sub_cmd' {
             [CompletionResult]::new('--config', 'config', [CompletionResultType]::ParameterName, 'the other case to test')
-            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information (use ''--help'' for more detail)')
-            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information (use ''--help'' for more detail)')
+            [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help (''--help'' for more)')
+            [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help (''--help'' for more)')
             [CompletionResult]::new('-V', 'V', [CompletionResultType]::ParameterName, 'Print version information')
             [CompletionResult]::new('--version', 'version', [CompletionResultType]::ParameterName, 'Print version information')
             break

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -63,8 +63,8 @@ _arguments "${_arguments_options[@]}" \
 _arguments "${_arguments_options[@]}" \
 '--config=[the other case to test]: :((Lest\ quotes,\ aren'\''t\ escaped.\:"help,with,comma"
 Second\ to\ trigger\ display\ of\ options\:""))' \
-'-h[Print help information (use `--help` for more detail)]' \
-'--help[Print help information (use `--help` for more detail)]' \
+'-h[Print help information (use '\''--help'\'' for more detail)]' \
+'--help[Print help information (use '\''--help'\'' for more detail)]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
 && ret=0

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -63,8 +63,8 @@ _arguments "${_arguments_options[@]}" \
 _arguments "${_arguments_options[@]}" \
 '--config=[the other case to test]: :((Lest\ quotes,\ aren'\''t\ escaped.\:"help,with,comma"
 Second\ to\ trigger\ display\ of\ options\:""))' \
-'-h[Print help information (use '\''--help'\'' for more detail)]' \
-'--help[Print help information (use '\''--help'\'' for more detail)]' \
+'-h[Print help ('\''--help'\'' for more)]' \
+'--help[Print help ('\''--help'\'' for more)]' \
 '-V[Print version information]' \
 '--version[Print version information]' \
 && ret=0

--- a/clap_mangen/tests/snapshots/possible_values.bash.roff
+++ b/clap_mangen/tests/snapshots/possible_values.bash.roff
@@ -25,7 +25,7 @@ slow: use the slow method
 .RE
 .TP
 /fB/-h/fR, /fB/-/-help/fR
-Print help information (use `/-h` for a summary)
+Print help information (use /*(Aq/-h/*(Aq for a summary)
 .TP
 [/fIpositional_choice/fR]
 Pick the Position you want the command to run in

--- a/clap_mangen/tests/snapshots/value_env.bash.roff
+++ b/clap_mangen/tests/snapshots/value_env.bash.roff
@@ -15,4 +15,4 @@ May also be specified with the /fBCONFIG_FILE/fR environment variable.
 .RE
 .TP
 /fB/-h/fR, /fB/-/-help/fR
-Print help information (use `/-h` for a summary)
+Print help information (use /*(Aq/-h/*(Aq for a summary)

--- a/examples/tutorial_builder/04_01_enum.md
+++ b/examples/tutorial_builder/04_01_enum.md
@@ -28,7 +28,7 @@ Arguments:
   <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 
 $ 04_01_enum fast

--- a/examples/tutorial_builder/04_01_enum.md
+++ b/examples/tutorial_builder/04_01_enum.md
@@ -14,7 +14,7 @@ Arguments:
 
 Options:
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -28,7 +28,7 @@ Arguments:
   <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 
 $ 04_01_enum fast

--- a/examples/tutorial_derive/04_01_enum.md
+++ b/examples/tutorial_derive/04_01_enum.md
@@ -28,7 +28,7 @@ Arguments:
   <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 
 $ 04_01_enum_derive fast

--- a/examples/tutorial_derive/04_01_enum.md
+++ b/examples/tutorial_derive/04_01_enum.md
@@ -14,7 +14,7 @@ Arguments:
 
 Options:
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -28,7 +28,7 @@ Arguments:
   <MODE>  What mode to run the program in [possible values: fast, slow]
 
 Options:
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 
 $ 04_01_enum_derive fast

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -4241,7 +4241,9 @@ impl Command {
                 .action(ArgAction::Help);
             if self.long_help_exists {
                 arg = arg
-                    .help("Print help information (use '--help' for more detail)")
+                    // keep this message brief, for applications that want to
+                    // use the two-column short help format
+                    .help("Print help ('--help' for more)")
                     .long_help("Print help information (use '-h' for a summary)");
             } else {
                 arg = arg.help("Print help information");

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -4241,8 +4241,8 @@ impl Command {
                 .action(ArgAction::Help);
             if self.long_help_exists {
                 arg = arg
-                    .help("Print help information (use `--help` for more detail)")
-                    .long_help("Print help information (use `-h` for a summary)");
+                    .help("Print help information (use '--help' for more detail)")
+                    .long_help("Print help information (use '-h' for a summary)");
             } else {
                 arg = arg.help("Print help information");
             }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -265,7 +265,7 @@ tests clap library
 Usage: clap-test
 
 Options:
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 
 some text that comes after the help
@@ -279,7 +279,7 @@ Usage: clap-test
 
 Options:
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -470,7 +470,7 @@ Options:
           - second: short help
 
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 ";
     let cmd = Command::new("test")
         .term_width(67)
@@ -648,7 +648,7 @@ Options:
           A coffeehouse, coffee shop, or café.
 
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -990,7 +990,7 @@ Arguments:
 
 Options:
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -1689,7 +1689,7 @@ does stuff
 Usage: test [OPTIONS] --song <song> --song-volume <volume>
 
 Options:
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 
 OVERRIDE SPECIAL:
@@ -1745,7 +1745,7 @@ Usage: ctest foo
 
 Options:
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -1768,7 +1768,7 @@ About foo
 Usage: ctest foo
 
 Options:
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 ";
 
@@ -1793,7 +1793,7 @@ Arguments:
 
 Options:
   -f          
-  -h, --help  Print help information (use `--help` for more detail)
+  -h, --help  Print help information (use '--help' for more detail)
 ";
 
     let cmd = Command::new("demo")
@@ -1948,7 +1948,7 @@ Options:
           and on, so I'll stop now.
 
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 ";
 
     let cmd = Command::new("prog").arg(

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -265,7 +265,7 @@ tests clap library
 Usage: clap-test
 
 Options:
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 
 some text that comes after the help
@@ -1689,7 +1689,7 @@ does stuff
 Usage: test [OPTIONS] --song <song> --song-volume <volume>
 
 Options:
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 
 OVERRIDE SPECIAL:
@@ -1768,7 +1768,7 @@ About foo
 Usage: ctest foo
 
 Options:
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 ";
 
@@ -1793,7 +1793,7 @@ Arguments:
 
 Options:
   -f          
-  -h, --help  Print help information (use '--help' for more detail)
+  -h, --help  Print help ('--help' for more)
 ";
 
     let cmd = Command::new("demo")

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -36,7 +36,7 @@ Usage: test [OPTIONS]
 
 Options:
   -v, --visible  This text should be visible
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 ";
 
@@ -154,7 +154,7 @@ Usage: test [OPTIONS]
 Options:
   -c, --config   Some help text describing the --config arg
   -v, --visible  This text should be visible
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 ";
 

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -36,7 +36,7 @@ Usage: test [OPTIONS]
 
 Options:
   -v, --visible  This text should be visible
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 ";
 
@@ -80,7 +80,7 @@ Options:
           This text should be visible
 
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -117,7 +117,7 @@ Options:
           This text should be visible
 
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information
@@ -154,7 +154,7 @@ Usage: test [OPTIONS]
 Options:
   -c, --config   Some help text describing the --config arg
   -v, --visible  This text should be visible
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 ";
 

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -400,7 +400,7 @@ Arguments:
 
 Options:
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 ";
 
     /// Application help

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -11,6 +11,6 @@ Commands:
 
 Options:
       --verbose  log
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 """

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -11,6 +11,6 @@ Commands:
 
 Options:
       --verbose  log
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 """

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -10,7 +10,7 @@ Commands:
 
 Options:
       --verbose  log
-  -h, --help     Print help information (use `--help` for more detail)
+  -h, --help     Print help information (use '--help' for more detail)
   -V, --version  Print version information
 """
 stderr = ""

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -10,7 +10,7 @@ Commands:
 
 Options:
       --verbose  log
-  -h, --help     Print help information (use '--help' for more detail)
+  -h, --help     Print help ('--help' for more)
   -V, --version  Print version information
 """
 stderr = ""

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -15,7 +15,7 @@ Options:
           more log
 
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -15,7 +15,7 @@ Options:
           more log
 
   -h, --help
-          Print help information (use `-h` for a summary)
+          Print help information (use '-h' for a summary)
 
   -V, --version
           Print version information


### PR DESCRIPTION
Applications may want to constrain their short help to use the two-column format so the `-h` output is as compact as possible.  They might do this by optimizing short help texts to fit within the right-hand column on 80-character terminals, and then providing long help texts with more info.  However, #4159 made the short help text for `-h`/`--help` much longer when the short and long help are different, forcing short help to wrap to the multiple-line format if medium-sized option/value names are used.

Reword the short help for this case to be as compact as possible.  The net length is still a few characters longer than in clap 3, but this still substantially increases the maximum width of the left column while continuing to document the difference between `-h` and `--help`.

Also use single quotes around the strings `-h` and `--help` in help output.  This is more consistent and improves readability a bit.

Fixes #4409.