### PR TITLE
add ability to parse additional group methods

### DIFF
--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -86,6 +86,7 @@ impl Parse for ClapAttr {
         let magic = match name_str.as_str() {
             "rename_all" => Some(MagicAttrName::RenameAll),
             "rename_all_env" => Some(MagicAttrName::RenameAllEnv),
+            "required" => Some(MagicAttrName::Required),
             "skip" => Some(MagicAttrName::Skip),
             "next_display_order" => Some(MagicAttrName::NextDisplayOrder),
             "next_help_heading" => Some(MagicAttrName::NextHelpHeading),
@@ -168,6 +169,7 @@ pub enum MagicAttrName {
     Version,
     RenameAllEnv,
     RenameAll,
+    Required,
     Skip,
     DefaultValueT,
     DefaultValuesT,

--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -86,7 +86,6 @@ impl Parse for ClapAttr {
         let magic = match name_str.as_str() {
             "rename_all" => Some(MagicAttrName::RenameAll),
             "rename_all_env" => Some(MagicAttrName::RenameAllEnv),
-            "required" => Some(MagicAttrName::Required),
             "skip" => Some(MagicAttrName::Skip),
             "next_display_order" => Some(MagicAttrName::NextDisplayOrder),
             "next_help_heading" => Some(MagicAttrName::NextHelpHeading),
@@ -169,7 +168,6 @@ pub enum MagicAttrName {
     Version,
     RenameAllEnv,
     RenameAll,
-    Required,
     Skip,
     DefaultValueT,
     DefaultValuesT,

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -368,6 +368,7 @@ pub fn gen_augment(
         quote!()
     } else {
         let group_id = parent_item.ident().unraw().to_string();
+        let required = parent_item.required_group();
         let literal_group_members = fields
             .iter()
             .filter_map(|(_field, item)| {
@@ -404,6 +405,7 @@ pub fn gen_augment(
             .group(
                 clap::ArgGroup::new(#group_id)
                     .multiple(true)
+                    .required(#required)
                     .args(#literal_group_members)
             )
         )

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -368,7 +368,6 @@ pub fn gen_augment(
         quote!()
     } else {
         let group_id = parent_item.ident().unraw().to_string();
-        let required = parent_item.required_group();
         let literal_group_members = fields
             .iter()
             .filter_map(|(_field, item)| {
@@ -401,11 +400,13 @@ pub fn gen_augment(
             }};
         }
 
+        let group_methods = parent_item.group_methods();
+
         quote!(
             .group(
                 clap::ArgGroup::new(#group_id)
                     .multiple(true)
-                    .required(#required)
+                    #group_methods
                     .args(#literal_group_members)
             )
         )

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -48,6 +48,7 @@ pub struct Item {
     next_help_heading: Option<Method>,
     is_enum: bool,
     is_positional: bool,
+    required_group: bool,
     skip_group: bool,
     kind: Sp<Kind>,
 }
@@ -272,6 +273,7 @@ impl Item {
             next_help_heading: None,
             is_enum: false,
             is_positional: true,
+            required_group: false,
             skip_group: false,
             kind,
         }
@@ -824,6 +826,10 @@ impl Item {
                     self.env_casing = CasingStyle::from_lit(lit);
                 }
 
+                Some(MagicAttrName::Required) if actual_attr_kind == AttrKind::Group => {
+                    self.required_group = true;
+                }
+
                 Some(MagicAttrName::Skip) if actual_attr_kind == AttrKind::Group => {
                     self.skip_group = true;
                 }
@@ -838,6 +844,7 @@ impl Item {
                 | Some(MagicAttrName::LongHelp)
                 | Some(MagicAttrName::Author)
                 | Some(MagicAttrName::Version)
+                | Some(MagicAttrName::Required)
                  => {
                     let expr = attr.value_or_abort();
                     self.push_method(*attr.kind.get(), attr.name.clone(), expr);
@@ -1057,6 +1064,10 @@ impl Item {
         self.methods
             .iter()
             .any(|m| m.name != "help" && m.name != "long_help")
+    }
+
+    pub fn required_group(&self) -> bool {
+        self.required_group
     }
 
     pub fn skip_group(&self) -> bool {

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -120,3 +120,47 @@ fn helpful_panic_on_duplicate_groups() {
     use clap::CommandFactory;
     Opt::command().debug_assert();
 }
+
+#[test]
+fn required_group() {
+    #[derive(Parser, Debug)]
+    struct Opt {
+        #[command(flatten)]
+        source: Source,
+        #[command(flatten)]
+        dest: Dest,
+    }
+
+    #[derive(clap::Args, Debug)]
+    #[group(required)]
+    struct Source {
+        #[arg(long)]
+        from_path: Option<std::path::PathBuf>,
+        #[arg(long)]
+        from_git: Option<String>,
+    }
+
+    #[derive(clap::Args, Debug)]
+    #[group(required = true)]
+    struct Dest {
+        #[arg(long)]
+        to_path: Option<std::path::PathBuf>,
+        #[arg(long)]
+        to_git: Option<String>,
+    }
+
+    use clap::CommandFactory;
+    let source_id = clap::Id::from("Source");
+    let dest_id = clap::Id::from("Dest");
+    let opt_command = Opt::command();
+    let source_group = opt_command
+        .get_groups()
+        .find(|g| g.get_id() == &source_id)
+        .unwrap();
+    let dest_group = opt_command
+        .get_groups()
+        .find(|g| g.get_id() == &dest_id)
+        .unwrap();
+    assert!(source_group.is_required_set());
+    assert!(dest_group.is_required_set());
+}

--- a/tests/derive_ui/group_name_attribute.rs
+++ b/tests/derive_ui/group_name_attribute.rs
@@ -1,0 +1,23 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "basic", subcommand)]
+struct Opt {
+    #[command(flatten)]
+    source: Source,
+}
+
+#[derive(clap::Args, Debug)]
+#[group(required = true, name = "src")]
+struct Source {
+    #[arg(short)]
+    git: String,
+
+    #[arg(short)]
+    path: String,
+}
+
+fn main() {
+    let opt = Opt::parse();
+    println!("{:?}", opt);
+}

--- a/tests/derive_ui/group_name_attribute.stderr
+++ b/tests/derive_ui/group_name_attribute.stderr
@@ -1,0 +1,7 @@
+error: `#[group(required = true, name = "src")]` does not support name
+ --> $DIR/group_name_attribute.rs:3:10
+   |
+11 |#[group(required = true, name = "src")]
+   |                         ^^^^^^^^^^^^
+   |
+  = note: this error originates in the derive macro `group` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Towards completing #4574 , let's add the other methods for `group` derive.
This is my first PR for Clap and a lot of this was Cargo coding.
Please forgive anything that seems silly.
I'm very open to feedback :)