### PR TITLE
fix(help): Don't style newlines

### DIFF
--- a/src/output/help_template.rs
+++ b/src/output/help_template.rs
@@ -368,7 +368,8 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                     .get_subcommand_help_heading()
                     .unwrap_or(&default_help_heading),
             );
-            self.header(":\n");
+            self.header(":");
+            self.none("\n");
 
             self.write_subcommands(self.cmd);
         }
@@ -379,7 +380,8 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             }
             first = false;
             // Write positional args if any
-            self.header("Arguments:\n");
+            self.header("Arguments:");
+            self.none("\n");
             self.write_args(&pos, "Arguments", positional_sort_key);
         }
 
@@ -388,7 +390,8 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 self.none("\n\n");
             }
             first = false;
-            self.header("Options:\n");
+            self.header("Options:");
+            self.none("\n");
             self.write_args(&non_pos, "Options", option_sort_key);
         }
         if !custom_headings.is_empty() {
@@ -410,7 +413,9 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                         self.none("\n\n");
                     }
                     first = false;
-                    self.header(format!("{heading}:\n"));
+                    self.header(heading);
+                    self.header(":");
+                    self.none("\n");
                     self.write_args(&args, heading, option_sort_key);
                 }
             }


### PR DESCRIPTION
Windows will style all blank space until the end of line (sometimes).

This was split out of #4765

Fixes #4431

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
