### PR TITLE
chore: Bump MSRV to 1.64.0

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,1 @@
-msrv = "1.60.0"  # MSRV
+msrv = "1.64.0"  # MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         build: [msrv, wasm, wasm-wasi, debug, release]
         include:
           - build: msrv
-            rust: 1.60.0  # MSRV
+            rust: 1.64.0  # MSRV
             target: x86_64-unknown-linux-gnu
             features: full
           - build: wasm
@@ -124,7 +124,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.64.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v2
@@ -139,7 +139,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.64.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v2
@@ -174,7 +174,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0  # MSRV
+        toolchain: 1.64.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -92,9 +92,9 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.60.0  # MSRV
+        - 1.64.0  # MSRV
         - stable
-    continue-on-error: ${{ matrix.rust != '1.60.0' }}  # MSRV
+    continue-on-error: ${{ matrix.rust != '1.64.0' }}  # MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,20 @@ members = [
   "clap_mangen",
 ]
 
+[workspace.package]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.64.0"  # MSRV
+include = [
+  "build.rs",
+  "src/**/*",
+  "Cargo.toml",
+  "LICENSE*",
+  "README.md",
+  "benches/**/*",
+  "examples/**/*"
+]
+
 [package]
 name = "clap"
 version = "4.0.32"
@@ -21,18 +35,10 @@ keywords = [
   "parser",
   "parse"
 ]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.64.0"  # MSRV
-include = [
-  "build.rs",
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "benches/**/*",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.docs.rs]
 features = ["unstable-doc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifneq (${TOOLCHAIN_TARGET},)
   ARGS+=--target ${TOOLCHAIN_TARGET}
 endif
 
-MSRV?=1.60.0
+MSRV?=1.64.0
 
 _FEATURES = minimal default wasm full debug release
 _FEATURES_minimal = --no-default-features --features "std"

--- a/clap_bench/Cargo.toml
+++ b/clap_bench/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Benchmarks for clap"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 publish = false
 
 [package.metadata.release]

--- a/clap_bench/Cargo.toml
+++ b/clap_bench/Cargo.toml
@@ -2,10 +2,11 @@
 name = "clap_bench"
 version = "0.0.0"
 description = "Benchmarks for clap"
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.64.0"  # MSRV
 publish = false
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.release]
 release = false

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -10,18 +10,10 @@ keywords = [
   "completion",
   "bash",
 ]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.64.0"  # MSRV
