### PR TITLE
Num args

### DIFF
--- a/examples/tutorial_builder/03_03_positional_mult.rs
+++ b/examples/tutorial_builder/03_03_positional_mult.rs
@@ -2,8 +2,7 @@ use clap::{command, Arg, ArgAction};
 
 fn main() {
     let matches = command!() // requires `cargo` feature
-        .arg(Arg::new("name").num_args(1..)
-        .action(ArgAction::Append))
+        .arg(Arg::new("name").num_args(1..).action(ArgAction::Append))
         .get_matches();
 
     let args = matches

--- a/examples/tutorial_builder/03_03_positional_mult.rs
+++ b/examples/tutorial_builder/03_03_positional_mult.rs
@@ -2,7 +2,8 @@ use clap::{command, Arg, ArgAction};
 
 fn main() {
     let matches = command!() // requires `cargo` feature
-        .arg(Arg::new("name").action(ArgAction::Append))
+        .arg(Arg::new("name").num_args(1..)
+        .action(ArgAction::Append))
         .get_matches();
 
     let args = matches

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -406,6 +406,17 @@ impl<'cmd> Parser<'cmd> {
                         _parse_result
                     );
                 } else {
+                    if let Some(length_range) = arg.get_num_args() {
+                        if length_range.max_values() == 1 && matcher.args.get(arg.get_id()).is_some() {
+                            return Err(ClapError::unknown_argument(
+                                self.cmd,
+                                arg_os.display().to_string(),
+                                None,
+                                true,
+                                Usage::new(self.cmd).create_usage_with_title(&[]),
+                            ));
+                        }                        
+                    }
                     let arg_values = matcher.pending_values_mut(
                         arg.get_id(),
                         Some(Identifier::Index),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -407,7 +407,9 @@ impl<'cmd> Parser<'cmd> {
                     );
                 } else {
                     if let Some(length_range) = arg.get_num_args() {
-                        if length_range.max_values() == 1 && matcher.args.get(arg.get_id()).is_some() {
+                        if length_range.max_values() == 1
+                            && matcher.args.get(arg.get_id()).is_some()
+                        {
                             return Err(ClapError::unknown_argument(
                                 self.cmd,
                                 arg_os.display().to_string(),
@@ -415,7 +417,7 @@ impl<'cmd> Parser<'cmd> {
                                 true,
                                 Usage::new(self.cmd).create_usage_with_title(&[]),
                             ));
-                        }                        
+                        }
                     }
                     let arg_values = matcher.pending_values_mut(
                         arg.get_id(),


### PR DESCRIPTION
Fixed #4507 

PR will check argument which allow to have one value on argument and check if it's render before and `pending` list is empty then evaluate the arguments .
One tests fixes , which doesn't contain _num_args_ on it too .
