### PR TITLE
Fix typo in clap-derive error message

### DIFF
--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -70,7 +70,7 @@ impl ClapAttr {
             AttrValue::Expr(_) | AttrValue::Call(_) => {
                 abort!(
                     self.name,
-                    "attribute `{}` can only accept string litersl",
+                    "attribute `{}` can only accept string literals",
                     self.name
                 )
             }


### PR DESCRIPTION
I assume "litersl" should be "literals"?

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
