### PR TITLE
docs(examples): Differentiate struct from command name

### DIFF
--- a/examples/cargo-example-derive.rs
+++ b/examples/cargo-example-derive.rs
@@ -3,18 +3,18 @@ use clap::Parser;
 #[derive(Parser)] // requires `derive` feature
 #[command(name = "cargo")]
 #[command(bin_name = "cargo")]
-enum Cargo {
-    ExampleDerive(ExampleDerive),
+enum CargoCli {
+    ExampleDerive(ExampleDeriveArgs),
 }
 
 #[derive(clap::Args)]
 #[command(author, version, about, long_about = None)]
-struct ExampleDerive {
+struct ExampleDeriveArgs {
     #[arg(long)]
     manifest_path: Option<std::path::PathBuf>,
 }
 
 fn main() {
-    let Cargo::ExampleDerive(args) = Cargo::parse();
+    let CargoCli::ExampleDerive(args) = CargoCli::parse();
     println!("{:?}", args.manifest_path);
 }

--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -102,13 +102,13 @@ Options:
   -h, --help  Print help
 
 $ git-derive stash -m "Prototype"
-Pushing StashPush { message: Some("Prototype") }
+Pushing StashPushArgs { message: Some("Prototype") }
 
 $ git-derive stash pop
 Popping None
 
 $ git-derive stash push -m "Prototype"
-Pushing StashPush { message: Some("Prototype") }
+Pushing StashPushArgs { message: Some("Prototype") }
 
 $ git-derive stash pop
 Popping None

--- a/examples/git-derive.rs
+++ b/examples/git-derive.rs
@@ -53,7 +53,7 @@ enum Commands {
         #[arg(required = true)]
         path: Vec<PathBuf>,
     },
-    Stash(Stash),
+    Stash(StashArgs),
     #[command(external_subcommand)]
     External(Vec<OsString>),
 }
@@ -76,23 +76,23 @@ impl std::fmt::Display for ColorWhen {
 
 #[derive(Debug, Args)]
 #[command(args_conflicts_with_subcommands = true)]
-struct Stash {
+struct StashArgs {
     #[command(subcommand)]
     command: Option<StashCommands>,
 
     #[command(flatten)]
-    push: StashPush,
+    push: StashPushArgs,
 }
 
 #[derive(Debug, Subcommand)]
 enum StashCommands {
-    Push(StashPush),
+    Push(StashPushArgs),
     Pop { stash: Option<String> },
     Apply { stash: Option<String> },
 }
 
 #[derive(Debug, Args)]
-struct StashPush {
+struct StashPushArgs {
     #[arg(short, long)]
     message: Option<String>,
 }

--- a/examples/tutorial_derive/03_04_subcommands_alt.rs
+++ b/examples/tutorial_derive/03_04_subcommands_alt.rs
@@ -11,11 +11,11 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Adds files to myapp
-    Add(Add),
+    Add(AddArgs),
 }
 
 #[derive(Args)]
-struct Add {
+struct AddArgs {
     name: Option<String>,
 }
 


### PR DESCRIPTION
This supersedes #4692

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
