### PR TITLE
feat(derive): Allow custom `clap` locations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,11 @@ path = "examples/repl.rs"
 required-features = ["help"]
 
 [[example]]
+name = "custom-clap-path-derive"
+path = "examples/custom-clap-path-derive.rs"
+required-features = ["derive"]
+
+[[example]]
 name = "01_quick"
 path = "examples/tutorial_builder/01_quick.rs"
 required-features = ["cargo"]

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -22,6 +22,7 @@ pub fn gen_for_struct(item: &Item, item_name: &Ident, generics: &Generics) -> To
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let name = item.cased_name();
+    let clap_path = item.clap_path();
     let app_var = Ident::new("__clap_app", Span::call_site());
 
     let tokens = quote! {
@@ -38,15 +39,15 @@ pub fn gen_for_struct(item: &Item, item_name: &Ident, generics: &Generics) -> To
             clippy::suspicious_else_formatting,
         )]
         #[deny(clippy::correctness)]
-        impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {
-            fn command<'b>() -> clap::Command {
-                let #app_var = clap::Command::new(#name);
-                <Self as clap::Args>::augment_args(#app_var)
+        impl #impl_generics #clap_path::CommandFactory for #item_name #ty_generics #where_clause {
+            fn command<'b>() -> #clap_path::Command {
+                let #app_var = #clap_path::Command::new(#name);
+                <Self as #clap_path::Args>::augment_args(#app_var)
             }
 
-            fn command_for_update<'b>() -> clap::Command {
-                let #app_var = clap::Command::new(#name);
-                <Self as clap::Args>::augment_args_for_update(#app_var)
+            fn command_for_update<'b>() -> #clap_path::Command {
+                let #app_var = #clap_path::Command::new(#name);
+                <Self as #clap_path::Args>::augment_args_for_update(#app_var)
             }
         }
     };
@@ -58,6 +59,7 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, generics: &Generics) -> Toke
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let name = item.cased_name();
+    let clap_path = item.clap_path();
     let app_var = Ident::new("__clap_app", Span::call_site());
 
     quote! {
@@ -74,17 +76,17 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, generics: &Generics) -> Toke
             clippy::suspicious_else_formatting,
         )]
         #[deny(clippy::correctness)]
-        impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {
-            fn command<'b>() -> clap::Command {
-                let #app_var = clap::Command::new(#name)
+        impl #impl_generics #clap_path::CommandFactory for #item_name #ty_generics #where_clause {
+            fn command<'b>() -> #clap_path::Command {
+                let #app_var = #clap_path::Command::new(#name)
                     .subcommand_required(true)
                     .arg_required_else_help(true);
-                <Self as clap::Subcommand>::augment_subcommands(#app_var)
+                <Self as #clap_path::Subcommand>::augment_subcommands(#app_var)
             }
 
-            fn command_for_update<'b>() -> clap::Command {
-                let #app_var = clap::Command::new(#name);
-                <Self as clap::Subcommand>::augment_subcommands_for_update(#app_var)
+            fn command_for_update<'b>() -> #clap_path::Command {
+                let #app_var = #clap_path::Command::new(#name);
+                <Self as #clap_path::Subcommand>::augment_subcommands_for_update(#app_var)
             }
         }
     }

--- a/clap_derive/src/derives/parser.rs
+++ b/clap_derive/src/derives/parser.rs
@@ -15,11 +15,9 @@
 use proc_macro2::TokenStream;
 use proc_macro_error::abort_call_site;
 use quote::quote;
-use syn::Ident;
-use syn::Variant;
 use syn::{
     self, punctuated::Punctuated, token::Comma, Data, DataStruct, DeriveInput, Field, Fields,
-    Generics,
+    Generics, Ident, Variant,
 };
 
 use crate::derives::{args, into_app, subcommand};
@@ -96,11 +94,12 @@ fn gen_for_struct(
 ) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let clap_path = item.clap_path();
     let into_app = into_app::gen_for_struct(item, item_name, generics);
     let args = args::gen_for_struct(item, item_name, generics, fields);
 
     quote! {
-        impl #impl_generics clap::Parser for #item_name #ty_generics #where_clause {}
+        impl #impl_generics #clap_path::Parser for #item_name #ty_generics #where_clause {}
 
         #into_app
         #args
@@ -115,11 +114,12 @@ fn gen_for_enum(
 ) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let clap_path = item.clap_path();
     let into_app = into_app::gen_for_enum(item, item_name, generics);
     let subcommand = subcommand::gen_for_enum(item, item_name, generics, variants);
 
     quote! {
-        impl #impl_generics clap::Parser for #item_name #ty_generics #where_clause {}
+        impl #impl_generics #clap_path::Parser for #item_name #ty_generics #where_clause {}
 
         #into_app
         #subcommand

--- a/clap_derive/src/utils/spanned.rs
+++ b/clap_derive/src/utils/spanned.rs
@@ -2,7 +2,10 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::ToTokens;
 use syn::LitStr;
 
-use std::ops::{Deref, DerefMut};
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
 
 /// An entity with a span attached.
 #[derive(Debug, Copy, Clone)]
@@ -48,6 +51,16 @@ impl From<Ident> for Sp<String> {
     }
 }
 
+impl TryFrom<Sp<String>> for Ident {
+    type Error = syn::Error;
+
+    fn try_from(value: Sp<String>) -> Result<Self, Self::Error> {
+        let mut ident = syn::parse_str::<Ident>(value.get())?;
+        ident.set_span(value.span());
+        Ok(ident)
+    }
+}
+
 impl From<LitStr> for Sp<String> {
     fn from(lit: LitStr) -> Self {
         Sp {
@@ -85,5 +98,11 @@ impl<T: ToTokens> ToTokens for Sp<T> {
         });
 
         stream.extend(tt);
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Sp<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.val, f)
     }
 }

--- a/examples/custom-clap-path-derive.rs
+++ b/examples/custom-clap-path-derive.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+pub mod foo {
+    pub use clap;
+}
+
+#[derive(Parser)] // requires `derive` feature
+#[clap(crate = "foo::clap")]
+enum Cargo {
+    ExampleDerive(ExampleDerive),
+}
+
+#[derive(clap::Args)]
+#[command(author, version, about, long_about = None)]
+#[clap(crate = "foo::clap")]
+struct ExampleDerive {
+    #[arg(long)]
+    manifest_path: Option<std::path::PathBuf>,
+}
+
+fn main() {
+    let Cargo::ExampleDerive(args) = Cargo::parse();
+    println!("{:?}", args.manifest_path);
+}


### PR DESCRIPTION
Before the location was hardcoded to `clap`. This is a PR to implement the related feature request #4414 , which I wrote because currently when I wrap `clap` downstream users still have to have `clap` in their `Cargo.toml`, which is a papercut, but also means there is work to marshall versions for the user.

This patch allows a `clap` user to wrap the crate including derive macros, by re-exporting `clap` (possibly hidden from docs) and then using that re-exported location in generated code.

Closes #4414 

Things to be resolve before this is ready for merge (assuming that outcome):

 - [ ] documentation
 - [ ] failing ui tests (I'm not sure why they are failing/why it's changed. help appreciated)