### PR TITLE
fix(derive): Allow defaulted value parser for '()' fields

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -233,9 +233,9 @@ pub fn gen_augment(
 
                 let implicit_methods = match **ty {
                     Ty::Unit => {
+                        // Leaving out `value_parser` as it will always fail
                         quote_spanned! { ty.span()=>
                             .value_name(#value_name)
-                            #value_parser
                             #action
                         }
                     }

--- a/tests/derive/flags.rs
+++ b/tests/derive/flags.rs
@@ -281,3 +281,54 @@ fn override_implicit_from_flag_positional() {
         Opt::try_parse_from(&["test", "true"]).unwrap()
     );
 }
+
+#[test]
+fn unit_for_negation() {
+    #[derive(Parser, PartialEq, Eq, Debug)]
+    struct Opt {
+        #[arg(long)]
+        arg: bool,
+        #[arg(long, action = ArgAction::SetTrue, overrides_with = "arg")]
+        no_arg: (),
+    }
+
+    assert_eq!(
+        Opt {
+            arg: false,
+            no_arg: ()
+        },
+        Opt::try_parse_from(&["test"]).unwrap()
+    );
+
+    assert_eq!(
+        Opt {
+            arg: true,
+            no_arg: ()
+        },
+        Opt::try_parse_from(&["test", "--arg"]).unwrap()
+    );
+
+    assert_eq!(
+        Opt {
+            arg: false,
+            no_arg: ()
+        },
+        Opt::try_parse_from(&["test", "--no-arg"]).unwrap()
+    );
+
+    assert_eq!(
+        Opt {
+            arg: true,
+            no_arg: ()
+        },
+        Opt::try_parse_from(&["test", "--no-arg", "--arg"]).unwrap()
+    );
+
+    assert_eq!(
+        Opt {
+            arg: false,
+            no_arg: ()
+        },
+        Opt::try_parse_from(&["test", "--arg", "--no-arg"]).unwrap()
+    );
+}


### PR DESCRIPTION
Inspired by #4458

This is a compatible change because it turns a compiler error into a working case.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
