### PR TITLE
fix(help): Respect `disable_colored_help` for `arg_required_else_help`

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -242,7 +242,10 @@ impl<F: ErrorFormatter> Error<F> {
     /// ```
     pub fn print(&self) -> io::Result<()> {
         let style = self.formatted();
-        let color_when = if self.kind() == ErrorKind::DisplayHelp {
+        let color_when = if matches!(
+            self.kind(),
+            ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
+        ) {
             self.inner.color_help_when
         } else {
             self.inner.color_when


### PR DESCRIPTION
Fixes #4671

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
