### PR TITLE
Improve builder::str::inner::Inner::into_string implementation

### DIFF
--- a/src/builder/str.rs
+++ b/src/builder/str.rs
@@ -246,7 +246,10 @@ pub(crate) mod inner {
         }
 
         pub(crate) fn into_string(self) -> String {
-            self.as_str().to_owned()
+            match self {
+                Self::Static(s) => s.to_owned(),
+                Self::Owned(s) => s.into(),
+            }
         }
     }
 }


### PR DESCRIPTION
Since `Inner::into_string` already takes ownership of `self` we can avoid unnecessary copy and allocation by moving `Box<str>` and using its implementation of `Into<String>`.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
