### PR TITLE
fix(tests): suggestions.rs tests not running due to typo

### DIFF
--- a/src/parser/features/suggestions.rs
+++ b/src/parser/features/suggestions.rs
@@ -72,7 +72,7 @@ where
     }
 }
 
-#[cfg(all(test, features = "suggestions"))]
+#[cfg(all(test, feature = "suggestions"))]
 mod test {
     use super::*;
 


### PR DESCRIPTION
The tests here are not executed because of typo `features` instead of `feature`
If one fixes the typo so that tests run, they actually fail
So one should add `ignore` in a further commit

Fixes #4661
