### PR TITLE
feat(derive): add markdown parsing of doc comments in derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
+ "pulldown-cmark",
  "quote",
  "syn",
 ]
@@ -368,6 +369,15 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -652,6 +662,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -42,6 +42,7 @@ quote = "1.0.9"
 proc-macro2 = "1.0.42"
 heck = "0.4.0"
 proc-macro-error = "1"
+pulldown-cmark = "0.9"
 
 [features]
 default = []

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -25,7 +25,7 @@ use syn::{
 };
 
 use crate::attr::*;
-use crate::utils::{inner_type, is_simple_ty, process_doc_comment, Sp, Ty};
+use crate::utils::{inner_type, is_simple_ty, process_doc_comment, process_md_doc_comment, Sp, Ty};
 
 /// Default casing style for generated arguments.
 pub const DEFAULT_CASING: CasingStyle = CasingStyle::Kebab;
@@ -896,7 +896,14 @@ impl Item {
             })
             .collect();
 
-        let (short, long) = process_doc_comment(comment_parts, name, !self.verbatim_doc_comment);
+        let (short, long) = if self.verbatim_doc_comment {
+            process_doc_comment(comment_parts, name, !self.verbatim_doc_comment)
+        } else if !self.verbatim_doc_comment {
+            // TODO: ^ change to markdown marker or make default?
+            process_md_doc_comment(comment_parts, name)
+        } else {
+            process_md_doc_comment(comment_parts, name)
+        };
         self.doc_comment.extend(short);
         if supports_long_help {
             self.doc_comment.extend(long);
@@ -1191,7 +1198,7 @@ impl Kind {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Method {
     name: Ident,
     args: TokenStream,

--- a/clap_derive/src/utils/doc_comments.rs
+++ b/clap_derive/src/utils/doc_comments.rs
@@ -5,8 +5,250 @@
 
 use crate::item::Method;
 
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::iter;
+
+pub fn process_md_doc_comment(lines: Vec<String>, name: &str) -> (Option<Method>, Option<Method>) {
+    use pulldown_cmark::{Event, Parser, Tag};
+
+    let text = lines
+        .iter()
+        .skip_while(|s| is_blank(s))
+        .flat_map(|s| s.split('\n'))
+        .map(|l| if l.starts_with(' ') { &l[1..] } else { l })
+        .collect::<Vec<&str>>()
+        .join("\n");
+
+    let mut short = TokenStream::new();
+    let mut long = TokenStream::new();
+    let mut man = TokenStream::new();
+
+    let parser = Parser::new(&text);
+
+    // ordered list of parent blocks where we're currently parsing
+    let mut blocking = Vec::new();
+    // ordered list of inline features currently active where we're parsing
+    let mut inliners = Vec::new();
+
+    #[derive(PartialEq)]
+    enum State {
+        Short,
+        Long,
+        Man,
+    }
+
+    let mut state = State::Short;
+
+    for def in parser {
+        let chunk = match def {
+            Event::Start(tag) => {
+                match &tag {
+                    Tag::Paragraph => blocking.push(tag),
+                    Tag::Heading(_level, _fragment, _classes) => todo!("heading"), //blocking.push(tag),
+                    Tag::BlockQuote => todo!("blockquote"), //blocking.push(tag),
+                    Tag::CodeBlock(_kind) => todo!("codeblock"), //blocking.push(tag),
+                    Tag::List(_start) => todo!("list"),     //blocking.push(tag),
+                    Tag::Item => todo!("item"),             //blocking.push(tag),
+                    Tag::FootnoteDefinition(_label) => todo!("footnote"), //blocking.push(tag),
+                    Tag::Table(_alignment) => todo!("table"), //blocking.push(tag),
+                    Tag::TableHead => todo!("tablehead"),   //blocking.push(tag),
+                    Tag::TableRow => todo!("tablerow"),     //blocking.push(tag),
+                    Tag::TableCell => todo!("tablecell"),   //blocking.push(tag),
+                    Tag::Emphasis => inliners.push(tag),
+                    Tag::Strong => inliners.push(tag),
+                    Tag::Strikethrough => todo!("strike"), //inliners.push(tag),
+                    Tag::Link(_type, _url, _title) => {}   //todo!("link"), //inliners.push(tag),
+                    Tag::Image(_type, _url, _title) => todo!("image"), //inliners.push(tag),
+                };
+                None
+            }
+            Event::Text(t) => {
+                let t = t.as_ref();
+                // StyledStr can only define a single style, just take last inline container
+                match inliners.last() {
+                    None => Some(quote!(text.none(#t);)),
+                    Some(Tag::Strong) => Some(quote!(text.literal(#t);)),
+                    Some(Tag::Emphasis) => Some(quote!(text.italic(#t);)),
+                    _ => todo!(),
+                }
+            }
+            Event::End(tag) => match &tag {
+                // only got twenty dollars in my pocket...
+                Tag::Paragraph => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    if state == State::Short {
+                        state = State::Long;
+                    }
+
+                    Some(quote!(text.none("\n\n");))
+                }
+                Tag::Heading(_level, _fragment, _classes) => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    state = State::Man;
+
+                    Some(quote!(text.none("\n\n");))
+                }
+                Tag::BlockQuote => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::CodeBlock(_kind) => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::List(_start) => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::Item => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::FootnoteDefinition(_label) => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::Table(_alignment) => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::TableHead => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::TableRow => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::TableCell => {
+                    assert_eq!(blocking.pop(), Some(tag));
+                    None
+                }
+                Tag::Emphasis => {
+                    assert_eq!(inliners.pop(), Some(tag));
+                    None
+                }
+                Tag::Strong => {
+                    assert_eq!(inliners.pop(), Some(tag));
+                    None
+                }
+                Tag::Strikethrough => {
+                    assert_eq!(inliners.pop(), Some(tag));
+                    None
+                }
+                Tag::Link(_type, _url, _title) => {
+                    //assert_eq!(inliners.pop(), Some(tag));
+                    None
+                }
+                Tag::Image(_type, _url, _title) => {
+                    assert_eq!(inliners.pop(), Some(tag));
+                    None
+                }
+            },
+            Event::Code(t) => {
+                let t = t.as_ref();
+                Some(quote!(text.code(#t);))
+            }
+            Event::Html(_) => {
+                todo!("drop or panic?")
+            }
+            Event::FootnoteReference(_) => {
+                todo!("can this be handled? just leave the markdown as-is?")
+            }
+            // single line breaks within paragraphs
+            Event::SoftBreak => Some(quote!(text.none(" ");)),
+            // double line breaks between paragraphs
+            // TODO: peek into the parser to check if there's more content coming to avoid adding
+            // blank lines at the end.
+            Event::HardBreak => Some(quote!(text.none("\n\n");)),
+            Event::Rule => {
+                todo!("would need terminal width for this? is there any sort of responsive way to do this?")
+            }
+            Event::TaskListMarker(checked) => {
+                let _marker = if checked { '☑' } else { '☐' };
+                None
+            }
+        };
+
+        if let Some(chunk) = chunk {
+            match state {
+                State::Short => {
+                    short.extend(chunk.clone());
+                    long.extend(chunk.clone());
+                    man.extend(chunk);
+                }
+                State::Long => {
+                    long.extend(chunk.clone());
+                    man.extend(chunk);
+                }
+                State::Man => {
+                    man.extend(chunk);
+                }
+            }
+        }
+    }
+
+    let short_name = format_ident!("{}", name);
+    let long_name = format_ident!("long_{}", name);
+
+    let short_about = if short.is_empty() {
+        None
+    } else {
+        let text_block = quote! {
+            {
+                let mut text = clap::builder::StyledStr::new();
+                #short
+                text
+            }
+        };
+        Some(Method::new(short_name, text_block))
+    };
+
+    let long_about = if long.is_empty() {
+        None
+    } else {
+        let text_block = quote! {
+            {
+                let mut text = clap::builder::StyledStr::new();
+                #long
+                text
+            }
+        };
+        Some(Method::new(long_name, text_block))
+    };
+
+    (short_about, long_about)
+}
+
+#[test]
+fn md() {
+    let inp = r##"
+This is the __short__ desciption.
+
+This is the *long* description, it contains an [inline link](rust-lang.org).
+"##;
+    let _ = r##"
+
+It also contains a [ref link].
+
+# Examples
+
+```
+frobulate compular
+```
+
+[ref link]: https://github.com/clap-rs/clap
+
+Okay.
+
+    "##;
+
+    // mangle input to match how we'd normally get it
+    let lines: Vec<String> = inp.lines().map(|l| format!(" {}", l)).collect();
+
+    let tokens = dbg!(process_md_doc_comment(lines.clone(), "frobulate"));
+}
 
 pub fn process_doc_comment(
     lines: Vec<String>,

--- a/clap_derive/src/utils/mod.rs
+++ b/clap_derive/src/utils/mod.rs
@@ -3,7 +3,7 @@ mod spanned;
 mod ty;
 
 pub use self::{
-    doc_comments::process_doc_comment,
+    doc_comments::{process_doc_comment, process_md_doc_comment},
     spanned::Sp,
     ty::{inner_type, is_simple_ty, sub_type, subty_if_name, Ty},
 };

--- a/src/builder/styled_str.rs
+++ b/src/builder/styled_str.rs
@@ -28,38 +28,56 @@ impl StyledStr {
         AnsiDisplay { styled: self }
     }
 
-    pub(crate) fn header(&mut self, msg: impl Into<String>) {
+    /// Display string as header.
+    pub fn header(&mut self, msg: impl Into<String>) {
         self.stylize_(Some(Style::Header), msg.into());
     }
 
-    pub(crate) fn literal(&mut self, msg: impl Into<String>) {
+    /// Display string as literal.
+    pub fn literal(&mut self, msg: impl Into<String>) {
         self.stylize_(Some(Style::Literal), msg.into());
     }
 
-    pub(crate) fn placeholder(&mut self, msg: impl Into<String>) {
+    /// Display string as placeholder.
+    pub fn placeholder(&mut self, msg: impl Into<String>) {
         self.stylize_(Some(Style::Placeholder), msg.into());
     }
 
     #[cfg_attr(not(feature = "error-context"), allow(dead_code))]
-    pub(crate) fn good(&mut self, msg: impl Into<String>) {
+    /// Display string as good.
+    pub fn good(&mut self, msg: impl Into<String>) {
         self.stylize_(Some(Style::Good), msg.into());
     }
 
     #[cfg_attr(not(feature = "error-context"), allow(dead_code))]
-    pub(crate) fn warning(&mut self, msg: impl Into<String>) {
+    /// Display string as warning.
+    pub fn warning(&mut self, msg: impl Into<String>) {
         self.stylize_(Some(Style::Warning), msg.into());
     }
 
-    pub(crate) fn error(&mut self, msg: impl Into<String>) {
+    /// Display string as error.
+    pub fn error(&mut self, msg: impl Into<String>) {
         self.stylize_(Some(Style::Error), msg.into());
     }
 
     #[allow(dead_code)]
-    pub(crate) fn hint(&mut self, msg: impl Into<String>) {
+    /// Display string as hint.
+    pub fn hint(&mut self, msg: impl Into<String>) {
         self.stylize_(Some(Style::Hint), msg.into());
     }
 
-    pub(crate) fn none(&mut self, msg: impl Into<String>) {
+    /// Display string as code.
+    pub fn code(&mut self, msg: impl Into<String>) {
+        self.stylize_(Some(Style::Code), msg.into());
+    }
+
+    /// Display string as italic.
+    pub fn italic(&mut self, msg: impl Into<String>) {
+        self.stylize_(Some(Style::Italic), msg.into());
+    }
+
+    /// Display string without any defined style.
+    pub fn none(&mut self, msg: impl Into<String>) {
         self.stylize_(None, msg.into());
     }
 
@@ -221,6 +239,12 @@ impl StyledStr {
                 Some(Style::Hint) => {
                     color.set_dimmed(true);
                 }
+                Some(Style::Code) => {
+                    color.set_bold(true);
+                }
+                Some(Style::Italic) => {
+                    color.set_italic(true);
+                }
                 None => {}
             }
 
@@ -329,6 +353,8 @@ pub(crate) enum Style {
     Warning,
     Error,
     Hint,
+    Code,
+    Italic,
 }
 
 impl Style {
@@ -341,6 +367,8 @@ impl Style {
             Self::Warning => 4,
             Self::Error => 5,
             Self::Hint => 6,
+            Self::Code => 7,
+            Self::Italic => 8,
         }
     }
 }


### PR DESCRIPTION
This is an early draft of a PR that will resolve #2389. I wanted to get some feedback on intent in a few places to make sure I'm doing the right thing.

This largely takes the tack that was laid out in #2389.

**Markdown parsing is done within derive.**

This [was all but explicitly stated](https://github.com/clap-rs/clap/issues/2389#issuecomment-1003009619), and is, I believe, the right place to do the parsing.

**Then a `StyledStr` is output into the user's expanded code.**

`StyledStr` isn't explicitly mentioned, but it's what the generated function takes and what `Colorizer` uses internally, so I assume this is right.

Though, `StyledStr` doesn't have things like bold and italic itself directly and I'm not sure if it's the right place to add it. I know you also have `anstyle`, but I'm not sure that makes sense to use here since `StyledStr` seems to denote more semantic contexts. The biggest problem there is I'm not sure what to do when some text is ***bold and italic*** or worse a heading that is partly styled or any other combination of things since it only tracks a single enum variant for the style.

This PR also makes the basic styling functions on `StyledStr` `pub` so that they can be used from the derived code. I'm not sure if that's acceptable or not. We could hide them from the docs if you'd prefer they weren't fully public.

**Markdown is parsed with `pulldown-cmark`**

`pulldown-cmark` isn't perfectly suited to what I'm doing here, but I think it's the only real option that will work.

* `pulldown-cmark` seems to assume you'd only ever want to output html, and omits telling us a lot of information that would be helpful for outputting back to psuedo markdown. Doesn't let me do everything I want, but is good enough.
* `comrak` parses as github flavored markdown, but doc comments in rust are parsed by Rust as commonmark markdown. It's much heavier than `pulldown-cmark`. Though it does have a somewhat better API for what we're trying to accomplish. Didn't try it though, don't know what other problems we'd run into.
* `minimad` doesn't parse blocks and only parses some inlines. To be able to use this we'd have the write the first half of a markdown parser anyway.
* `mini_markdown`, as mentioned in your rosetta repo, doesn't have a stable API yet and from a cursory glance doesn't seem complete enough. May be useful in the future.
* [a custom parser] I actually started on this idea before realizing just how complex of a thing that would end up being. Best not to make an already large project 10x larger.

# Formatting

As far as I'm aware there's not canonical representation of formatted markdown in the terminal. As part of this PR I'm essentially inventing one. A lot of things can't be represented in any native way in terminal output and will "fallback to markdown" for which I just mean output text that looks like markdown. Markdown was based on how people were already writings things in plaintext files after all.

Most of these aren't done, I wanted to get feedback before I go about implementing some of the harder ones. There are some that require a lot of other probably wide-reaching changes, pretty much anything that requires nested styling.

## Block Elements

**Thematic breaks**

> AKA a horizontal rule:
>
> ---

Fallback to markdown, insert a `---` line.

Could potentially write `-`s across the whole terminal/written area if I have that info available at the time. This would require a `StyledStr` with a new `Style` and no actual str.

**Headings**

Unsure. Probably set to `StyledStr::heading()`, and ignore level. 

In the future could add levels to `StyledStr::heading`, not sure how headings other than the first level should even be styled though.

Could also explicitly disallow more than a certain number of heading levels.

**Code Blocks**

Fallback to markdown but always output in the style of an indented code block.

Could consider syntax highlighting in the future, that would require setting colors on segments within the codeblock.

**HTML Blocks**

Probably just drop them and all of their content. I can't think of anything else to do with them.

**Paragraphs**

Merge into a single line of text that is wrapped as appropriate during output. (Though see also Hard/Soft Line Break.)

**Blank Lines**

> That is _extra_ blank lines beyond those that determine block structure.

Ignored. I believe this is essentially what already happens to doc comments.

**Quotes**

Fallback to markdown, prefix lines of block with `> `.

This is the big problem child with styling. it probably needs to be a single `StyledStr::quote()`, but that then means that nothing inside it can be styled in any way. This would have to be done this way so that at output time the quoted things can wrap, but still be prepended. Having any internal styling would depend on a `StyledStr` that can contain other internal `StyledStr`.

**Lists**

Fall back to markdown, but with proper item numbering & unified bullets.

Output plain text markdown so that inner styling works. This might cause minor formatting problems with wrapping, I haven't looked yet at how exactly that works.

## Inlines

**Code Span**

Make bold, this seems to be how "code" in manpages gets formatted for the terminal.

**Emphasis and strong emphasis**

Emphasis -> italic, Strong Emphasis -> Bold

(Note: don't currently have a way to represent both at the same time, currently will just choose the innermost one. This could be solved with a special case `BoldItalic` style if we wanted to fix it short term.)

**~strikethrough~**

Show striked.

(Though strikethrough isn't supported in `termcolor`, but there is [an open PR for it](https://github.com/BurntSushi/termcolor/pull/47). This would have to wait for that or a change over to `anstyle`. For now just fallback to markdown

**Links**

I don't have a good answer for this. Currently this just removed the link syntax and URL completely so that help text doesn't get too verbose.

Could possibly keep that for short help text & for manpages convert all links to ref-style links. Long help could go either way.

**Images**

Removed.

Could consider keeping the alt/title text.

**Autolinks**

Fallback to markdown. This is just a link in `<` `>` so some terminals will detect it as a link anyway.

**HTML**

Again, remove.

**Hard Line Break**

> This is when you have  
> two spaces at the end of a line  
> which forces a line break.

Insert a `\n` into the text.

**Soft Line Break**

Join the lines with a space.

**Text**

Is text, show text.

# Stubs

This code also contains (or will contain) some stubs for future expansion:

**Manual Sections**

Right now the doc comment is parsed into `short_about` and `long_about` implicitly based on the first blank line. This keeps that (assuming the first non-blank line is text and not something else), but also adds splitting out anything with a heading as manual content. (Though nothing is done with that content at the moment, I'm assuming it would make sense to make it available to `clap_mangen` in the future.)

**Markdown Manuals**

There's a few things that only make sense in this context. We want to render our manpages in our reference docs site. Eventually I want to be able to build a "markdown manpage" out of the doc comment markdown without round tripping through roff first.

# Other Open Questions

**Make This the Default or Require Opt-In**

Right now I just have this basically hacked in to be the default formatting.

I _think_ this should be safe to become the default. That's based on the assumption that anyone who was trying to do anything funky would be using `verbatim_doc_comment`.

The only possible exception would be cutting off the long help text at the first valid heading. I imagine it would be unlikely to cause problems, but there's definitely a possibility there. That might be something that would have to be opt-in, at least until there's another breaking release.

This is probably a question that can remain open until this to closer to done. I'll have a better idea of other problems by then too.

---

Phew, that was a long one.

# tl;dr

* Hooray markdown!
* What's the future of `StyledStr`? Should it morph to support nested styles?
* Any issues with the proposed formatting above?
* Do you have a preference between getting some basic formatting in quickly or getting as close to handling all of the formatting that markdown can possibly represent properly handled before merging?

# TODO

- [ ] finish translation of all desired blocks and inlines
- [ ] feature flag parsing & pulldown-cmark dependency
- [ ] docs
- [ ] [... lots of other things]