### PR TITLE
fix(error): Try to soften unexpected argument/value errors

### DIFF
--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -35,7 +35,7 @@ Value of derived: DerivedArgs {
 ```console
 $ interop_augment_args --unknown
 ? failed
-error: unexpected argument '--unknown'
+error: unexpected argument '--unknown' found
 
 Usage: interop_augment_args[EXE] [OPTIONS]
 
@@ -70,7 +70,7 @@ Derived subcommands: Derived {
 ```console
 $ interop_augment_subcommands derived --unknown
 ? failed
-error: unexpected argument '--unknown'
+error: unexpected argument '--unknown' found
 
 Usage: interop_augment_subcommands[EXE] derived [OPTIONS]
 
@@ -140,7 +140,7 @@ Cli {
 ```console
 $ interop_hand_subcommand add --unknown
 ? failed
-error: unexpected argument '--unknown'
+error: unexpected argument '--unknown' found
 
   note: to pass '--unknown' as a value, use '-- --unknown'
 
@@ -239,7 +239,7 @@ Cli {
 ```console
 $ interop_flatten_hand_args --unknown
 ? failed
-error: unexpected argument '--unknown'
+error: unexpected argument '--unknown' found
 
 Usage: interop_flatten_hand_args[EXE] [OPTIONS]
 

--- a/examples/escaped-positional-derive.md
+++ b/examples/escaped-positional-derive.md
@@ -33,7 +33,7 @@ Notice that we can't pass positional arguments before `--`:
 ```console
 $ escaped-positional-derive foo bar
 ? failed
-error: unexpected argument 'foo'
+error: unexpected argument 'foo' found
 
 Usage: escaped-positional-derive[EXE] [OPTIONS] [-- <SLOP>...]
 

--- a/examples/escaped-positional.md
+++ b/examples/escaped-positional.md
@@ -33,7 +33,7 @@ Notice that we can't pass positional arguments before `--`:
 ```console
 $ escaped-positional foo bar
 ? failed
-error: unexpected argument 'foo'
+error: unexpected argument 'foo' found
 
 Usage: escaped-positional[EXE] [OPTIONS] [-- <SLOP>...]
 

--- a/src/error/format.rs
+++ b/src/error/format.rs
@@ -282,7 +282,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                 styled.warning(invalid_value);
                 styled.none("' for '");
                 styled.warning(invalid_arg);
-                styled.none("'; no more were expected");
+                styled.none("' found; no more were expected");
                 true
             } else {
                 false
@@ -360,7 +360,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
                 styled.none("unexpected argument '");
                 styled.warning(invalid_arg.to_string());
-                styled.none("'");
+                styled.none("' found");
                 true
             } else {
                 false

--- a/src/error/kind.rs
+++ b/src/error/kind.rs
@@ -317,11 +317,11 @@ impl ErrorKind {
     pub fn as_str(self) -> Option<&'static str> {
         match self {
             Self::InvalidValue => Some("one of the values isn't valid for an argument"),
-            Self::UnknownArgument => Some("unexpected argument"),
+            Self::UnknownArgument => Some("unexpected argument found"),
             Self::InvalidSubcommand => Some("unrecognized subcommand"),
             Self::NoEquals => Some("equal is needed when assigning values to one of the arguments"),
             Self::ValueValidation => Some("invalid value for one of the arguments"),
-            Self::TooManyValues => Some("unexpected value for an argument"),
+            Self::TooManyValues => Some("unexpected value for an argument found"),
             Self::TooFewValues => Some("more values required for an argument"),
             Self::WrongNumberOfValues => Some("too many or too few values for an argument"),
             Self::ArgumentConflict => {

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -734,7 +734,7 @@ fn args_negate_subcommands_two_levels() {
 #[cfg(feature = "error-context")]
 fn subcommand_conflict_error_message() {
     static CONFLICT_ERR: &str = "\
-error: unexpected argument 'sub1'
+error: unexpected argument 'sub1' found
 
 Usage: test [OPTIONS]
        test <COMMAND>

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -106,7 +106,7 @@ fn kind_formats_validation_error() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: unexpected argument
+error: unexpected argument found
 ";
     assert_error(err, expected_kind, MESSAGE, true);
 }
@@ -120,7 +120,7 @@ fn rich_formats_validation_error() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: unexpected argument 'unused'
+error: unexpected argument 'unused' found
 
 Usage: test
 
@@ -139,7 +139,7 @@ fn suggest_trailing() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: unexpected argument '--foo'
+error: unexpected argument '--foo' found
 
   note: to pass '--foo' as a value, use '-- --foo'
 
@@ -160,7 +160,7 @@ fn trailing_already_in_use() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: unexpected argument '--foo'
+error: unexpected argument '--foo' found
 
 Usage: rg [PATTERN]
 
@@ -179,7 +179,7 @@ fn cant_use_trailing() {
     let err = res.unwrap_err();
     let expected_kind = ErrorKind::UnknownArgument;
     static MESSAGE: &str = "\
-error: unexpected argument '--foo'
+error: unexpected argument '--foo' found
 
 Usage: test
 

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -140,7 +140,7 @@ fn multiple_flags_in_single() {
 #[cfg(feature = "error-context")]
 fn unexpected_value_error() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
-error: unexpected value 'foo' for '--a-flag'; no more were expected
+error: unexpected value 'foo' for '--a-flag' found; no more were expected
 
 Usage: mycat --a-flag [filename]
 
@@ -158,7 +158,7 @@ For more information, try '--help'.
 #[cfg(feature = "error-context")]
 fn issue_1284_argument_in_flag_style() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
-error: unexpected argument '--another-flag'
+error: unexpected argument '--another-flag' found
 
   note: to pass '--another-flag' as a value, use '-- --another-flag'
 
@@ -202,7 +202,7 @@ For more information, try '--help'.
 #[cfg(feature = "error-context")]
 fn issue_2308_multiple_dashes() {
     static MULTIPLE_DASHES: &str = "\
-error: unexpected argument '-----'
+error: unexpected argument '-----' found
 
   note: to pass '-----' as a value, use '-- -----'
 

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -446,7 +446,7 @@ fn leading_hyphen_with_only_pos_follows() {
 #[cfg(feature = "error-context")]
 fn did_you_mean() {
     static DYM: &str = "\
-error: unexpected argument '--optio'
+error: unexpected argument '--optio' found
 
   note: argument '--option' exists
 
@@ -544,7 +544,7 @@ fn issue_1105_empty_value_short_explicit_no_space() {
 #[cfg(feature = "error-context")]
 fn issue_1073_suboptimal_flag_suggestion() {
     static DYM_ISSUE_1073: &str = "\
-error: unexpected argument '--files-without-matches'
+error: unexpected argument '--files-without-matches' found
 
   note: argument '--files-without-match' exists
 

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -139,7 +139,7 @@ For more information, try '--help'.
 #[cfg(feature = "error-context")]
 fn subcmd_did_you_mean_output_arg() {
     static EXPECTED: &str = "\
-error: unexpected argument '--subcmarg'
+error: unexpected argument '--subcmarg' found
 
   note: 'subcmd --subcmdarg' exists
 
@@ -159,7 +159,7 @@ For more information, try '--help'.
 #[cfg(feature = "error-context")]
 fn subcmd_did_you_mean_output_arg_false_positives() {
     static EXPECTED: &str = "\
-error: unexpected argument '--subcmarg'
+error: unexpected argument '--subcmarg' found
 
 Usage: dym [COMMAND]
 
@@ -351,7 +351,7 @@ fn subcommand_placeholder_test() {
 #[cfg(feature = "error-context")]
 fn subcommand_used_after_double_dash() {
     static SUBCMD_AFTER_DOUBLE_DASH: &str = "\
-error: unexpected argument 'subcmd'
+error: unexpected argument 'subcmd' found
 
   note: subcommand 'subcmd' exists; to use it, remove the '--' before it
 

--- a/tests/ui/error_stderr.toml
+++ b/tests/ui/error_stderr.toml
@@ -3,7 +3,7 @@ args = ["--unknown-argument"]
 status.code = 2
 stdout = ""
 stderr = """
-error: unexpected argument '--unknown-argument'
+error: unexpected argument '--unknown-argument' found
 
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 


### PR DESCRIPTION
Adding "found" might seem minor but I feel it has a slight softening on the message.  It also maintains scanability as it is at the end and short.

As this is a one-off message change and not a styling issue to be consistent with, I think this is safe to put in a patch release.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
