### PR TITLE
perf(parser): Reduce lookups for conflicts 

### DIFF
--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -231,7 +231,7 @@ impl Man {
     }
 
     fn _render_version_section(&self, roff: &mut Roff) {
-        let version = roman(&render::version(&self.cmd));
+        let version = roman(render::version(&self.cmd));
         roff.control("SH", ["VERSION"]);
         roff.text([version]);
     }

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -13,7 +13,7 @@ pub(crate) fn about(roff: &mut Roff, cmd: &clap::Command) {
         Some(about) => format!("{} - {}", cmd.get_name(), about),
         None => cmd.get_name().to_string(),
     };
-    roff.text([roman(&s)]);
+    roff.text([roman(s)]);
 }
 
 pub(crate) fn description(roff: &mut Roff, cmd: &clap::Command) {
@@ -36,19 +36,19 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
         match (opt.get_short(), opt.get_long()) {
             (Some(short), Some(long)) => {
                 line.push(roman(lhs));
-                line.push(bold(&format!("-{}", short)));
+                line.push(bold(format!("-{}", short)));
                 line.push(roman("|"));
-                line.push(bold(&format!("--{}", long)));
+                line.push(bold(format!("--{}", long)));
                 line.push(roman(rhs));
             }
             (Some(short), None) => {
                 line.push(roman(lhs));
-                line.push(bold(&format!("-{} ", short)));
+                line.push(bold(format!("-{} ", short)));
                 line.push(roman(rhs));
             }
             (None, Some(long)) => {
                 line.push(roman(lhs));
-                line.push(bold(&format!("--{}", long)));
+                line.push(bold(format!("--{}", long)));
                 line.push(roman(rhs));
             }
             (None, None) => continue,
@@ -101,12 +101,12 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
 
         if let Some(value) = &opt.get_value_names() {
             header.push(roman("="));
-            header.push(italic(&value.join(" ")));
+            header.push(italic(value.join(" ")));
         }
 
         if let Some(defs) = option_default_values(opt) {
             header.push(roman(" "));
-            header.push(roman(&defs));
+            header.push(roman(defs));
         }
 
         let mut body = vec![];
@@ -168,13 +168,13 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
         header.push(roman(rhs));
 
         if let Some(defs) = option_default_values(pos) {
-            header.push(roman(&format!(" {}", defs)));
+            header.push(roman(format!(" {}", defs)));
         }
 
         let mut body = vec![];
         let mut arg_help_written = false;
         if let Some(help) = option_help(pos) {
-            body.push(roman(&help.to_string()));
+            body.push(roman(help.to_string()));
             arg_help_written = true;
         }
 
@@ -229,7 +229,7 @@ pub(crate) fn subcommands(roff: &mut Roff, cmd: &clap::Command, section: &str) {
             sub.get_name(),
             section
         );
-        roff.text([roman(&name)]);
+        roff.text([roman(name)]);
 
         if let Some(about) = sub.get_about().or_else(|| sub.get_long_about()) {
             for line in about.to_string().lines() {
@@ -273,11 +273,11 @@ fn markers(required: bool) -> (&'static str, &'static str) {
 }
 
 fn short_option(opt: char) -> Inline {
-    bold(&format!("-{}", opt))
+    bold(format!("-{}", opt))
 }
 
 fn long_option(opt: &str) -> Inline {
-    bold(&format!("--{}", opt))
+    bold(format!("--{}", opt))
 }
 
 fn option_help(opt: &clap::Arg) -> Option<&clap::builder::StyledStr> {

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), String> {
 fn respond(line: &str) -> Result<bool, String> {
     let args = shlex::split(line).ok_or("error: Invalid quoting")?;
     let matches = cli()
-        .try_get_matches_from(&args)
+        .try_get_matches_from(args)
         .map_err(|e| e.to_string())?;
     match matches.subcommand() {
         Some(("ping", _matches)) => {

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -487,7 +487,7 @@ impl Command {
     /// [`Command::try_get_matches_from_mut`]: Command::try_get_matches_from_mut()
     #[inline]
     pub fn get_matches(self) -> ArgMatches {
-        self.get_matches_from(&mut env::args_os())
+        self.get_matches_from(env::args_os())
     }
 
     /// Parse [`env::args_os`], exiting on failure.
@@ -545,7 +545,7 @@ impl Command {
     #[inline]
     pub fn try_get_matches(self) -> ClapResult<ArgMatches> {
         // Start the parsing
-        self.try_get_matches_from(&mut env::args_os())
+        self.try_get_matches_from(env::args_os())
     }
 
     /// Parse the specified arguments, exiting on failure.

--- a/src/parser/arg_matcher.rs
+++ b/src/parser/arg_matcher.rs
@@ -113,6 +113,10 @@ impl ArgMatcher {
         self.matches.args.keys()
     }
 
+    pub(crate) fn args(&self) -> crate::util::flat_map::Iter<'_, Id, MatchedArg> {
+        self.matches.args.iter()
+    }
+
     pub(crate) fn entry(&mut self, arg: Id) -> crate::util::Entry<Id, MatchedArg> {
         self.matches.args.entry(arg)
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::single_component_path_imports)]
 
-mod flat_map;
-mod flat_set;
+pub(crate) mod flat_map;
+pub(crate) mod flat_set;
 mod graph;
 mod id;
 mod str_to_bool;


### PR DESCRIPTION
We already need to lookup every present-arg for conflicts, so we might
as well cache it ahead of time.  This let's us move some operations to
be immutable so we can more easily cache other lookups.

For me, this gave a 70% speed improvement for #4516 with mixed results
on normal benchmarks