### PR TITLE
fix(builder): don't require mut for is_multiple

### DIFF
--- a/src/builder/arg_group.rs
+++ b/src/builder/arg_group.rs
@@ -270,7 +270,7 @@ impl ArgGroup {
     ///
     /// assert!(group.is_multiple());
     /// ```
-    pub fn is_multiple(&mut self) -> bool {
+    pub fn is_multiple(&self) -> bool {
         self.multiple
     }
 
@@ -577,10 +577,10 @@ mod test {
     fn arg_group_expose_is_multiple_helper() {
         let args: Vec<Id> = vec!["a1".into(), "a4".into()];
 
-        let mut grp_multiple = ArgGroup::new("test_multiple").args(&args).multiple(true);
+        let grp_multiple = ArgGroup::new("test_multiple").args(&args).multiple(true);
         assert!(grp_multiple.is_multiple());
 
-        let mut grp_not_multiple = ArgGroup::new("test_multiple").args(&args).multiple(false);
+        let grp_not_multiple = ArgGroup::new("test_multiple").args(&args).multiple(false);
         assert!(!grp_not_multiple.is_multiple());
     }
 


### PR DESCRIPTION
While pursuing an implementation for #4574, I noticed the that the `is_multiple` function requires a mutable reference to `self`. But this function is just a simple accessor. The `mut` requirement is onerous. Let's relax the requirement so that we don't need to have a mutable version of an `ArgGroup` just to check if it allows multiple arguments.