### PR TITLE
Update reference to example in docs

### DIFF
--- a/clap_complete/src/generator/mod.rs
+++ b/clap_complete/src/generator/mod.rs
@@ -193,7 +193,7 @@ where
 ///
 /// # Examples
 ///
-/// Assuming a separate `cli.rs` like the [example above](generate_to()),
+/// Assuming a separate `cli.rs` like the [`generate_to` example](generate_to()),
 /// we can let users generate a completion script using a command:
 ///
 /// ```ignore


### PR DESCRIPTION
This points to "the example above", but there's no example above when this gets rendered in docs.rs:

https://docs.rs/clap_complete/latest/clap_complete/generator/fn.generate.html

I suppose this reference is just stale since moving docs from a single markdown file or something similar.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
