### PR TITLE
Default max_term_width to 100

### DIFF
--- a/src/output/help_template.rs
+++ b/src/output/help_template.rs
@@ -101,7 +101,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 let (current_width, _h) = dimensions();
                 let current_width = current_width.unwrap_or(100);
                 let max_width = match cmd.get_max_term_width() {
-                    None | Some(0) => usize::MAX,
+                    None | Some(0) => 100,
                     Some(mw) => mw,
                 };
                 cmp::min(current_width, max_width)


### PR DESCRIPTION
IIRC this is what it was before. I think it's better to default things to be more readable than force everyone to pick some inconsistent max_width. The people that still want infinite max width can set it to usize::MAX manually.

Closes https://github.com/clap-rs/clap/issues/4295