### PR TITLE
(clap v3) require textwrap 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
  "strsim",
  "termcolor",
  "terminal_size",
- "textwrap 0.15.1",
+ "textwrap 0.16.0",
  "trybuild",
  "trycmd",
  "unicase",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 dependencies = [
  "terminal_size",
  "unicode-width",
@@ -1040,9 +1040,9 @@ checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ bench = false
 clap_derive = { path = "./clap_derive", version = "=3.2.18", optional = true }
 clap_lex = { path = "./clap_lex", version = "0.2.2" }
 bitflags = "1.2"
-textwrap = { version = "0.15.1", default-features = false, features = [] }
+textwrap = { version = "0.16", default-features = false, features = [] }
 unicase = { version = "2.6", optional = true }
 indexmap = "1.0"
 strsim = { version = "0.10",  optional = true }


### PR DESCRIPTION
Version 0.15.1 was yanked because it should have been 0.16.

Fixes #4418.
