### PR TITLE
fix(help): Update auto-next-line to use new padding

### DIFF
--- a/src/output/help_template.rs
+++ b/src/output/help_template.rs
@@ -939,7 +939,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         self.none(TAB);
         self.writer.extend(sc_str.into_iter());
         if !next_line_help {
-            self.spaces(width.max(longest + TAB_WIDTH) - width);
+            self.spaces(longest + TAB_WIDTH - width);
         }
     }
 }

--- a/src/output/help_template.rs
+++ b/src/output/help_template.rs
@@ -689,7 +689,11 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             // force_next_line
             let h = arg.get_help().unwrap_or_default();
             let h_w = h.display_width() + display_width(spec_vals);
-            let taken = longest + 12;
+            let taken = if arg.is_positional() {
+                longest + TAB_WIDTH * 2
+            } else {
+                longest + TAB_WIDTH * 2 + 4 // See `fn short` for the 4
+            };
             self.term_w >= taken
                 && (taken as f32 / self.term_w as f32) > 0.40
                 && h_w > (self.term_w - taken)
@@ -925,7 +929,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             // force_next_line
             let h = cmd.get_about().unwrap_or_default();
             let h_w = h.display_width() + display_width(spec_vals);
-            let taken = longest + 12;
+            let taken = longest + TAB_WIDTH * 2;
             self.term_w >= taken
                 && (taken as f32 / self.term_w as f32) > 0.40
                 && h_w > (self.term_w - taken)

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -355,17 +355,14 @@ fn wrapped_help() {
 Usage: test [OPTIONS]
 
 Options:
-  -a, --all
-          Also do versioning for private crates (will not be
-          published)
-      --exact
-          Specify inter dependency version numbers exactly with `=`
-      --no-git-commit
-          Do not commit version changes
-      --no-git-push
-          Do not push generated commit and tags to git remote
-  -h, --help
-          Print help information
+  -a, --all            Also do versioning for private crates (will
+                       not be published)
+      --exact          Specify inter dependency version numbers
+                       exactly with `=`
+      --no-git-commit  Do not commit version changes
+      --no-git-push    Do not push generated commit and tags to git
+                       remote
+  -h, --help           Print help information
 ";
     let cmd = Command::new("test")
         .term_width(67)


### PR DESCRIPTION
In clap v4, we changed the padding from 4 to 2 but we didn't update our
calculation for when to switch to next-line-help as it was a magic
number (we tried to catch all of these).

When updating the tests, we also missed that a test was being wrapped
too narrowly

This was found while discussing #3300