### PR TITLE
fix(derive): Allow `clippy::almost_swapped`

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -109,6 +109,7 @@ pub fn gen_for_struct(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #item_name #ty_generics #where_clause {
@@ -144,6 +145,7 @@ pub fn gen_for_struct(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::Args for #item_name #ty_generics #where_clause {

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -36,6 +36,7 @@ pub fn gen_for_struct(item: &Item, item_name: &Ident, generics: &Generics) -> To
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {
@@ -72,6 +73,7 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, generics: &Generics) -> Toke
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -80,6 +80,7 @@ pub fn gen_for_enum(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #item_name #ty_generics #where_clause {
@@ -106,6 +107,7 @@ pub fn gen_for_enum(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
         impl #impl_generics clap::Subcommand for #item_name #ty_generics #where_clause {

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -65,6 +65,7 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, variants: &[(&Variant, Item)
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
         impl clap::ValueEnum for #item_name {


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Closes #4733 
