### PR TITLE
Mangen no longer generates suggestions for options that don't take values

### DIFF
--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -45,7 +45,7 @@ clap = { path = "../", version = "4.0.0", default-features = false, features = [
 
 [dev-dependencies]
 snapbox = { version = "0.4", features = ["diff"] }
-clap = { path = "../", version = "4.0.0", default-features = false, features = ["std", "help"] }
+clap = { path = "../", version = "4.0.0", default-features = false, features = ["std", "help", "derive"] }
 
 [features]
 default = []

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -99,9 +99,11 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
             (None, None) => vec![],
         };
 
-        if let Some(value) = &opt.get_value_names() {
-            header.push(roman("="));
-            header.push(italic(&value.join(" ")));
+        if opt.get_action().takes_values() {
+            if let Some(value) = &opt.get_value_names() {
+                header.push(roman("="));
+                header.push(italic(&value.join(" ")));
+            }
         }
 
         if let Some(defs) = option_default_values(opt) {

--- a/clap_mangen/tests/common.rs
+++ b/clap_mangen/tests/common.rs
@@ -312,3 +312,17 @@ pub fn possible_values_command(name: &'static str) -> clap::Command {
                 ]),
         )
 }
+
+/// Checks to make sure boolean valued "Flag options" do not generate
+/// suggestions for a parameter. i.e:
+///     --boolean_flag=BOOLEAN_FLAG
+///
+/// This is both confusing and suggest erroneous behavior as clap will fail if you
+/// pass a value to a boolean flag
+pub fn flag_without_value(name: &'static str) -> clap::Command {
+    clap::Command::new(name).arg(
+        clap::Arg::new("is_bool")
+            .long("is_bool")
+            .action(clap::ArgAction::SetTrue),
+    )
+}

--- a/clap_mangen/tests/common.rs
+++ b/clap_mangen/tests/common.rs
@@ -312,17 +312,3 @@ pub fn possible_values_command(name: &'static str) -> clap::Command {
                 ]),
         )
 }
-
-/// Checks to make sure boolean valued "Flag options" do not generate
-/// suggestions for a parameter. i.e:
-///     --boolean_flag=BOOLEAN_FLAG
-///
-/// This is both confusing and suggest erroneous behavior as clap will fail if you
-/// pass a value to a boolean flag
-pub fn flag_without_value(name: &'static str) -> clap::Command {
-    clap::Command::new(name).arg(
-        clap::Arg::new("is_bool")
-            .long("is_bool")
-            .action(clap::ArgAction::SetTrue),
-    )
-}

--- a/clap_mangen/tests/derive.rs
+++ b/clap_mangen/tests/derive.rs
@@ -1,0 +1,36 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(name = "my-app")]
+pub struct BasicCommand {
+    #[clap(short, global = true)]
+    config: bool,
+
+    #[clap(short, conflicts_with("config"))]
+    v: bool,
+
+    #[command(subcommand)]
+    test: Option<BasicCommandSubCommand>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum BasicCommandSubCommand {
+    /// Subcommand
+    Test {
+        #[clap(short, action(clap::ArgAction::Count))]
+        debug: u8,
+    },
+}
+
+// Checks to make sure boolean valued "Flag options" do not generate
+// suggestions for a parameter. i.e:
+//     --boolean_flag=BOOLEAN_FLAG
+//
+// This is both confusing and suggest erroneous behavior as clap will fail if you
+// pass a value to a boolean flag
+#[derive(Parser, Debug)]
+#[command(name = "my-app")]
+pub struct FlagWithoutValue {
+    #[clap(long)]
+    boolean_flag: bool,
+}

--- a/clap_mangen/tests/roff.rs
+++ b/clap_mangen/tests/roff.rs
@@ -1,4 +1,7 @@
 mod common;
+mod derive;
+
+use clap::CommandFactory;
 
 #[test]
 fn basic() {
@@ -72,9 +75,14 @@ fn possible_values() {
 
 #[test]
 fn flag_without_value() {
-    let name = "my-app";
-    let cmd = common::flag_without_value(name);
+    let cmd = derive::FlagWithoutValue::command();
     common::assert_matches_path("tests/snapshots/flag_without_value.bash.roff", cmd);
+}
+
+#[test]
+fn derive_basic_command() {
+    let cmd = derive::BasicCommand::command();
+    common::assert_matches_path("tests/snapshots/basic.bash.roff", cmd);
 }
 
 #[test]

--- a/clap_mangen/tests/roff.rs
+++ b/clap_mangen/tests/roff.rs
@@ -71,6 +71,13 @@ fn possible_values() {
 }
 
 #[test]
+fn flag_without_value() {
+    let name = "my-app";
+    let cmd = common::flag_without_value(name);
+    common::assert_matches_path("tests/snapshots/flag_without_value.bash.roff", cmd);
+}
+
+#[test]
 fn sub_subcommands_help() {
     let name = "my-app";
     let mut cmd = common::sub_subcommands_command(name);

--- a/clap_mangen/tests/snapshots/flag_without_value.bash.roff
+++ b/clap_mangen/tests/snapshots/flag_without_value.bash.roff
@@ -4,11 +4,11 @@
 .SH NAME
 my/-app
 .SH SYNOPSIS
-/fBmy/-app/fR [/fB/-/-is_bool/fR] [/fB/-h/fR|/fB/-/-help/fR] 
+/fBmy/-app/fR [/fB/-/-boolean/-flag/fR] [/fB/-h/fR|/fB/-/-help/fR] 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-/fB/-/-is_bool/fR
+/fB/-/-boolean/-flag/fR
 
 .TP
 /fB/-h/fR, /fB/-/-help/fR

--- a/clap_mangen/tests/snapshots/flag_without_value.bash.roff
+++ b/clap_mangen/tests/snapshots/flag_without_value.bash.roff
@@ -1,0 +1,15 @@
+.ie /n(.g .ds Aq /(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my/-app
+.SH SYNOPSIS
+/fBmy/-app/fR [/fB/-/-is_bool/fR] [/fB/-h/fR|/fB/-/-help/fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+/fB/-/-is_bool/fR
+
+.TP
+/fB/-h/fR, /fB/-/-help/fR
+Print help information


### PR DESCRIPTION
The man generation would generate suggestions for all options of values they should take, even if the argument did not take values. This adds a simple check to make sure only options that take values offer a suggestion. 

See examples in underlying issue.

fixes: #4443

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
