### PR TITLE
Fix and improve name inference on conflicts

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -560,8 +560,14 @@ impl<'cmd> Parser<'cmd> {
                 // `tes` and `test`.
                 let v = self
                     .cmd
-                    .all_subcommand_names()
-                    .filter(|s| s.starts_with(arg))
+                    .get_subcommands()
+                    .filter_map(|s| {
+                        if s.get_name().starts_with(arg) {
+                            return Some(s.get_name());
+                        }
+
+                        s.get_all_aliases().find(|s| s.starts_with(arg))
+                    })
                     .collect::<Vec<_>>();
 
                 if v.len() == 1 {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -760,16 +760,26 @@ impl<'cmd> Parser<'cmd> {
             debug!("Parser::parse_long_arg: Found valid arg or flag '{}'", arg);
             Some((long_arg, arg))
         } else if self.cmd.is_infer_long_args_set() {
-            self.cmd.get_arguments().find_map(|a| {
-                if let Some(long) = a.get_long() {
-                    if long.starts_with(long_arg) {
-                        return Some((long, a));
+            let v = self
+                .cmd
+                .get_arguments()
+                .filter_map(|a| {
+                    if let Some(long) = a.get_long() {
+                        if long.starts_with(long_arg) {
+                            return Some((long, a));
+                        }
                     }
-                }
-                a.aliases
-                    .iter()
-                    .find_map(|(alias, _)| alias.starts_with(long_arg).then(|| (alias.as_str(), a)))
-            })
+                    a.aliases.iter().find_map(|(alias, _)| {
+                        alias.starts_with(long_arg).then(|| (alias.as_str(), a))
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            if v.len() == 1 {
+                Some(v[0])
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -253,6 +253,16 @@ fn infer_subcommands_pass_exact_match() {
     assert_eq!(m.subcommand_name(), Some("test"));
 }
 
+#[test]
+fn infer_subcommands_pass_conflicting_aliases() {
+    let m = Command::new("prog")
+        .infer_subcommands(true)
+        .subcommand(Command::new("test").aliases(["testa", "t", "testb"]))
+        .try_get_matches_from(vec!["prog", "te"])
+        .unwrap();
+    assert_eq!(m.subcommand_name(), Some("test"));
+}
+
 #[cfg(feature = "suggestions")]
 #[test]
 fn infer_subcommands_fail_suggestions() {

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -659,7 +659,7 @@ fn issue_2279() {
 }
 
 #[test]
-fn infer_long_arg() {
+fn infer_long_arg_pass() {
     let cmd = Command::new("test")
         .infer_long_args(true)
         .arg(
@@ -715,4 +715,43 @@ fn infer_long_arg() {
 
     let matches = cmd.clone().try_get_matches_from(["test", "--a"]).unwrap();
     assert!(*matches.get_one::<bool>("arg").expect("defaulted by clap"));
+}
+
+#[test]
+fn infer_long_arg_pass_conflicts_exact_match() {
+    let cmd = Command::new("test")
+        .infer_long_args(true)
+        .arg(Arg::new("arg").long("arg").action(ArgAction::SetTrue))
+        .arg(Arg::new("arg2").long("arg2").action(ArgAction::SetTrue));
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--arg"]).unwrap();
+    assert!(*matches.get_one::<bool>("arg").expect("defaulted by clap"));
+
+    let matches = cmd
+        .clone()
+        .try_get_matches_from(["test", "--arg2"])
+        .unwrap();
+    assert!(*matches.get_one::<bool>("arg2").expect("defaulted by clap"));
+}
+
+#[test]
+fn infer_long_arg_fail_conflicts() {
+    let cmd = Command::new("test")
+        .infer_long_args(true)
+        .arg(
+            Arg::new("abc-123")
+                .long("abc-123")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("abc-xyz")
+                .long("abc-xyz")
+                .action(ArgAction::SetTrue),
+        );
+
+    let error = cmd
+        .clone()
+        .try_get_matches_from(["test", "--abc"])
+        .unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::UnknownArgument);
 }

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -735,6 +735,21 @@ fn infer_long_arg_pass_conflicts_exact_match() {
 }
 
 #[test]
+fn infer_long_arg_pass_conflicting_aliases() {
+    let cmd = Command::new("test").infer_long_args(true).arg(
+        Arg::new("abc-123")
+            .long("abc-123")
+            .aliases(["a", "abc-xyz"])
+            .action(ArgAction::SetTrue),
+    );
+
+    let matches = cmd.clone().try_get_matches_from(["test", "--ab"]).unwrap();
+    assert!(*matches
+        .get_one::<bool>("abc-123")
+        .expect("defaulted by clap"));
+}
+
+#[test]
 fn infer_long_arg_fail_conflicts() {
     let cmd = Command::new("test")
         .infer_long_args(true)


### PR DESCRIPTION
- Long args would pick a random arg upon conflict.
- Subcommands would fail to infer if the conflicts occurred within aliases.