### PR TITLE
fix: remove strict linting from generated code

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -111,7 +111,6 @@ pub fn gen_for_struct(
             clippy::suspicious_else_formatting,
             clippy::almost_swapped,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #item_name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())
@@ -147,7 +146,6 @@ pub fn gen_for_struct(
             clippy::suspicious_else_formatting,
             clippy::almost_swapped,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::Args for #item_name #ty_generics #where_clause {
             fn group_id() -> Option<clap::Id> {
                 #group_id

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -38,7 +38,6 @@ pub fn gen_for_struct(item: &Item, item_name: &Ident, generics: &Generics) -> To
             clippy::suspicious_else_formatting,
             clippy::almost_swapped,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {
             fn command<'b>() -> clap::Command {
                 let #app_var = clap::Command::new(#name);
@@ -75,7 +74,6 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, generics: &Generics) -> Toke
             clippy::suspicious_else_formatting,
             clippy::almost_swapped,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {
             fn command<'b>() -> clap::Command {
                 let #app_var = clap::Command::new(#name)

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -82,7 +82,6 @@ pub fn gen_for_enum(
             clippy::suspicious_else_formatting,
             clippy::almost_swapped,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #item_name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())
@@ -109,7 +108,6 @@ pub fn gen_for_enum(
             clippy::suspicious_else_formatting,
             clippy::almost_swapped,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::Subcommand for #item_name #ty_generics #where_clause {
             fn augment_subcommands <'b>(__clap_app: clap::Command) -> clap::Command {
                 #augmentation

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -67,7 +67,6 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, variants: &[(&Variant, Item)
             clippy::suspicious_else_formatting,
             clippy::almost_swapped,
         )]
-        #[deny(clippy::correctness)]
         impl clap::ValueEnum for #item_name {
             #value_variants
             #to_possible_value


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

fix https://github.com/clap-rs/clap/issues/4733

Removes `#[deny(clippy::correctness)]` from generated code, added in https://github.com/clap-rs/clap/pull/1726

Macros really shouldn't be making lints stricter, just causes more noise in user code when they're triggered. Macro code naturally will have lint false positives
