### PR TITLE
docs: Add subcommand comment

### DIFF
--- a/examples/cargo-example-derive.rs
+++ b/examples/cargo-example-derive.rs
@@ -4,12 +4,13 @@ use clap::Parser;
 #[command(name = "cargo")]
 #[command(bin_name = "cargo")]
 enum Cargo {
-    ExampleDerive(ExampleDerive),
+    // Subcommand name “example-derive” generated from variant name
+    ExampleDerive(ExampleDeriveArgs),
 }
 
 #[derive(clap::Args)]
 #[command(author, version, about, long_about = None)]
-struct ExampleDerive {
+struct ExampleDeriveArgs {
     #[arg(long)]
     manifest_path: Option<std::path::PathBuf>,
 }


### PR DESCRIPTION
Discussed in comment https://github.com/clap-rs/clap/pull/4692#discussion_r1095242457 this adds a comment explaining where the subcommand name "example-derive" comes from.

I also modified the `ExampleDerive` struct to be `ExampleDeriveArgs`. This means the variant and its struct no longer have the same name and that it's clearer that the struct contains the args.