### PR TITLE
docs: Present other environment variable alternatives to `crate_name!`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -85,6 +85,12 @@ macro_rules! crate_description {
 
 /// Allows you to pull the name from your Cargo.toml at compile time.
 ///
+/// **NOTE:** This macro extracts the name from an environment variable `CARGO_PKG_NAME`.
+/// When the crate name is set to something different from the package name,
+/// use environment variables `CARGO_CRATE_NAME` or `CARGO_BIN_NAME`.
+/// See [the Cargo Book](https://doc.rust-lang.org/cargo/reference/environment-variables.html)
+/// for more information.
+///
 /// # Examples
 ///
 /// ```no_run


### PR DESCRIPTION
This PR will add a note to the description on `crate_name!` macro about where the name in the output come from.

There are 3 name-related environment variables in cargo, `CARGO_PKG_NAME`, `CARGO_CRATE_NAME`, and `CARGO_BIN_NAME`, and the `crate_name!` macro uses the 1st one among them.  This means that `foo` is used as the name in the case of Cargo.toml as shown below:

```toml
[package]
name = "foo"

[[bin]]
name = "bar"
```

Since the `crate_*` macros are under consideration for deprecation in #2840, and changing the source to another environment variable would result in the behavior change, I think it would be best to add a note to the documentation.

If you have suggestions, I would appreciate it.
Thank you very much.