### PR TITLE
fix: clippy rules order

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -109,9 +109,9 @@ pub fn gen_for_struct(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
-            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
+        #[allow(clippy::almost_swapped)]
         impl #impl_generics clap::FromArgMatches for #item_name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())
@@ -145,9 +145,9 @@ pub fn gen_for_struct(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
-            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
+        #[allow(clippy::almost_swapped)]
         impl #impl_generics clap::Args for #item_name #ty_generics #where_clause {
             fn group_id() -> Option<clap::Id> {
                 #group_id

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -36,9 +36,9 @@ pub fn gen_for_struct(item: &Item, item_name: &Ident, generics: &Generics) -> To
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
-            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
+        #[allow(clippy::almost_swapped)]
         impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {
             fn command<'b>() -> clap::Command {
                 let #app_var = clap::Command::new(#name);
@@ -73,9 +73,9 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, generics: &Generics) -> Toke
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
-            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
+        #[allow(clippy::almost_swapped)]
         impl #impl_generics clap::CommandFactory for #item_name #ty_generics #where_clause {
             fn command<'b>() -> clap::Command {
                 let #app_var = clap::Command::new(#name)

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -80,9 +80,9 @@ pub fn gen_for_enum(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
-            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
+        #[allow(clippy::almost_swapped)]
         impl #impl_generics clap::FromArgMatches for #item_name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())
@@ -107,9 +107,9 @@ pub fn gen_for_enum(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
-            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
+        #[allow(clippy::almost_swapped)]
         impl #impl_generics clap::Subcommand for #item_name #ty_generics #where_clause {
             fn augment_subcommands <'b>(__clap_app: clap::Command) -> clap::Command {
                 #augmentation

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -65,9 +65,9 @@ pub fn gen_for_enum(item: &Item, item_name: &Ident, variants: &[(&Variant, Item)
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
-            clippy::almost_swapped,
         )]
         #[deny(clippy::correctness)]
+        #[allow(clippy::almost_swapped)]
         impl clap::ValueEnum for #item_name {
             #value_variants
             #to_possible_value


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Follow up to #4735. Currently, `#[deny(clippy::correctness)]` takes precedence over `#[allow(clippy::almost_swapped)]`. Change the order of rules.

Ref #4733

Alternative to #4739 