-include = [
-  "build.rs",
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "benches/**/*",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_complete_fig/Cargo.toml
+++ b/clap_complete_fig/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_complete_fig/Cargo.toml
+++ b/clap_complete_fig/Cargo.toml
@@ -10,18 +10,10 @@ keywords = [
   "completion",
   "fig",
 ]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.64.0"  # MSRV
-include = [
-  "build.rs",
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "benches/**/*",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -11,18 +11,10 @@ keywords = [
   "derive",
   "proc_macro"
 ]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.64.0"  # MSRV
-include = [
-  "build.rs",
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "benches/**/*",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/clap_lex/Cargo.toml
+++ b/clap_lex/Cargo.toml
@@ -11,18 +11,10 @@ keywords = [
   "parser",
   "parse"
 ]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.64.0"  # MSRV
-include = [
-  "build.rs",
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "benches/**/*",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/clap_lex/Cargo.toml
+++ b/clap_lex/Cargo.toml
@@ -13,7 +13,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -10,18 +10,10 @@ keywords = [
   "generate",
   "manpage",
 ]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-rust-version = "1.64.0"  # MSRV
-include = [
-  "build.rs",
-  "src/**/*",
-  "Cargo.toml",
-  "LICENSE*",
-  "README.md",
-  "benches/**/*",
-  "examples/**/*"
-]
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+include.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"  # MSRV
+rust-version = "1.64.0"  # MSRV
 include = [
   "build.rs",
   "src/**/*",

--- a/src/builder/range.rs
+++ b/src/builder/range.rs
@@ -92,7 +92,7 @@ impl ValueRange {
     }
 
     pub(crate) fn num_values(&self) -> Option<usize> {
-        self.is_fixed().then(|| self.start_inclusive)
+        self.is_fixed().then_some(self.start_inclusive)
     }
 
     pub(crate) fn accepts_more(&self, current: usize) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!   - Leverage feature flags to keep to one active branch
 //!   - Being under [WG-CLI](https://github.com/rust-cli/team/) to increase the bus factor
 //! - We follow semver and will wait about 6-9 months between major breaking changes
-//! - We will support the last two minor Rust releases (MSRV, currently 1.60.0)
+//! - We will support the last two minor Rust releases (MSRV, currently 1.64.0)
 //!
 //! While these aspirations can be at odds with fast build times and low binary
 //! size, we will still strive to keep these reasonable for the flexibility you

--- a/src/parser/arg_matcher.rs
+++ b/src/parser/arg_matcher.rs
@@ -186,7 +186,7 @@ impl ArgMatcher {
         let num_pending = self
             .pending
             .as_ref()
-            .and_then(|p| (p.id == *o.get_id()).then(|| p.raw_vals.len()))
+            .and_then(|p| (p.id == *o.get_id()).then_some(p.raw_vals.len()))
             .unwrap_or(0);
         debug!(
             "ArgMatcher::needs_more_vals: o={}, pending={}",

--- a/src/util/flat_map.rs
+++ b/src/util/flat_map.rs
@@ -69,7 +69,7 @@ impl<K: PartialEq + Eq, V> FlatMap<K, V> {
             .keys
             .iter()
             .enumerate()
-            .find_map(|(i, k)| (k.borrow() == key).then(|| i)));
+            .find_map(|(i, k)| (k.borrow() == key).then_some(i)));
         let key = self.keys.remove(index);
         let value = self.values.remove(index);
         Some((key, value))

--- a/tests/derive_ui.rs
+++ b/tests/derive_ui.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 
 #[cfg(feature = "derive")]
-#[rustversion::attr(any(not(stable), before(1.60), since(1.61)), ignore)] // MSRV
+#[rustversion::attr(any(not(stable), before(1.64), since(1.65)), ignore)] // MSRV
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/derive_ui/bool_value_enum.stderr
+++ b/tests/derive_ui/bool_value_enum.stderr
@@ -3,3 +3,5 @@ error[E0277]: the trait bound `bool: ValueEnum` is not satisfied
   |
 6 |     #[arg(short, value_enum, default_value_t)]
   |                              ^^^^^^^^^^^^^^^ the trait `ValueEnum` is not implemented for `bool`
+  |
+  = help: the trait `ValueEnum` is implemented for `ColorChoice`

--- a/tests/derive_ui/enum_variant_not_args.stderr
+++ b/tests/derive_ui/enum_variant_not_args.stderr
@@ -3,3 +3,5 @@ error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
   |
 3 |     Sub(SubCmd),
   |         ^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+  |
+  = help: the trait `clap::Args` is implemented for `Box<T>`

--- a/tests/derive_ui/flatten_enum_in_struct.stderr
+++ b/tests/derive_ui/flatten_enum_in_struct.stderr
@@ -3,3 +3,7 @@ error[E0277]: the trait bound `SubCmd: clap::Args` is not satisfied
   |
 3 |     #[command(flatten)]
   |               ^^^^^^^ the trait `clap::Args` is not implemented for `SubCmd`
+  |
+  = help: the following other types implement trait `clap::Args`:
+            Box<T>
+            Opt

--- a/tests/derive_ui/flatten_struct_in_enum.stderr
+++ b/tests/derive_ui/flatten_struct_in_enum.stderr
@@ -4,4 +4,7 @@ error[E0277]: the trait bound `SubCmd: Subcommand` is not satisfied
 1 | #[derive(clap::Parser)]
   |          ^^^^^^^^^^^^ the trait `Subcommand` is not implemented for `SubCmd`
   |
+  = help: the following other types implement trait `Subcommand`:
+            Box<T>
+            Opt
   = note: this error originates in the derive macro `clap::Parser` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/derive_ui/tuple_struct.stderr
+++ b/tests/derive_ui/tuple_struct.stderr
@@ -10,7 +10,7 @@ error[E0599]: no function or associated item named `parse` found for struct `Opt
   --> tests/derive_ui/tuple_struct.rs:16:20
    |
 13 | struct Opt(u32);
-   | ---------------- function or associated item `parse` not found for this
+   | ---------- function or associated item `parse` not found for this struct
 ...
 16 |     let opt = Opt::parse();
    |                    ^^^^^ function or associated item not found in `Opt`


### PR DESCRIPTION
This allows using workspace inheritance which reduces the number of places we need to update on changes.  Before, it was easy to remember to update the root manifest and forget the rest.