### PR TITLE
fix(help): Clarify that 'help' command accepts multiple

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -4287,7 +4287,7 @@ impl Command {
                         .action(ArgAction::Append)
                         .num_args(..)
                         .value_name("COMMAND")
-                        .help("The subcommand whose help message to display"),
+                        .help("Print help for the subcommand(s)"),
                 )
             };
             self._propagate_subcommand(&mut help_subcmd);

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -1989,7 +1989,7 @@ Print this message or the help of the given subcommand(s)
 Usage: myapp help [COMMAND]...
 
 Arguments:
-  [COMMAND]...  The subcommand whose help message to display
+  [COMMAND]...  Print help for the subcommand(s)
 ";
 
     let cmd = Command::new("myapp")
@@ -2006,7 +2006,7 @@ Print this message or the help of the given subcommand(s)
 Usage: myapp subcmd help [COMMAND]...
 
 Arguments:
-  [COMMAND]...  The subcommand whose help message to display
+  [COMMAND]...  Print help for the subcommand(s)
 ";
 
     let cmd = Command::new("myapp")
@@ -2054,7 +2054,7 @@ Print this message or the help of the given subcommand(s)
 Usage: myapp help [COMMAND]...
 
 Arguments:
-  [COMMAND]...  The subcommand whose help message to display
+  [COMMAND]...  Print help for the subcommand(s)
 ";
 
     let cmd = Command::new("myapp")
@@ -2561,7 +2561,7 @@ Print this message or the help of the given subcommand(s)
 Usage: example help [COMMAND]...
 
 Arguments:
-  [COMMAND]...  The subcommand whose help message to display
+  [COMMAND]...  Print help for the subcommand(s)
 ",
         false,
     );
@@ -2603,7 +2603,7 @@ Print this message or the help of the given subcommand(s)
 Usage: example help [COMMAND]...
 
 Arguments:
-  [COMMAND]...  The subcommand whose help message to display
+  [COMMAND]...  Print help for the subcommand(s)
 ",
         false,
     );


### PR DESCRIPTION
Making this plural can go either way as
- Clarify it is plural
- This is all really to simulate actually doing subcommands and you only do one at a time

For now, I lean towards clarifying it is plural

I also tweaked the message to be more consistent with how `--help` and `-h` describe themselves.

Fixes #4342

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
