### PR TITLE
fix(error): More closely match rustc's error style

### DIFF
--- a/clap_complete/src/shells/shell.rs
+++ b/clap_complete/src/shells/shell.rs
@@ -42,7 +42,7 @@ impl FromStr for Shell {
                 return Ok(*variant);
             }
         }
-        Err(format!("Invalid variant: {}", s))
+        Err(format!("invalid variant: {}", s))
     }
 }
 

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -39,7 +39,7 @@ error: found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 Usage: interop_augment_args[EXE] [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -74,7 +74,7 @@ error: found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 Usage: interop_augment_subcommands[EXE] derived [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -85,7 +85,7 @@ error: the subcommand 'unknown' wasn't recognized
 
 Usage: interop_augment_subcommands[EXE] [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -146,7 +146,7 @@ error: found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 Usage: interop_hand_subcommand[EXE] add [NAME]...
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -189,7 +189,7 @@ error: the subcommand 'unknown' wasn't recognized
 
 Usage: interop_hand_subcommand[EXE] [OPTIONS] <COMMAND>
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -243,6 +243,6 @@ error: found argument '--unknown' which wasn't expected, or isn't valid in this 
 
 Usage: interop_flatten_hand_args[EXE] [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -35,7 +35,7 @@ Value of derived: DerivedArgs {
 ```console
 $ interop_augment_args --unknown
 ? failed
-error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
+error: found argument '--unknown' which wasn't expected, or isn't valid in this context
 
 Usage: interop_augment_args[EXE] [OPTIONS]
 
@@ -70,7 +70,7 @@ Derived subcommands: Derived {
 ```console
 $ interop_augment_subcommands derived --unknown
 ? failed
-error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
+error: found argument '--unknown' which wasn't expected, or isn't valid in this context
 
 Usage: interop_augment_subcommands[EXE] derived [OPTIONS]
 
@@ -81,7 +81,7 @@ For more information try '--help'
 ```console
 $ interop_augment_subcommands unknown
 ? failed
-error: The subcommand 'unknown' wasn't recognized
+error: the subcommand 'unknown' wasn't recognized
 
 Usage: interop_augment_subcommands[EXE] [COMMAND]
 
@@ -140,7 +140,7 @@ Cli {
 ```console
 $ interop_hand_subcommand add --unknown
 ? failed
-error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
+error: found argument '--unknown' which wasn't expected, or isn't valid in this context
 
   note: to pass '--unknown' as a value, use '-- --unknown'
 
@@ -185,7 +185,7 @@ Cli {
 ```console
 $ interop_hand_subcommand unknown
 ? failed
-error: The subcommand 'unknown' wasn't recognized
+error: the subcommand 'unknown' wasn't recognized
 
 Usage: interop_hand_subcommand[EXE] [OPTIONS] <COMMAND>
 
@@ -239,7 +239,7 @@ Cli {
 ```console
 $ interop_flatten_hand_args --unknown
 ? failed
-error: Found argument '--unknown' which wasn't expected, or isn't valid in this context
+error: found argument '--unknown' which wasn't expected, or isn't valid in this context
 
 Usage: interop_flatten_hand_args[EXE] [OPTIONS]
 

--- a/examples/escaped-positional-derive.md
+++ b/examples/escaped-positional-derive.md
@@ -37,7 +37,7 @@ error: found argument 'foo' which wasn't expected, or isn't valid in this contex
 
 Usage: escaped-positional-derive[EXE] [OPTIONS] [-- <SLOP>...]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 

--- a/examples/escaped-positional-derive.md
+++ b/examples/escaped-positional-derive.md
@@ -33,7 +33,7 @@ Notice that we can't pass positional arguments before `--`:
 ```console
 $ escaped-positional-derive foo bar
 ? failed
-error: Found argument 'foo' which wasn't expected, or isn't valid in this context
+error: found argument 'foo' which wasn't expected, or isn't valid in this context
 
 Usage: escaped-positional-derive[EXE] [OPTIONS] [-- <SLOP>...]
 

--- a/examples/escaped-positional.md
+++ b/examples/escaped-positional.md
@@ -33,7 +33,7 @@ Notice that we can't pass positional arguments before `--`:
 ```console
 $ escaped-positional foo bar
 ? failed
-error: Found argument 'foo' which wasn't expected, or isn't valid in this context
+error: found argument 'foo' which wasn't expected, or isn't valid in this context
 
 Usage: escaped-positional[EXE] [OPTIONS] [-- <SLOP>...]
 

--- a/examples/escaped-positional.md
+++ b/examples/escaped-positional.md
@@ -37,7 +37,7 @@ error: found argument 'foo' which wasn't expected, or isn't valid in this contex
 
 Usage: escaped-positional[EXE] [OPTIONS] [-- <SLOP>...]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -71,7 +71,7 @@ error: the argument '--search <search>...' cannot be used with '--info'
 
 Usage: pacman[EXE] {sync|--sync|-S} --search <search>... <package>...
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -67,7 +67,7 @@ And errors:
 ```console
 $ pacman -S -s foo -i bar
 ? failed
-error: The argument '--search <search>...' cannot be used with '--info'
+error: the argument '--search <search>...' cannot be used with '--info'
 
 Usage: pacman[EXE] {sync|--sync|-S} --search <search>... <package>...
 

--- a/examples/tutorial_builder/03_01_flag_bool.md
+++ b/examples/tutorial_builder/03_01_flag_bool.md
@@ -17,7 +17,7 @@ verbose: true
 
 $ 03_01_flag_bool --verbose --verbose
 ? failed
-error: The argument '--verbose' was provided more than once, but cannot be used multiple times
+error: the argument '--verbose' was provided more than once, but cannot be used multiple times
 
 Usage: 03_01_flag_bool[EXE] [OPTIONS]
 

--- a/examples/tutorial_builder/03_01_flag_bool.md
+++ b/examples/tutorial_builder/03_01_flag_bool.md
@@ -21,6 +21,6 @@ error: the argument '--verbose' was provided more than once, but cannot be used 
 
 Usage: 03_01_flag_bool[EXE] [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_builder/04_01_enum.md
+++ b/examples/tutorial_builder/04_01_enum.md
@@ -42,6 +42,6 @@ $ 04_01_enum medium
 error: 'medium' isn't a valid value for '<MODE>'
   [possible values: fast, slow]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_builder/04_01_enum.rs
+++ b/examples/tutorial_builder/04_01_enum.rs
@@ -38,7 +38,7 @@ impl std::str::FromStr for Mode {
                 return Ok(*variant);
             }
         }
-        Err(format!("Invalid variant: {}", s))
+        Err(format!("invalid variant: {}", s))
     }
 }
 

--- a/examples/tutorial_builder/04_01_possible.md
+++ b/examples/tutorial_builder/04_01_possible.md
@@ -22,6 +22,6 @@ $ 04_01_possible medium
 error: 'medium' isn't a valid value for '<MODE>'
   [possible values: fast, slow]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_builder/04_02_parse.md
+++ b/examples/tutorial_builder/04_02_parse.md
@@ -18,12 +18,12 @@ $ 04_02_parse foobar
 ? failed
 error: invalid value 'foobar' for '<PORT>': invalid digit found in string
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_02_parse_derive 0
 ? failed
 error: invalid value '0' for '<PORT>': 0 is not in 1..=65535
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_builder/04_02_parse.md
+++ b/examples/tutorial_builder/04_02_parse.md
@@ -16,13 +16,13 @@ PORT = 22
 
 $ 04_02_parse foobar
 ? failed
-error: Invalid value 'foobar' for '<PORT>': invalid digit found in string
+error: invalid value 'foobar' for '<PORT>': invalid digit found in string
 
 For more information try '--help'
 
 $ 04_02_parse_derive 0
 ? failed
-error: Invalid value '0' for '<PORT>': 0 is not in 1..=65535
+error: invalid value '0' for '<PORT>': 0 is not in 1..=65535
 
 For more information try '--help'
 

--- a/examples/tutorial_builder/04_02_validate.md
+++ b/examples/tutorial_builder/04_02_validate.md
@@ -18,12 +18,12 @@ $ 04_02_validate foobar
 ? failed
 error: invalid value 'foobar' for '<PORT>': `foobar` isn't a port number
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_02_validate 0
 ? failed
 error: invalid value '0' for '<PORT>': port not in range 1-65535
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_builder/04_02_validate.md
+++ b/examples/tutorial_builder/04_02_validate.md
@@ -16,13 +16,13 @@ PORT = 22
 
 $ 04_02_validate foobar
 ? failed
-error: Invalid value 'foobar' for '<PORT>': `foobar` isn't a port number
+error: invalid value 'foobar' for '<PORT>': `foobar` isn't a port number
 
 For more information try '--help'
 
 $ 04_02_validate 0
 ? failed
-error: Invalid value '0' for '<PORT>': Port not in range 1-65535
+error: invalid value '0' for '<PORT>': port not in range 1-65535
 
 For more information try '--help'
 

--- a/examples/tutorial_builder/04_02_validate.rs
+++ b/examples/tutorial_builder/04_02_validate.rs
@@ -28,7 +28,7 @@ fn port_in_range(s: &str) -> Result<u16, String> {
         Ok(port as u16)
     } else {
         Err(format!(
-            "Port not in range {}-{}",
+            "port not in range {}-{}",
             PORT_RANGE.start(),
             PORT_RANGE.end()
         ))

--- a/examples/tutorial_builder/04_03_relations.md
+++ b/examples/tutorial_builder/04_03_relations.md
@@ -24,7 +24,7 @@ error: the following required arguments were not provided:
 
 Usage: 04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_03_relations --major
 Version: 2.2.3
@@ -35,7 +35,7 @@ error: the argument '--major' cannot be used with '--minor'
 
 Usage: 04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_03_relations --major -c config.toml
 ? failed
@@ -44,7 +44,7 @@ error: the following required arguments were not provided:
 
 Usage: 04_03_relations[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_03_relations --major -c config.toml --spec-in input.txt
 Version: 2.2.3

--- a/examples/tutorial_builder/04_03_relations.md
+++ b/examples/tutorial_builder/04_03_relations.md
@@ -19,7 +19,7 @@ Options:
 
 $ 04_03_relations
 ? failed
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <--set-ver <VER>|--major|--minor|--patch>
 
 Usage: 04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
@@ -31,7 +31,7 @@ Version: 2.2.3
 
 $ 04_03_relations --major --minor
 ? failed
-error: The argument '--major' cannot be used with '--minor'
+error: the argument '--major' cannot be used with '--minor'
 
 Usage: 04_03_relations[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
@@ -39,7 +39,7 @@ For more information try '--help'
 
 $ 04_03_relations --major -c config.toml
 ? failed
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <INPUT_FILE|--spec-in <SPEC_IN>>
 
 Usage: 04_03_relations[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>

--- a/examples/tutorial_builder/04_04_custom.md
+++ b/examples/tutorial_builder/04_04_custom.md
@@ -23,7 +23,7 @@ error: Can only modify one version field
 
 Usage: 04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_04_custom --major
 Version: 2.2.3
@@ -34,7 +34,7 @@ error: Can only modify one version field
 
 Usage: 04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_04_custom --major -c config.toml
 ? failed
@@ -43,7 +43,7 @@ error: INPUT_FILE or --spec-in is required when using --config
 
 Usage: 04_04_custom[EXE] [OPTIONS] [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_04_custom --major -c config.toml --spec-in input.txt
 Version: 2.2.3

--- a/examples/tutorial_derive/03_01_flag_bool.md
+++ b/examples/tutorial_derive/03_01_flag_bool.md
@@ -21,6 +21,6 @@ error: the argument '--verbose' was provided more than once, but cannot be used 
 
 Usage: 03_01_flag_bool_derive[EXE] [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_derive/03_01_flag_bool.md
+++ b/examples/tutorial_derive/03_01_flag_bool.md
@@ -17,7 +17,7 @@ verbose: true
 
 $ 03_01_flag_bool_derive --verbose --verbose
 ? failed
-error: The argument '--verbose' was provided more than once, but cannot be used multiple times
+error: the argument '--verbose' was provided more than once, but cannot be used multiple times
 
 Usage: 03_01_flag_bool_derive[EXE] [OPTIONS]
 

--- a/examples/tutorial_derive/04_01_enum.md
+++ b/examples/tutorial_derive/04_01_enum.md
@@ -42,6 +42,6 @@ $ 04_01_enum_derive medium
 error: 'medium' isn't a valid value for '<MODE>'
   [possible values: fast, slow]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_derive/04_02_parse.md
+++ b/examples/tutorial_derive/04_02_parse.md
@@ -16,13 +16,13 @@ PORT = 22
 
 $ 04_02_parse_derive foobar
 ? failed
-error: Invalid value 'foobar' for '<PORT>': invalid digit found in string
+error: invalid value 'foobar' for '<PORT>': invalid digit found in string
 
 For more information try '--help'
 
 $ 04_02_parse_derive 0
 ? failed
-error: Invalid value '0' for '<PORT>': 0 is not in 1..=65535
+error: invalid value '0' for '<PORT>': 0 is not in 1..=65535
 
 For more information try '--help'
 

--- a/examples/tutorial_derive/04_02_parse.md
+++ b/examples/tutorial_derive/04_02_parse.md
@@ -18,12 +18,12 @@ $ 04_02_parse_derive foobar
 ? failed
 error: invalid value 'foobar' for '<PORT>': invalid digit found in string
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_02_parse_derive 0
 ? failed
 error: invalid value '0' for '<PORT>': 0 is not in 1..=65535
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_derive/04_02_validate.md
+++ b/examples/tutorial_derive/04_02_validate.md
@@ -16,13 +16,13 @@ PORT = 22
 
 $ 04_02_validate_derive foobar
 ? failed
-error: Invalid value 'foobar' for '<PORT>': `foobar` isn't a port number
+error: invalid value 'foobar' for '<PORT>': `foobar` isn't a port number
 
 For more information try '--help'
 
 $ 04_02_validate_derive 0
 ? failed
-error: Invalid value '0' for '<PORT>': Port not in range 1-65535
+error: invalid value '0' for '<PORT>': port not in range 1-65535
 
 For more information try '--help'
 

--- a/examples/tutorial_derive/04_02_validate.md
+++ b/examples/tutorial_derive/04_02_validate.md
@@ -18,12 +18,12 @@ $ 04_02_validate_derive foobar
 ? failed
 error: invalid value 'foobar' for '<PORT>': `foobar` isn't a port number
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_02_validate_derive 0
 ? failed
 error: invalid value '0' for '<PORT>': port not in range 1-65535
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/examples/tutorial_derive/04_02_validate.rs
+++ b/examples/tutorial_derive/04_02_validate.rs
@@ -26,7 +26,7 @@ fn port_in_range(s: &str) -> Result<u16, String> {
         Ok(port as u16)
     } else {
         Err(format!(
-            "Port not in range {}-{}",
+            "port not in range {}-{}",
             PORT_RANGE.start(),
             PORT_RANGE.end()
         ))

--- a/examples/tutorial_derive/04_03_relations.md
+++ b/examples/tutorial_derive/04_03_relations.md
@@ -24,7 +24,7 @@ error: the following required arguments were not provided:
 
 Usage: 04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_03_relations_derive --major
 Version: 2.2.3
@@ -35,7 +35,7 @@ error: the argument '--major' cannot be used with '--minor'
 
 Usage: 04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_03_relations_derive --major -c config.toml
 ? failed
@@ -44,7 +44,7 @@ error: the following required arguments were not provided:
 
 Usage: 04_03_relations_derive[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_03_relations_derive --major -c config.toml --spec-in input.txt
 Version: 2.2.3

--- a/examples/tutorial_derive/04_03_relations.md
+++ b/examples/tutorial_derive/04_03_relations.md
@@ -19,7 +19,7 @@ Options:
 
 $ 04_03_relations_derive
 ? failed
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <--set-ver <VER>|--major|--minor|--patch>
 
 Usage: 04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
@@ -31,7 +31,7 @@ Version: 2.2.3
 
 $ 04_03_relations_derive --major --minor
 ? failed
-error: The argument '--major' cannot be used with '--minor'
+error: the argument '--major' cannot be used with '--minor'
 
 Usage: 04_03_relations_derive[EXE] <--set-ver <VER>|--major|--minor|--patch> [INPUT_FILE]
 
@@ -39,7 +39,7 @@ For more information try '--help'
 
 $ 04_03_relations_derive --major -c config.toml
 ? failed
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <INPUT_FILE|--spec-in <SPEC_IN>>
 
 Usage: 04_03_relations_derive[EXE] -c <CONFIG> <--set-ver <VER>|--major|--minor|--patch> <INPUT_FILE|--spec-in <SPEC_IN>>

--- a/examples/tutorial_derive/04_04_custom.md
+++ b/examples/tutorial_derive/04_04_custom.md
@@ -23,7 +23,7 @@ error: Can only modify one version field
 
 Usage: clap [OPTIONS] [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_04_custom_derive --major
 Version: 2.2.3
@@ -34,7 +34,7 @@ error: Can only modify one version field
 
 Usage: clap [OPTIONS] [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_04_custom_derive --major -c config.toml
 ? failed
@@ -43,7 +43,7 @@ error: INPUT_FILE or --spec-in is required when using --config
 
 Usage: clap [OPTIONS] [INPUT_FILE]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ 04_04_custom_derive --major -c config.toml --spec-in input.txt
 Version: 2.2.3

--- a/examples/typed-derive.md
+++ b/examples/typed-derive.md
@@ -24,7 +24,7 @@ Args { optimization: Some(1), include: None, bind: None, sleep: None, defines: [
 
 $ typed-derive -O plaid
 ? failed
-error: Invalid value 'plaid' for '-O <OPTIMIZATION>': invalid digit found in string
+error: invalid value 'plaid' for '-O <OPTIMIZATION>': invalid digit found in string
 
 For more information try '--help'
 
@@ -44,7 +44,7 @@ Args { optimization: None, include: None, bind: Some(192.0.0.1), sleep: None, de
 
 $ typed-derive --bind localhost
 ? failed
-error: Invalid value 'localhost' for '--bind <BIND>': invalid IP address syntax
+error: invalid value 'localhost' for '--bind <BIND>': invalid IP address syntax
 
 For more information try '--help'
 
@@ -57,7 +57,7 @@ Args { optimization: None, include: None, bind: None, sleep: Some(Duration(10s))
 
 $ typed-derive --sleep forever
 ? failed
-error: Invalid value 'forever' for '--sleep <SLEEP>': expected number at 0
+error: invalid value 'forever' for '--sleep <SLEEP>': expected number at 0
 
 For more information try '--help'
 
@@ -70,13 +70,13 @@ Args { optimization: None, include: None, bind: None, sleep: None, defines: [("F
 
 $ typed-derive -D Foo
 ? failed
-error: Invalid value 'Foo' for '-D <DEFINES>': invalid KEY=value: no `=` found in `Foo`
+error: invalid value 'Foo' for '-D <DEFINES>': invalid KEY=value: no `=` found in `Foo`
 
 For more information try '--help'
 
 $ typed-derive -D Foo=Bar
 ? failed
-error: Invalid value 'Foo=Bar' for '-D <DEFINES>': invalid digit found in string
+error: invalid value 'Foo=Bar' for '-D <DEFINES>': invalid digit found in string
 
 For more information try '--help'
 
@@ -92,7 +92,7 @@ Args { optimization: None, include: None, bind: None, sleep: None, defines: [], 
 
 $ typed-derive --port
 ? failed
-error: The argument '--port <PORT>' requires a value but none was supplied
+error: the argument '--port <PORT>' requires a value but none was supplied
   [possible values: 22, 80]
 
 For more information try '--help'
@@ -116,7 +116,7 @@ Args { optimization: None, include: None, bind: None, sleep: None, defines: [], 
 
 $ typed-derive --log-level
 ? failed
-error: The argument '--log-level <LOG_LEVEL>' requires a value but none was supplied
+error: the argument '--log-level <LOG_LEVEL>' requires a value but none was supplied
   [possible values: info, debug, info, warn, error]
 
 For more information try '--help'

--- a/examples/typed-derive.md
+++ b/examples/typed-derive.md
@@ -26,7 +26,7 @@ $ typed-derive -O plaid
 ? failed
 error: invalid value 'plaid' for '-O <OPTIMIZATION>': invalid digit found in string
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -46,7 +46,7 @@ $ typed-derive --bind localhost
 ? failed
 error: invalid value 'localhost' for '--bind <BIND>': invalid IP address syntax
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -59,7 +59,7 @@ $ typed-derive --sleep forever
 ? failed
 error: invalid value 'forever' for '--sleep <SLEEP>': expected number at 0
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -72,13 +72,13 @@ $ typed-derive -D Foo
 ? failed
 error: invalid value 'Foo' for '-D <DEFINES>': invalid KEY=value: no `=` found in `Foo`
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ typed-derive -D Foo=Bar
 ? failed
 error: invalid value 'Foo=Bar' for '-D <DEFINES>': invalid digit found in string
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -95,14 +95,14 @@ $ typed-derive --port
 error: the argument '--port <PORT>' requires a value but none was supplied
   [possible values: 22, 80]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ typed-derive --port 3000
 ? failed
 error: '3000' isn't a valid value for '--port <PORT>'
   [possible values: 22, 80]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```
 
@@ -119,13 +119,13 @@ $ typed-derive --log-level
 error: the argument '--log-level <LOG_LEVEL>' requires a value but none was supplied
   [possible values: info, debug, info, warn, error]
 
-For more information try '--help'
+For more information, try '--help'.
 
 $ typed-derive --log-level critical
 ? failed
 error: 'critical' isn't a valid value for '--log-level <LOG_LEVEL>'
   [possible values: info, debug, info, warn, error]
 
-For more information try '--help'
+For more information, try '--help'.
 
 ```

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -385,7 +385,7 @@ pub trait ValueEnum: Sized + Clone {
                     .matches(input, ignore_case)
             })
             .cloned()
-            .ok_or_else(|| format!("Invalid variant: {}", input))
+            .ok_or_else(|| format!("invalid variant: {}", input))
     }
 
     /// The canonical argument value.

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -417,9 +417,9 @@ pub(crate) fn get_help_flag(cmd: &Command) -> Option<&'static str> {
 
 fn try_help(styled: &mut StyledStr, help: Option<&str>) {
     if let Some(help) = help {
-        styled.none("\n\nFor more information try '");
+        styled.none("\n\nFor more information, try '");
         styled.literal(help.to_owned());
-        styled.none("'\n");
+        styled.none("'.\n");
     } else {
         styled.none("\n");
     }

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -36,7 +36,7 @@ impl ErrorFormatter for KindFormatter {
         } else if let Some(source) = error.inner.source.as_ref() {
             styled.none(source.to_string());
         } else {
-            styled.none("Unknown cause");
+            styled.none("unknown cause");
         }
         styled.none("\n");
         styled
@@ -60,7 +60,7 @@ impl ErrorFormatter for RichFormatter {
             } else if let Some(source) = error.inner.source.as_ref() {
                 styled.none(source.to_string());
             } else {
-                styled.none("Unknown cause");
+                styled.none("unknown cause");
             }
         }
 
@@ -129,11 +129,11 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                 (invalid_arg, prior_arg)
             {
                 if ContextValue::String(invalid_arg.clone()) == *prior_arg {
-                    styled.none("The argument '");
+                    styled.none("the argument '");
                     styled.warning(invalid_arg);
                     styled.none("' was provided more than once, but cannot be used multiple times");
                 } else {
-                    styled.none("The argument '");
+                    styled.none("the argument '");
                     styled.warning(invalid_arg);
                     styled.none("' cannot be used with");
 
@@ -164,7 +164,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
         ErrorKind::NoEquals => {
             let invalid_arg = error.get(ContextKind::InvalidArg);
             if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
-                styled.none("Equal sign is needed when assigning values to '");
+                styled.none("equal sign is needed when assigning values to '");
                 styled.warning(invalid_arg);
                 styled.none("'");
                 true
@@ -181,7 +181,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, invalid_value)
             {
                 if invalid_value.is_empty() {
-                    styled.none("The argument '");
+                    styled.none("the argument '");
                     styled.warning(invalid_arg);
                     styled.none("' requires a value but none was supplied");
                 } else {
@@ -216,7 +216,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
         ErrorKind::InvalidSubcommand => {
             let invalid_sub = error.get(ContextKind::InvalidSubcommand);
             if let Some(ContextValue::String(invalid_sub)) = invalid_sub {
-                styled.none("The subcommand '");
+                styled.none("the subcommand '");
                 styled.warning(invalid_sub);
                 styled.none("' wasn't recognized");
                 true
@@ -227,7 +227,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
         ErrorKind::MissingRequiredArgument => {
             let invalid_arg = error.get(ContextKind::InvalidArg);
             if let Some(ContextValue::Strings(invalid_arg)) = invalid_arg {
-                styled.none("The following required arguments were not provided:");
+                styled.none("the following required arguments were not provided:");
                 for v in invalid_arg {
                     styled.none("\n");
                     styled.none(TAB);
@@ -276,7 +276,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                 Some(ContextValue::String(invalid_value)),
             ) = (invalid_arg, invalid_value)
             {
-                styled.none("The value '");
+                styled.none("the value '");
                 styled.warning(invalid_value);
                 styled.none("' was provided to '");
                 styled.warning(invalid_arg);
@@ -297,7 +297,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, actual_num_values, min_values)
             {
                 let were_provided = singular_or_plural(*actual_num_values as usize);
-                styled.none("The argument '");
+                styled.none("the argument '");
                 styled.warning(invalid_arg);
                 styled.none("' requires at least ");
                 styled.warning(min_values.to_string());
@@ -317,7 +317,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                 Some(ContextValue::String(invalid_value)),
             ) = (invalid_arg, invalid_value)
             {
-                styled.none("Invalid value '");
+                styled.none("invalid value '");
                 styled.warning(invalid_value);
                 styled.none("' for '");
                 styled.warning(invalid_arg);
@@ -343,7 +343,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, actual_num_values, num_values)
             {
                 let were_provided = singular_or_plural(*actual_num_values as usize);
-                styled.none("The argument '");
+                styled.none("the argument '");
                 styled.warning(invalid_arg);
                 styled.none("' requires ");
                 styled.warning(num_values.to_string());
@@ -358,7 +358,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
         ErrorKind::UnknownArgument => {
             let invalid_arg = error.get(ContextKind::InvalidArg);
             if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
-                styled.none("Found argument '");
+                styled.none("found argument '");
                 styled.warning(invalid_arg.to_string());
                 styled.none("' which wasn't expected, or isn't valid in this context");
                 true

--- a/src/error/kind.rs
+++ b/src/error/kind.rs
@@ -82,7 +82,7 @@ pub enum ErrorKind {
     /// fn is_numeric(val: &str) -> Result<(), String> {
     ///     match val.parse::<i64>() {
     ///         Ok(..) => Ok(()),
-    ///         Err(..) => Err(String::from("Value wasn't a number!")),
+    ///         Err(..) => Err(String::from("value wasn't a number!")),
     ///     }
     /// }
     ///
@@ -316,24 +316,24 @@ impl ErrorKind {
     /// End-user description of the error case, where relevant
     pub fn as_str(self) -> Option<&'static str> {
         match self {
-            Self::InvalidValue => Some("One of the values isn't valid for an argument"),
+            Self::InvalidValue => Some("one of the values isn't valid for an argument"),
             Self::UnknownArgument => {
-                Some("Found an argument which wasn't expected or isn't valid in this context")
+                Some("found an argument which wasn't expected or isn't valid in this context")
             }
-            Self::InvalidSubcommand => Some("A subcommand wasn't recognized"),
-            Self::NoEquals => Some("Equal is needed when assigning values to one of the arguments"),
-            Self::ValueValidation => Some("Invalid value for one of the arguments"),
-            Self::TooManyValues => Some("An argument received an unexpected value"),
-            Self::TooFewValues => Some("An argument requires more values"),
-            Self::WrongNumberOfValues => Some("An argument received too many or too few values"),
+            Self::InvalidSubcommand => Some("a subcommand wasn't recognized"),
+            Self::NoEquals => Some("equal is needed when assigning values to one of the arguments"),
+            Self::ValueValidation => Some("invalid value for one of the arguments"),
+            Self::TooManyValues => Some("an argument received an unexpected value"),
+            Self::TooFewValues => Some("an argument requires more values"),
+            Self::WrongNumberOfValues => Some("an argument received too many or too few values"),
             Self::ArgumentConflict => {
-                Some("An argument cannot be used with one or more of the other specified arguments")
+                Some("an argument cannot be used with one or more of the other specified arguments")
             }
             Self::MissingRequiredArgument => {
-                Some("One or more required arguments were not provided")
+                Some("one or more required arguments were not provided")
             }
-            Self::MissingSubcommand => Some("A subcommand is required but one was not provided"),
-            Self::InvalidUtf8 => Some("Invalid UTF-8 was detected in one or more arguments"),
+            Self::MissingSubcommand => Some("a subcommand is required but one was not provided"),
+            Self::InvalidUtf8 => Some("invalid UTF-8 was detected in one or more arguments"),
             Self::DisplayHelp => None,
             Self::DisplayHelpOnMissingArgumentOrSubcommand => None,
             Self::DisplayVersion => None,

--- a/src/util/color.rs
+++ b/src/util/color.rs
@@ -82,7 +82,7 @@ impl std::str::FromStr for ColorChoice {
                 return Ok(*variant);
             }
         }
-        Err(format!("Invalid variant: {}", s))
+        Err(format!("invalid variant: {}", s))
     }
 }
 

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -67,7 +67,7 @@ error: 'sc_required' requires a subcommand but one was not provided
 
 Usage: sc_required <COMMAND>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("sc_required")

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -325,7 +325,7 @@ error: the argument '--flag...' cannot be used with '-F'
 
 Usage: clap-test --flag... --long-option-2 <option2> <positional> <positional2> [positional3]...
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -344,7 +344,7 @@ error: the argument '-F' cannot be used with '--flag...'
 
 Usage: clap-test -F --long-option-2 <option2> <positional> <positional2> [positional3]...
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -363,7 +363,7 @@ error: the argument '-F' was provided more than once, but cannot be used multipl
 
 Usage: clap-test [OPTIONS] [positional] [positional2] [positional3]... [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(utils::complex_app(), "clap-test -F -F", ERR, true);
@@ -377,7 +377,7 @@ error: the argument '--flag...' cannot be used with '-F'
 
 Usage: clap-test --flag... --long-option-2 <option2> <positional> <positional2> [positional3]...
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -396,7 +396,7 @@ error: the argument '-F' cannot be used with '--flag...'
 
 Usage: clap-test -F --long-option-2 <option2> <positional> <positional2> [positional3]...
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -417,7 +417,7 @@ error: the argument '--one' cannot be used with:
 
 Usage: three_conflicting_arguments --one
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("three_conflicting_arguments")
@@ -739,7 +739,7 @@ error: found argument 'sub1' which wasn't expected, or isn't valid in this conte
 Usage: test [OPTIONS]
        test <COMMAND>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("test")

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -321,7 +321,7 @@ fn get_arg_conflicts_with_group() {
 #[cfg(feature = "error-context")]
 fn conflict_output() {
     static CONFLICT_ERR: &str = "\
-error: The argument '--flag...' cannot be used with '-F'
+error: the argument '--flag...' cannot be used with '-F'
 
 Usage: clap-test --flag... --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -340,7 +340,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn conflict_output_rev() {
     static CONFLICT_ERR_REV: &str = "\
-error: The argument '-F' cannot be used with '--flag...'
+error: the argument '-F' cannot be used with '--flag...'
 
 Usage: clap-test -F --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -359,7 +359,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn conflict_output_repeat() {
     static ERR: &str = "\
-error: The argument '-F' was provided more than once, but cannot be used multiple times
+error: the argument '-F' was provided more than once, but cannot be used multiple times
 
 Usage: clap-test [OPTIONS] [positional] [positional2] [positional3]... [COMMAND]
 
@@ -373,7 +373,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn conflict_output_with_required() {
     static CONFLICT_ERR: &str = "\
-error: The argument '--flag...' cannot be used with '-F'
+error: the argument '--flag...' cannot be used with '-F'
 
 Usage: clap-test --flag... --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -392,7 +392,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn conflict_output_rev_with_required() {
     static CONFLICT_ERR_REV: &str = "\
-error: The argument '-F' cannot be used with '--flag...'
+error: the argument '-F' cannot be used with '--flag...'
 
 Usage: clap-test -F --long-option-2 <option2> <positional> <positional2> [positional3]...
 
@@ -411,7 +411,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn conflict_output_three_conflicting() {
     static CONFLICT_ERR_THREE: &str = "\
-error: The argument '--one' cannot be used with:
+error: the argument '--one' cannot be used with:
   --two
   --three
 
@@ -469,7 +469,7 @@ fn two_conflicting_arguments() {
     let a = a.unwrap_err();
     assert!(
         a.to_string()
-            .contains("The argument \'--develop\' cannot be used with \'--production\'"),
+            .contains("the argument \'--develop\' cannot be used with \'--production\'"),
         "{}",
         a
     );
@@ -503,7 +503,7 @@ fn three_conflicting_arguments() {
     let a = a.unwrap_err();
     assert!(
         a.to_string()
-            .contains("The argument \'--one\' cannot be used with:"),
+            .contains("the argument \'--one\' cannot be used with:"),
         "{}",
         a
     );
@@ -734,7 +734,7 @@ fn args_negate_subcommands_two_levels() {
 #[cfg(feature = "error-context")]
 fn subcommand_conflict_error_message() {
     static CONFLICT_ERR: &str = "\
-error: Found argument 'sub1' which wasn't expected, or isn't valid in this context
+error: found argument 'sub1' which wasn't expected, or isn't valid in this context
 
 Usage: test [OPTIONS]
        test <COMMAND>

--- a/tests/builder/default_missing_vals.rs
+++ b/tests/builder/default_missing_vals.rs
@@ -277,7 +277,7 @@ fn default_missing_values_are_possible_values() {
 #[cfg(debug_assertions)]
 #[test]
 #[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_missing_value=\"value\" failed validation: error: Invalid value 'value' for '[arg]"]
+#[should_panic = "Argument `arg`'s default_missing_value=\"value\" failed validation: error: invalid value 'value' for '[arg]"]
 fn default_missing_values_are_valid() {
     use clap::{Arg, Command};
 

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -735,7 +735,7 @@ error: the following required arguments were not provided:
 
 Usage: bug <input>
 
-For more information try '--help'
+For more information, try '--help'.
 ",
         true,
     );

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -52,7 +52,7 @@ fn opt_without_value_fail() {
     assert_eq!(err.kind(), ErrorKind::InvalidValue);
     assert!(err
         .to_string()
-        .contains("The argument '-o <opt>' requires a value but none was supplied"));
+        .contains("the argument '-o <opt>' requires a value but none was supplied"));
 }
 
 #[test]
@@ -730,7 +730,7 @@ fn default_vals_donnot_show_in_smart_usage() {
         cmd,
         "bug",
         "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <input>
 
 Usage: bug <input>
@@ -812,7 +812,7 @@ fn default_values_are_possible_values() {
 #[cfg(debug_assertions)]
 #[test]
 #[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_value=\"one\" failed validation: error: Invalid value 'one' for '[arg]"]
+#[should_panic = "Argument `arg`'s default_value=\"one\" failed validation: error: invalid value 'one' for '[arg]"]
 fn invalid_default_values() {
     use clap::{Arg, Command};
 
@@ -842,7 +842,7 @@ fn valid_delimited_default_values() {
 #[cfg(debug_assertions)]
 #[test]
 #[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_value=\"one\" failed validation: error: Invalid value 'one' for '[arg]"]
+#[should_panic = "Argument `arg`'s default_value=\"one\" failed validation: error: invalid value 'one' for '[arg]"]
 fn invalid_delimited_default_values() {
     use clap::{Arg, Command};
 

--- a/tests/builder/double_require.rs
+++ b/tests/builder/double_require.rs
@@ -64,7 +64,7 @@ error: the following required arguments were not provided:
 
 Usage: prog -b -c
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let res = cmd().try_get_matches_from(vec!["", "-b"]);
@@ -79,7 +79,7 @@ error: the following required arguments were not provided:
 
 Usage: prog -c -b
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let res = cmd().try_get_matches_from(vec!["", "-c"]);

--- a/tests/builder/double_require.rs
+++ b/tests/builder/double_require.rs
@@ -59,7 +59,7 @@ fn help_text() {
 #[cfg(feature = "error-context")]
 fn no_duplicate_error() {
     static ONLY_B_ERROR: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   -c
 
 Usage: prog -b -c
@@ -74,7 +74,7 @@ For more information try '--help'
     assert_eq!(err.to_string(), ONLY_B_ERROR);
 
     static ONLY_C_ERROR: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   -b
 
 Usage: prog -c -b

--- a/tests/builder/empty_values.rs
+++ b/tests/builder/empty_values.rs
@@ -122,7 +122,7 @@ fn no_empty_values_without_equals_but_requires_equals() {
 
 Usage: config [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(cmd, "config --config", NO_EUQALS_ERROR, true);

--- a/tests/builder/empty_values.rs
+++ b/tests/builder/empty_values.rs
@@ -118,7 +118,7 @@ fn no_empty_values_without_equals_but_requires_equals() {
     assert_eq!(m.unwrap_err().kind(), ErrorKind::NoEquals);
 
     static NO_EUQALS_ERROR: &str =
-        "error: Equal sign is needed when assigning values to '--config=<config>'
+        "error: equal sign is needed when assigning values to '--config=<config>'
 
 Usage: config [OPTIONS]
 

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -27,7 +27,7 @@ fn app_error() {
 
 Usage: test [OPTIONS] --all
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     let cmd = Command::new("test")
         .arg(
@@ -124,7 +124,7 @@ error: found argument 'unused' which wasn't expected, or isn't valid in this con
 
 Usage: test
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     assert_error(err, expected_kind, MESSAGE, true);
 }
@@ -145,7 +145,7 @@ error: found argument '--foo' which wasn't expected, or isn't valid in this cont
 
 Usage: rg [PATTERN]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     assert_error(err, expected_kind, MESSAGE, true);
 }
@@ -164,7 +164,7 @@ error: found argument '--foo' which wasn't expected, or isn't valid in this cont
 
 Usage: rg [PATTERN]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     assert_error(err, expected_kind, MESSAGE, true);
 }
@@ -183,7 +183,7 @@ error: found argument '--foo' which wasn't expected, or isn't valid in this cont
 
 Usage: test
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     assert_error(err, expected_kind, MESSAGE, true);
 }

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -23,7 +23,7 @@ fn assert_error<F: clap::error::ErrorFormatter>(
 
 #[test]
 fn app_error() {
-    static MESSAGE: &str = "error: Failed for mysterious reasons
+    static MESSAGE: &str = "error: failed for mysterious reasons
 
 Usage: test [OPTIONS] --all
 
@@ -55,7 +55,7 @@ For more information try '--help'
         );
     let mut cmd = cmd;
     let expected_kind = ErrorKind::InvalidValue;
-    let err = cmd.error(expected_kind, "Failed for mysterious reasons");
+    let err = cmd.error(expected_kind, "failed for mysterious reasons");
     assert_error(err, expected_kind, MESSAGE, true);
 }
 
@@ -106,7 +106,7 @@ fn kind_formats_validation_error() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: Found an argument which wasn't expected or isn't valid in this context
+error: found an argument which wasn't expected or isn't valid in this context
 ";
     assert_error(err, expected_kind, MESSAGE, true);
 }
@@ -120,7 +120,7 @@ fn rich_formats_validation_error() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: Found argument 'unused' which wasn't expected, or isn't valid in this context
+error: found argument 'unused' which wasn't expected, or isn't valid in this context
 
 Usage: test
 
@@ -139,7 +139,7 @@ fn suggest_trailing() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: Found argument '--foo' which wasn't expected, or isn't valid in this context
+error: found argument '--foo' which wasn't expected, or isn't valid in this context
 
   note: to pass '--foo' as a value, use '-- --foo'
 
@@ -160,7 +160,7 @@ fn trailing_already_in_use() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: Found argument '--foo' which wasn't expected, or isn't valid in this context
+error: found argument '--foo' which wasn't expected, or isn't valid in this context
 
 Usage: rg [PATTERN]
 
@@ -179,7 +179,7 @@ fn cant_use_trailing() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: Found argument '--foo' which wasn't expected, or isn't valid in this context
+error: found argument '--foo' which wasn't expected, or isn't valid in this context
 
 Usage: test
 

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -140,7 +140,7 @@ fn multiple_flags_in_single() {
 #[cfg(feature = "error-context")]
 fn unexpected_value_error() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
-error: The value 'foo' was provided to '--a-flag' but it wasn't expecting any more values
+error: the value 'foo' was provided to '--a-flag' but it wasn't expecting any more values
 
 Usage: mycat --a-flag [filename]
 
@@ -158,7 +158,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn issue_1284_argument_in_flag_style() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
-error: Found argument '--another-flag' which wasn't expected, or isn't valid in this context
+error: found argument '--another-flag' which wasn't expected, or isn't valid in this context
 
   note: to pass '--another-flag' as a value, use '-- --another-flag'
 
@@ -202,7 +202,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn issue_2308_multiple_dashes() {
     static MULTIPLE_DASHES: &str = "\
-error: Found argument '-----' which wasn't expected, or isn't valid in this context
+error: found argument '-----' which wasn't expected, or isn't valid in this context
 
   note: to pass '-----' as a value, use '-- -----'
 

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -144,7 +144,7 @@ error: the value 'foo' was provided to '--a-flag' but it wasn't expecting any mo
 
 Usage: mycat --a-flag [filename]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("mycat")
@@ -164,7 +164,7 @@ error: found argument '--another-flag' which wasn't expected, or isn't valid in 
 
 Usage: mycat [OPTIONS] [filename]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("mycat")
@@ -208,7 +208,7 @@ error: found argument '-----' which wasn't expected, or isn't valid in this cont
 
 Usage: test <arg>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     let cmd = Command::new("test").arg(Arg::new("arg").action(ArgAction::Set).required(true));
 

--- a/tests/builder/groups.rs
+++ b/tests/builder/groups.rs
@@ -131,7 +131,7 @@ fn empty_group() {
 #[test]
 #[cfg(feature = "error-context")]
 fn req_group_usage_string() {
-    static REQ_GROUP_USAGE: &str = "error: The following required arguments were not provided:
+    static REQ_GROUP_USAGE: &str = "error: the following required arguments were not provided:
   <base|--delete>
 
 Usage: clap-test <base|--delete>
@@ -157,7 +157,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn req_group_with_conflict_usage_string() {
     static REQ_GROUP_CONFLICT_USAGE: &str = "\
-error: The argument '--delete' cannot be used with '[base]'
+error: the argument '--delete' cannot be used with '[base]'
 
 Usage: clap-test <base|--delete>
 
@@ -187,7 +187,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn req_group_with_conflict_usage_string_only_options() {
     static REQ_GROUP_CONFLICT_ONLY_OPTIONS: &str = "\
-error: The argument '--delete' cannot be used with '--all'
+error: the argument '--delete' cannot be used with '--all'
 
 Usage: clap-test <--all|--delete>
 
@@ -305,7 +305,7 @@ fn group_acts_like_arg() {
 #[test]
 fn conflict_with_overlapping_group_in_error() {
     static ERR: &str = "\
-error: The argument '--major' cannot be used with '--minor'
+error: the argument '--major' cannot be used with '--minor'
 
 Usage: prog --major
 
@@ -324,7 +324,7 @@ For more information try '--help'
 #[test]
 fn requires_group_with_overlapping_group_in_error() {
     static ERR: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <--in|--spec>
 
 Usage: prog --config <--in|--spec>

--- a/tests/builder/groups.rs
+++ b/tests/builder/groups.rs
@@ -136,7 +136,7 @@ fn req_group_usage_string() {
 
 Usage: clap-test <base|--delete>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("req_group")
@@ -161,7 +161,7 @@ error: the argument '--delete' cannot be used with '[base]'
 
 Usage: clap-test <base|--delete>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("req_group")
@@ -191,7 +191,7 @@ error: the argument '--delete' cannot be used with '--all'
 
 Usage: clap-test <--all|--delete>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("req_group")
@@ -309,7 +309,7 @@ error: the argument '--major' cannot be used with '--minor'
 
 Usage: prog --major
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("prog")
@@ -329,7 +329,7 @@ error: the following required arguments were not provided:
 
 Usage: prog --config <--in|--spec>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("prog")

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -83,7 +83,7 @@ fn help_multi_subcommand_error() {
 
 Usage: ctest subcmd multi [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     utils::assert_eq(EXPECTED, err.to_string());
 }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -79,7 +79,7 @@ fn help_multi_subcommand_error() {
         .try_get_matches_from(["ctest", "help", "subcmd", "multi", "foo"])
         .unwrap_err();
 
-    static EXPECTED: &str = "error: The subcommand 'foo' wasn't recognized
+    static EXPECTED: &str = "error: the subcommand 'foo' wasn't recognized
 
 Usage: ctest subcmd multi [OPTIONS]
 

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -21,7 +21,7 @@ fn require_equals_fail() {
 #[test]
 #[cfg(feature = "error-context")]
 fn require_equals_fail_message() {
-    static NO_EQUALS: &str = "error: Equal sign is needed when assigning values to '--config=<cfg>'
+    static NO_EQUALS: &str = "error: equal sign is needed when assigning values to '--config=<cfg>'
 
 Usage: prog [OPTIONS]
 
@@ -446,7 +446,7 @@ fn leading_hyphen_with_only_pos_follows() {
 #[cfg(feature = "error-context")]
 fn did_you_mean() {
     static DYM: &str = "\
-error: Found argument '--optio' which wasn't expected, or isn't valid in this context
+error: found argument '--optio' which wasn't expected, or isn't valid in this context
 
   note: argument '--option' exists
 
@@ -544,7 +544,7 @@ fn issue_1105_empty_value_short_explicit_no_space() {
 #[cfg(feature = "error-context")]
 fn issue_1073_suboptimal_flag_suggestion() {
     static DYM_ISSUE_1073: &str = "\
-error: Found argument '--files-without-matches' which wasn't expected, or isn't valid in this context
+error: found argument '--files-without-matches' which wasn't expected, or isn't valid in this context
 
   note: argument '--files-without-match' exists
 

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -25,7 +25,7 @@ fn require_equals_fail_message() {
 
 Usage: prog [OPTIONS]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     let cmd = Command::new("prog").arg(
         Arg::new("cfg")
@@ -452,7 +452,7 @@ error: found argument '--optio' which wasn't expected, or isn't valid in this co
 
 Usage: clap-test --option <opt>... [positional] [positional2] [positional3]...
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(utils::complex_app(), "clap-test --optio=foo", DYM, true);
@@ -550,7 +550,7 @@ error: found argument '--files-without-matches' which wasn't expected, or isn't 
 
 Usage: ripgrep-616 --files-without-match
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("ripgrep-616")

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -183,7 +183,7 @@ error: 'slo' isn't a valid value for '-O <option>'
 
   note: value 'slow' exists
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     #[cfg(not(feature = "suggestions"))]
@@ -191,7 +191,7 @@ For more information try '--help'
 error: 'slo' isn't a valid value for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -217,7 +217,7 @@ error: 'slo' isn't a valid value for '-O <option>'
 
   note: value 'slow' exists
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     #[cfg(not(feature = "suggestions"))]
@@ -225,7 +225,7 @@ For more information try '--help'
 error: 'slo' isn't a valid value for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -255,7 +255,7 @@ error: 'slo' isn't a valid value for '-O <option>'
 
   note: value 'slow' exists
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     #[cfg(not(feature = "suggestions"))]
@@ -263,7 +263,7 @@ For more information try '--help'
 error: 'slo' isn't a valid value for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -294,7 +294,7 @@ error: 'ludicrous' isn't a valid value for '-O <option>'
 
   note: value 'ludicrous speed' exists
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     #[cfg(not(feature = "suggestions"))]
@@ -302,7 +302,7 @@ For more information try '--help'
 error: 'ludicrous' isn't a valid value for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(
@@ -325,7 +325,7 @@ fn missing_possible_value_error() {
 error: the argument '-O <option>' requires a value but none was supplied
   [possible values: slow, fast, \"ludicrous speed\"]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -322,7 +322,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn missing_possible_value_error() {
     static MISSING_PV_ERROR: &str = "\
-error: The argument '-O <option>' requires a value but none was supplied
+error: the argument '-O <option>' requires a value but none was supplied
   [possible values: slow, fast, \"ludicrous speed\"]
 
 For more information try '--help'

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -90,7 +90,7 @@ error: the following required arguments were not provided:
 
 Usage: clap-test <flag> <opt> [bar]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("positional_required")
@@ -110,7 +110,7 @@ error: the following required arguments were not provided:
 
 Usage: clap-test <flag> [opt] [bar]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("positional_required")
@@ -131,7 +131,7 @@ error: the following required arguments were not provided:
 
 Usage: clap-test <flag> <foo> <opt> [bar]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("positional_required")
@@ -520,7 +520,7 @@ error: the following required arguments were not provided:
 
 Usage: clap-test --long-option-2 <option2> -F <positional> <positional2> [positional3]...
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     utils::assert_output(utils::complex_app(), "clap-test -F", MISSING_REQ, true);
@@ -763,7 +763,7 @@ error: the following required arguments were not provided:
 
 Usage: test --target <target> --input <input> --output <output>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("Test cmd")
@@ -807,7 +807,7 @@ error: the following required arguments were not provided:
 
 Usage: test --target <target> --input <input> --output <output>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("Test cmd")
@@ -932,7 +932,7 @@ error: the following required arguments were not provided:
 
 Usage: clap-test --opt=<FILE>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("clap-test").version("v1.4.8").arg(
@@ -956,7 +956,7 @@ error: the following required arguments were not provided:
 
 Usage: clap-test --opt=<FILE> --foo=<FILE>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("clap-test")
@@ -991,7 +991,7 @@ error: the following required arguments were not provided:
 
 Usage: clap-test --opt=<FILE> --foo=<FILE> <--g1=<FILE>|--g2=<FILE>>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("clap-test")
@@ -1071,7 +1071,7 @@ error: the following required arguments were not provided:
 
 Usage: test --c <c> --a <a> --b <b>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     let cmd = Command::new("test")
         .arg(
@@ -1116,7 +1116,7 @@ error: the following required arguments were not provided:
 
 Usage: example -x <X> -y <Y> -z <Z> <ID>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = issue_1158_app();
@@ -1451,7 +1451,7 @@ error: the argument '-b <b>' cannot be used with '-c <c>'
 
 Usage: clap-test -b <b> <a>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     utils::assert_output(cmd, "clap-test aaa -b bbb -c ccc", EXPECTED, true);
 }
@@ -1474,7 +1474,7 @@ error: the following required arguments were not provided:
 
 Usage: test --require-first <--first|--second>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     utils::assert_output(cmd, "test --require-first --second", EXPECTED, true);
 }

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -84,7 +84,7 @@ fn positional_required_2() {
 #[cfg(feature = "error-context")]
 fn positional_required_with_requires() {
     static POSITIONAL_REQ: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <flag>
   <opt>
 
@@ -105,7 +105,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn positional_required_with_requires_if_no_value() {
     static POSITIONAL_REQ_IF_NO_VAL: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <flag>
 
 Usage: clap-test <flag> [opt] [bar]
@@ -125,7 +125,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn positional_required_with_requires_if_value() {
     static POSITIONAL_REQ_IF_VAL: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <foo>
   <opt>
 
@@ -513,7 +513,7 @@ fn required_unless_any_err() {
 #[cfg(feature = "error-context")]
 fn missing_required_output() {
     static MISSING_REQ: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --long-option-2 <option2>
   <positional>
   <positional2>
@@ -758,7 +758,7 @@ fn required_if_any_all_values_present_fail() {
 #[cfg(feature = "error-context")]
 fn list_correct_required_args() {
     static COND_REQ_IN_USAGE: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --output <output>
 
 Usage: test --target <target> --input <input> --output <output>
@@ -802,7 +802,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn required_if_val_present_fail_error_output() {
     static COND_REQ_IN_USAGE: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --output <output>
 
 Usage: test --target <target> --input <input> --output <output>
@@ -927,7 +927,7 @@ fn required_ifs_wrong_val_mult_fail() {
 #[cfg(feature = "error-context")]
 fn require_eq() {
     static REQUIRE_EQUALS: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --opt=<FILE>
 
 Usage: clap-test --opt=<FILE>
@@ -951,7 +951,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn require_eq_filtered() {
     static REQUIRE_EQUALS_FILTERED: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --opt=<FILE>
 
 Usage: clap-test --opt=<FILE> --foo=<FILE>
@@ -986,7 +986,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn require_eq_filtered_group() {
     static REQUIRE_EQUALS_FILTERED_GROUP: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --opt=<FILE>
 
 Usage: clap-test --opt=<FILE> --foo=<FILE> <--g1=<FILE>|--g2=<FILE>>
@@ -1065,7 +1065,7 @@ fn issue_1158_app() -> Command {
 #[cfg(feature = "error-context")]
 fn multiple_required_unless_usage_printing() {
     static MULTIPLE_REQUIRED_UNLESS_USAGE: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --a <a>
   --b <b>
 
@@ -1109,7 +1109,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn issue_1158_conflicting_requirements() {
     static ISSUE_1158: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   -x <X>
   -y <Y>
   -z <Z>
@@ -1447,7 +1447,7 @@ fn required_error_doesnt_duplicate() {
                 .conflicts_with("b"),
         );
     const EXPECTED: &str = "\
-error: The argument '-b <b>' cannot be used with '-c <c>'
+error: the argument '-b <b>' cannot be used with '-c <c>'
 
 Usage: clap-test -b <b> <a>
 
@@ -1469,7 +1469,7 @@ fn required_require_with_group_shows_flag() {
                 .required(true),
         );
     const EXPECTED: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   --first
 
 Usage: test --require-first <--first|--second>

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -105,7 +105,7 @@ error: the subcommand 'subcm' wasn't recognized
 
 Usage: dym [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("dym").subcommand(Command::new("subcmd"));
@@ -125,7 +125,7 @@ error: the subcommand 'te' wasn't recognized
 
 Usage: dym [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("dym")
@@ -145,7 +145,7 @@ error: found argument '--subcmarg' which wasn't expected, or isn't valid in this
 
 Usage: dym [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("dym")
@@ -163,7 +163,7 @@ error: found argument '--subcmarg' which wasn't expected, or isn't valid in this
 
 Usage: dym [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("dym")
@@ -357,7 +357,7 @@ error: found argument 'subcmd' which wasn't expected, or isn't valid in this con
 
 Usage: cmd [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 ";
 
     let cmd = Command::new("cmd").subcommand(Command::new("subcmd"));
@@ -432,7 +432,7 @@ fn subcommand_not_recognized() {
 
 Usage: fake [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 ",
         true,
     );
@@ -506,7 +506,7 @@ error: the subcommand 'world' wasn't recognized
 
 Usage: <COMMAND>
 
-For more information try 'help'
+For more information, try 'help'.
 ";
     utils::assert_eq(HELLO_EXPECTED, err.to_string());
 
@@ -522,7 +522,7 @@ error: the subcommand 'baz' wasn't recognized
 
 Usage: <COMMAND>
 
-For more information try 'help'
+For more information, try 'help'.
 ";
         utils::assert_eq(BAZ_EXPECTED, err.to_string());
     }

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -98,7 +98,7 @@ fn multiple_aliases() {
 fn subcmd_did_you_mean_output() {
     #[cfg(feature = "suggestions")]
     static DYM_SUBCMD: &str = "\
-error: The subcommand 'subcm' wasn't recognized
+error: the subcommand 'subcm' wasn't recognized
 
   note: subcommand 'subcmd' exists
   note: to pass 'subcm' as a value, use 'dym -- subcm'
@@ -118,7 +118,7 @@ For more information try '--help'
 fn subcmd_did_you_mean_output_ambiguous() {
     #[cfg(feature = "suggestions")]
     static DYM_SUBCMD_AMBIGUOUS: &str = "\
-error: The subcommand 'te' wasn't recognized
+error: the subcommand 'te' wasn't recognized
 
   note: subcommand 'test', 'temp' exist
   note: to pass 'te' as a value, use 'dym -- te'
@@ -139,7 +139,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn subcmd_did_you_mean_output_arg() {
     static EXPECTED: &str = "\
-error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
+error: found argument '--subcmarg' which wasn't expected, or isn't valid in this context
 
   note: 'subcmd --subcmdarg' exists
 
@@ -159,7 +159,7 @@ For more information try '--help'
 #[cfg(feature = "error-context")]
 fn subcmd_did_you_mean_output_arg_false_positives() {
     static EXPECTED: &str = "\
-error: Found argument '--subcmarg' which wasn't expected, or isn't valid in this context
+error: found argument '--subcmarg' which wasn't expected, or isn't valid in this context
 
 Usage: dym [COMMAND]
 
@@ -351,7 +351,7 @@ fn subcommand_placeholder_test() {
 #[cfg(feature = "error-context")]
 fn subcommand_used_after_double_dash() {
     static SUBCMD_AFTER_DOUBLE_DASH: &str = "\
-error: Found argument 'subcmd' which wasn't expected, or isn't valid in this context
+error: found argument 'subcmd' which wasn't expected, or isn't valid in this context
 
   note: subcommand 'subcmd' exists; to use it, remove the '--' before it
 
@@ -428,7 +428,7 @@ fn subcommand_not_recognized() {
     utils::assert_output(
         cmd,
         "fake help",
-        "error: The subcommand 'help' wasn't recognized
+        "error: the subcommand 'help' wasn't recognized
 
 Usage: fake [COMMAND]
 
@@ -502,7 +502,7 @@ fn bad_multicall_command_error() {
     let err = cmd.clone().try_get_matches_from(["world"]).unwrap_err();
     assert_eq!(err.kind(), ErrorKind::InvalidSubcommand);
     static HELLO_EXPECTED: &str = "\
-error: The subcommand 'world' wasn't recognized
+error: the subcommand 'world' wasn't recognized
 
 Usage: <COMMAND>
 
@@ -515,7 +515,7 @@ For more information try 'help'
         let err = cmd.clone().try_get_matches_from(["baz"]).unwrap_err();
         assert_eq!(err.kind(), ErrorKind::InvalidSubcommand);
         static BAZ_EXPECTED: &str = "\
-error: The subcommand 'baz' wasn't recognized
+error: the subcommand 'baz' wasn't recognized
 
   note: subcommand 'bar' exists
   note: to pass 'baz' as a value, use ' -- baz'

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -45,7 +45,7 @@ fn implicit_struct_group() {
     }
 
     const OUTPUT: &str = "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <CRATES|--path <PATH>|--git <GIT>>
 
 Usage: prog --add <CRATES|--path <PATH>|--git <GIT>>

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -50,7 +50,7 @@ error: the following required arguments were not provided:
 
 Usage: prog --add <CRATES|--path <PATH>|--git <GIT>>
 
-For more information try '--help'
+For more information, try '--help'.
 ";
     assert_output::<Opt>("prog --add", OUTPUT, true);
 

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -223,7 +223,7 @@ fn derive_generated_error_has_full_context() {
 Usage: clap --req-str <REQ_STR>
        clap <COMMAND>
 
-For more information try '--help'
+For more information, try '--help'.
 "#;
     assert_eq!(result.unwrap_err().to_string(), expected);
 }

--- a/tests/ui/error_stderr.toml
+++ b/tests/ui/error_stderr.toml
@@ -3,7 +3,7 @@ args = ["--unknown-argument"]
 status.code = 2
 stdout = ""
 stderr = """
-error: Found argument '--unknown-argument' which wasn't expected, or isn't valid in this context
+error: found argument '--unknown-argument' which wasn't expected, or isn't valid in this context
 
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 

--- a/tests/ui/error_stderr.toml
+++ b/tests/ui/error_stderr.toml
@@ -7,5 +7,5 @@ error: found argument '--unknown-argument' which wasn't expected, or isn't valid
 
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
-For more information try '--help'
+For more information, try '--help'.
 """


### PR DESCRIPTION
This is a follow up to #4385.

For example, rustc provides this error:
```
error[E0425]: cannot find value `arg1` in this scope
    --> src/builder/command.rs:4249:23
     |
4249 |                 arg = arg1.help("Print help");
     |                       ^^^^ help: a local variable with a similar name exists: `arg`

For more information about this error, try `rustc --explain E0425`.
error: could not compile `clap` due to previous error
```

So with both PRs, we went from
```
error: Found argument '--unknown' which wasn't expected, or isn't valid in this context

  If you tried to supply '--unknown' as a value rather than a flag, use '-- --unknown'

Usage: interop_hand_subcommand[EXE] add [NAME]...

For more information try '--help'
```
to
```
error: found argument '--unknown' which wasn't expected, or isn't valid in this context

  note: to pass '--unknown' as a value, use '-- --unknown'

Usage: interop_hand_subcommand[EXE] add [NAME]...

For more information, try '--help'.
```