### PR TITLE
fix(complete): support the shell being specified with an absolute path

### DIFF
--- a/clap_complete/tests/general.rs
+++ b/clap_complete/tests/general.rs
@@ -9,3 +9,32 @@ fn infer_value_hint_for_path_buf() {
         .unwrap();
     assert_eq!(input.get_value_hint(), clap::builder::ValueHint::AnyPath);
 }
+
+#[cfg(windows)]
+#[test]
+fn shell_absolute_path() {
+    use clap_complete::Shell;
+
+    let path = std::path::Path::new(&std::env::var("PSHOME").unwrap()).join("powershell.exe");
+
+    let matches = clap::Command::new("test")
+        .arg(clap::Arg::new("shell").value_parser(clap::value_parser!(Shell)))
+        .get_matches_from(["myprog", path.to_str().unwrap()]);
+
+    assert_eq!(
+        matches.get_one::<Shell>("shell").unwrap(),
+        &Shell::PowerShell
+    );
+}
+
+#[cfg(not(windows))]
+#[test]
+fn shell_absolute_path() {
+    use clap_complete::Shell;
+
+    let matches = clap::Command::new("test")
+        .arg(clap::Arg::new("shell").value_parser(clap::value_parser!(Shell)))
+        .get_matches_from(["myprog", "/bin/bash"]);
+
+    assert_eq!(matches.get_one::<Shell>("shell").unwrap(), &Shell::Bash);
+}


### PR DESCRIPTION
This was failing because my `SHELL` is an absolute path. I know I can just `SHELL=zsh ./x` but I expect people would prefer to just be able to rely on their existing `SHELL` value.

```
error: invalid value '/usr/bin/zsh' for '<SHELL>'
  [possible values: bash, elvish, fish, powershell, zsh]

For more information, try '--help'.
```

```rust
use clap::{arg, Parser};
use clap_complete::Shell;

#[derive(Parser)]
struct Args {
    #[arg(env)]
    shell: Shell,
}

fn main() {
    Args::parse();
}
```