### PR TITLE
fix(man): Don't show default values for flags, show ellipsis for repeatable arguments

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -1,3 +1,4 @@
+use clap::ArgAction;
 use roff::{bold, italic, roman, Inline, Roff};
 
 pub(crate) fn subcommand_heading(cmd: &clap::Command) -> &str {
@@ -39,22 +40,24 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
                 line.push(roman("|"));
                 line.push(bold(&format!("--{}", long)));
                 line.push(roman(rhs));
-                line.push(roman(" "));
             }
             (Some(short), None) => {
                 line.push(roman(lhs));
                 line.push(bold(&format!("-{} ", short)));
                 line.push(roman(rhs));
-                line.push(roman(" "));
             }
             (None, Some(long)) => {
                 line.push(roman(lhs));
                 line.push(bold(&format!("--{}", long)));
                 line.push(roman(rhs));
-                line.push(roman(" "));
             }
-            (None, None) => (),
+            (None, None) => continue,
         };
+
+        if matches!(opt.get_action(), ArgAction::Count) {
+            line.push(roman("..."))
+        }
+        line.push(roman(" "));
     }
 
     for arg in cmd.get_positionals() {
@@ -306,7 +309,7 @@ fn option_environment(opt: &clap::Arg) -> Option<Vec<Inline>> {
 }
 
 fn option_default_values(opt: &clap::Arg) -> Option<String> {
-    if opt.is_hide_default_value_set() {
+    if opt.is_hide_default_value_set() || !opt.get_action().takes_values() {
         return None;
     } else if !opt.get_default_values().is_empty() {
         let values = opt

--- a/clap_mangen/tests/snapshots/aliases.bash.roff
+++ b/clap_mangen/tests/snapshots/aliases.bash.roff
@@ -9,7 +9,7 @@ my/-app /- testing bash completions
 testing bash completions
 .SH OPTIONS
 .TP
-/fB/-f/fR, /fB/-/-flag/fR [default: false]
+/fB/-f/fR, /fB/-/-flag/fR
 cmd flag
 .TP
 /fB/-o/fR, /fB/-/-option/fR

--- a/clap_mangen/tests/snapshots/basic.bash.roff
+++ b/clap_mangen/tests/snapshots/basic.bash.roff
@@ -8,10 +8,10 @@ my/-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-/fB/-c/fR [default: false]
+/fB/-c/fR
 
 .TP
-/fB/-v/fR [default: false]
+/fB/-v/fR
 
 .TP
 /fB/-h/fR, /fB/-/-help/fR

--- a/clap_mangen/tests/snapshots/feature_sample.bash.roff
+++ b/clap_mangen/tests/snapshots/feature_sample.bash.roff
@@ -4,12 +4,12 @@
 .SH NAME
 my/-app /- Tests completions
 .SH SYNOPSIS
-/fBmy/-app/fR [/fB/-c/fR|/fB/-/-config/fR] [/fB/-h/fR|/fB/-/-help/fR] [/fB/-V/fR|/fB/-/-version/fR] [/fIfile/fR] [/fIchoice/fR] [/fIsubcommands/fR]
+/fBmy/-app/fR [/fB/-c/fR|/fB/-/-config/fR]... [/fB/-h/fR|/fB/-/-help/fR] [/fB/-V/fR|/fB/-/-version/fR] [/fIfile/fR] [/fIchoice/fR] [/fIsubcommands/fR]
 .SH DESCRIPTION
 Tests completions
 .SH OPTIONS
 .TP
-/fB/-c/fR, /fB/-/-config/fR [default: 0]
+/fB/-c/fR, /fB/-/-config/fR
 some config file
 .TP
 /fB/-h/fR, /fB/-/-help/fR

--- a/clap_mangen/tests/snapshots/quoting.bash.roff
+++ b/clap_mangen/tests/snapshots/quoting.bash.roff
@@ -8,22 +8,22 @@ my/-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-/fB/-/-single/-quotes/fR [default: false]
+/fB/-/-single/-quotes/fR
 Can be /*(Aqalways/*(Aq, /*(Aqauto/*(Aq, or /*(Aqnever/*(Aq
 .TP
-/fB/-/-double/-quotes/fR [default: false]
+/fB/-/-double/-quotes/fR
 Can be "always", "auto", or "never"
 .TP
-/fB/-/-backticks/fR [default: false]
+/fB/-/-backticks/fR
 For more information see `echo test`
 .TP
-/fB/-/-backslash/fR [default: false]
+/fB/-/-backslash/fR
 Avoid /*(Aq//n/*(Aq
 .TP
-/fB/-/-brackets/fR [default: false]
+/fB/-/-brackets/fR
 List packages [filter]
 .TP
-/fB/-/-expansions/fR [default: false]
+/fB/-/-expansions/fR
 Execute the shell command with $SHELL
 .TP
 /fB/-h/fR, /fB/-/-help/fR

--- a/clap_mangen/tests/snapshots/special_commands.bash.roff
+++ b/clap_mangen/tests/snapshots/special_commands.bash.roff
@@ -4,12 +4,12 @@
 .SH NAME
 my/-app /- Tests completions
 .SH SYNOPSIS
-/fBmy/-app/fR [/fB/-c/fR|/fB/-/-config/fR] [/fB/-h/fR|/fB/-/-help/fR] [/fB/-V/fR|/fB/-/-version/fR] [/fIfile/fR] [/fIchoice/fR] [/fIsubcommands/fR]
+/fBmy/-app/fR [/fB/-c/fR|/fB/-/-config/fR]... [/fB/-h/fR|/fB/-/-help/fR] [/fB/-V/fR|/fB/-/-version/fR] [/fIfile/fR] [/fIchoice/fR] [/fIsubcommands/fR]
 .SH DESCRIPTION
 Tests completions
 .SH OPTIONS
 .TP
-/fB/-c/fR, /fB/-/-config/fR [default: 0]
+/fB/-c/fR, /fB/-/-config/fR
 some config file
 .TP
 /fB/-h/fR, /fB/-/-help/fR

--- a/clap_mangen/tests/snapshots/sub_subcommands.bash.roff
+++ b/clap_mangen/tests/snapshots/sub_subcommands.bash.roff
@@ -4,12 +4,12 @@
 .SH NAME
 my/-app /- Tests completions
 .SH SYNOPSIS
-/fBmy/-app/fR [/fB/-c/fR|/fB/-/-config/fR] [/fB/-h/fR|/fB/-/-help/fR] [/fB/-V/fR|/fB/-/-version/fR] [/fIfile/fR] [/fIchoice/fR] [/fIsubcommands/fR]
+/fBmy/-app/fR [/fB/-c/fR|/fB/-/-config/fR]... [/fB/-h/fR|/fB/-/-help/fR] [/fB/-V/fR|/fB/-/-version/fR] [/fIfile/fR] [/fIchoice/fR] [/fIsubcommands/fR]
 .SH DESCRIPTION
 Tests completions
 .SH OPTIONS
 .TP
-/fB/-c/fR, /fB/-/-config/fR [default: 0]
+/fB/-c/fR, /fB/-/-config/fR
 some config file
 .TP
 /fB/-h/fR, /fB/-/-help/fR


### PR DESCRIPTION
Fixes #4410.

The help generator for the main clap package uses the `Arg::is_takes_value_set()` method to determine whether it should show a default argument. (See `Arg::stylize_arg_suffix`, on line 4148 of `arg.rs`.) 

I ported the same logic over to clap_mangen, so boolean flag arguments no longer show `[default=false]` (or `[default=0]` for repeatable options), which is not valid.

I also noticed that the generated synopsis does not add a `...` ellipsis for repeatable flags, so I added that as well.

Finally, I updated the snapshot tests to reflect the above changes.

## Example

For the following program (this is essentially `clap_mangen/examples/man.rs`):

```rs

fn main() -> Result<(), std::io::Error> {
    let cmd = Command::new("myapp")
        .version("1.0")
        .author("Kevin K. <kbknapp@gmail.com>:Ola Nordmann <old@nordmann.no>")
        .about("Does awesome things")
        .long_about(
            "With a longer description to help clarify some things.

And a few newlines.",
        )
        .after_help("This is an extra section added to the end of the manpage.")
        .after_long_help("With even more text added.")
        .arg(
            arg!(-c --config <FILE> "Sets a custom config file")
                .long_help("Some more text about how to set a custom config file")
                .default_value("config.toml")
                .env("CONFIG_FILE"),
        )
        .arg(arg!([output] "Sets an output file").default_value("result.txt"))
        .arg(
            arg!(-d --debug ... "Turn debugging information on")
                .env("DEBUG_ON")
                .hide_env(true),
        )
        .subcommand(
            Command::new("test")
                .about("does testing things")
                .arg(arg!(-l --list "Lists test values")),
        );

    Man::new(cmd).render(&mut io::stdout())
}
```
you previously got

```
myapp(1)                                                                             General Commands Manual                                                                            myapp(1)

NAME
       myapp - Does awesome things

SYNOPSIS
       myapp [-c|--config] [--thing] [-d|--debug] [-h|--help] [-V|--version] [output] [subcommands]

DESCRIPTION
       With a longer description to help clarify some things.

       And a few newlines.

OPTIONS
       -c, --config=FILE [default: config.toml]
              Some more text about how to set a custom config file
              May also be specified with the CONFIG_FILE environment variable.

       --thing [default: false]
              Does a thing with a flag

       -d, --debug [default: 0]
              Turn debugging information on

       -h, --help
              Print help information (use `-h` for a summary)

       -V, --version
              Print version information

       [output] [default: result.txt]
              Sets an output file

SUBCOMMANDS
       myapp-test(1)
              does testing things

       myapp-help(1)
              Print this message or the help of the given subcommand(s)

EXTRA
       With even more text added.

VERSION
       v1.0

AUTHORS
       Kevin K. <kbknapp@gmail.com>:Ola Nordmann <old@nordmann.no>

                                                                                            myapp 1.0                                                                                   myapp(1)
```

and now get

```
myapp(1)                                                                             General Commands Manual                                                                            myapp(1)

NAME
       myapp - Does awesome things

SYNOPSIS
       myapp [-c|--config] [--thing] [-d|--debug]... [-h|--help] [-V|--version] [output] [subcommands]

DESCRIPTION
       With a longer description to help clarify some things.

       And a few newlines.

OPTIONS
       -c, --config=FILE [default: config.toml]
              Some more text about how to set a custom config file
              May also be specified with the CONFIG_FILE environment variable.

       --thing
              Does a thing with a flag

       -d, --debug
              Turn debugging information on

       -h, --help
              Print help information (use `-h` for a summary)

       -V, --version
              Print version information

       [output] [default: result.txt]
              Sets an output file

SUBCOMMANDS
       myapp-test(1)
              does testing things

       myapp-help(1)
              Print this message or the help of the given subcommand(s)

EXTRA
       With even more text added.

VERSION
       v1.0

AUTHORS
       Kevin K. <kbknapp@gmail.com>:Ola Nordmann <old@nordmann.no>

                                                                                            myapp 1.0                                                                                   myapp(1)
```
