### PR TITLE
fix(help): Don't accidentally show long help with `--help` when it isn't intended.

### DIFF
--- a/src/builder/command.rs
+++ b/src/builder/command.rs
@@ -4593,12 +4593,13 @@ impl Command {
         // specified by the user is sent through. If hide_short_help is not included,
         // then items specified with hidden_short_help will also be hidden.
         let should_long = |v: &Arg| {
-            v.get_long_help().is_some()
-                || v.is_hide_long_help_set()
-                || v.is_hide_short_help_set()
-                || v.get_possible_values()
-                    .iter()
-                    .any(PossibleValue::should_show_help)
+            !v.is_hide_set()
+                && (v.get_long_help().is_some()
+                    || v.is_hide_long_help_set()
+                    || v.is_hide_short_help_set()
+                    || v.get_possible_values()
+                        .iter()
+                        .any(PossibleValue::should_show_help))
         };
 
         // Subcommands aren't checked because we prefer short help for them, deferring to

--- a/tests/builder/hidden_args.rs
+++ b/tests/builder/hidden_args.rs
@@ -1,6 +1,6 @@
 use super::utils;
 
-use clap::{arg, Arg, ArgAction, Command};
+use clap::{arg, builder::PossibleValue, Arg, ArgAction, Command};
 
 static HIDDEN_ARGS: &str = "\
 tests stuff
@@ -277,4 +277,28 @@ fn hide_subcmds_only() {
         .subcommand(Command::new("sub").hide(true));
 
     utils::assert_output(cmd, "test --help", HIDDEN_SUBCMDS_ONLY, false);
+}
+
+#[test]
+fn hidden_arg_with_possible_value_with_help() {
+    // Normally the presence of a possible value with a help text triggers a
+    // change of the --help help text by appending `(see more with '--help')`
+    // or `(see a summary with '-h')`. When the argument is completely hidden
+    // we however do not want it to trigger that change.
+    static POS_VALS_HELP: &str = "\
+Usage: ctest
+
+Options:
+  -h, --help  Print help
+";
+    let app = Command::new("ctest").arg(
+        Arg::new("pos")
+            .hide(true)
+            .value_parser([
+                PossibleValue::new("fast"),
+                PossibleValue::new("slow").help("not as fast"),
+            ])
+            .action(ArgAction::Set),
+    );
+    utils::assert_output(app, "ctest --help", POS_VALS_HELP, false);
 }


### PR DESCRIPTION
We were accidentally showing long help just because a hidden argument had a description for a possible value.  This is most likely to be hit with the derive API as the value descriptions are automatically applied from documentation.