### PR TITLE
fix(mangen): Avoid spurious value names for derive args without values

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -99,9 +99,11 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
             (None, None) => vec![],
         };
 
-        if let Some(value) = &opt.get_value_names() {
-            header.push(roman("="));
-            header.push(italic(value.join(" ")));
+        if opt.get_action().takes_values() {
+            if let Some(value) = &opt.get_value_names() {
+                header.push(roman("="));
+                header.push(italic(value.join(" ")));
+            }
         }
 
         if let Some(defs) = option_default_values(opt) {

--- a/clap_mangen/tests/common.rs
+++ b/clap_mangen/tests/common.rs
@@ -312,3 +312,12 @@ pub fn possible_values_command(name: &'static str) -> clap::Command {
                 ]),
         )
 }
+
+pub fn value_name_without_arg(name: &'static str) -> clap::Command {
+    clap::Command::new(name).arg(
+        clap::Arg::new("flag")
+            .long("flag")
+            .value_name("SPURIOUS")
+            .action(clap::ArgAction::SetTrue),
+    )
+}

--- a/clap_mangen/tests/roff.rs
+++ b/clap_mangen/tests/roff.rs
@@ -83,3 +83,10 @@ fn sub_subcommands_help() {
         common::assert_matches_path("tests/snapshots/sub_subcommand_help.roff", cmd.clone());
     }
 }
+
+#[test]
+fn value_name_without_arg() {
+    let name = "my-app";
+    let cmd = common::value_name_without_arg(name);
+    common::assert_matches_path("tests/snapshots/value_name_without_arg.bash.roff", cmd);
+}

--- a/clap_mangen/tests/snapshots/value_name_without_arg.bash.roff
+++ b/clap_mangen/tests/snapshots/value_name_without_arg.bash.roff
@@ -1,0 +1,15 @@
+.ie /n(.g .ds Aq /(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my/-app
+.SH SYNOPSIS
+/fBmy/-app/fR [/fB/-/-flag/fR] [/fB/-h/fR|/fB/-/-help/fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+/fB/-/-flag/fR
+
+.TP
+/fB/-h/fR, /fB/-/-help/fR
+Print help


### PR DESCRIPTION
derive arguments like this:

    #[arg(long)]
    pub flag: bool,

were producing option descriptions like this:

    --flag=FLAG

`FLAG` is spurious.  It turns out that derive always sets a value name, for simplicity, even when there are no arguments.  Check for this case.

Fixes #4443.