### PR TITLE
feat: Assert argument has no default values in `try_contains_id`

### DIFF
--- a/src/parser/matches/arg_matches.rs
+++ b/src/parser/matches/arg_matches.rs
@@ -1219,6 +1219,13 @@ impl ArgMatches {
         ok!(self.verify_arg(id));
 
         let presence = self.args.contains_key(id);
+
+        debug_assert!(
+            !presence || !self.args.get(id).unwrap().has_default_val(),
+            "`contains_id` and `try_contains_id` always return `true` since `{:?}` has default value(s)",
+            id,
+        );
+
         Ok(presence)
     }
 }


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Fixes #4628

This PR implemented the check suggested at #4628, but tests are not fixed yet.

I'm not sure how to fix the failed tests. Many tests call `contains_id` for argument whose action is `SetTrue` or `SetFalse`. Should I remove these calls?
