### PR TITLE
fix: Make ArgPredicate non_exhaustive in v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.0.0 - ReleaseDate
+
+### Breaking Changes
+
+- Made `ArgPredicate` `non_exhaustive`
+
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 

--- a/src/builder/arg_predicate.rs
+++ b/src/builder/arg_predicate.rs
@@ -4,6 +4,7 @@ use crate::builder::OsStr;
 ///
 /// These do not apply to [`ValueSource::DefaultValue`][crate::parser::ValueSource::DefaultValue]
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "unstable-v4", non_exhaustive)]
 pub enum ArgPredicate {
     /// Is the argument present?
     IsPresent,


### PR DESCRIPTION
Didn't want to forget to do this

Inspired by #4487

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
