### PR TITLE
docs: Remove remaining references to clap attribute

### DIFF
--- a/clap_complete/examples/completion-derive.rs
+++ b/clap_complete/examples/completion-derive.rs
@@ -24,7 +24,7 @@ struct Opt {
     // If provided, outputs the completion file for given shell
     #[arg(long = "generate", value_enum)]
     generator: Option<Shell>,
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: Option<Commands>,
 }
 

--- a/examples/derive_ref/hand_subcommand.rs
+++ b/examples/derive_ref/hand_subcommand.rs
@@ -69,7 +69,7 @@ impl Subcommand for CliSub {
 struct Cli {
     #[arg(short, long)]
     top_level: bool,
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: CliSub,
 }
 

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -73,9 +73,9 @@ fn skip_group_avoids_duplicate_ids() {
     #[derive(clap::Args, Debug)]
     #[group(skip)]
     pub struct Compose<L: clap::Args, R: clap::Args> {
-        #[clap(flatten)]
+        #[command(flatten)]
         pub left: L,
-        #[clap(flatten)]
+        #[command(flatten)]
         pub right: R,
     }
 
@@ -108,9 +108,9 @@ fn helpful_panic_on_duplicate_groups() {
 
     #[derive(clap::Args, Debug)]
     pub struct Compose<L: clap::Args, R: clap::Args> {
-        #[clap(flatten)]
+        #[command(flatten)]
         pub left: L,
-        #[clap(flatten)]
+        #[command(flatten)]
         pub right: R,
     }
 


### PR DESCRIPTION
Noticed via [reddit](https://www.reddit.com/r/rust/comments/115wovh/clap_documentation/)