### PR TITLE
fix: Don't panic on non-built arg rendering

### DIFF
--- a/src/builder/arg.rs
+++ b/src/builder/arg.rs
@@ -4183,7 +4183,7 @@ impl Arg {
     fn render_arg_val(&self, required: bool) -> String {
         let mut rendered = String::new();
 
-        let num_vals = self.get_num_args().expect(INTERNAL_ERROR_MSG);
+        let num_vals = self.get_num_args().unwrap_or_else(|| 1.into());
 
         let mut val_names = if self.val_names.is_empty() {
             vec![self.id.as_internal_str().to_owned()]


### PR DESCRIPTION
For num_args, we'll just use the default

Fixes #4479

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
