### PR TITLE
add method to update env variables from custom source

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -488,7 +488,7 @@ impl Command {
     /// env::set_var("MYPROG_DATA_DIR", "/home/user/Work/clap");
     ///
     /// let env_vars = HashMap::from_iter(env::vars_os());
-    /// cmd.get_env_from(env_vars);
+    /// cmd.update_env_from(env_vars);
     /// 
     /// let m = cmd.get_matches_from(vec!["foo"]);
     /// assert_eq!("/home/user/Work/clap", m.get_one::<String>("data_dir").unwrap());

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -1,14 +1,14 @@
 #![cfg_attr(not(feature = "usage"), allow(unused_mut))]
 
 // Std
+#[cfg(feature = "env")]
+use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
 use std::fmt;
 use std::io;
 use std::ops::Index;
 use std::path::Path;
-#[cfg(feature = "env")]
-use std::collections::HashMap;
 
 // Internal
 use crate::builder::app_settings::{AppFlags, AppSettings};
@@ -495,7 +495,7 @@ impl Command {
     /// ```
     #[cfg(feature = "env")]
     pub fn update_env_from(&mut self, env_vars: HashMap<OsString, OsString>) {
-        for arg in self.args.args_mut().into_iter() {
+        for arg in self.args.args_mut() {
             if let Some((ref env_flag, ref mut maybe_env_value)) = arg.env {
                 if let Some(val) = env_vars.get::<OsString>(&env_flag.to_os_string()) {
                     maybe_env_value.replace(val.to_owned());

--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -472,14 +472,14 @@ impl Command {
     }
 
     /// Updates utilized environment values from custom source.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```rust
     /// # use std::env;
     /// # use std::collections::HashMap;
     /// # use clap::{Command, Arg};
-    /// 
+    ///
     /// let mut cmd = Command::new("myprog")
     ///     .arg(Arg::new("data_dir")
     ///         .long("data_dir")
@@ -489,7 +489,7 @@ impl Command {
     ///
     /// let env_vars = HashMap::from_iter(env::vars_os());
     /// cmd.update_env_from(env_vars);
-    /// 
+    ///
     /// let m = cmd.get_matches_from(vec!["foo"]);
     /// assert_eq!("/home/user/Work/clap", m.get_one::<String>("data_dir").unwrap());
     /// ```


### PR DESCRIPTION
See https://github.com/clap-rs/clap/issues/4607

# tldr

Adds a method that allows parsing environment variables from a custom source.

# Detailed description

When building Rust application that need to run without full access to `std::env`, e.g. when building an application that is supposed to run as a WebAssembly module as well as a standalone application, it becomes necessary to parse arguments from a custom source, such as `cli_args` iterator.

Currently, it is possible to pass in cli-args from a custom source but not environment variables, which means the WebAssembly module requires additional logic to parse arguments from environment variables. By having an `update_env_from` function, the standalone client and the WebAssembly module can share the same CLI code.

Example:
```rust
use std::env;
use std::collections::HashMap;
use clap::{Command, Arg};

let mut cmd = Command::new("myprog")
    .arg(Arg::new("data_dir")
        .long("data_dir")
        .env("MYPROG_DATA_DIR"));

env::set_var("MYPROG_DATA_DIR", "/home/user/Work/clap");

let env_vars = HashMap::from_iter(env::vars_os());
cmd.get_env_from(env_vars);

let m = cmd.get_matches_from(vec!["foo"]);
assert_eq!("/home/user/Work/clap", m.get_one::<String>("data_dir").unwrap());
 ```