### PR TITLE
Resolve conflicting subcommand name inference if from aliases

### DIFF
--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -558,14 +558,18 @@ impl<'cmd> Parser<'cmd> {
             if self.cmd.is_infer_subcommands_set() {
                 // For subcommand `test`, we accepts it's prefix: `t`, `te`,
                 // `tes` and `test`.
-                let v = self
-                    .cmd
-                    .all_subcommand_names()
-                    .filter(|s| s.starts_with(arg))
-                    .collect::<Vec<_>>();
+                let mut iter = self.cmd.get_subcommands().filter_map(|s| {
+                    if s.get_name().starts_with(arg) {
+                        return Some(s.get_name());
+                    }
 
-                if v.len() == 1 {
-                    return Some(v[0]);
+                    s.get_all_aliases().find(|s| s.starts_with(arg))
+                });
+
+                if let name @ Some(_) = iter.next() {
+                    if iter.next().is_none() {
+                        return name;
+                    }
                 }
 
                 // If there is any ambiguity, fallback to non-infer subcommand

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -253,6 +253,16 @@ fn infer_subcommands_pass_exact_match() {
     assert_eq!(m.subcommand_name(), Some("test"));
 }
 
+#[test]
+fn infer_subcommands_pass_conflicting_aliases() {
+    let m = Command::new("prog")
+        .infer_subcommands(true)
+        .subcommand(Command::new("test").aliases(["testa", "t", "testb"]))
+        .try_get_matches_from(vec!["prog", "te"])
+        .unwrap();
+    assert_eq!(m.subcommand_name(), Some("test"));
+}
+
 #[cfg(feature = "suggestions")]
 #[test]
 fn infer_subcommands_fail_suggestions() {


### PR DESCRIPTION
Subcommands would fail to infer if the conflicts occurred within aliases.

Again, avoiding allocations wins. Vec: 771.8 KiB. Iterator: 771.6 KiB