### PR TITLE
docs: Add docs for automatic --version derive

### DIFF
--- a/src/builder/action.rs
+++ b/src/builder/action.rs
@@ -248,6 +248,8 @@ pub enum ArgAction {
     ///
     /// Depending on the flag, [`Command::long_version`][super::Command::long_version] may be shown
     ///
+    /// When using `#[derive(clap::Parser)]` you need to add `#[command(version)]` to enable automatic `--version`
+    ///
     /// # Examples
     ///
     /// ```rust


### PR DESCRIPTION
I had trouble getting `--version` to work again after going from structopt to clap 4 and added a hint for my future self. :)