### PR TITLE
fix(mangen): Honor the bin_name when rendering manpages

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -28,8 +28,14 @@ pub(crate) fn description(roff: &mut Roff, cmd: &clap::Command) {
     }
 }
 
+fn get_command_name(cmd: &clap::Command) -> &str {
+    cmd.get_bin_name()
+        .or_else(|| cmd.get_display_name())
+        .unwrap_or_else(|| cmd.get_name())
+}
+
 pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
-    let mut line = vec![bold(cmd.get_name()), roman(" ")];
+    let mut line = vec![bold(get_command_name(cmd)), roman(" ")];
 
     for opt in cmd.get_arguments().filter(|i| !i.is_hide_set()) {
         let (lhs, rhs) = option_markers(opt);
@@ -225,12 +231,7 @@ pub(crate) fn subcommands(roff: &mut Roff, cmd: &clap::Command, section: &str) {
     for sub in cmd.get_subcommands().filter(|s| !s.is_hide_set()) {
         roff.control("TP", []);
 
-        let name = format!(
-            "{}-{}({})",
-            cmd.get_display_name().unwrap_or_else(|| cmd.get_name()),
-            sub.get_name(),
-            section
-        );
+        let name = format!("{}-{}({})", get_command_name(cmd), sub.get_name(), section);
         roff.text([roman(name)]);
 
         if let Some(about) = sub.get_about().or_else(|| sub.get_long_about()) {

--- a/clap_mangen/tests/snapshots/sub_subcommand_help.roff
+++ b/clap_mangen/tests/snapshots/sub_subcommand_help.roff
@@ -4,16 +4,16 @@
 .SH NAME
 help /- Print this message or the help of the given subcommand(s)
 .SH SYNOPSIS
-/fBhelp/fR [/fIsubcommands/fR]
+/fBmy/-app help/fR [/fIsubcommands/fR]
 .SH DESCRIPTION
 Print this message or the help of the given subcommand(s)
 .SH SUBCOMMANDS
 .TP
-my/-app/-help/-test(1)
+my/-app help/-test(1)
 tests things
 .TP
-my/-app/-help/-some_cmd(1)
+my/-app help/-some_cmd(1)
 top level subcommand
 .TP
-my/-app/-help/-help(1)
+my/-app help/-help(1)
 Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
This feels like an inoffensive update to the manpage renderer. As the synopsis section provides a sample invocation, we should prefer to use the `bin_name` over the Crate's name if one has been specified.

This did cause an interesting diff in the help subcommand ROFF snapshot test, where I discovered that the `help` command was not being prefixed with the parent command in the synopsis. Nor were spaces being used to delimit the app command from the subcommand name.  What's introduced in this PR _feels_ right to me, but I'll be interested to hear y'alls thoughts.

Thanks for the review!

Fixes #4757 