### PR TITLE
test(assert): Verify empty positional assert exists

### DIFF
--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1570,3 +1570,10 @@ fn issue_2229() {
     assert!(m.is_err());
     assert_eq!(m.unwrap_err().kind(), ErrorKind::WrongNumberOfValues);
 }
+
+#[test]
+#[should_panic = "Argument 'pos` is positional, it must take a value"]
+fn disallow_positionals_without_values() {
+    let cmd = Command::new("test").arg(Arg::new("pos").num_args(0));
+    cmd.debug_assert();
+}


### PR DESCRIPTION
Wondered if we had this for #4467.  Figured we should actually test it.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
