### PR TITLE
docs: Cut dead features from recommended test/lint commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Note: We have not yet determined the End-of-Life schedule for previous major ver
 To test with all features both enabled and disabled, you can run this command:
 
 ```sh
-$ cargo test --features "wrap_help yaml regex unstable-replace"
+$ cargo test --features "wrap_help unstable-replace"
 ```
 
 Sometimes it's helpful to only run a subset of the tests, which can be done via:
@@ -92,7 +92,7 @@ During the CI process `clap` runs against many different lints using [`clippy`](
 In order to check the code for lints and to format it run:
 
 ```sh
-$ cargo clippy --features "wrap_help yaml regex unstable-replace" -- -D warnings
+$ cargo clippy --features "wrap_help unstable-replace" -- -D warnings
 $ cargo fmt -- --check
 ```
 


### PR DESCRIPTION
Running the test command recommended in CONTRIBUTING.md gave:

    $ cargo test --features "wrap_help yaml regex unstable-replace"
    error: none of the selected packages contains these features: regex, yaml

Those two features were removed from Cargo.toml in #3963. Remove them here too.

(After this, there may still be a further fix to make: the text says "To test with all features both enabled and disabled", and I don't think that's what this command does. But at least now it works, which is a good step forward.)
