### PR TITLE
fix(derive): Allow skipping enum variants with a value

### DIFF
--- a/tests/derive/subcommands.rs
+++ b/tests/derive/subcommands.rs
@@ -532,7 +532,23 @@ fn skip_subcommand() {
         #[allow(dead_code)]
         #[command(skip)]
         Skip,
+
+        #[allow(dead_code)]
+        #[command(skip)]
+        Other(Other),
     }
+
+    #[allow(dead_code)]
+    #[derive(Debug, PartialEq, Eq)]
+    enum Other {
+        One,
+        Twp,
+    }
+
+    assert!(Subcommands::has_subcommand("add"));
+    assert!(Subcommands::has_subcommand("remove"));
+    assert!(!Subcommands::has_subcommand("skip"));
+    assert!(!Subcommands::has_subcommand("other"));
 
     assert_eq!(
         Opt::try_parse_from(&["test", "add"]).unwrap(),
@@ -549,6 +565,12 @@ fn skip_subcommand() {
     );
 
     let res = Opt::try_parse_from(&["test", "skip"]);
+    assert_eq!(
+        res.unwrap_err().kind(),
+        clap::error::ErrorKind::InvalidSubcommand,
+    );
+
+    let res = Opt::try_parse_from(&["test", "other"]);
     assert_eq!(
         res.unwrap_err().kind(),
         clap::error::ErrorKind::InvalidSubcommand,


### PR DESCRIPTION
Fixes #4411

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
