### PR TITLE
Revert "chore: Update bitflags dep to 2.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,12 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dd14596c0e5b954530d0e6f1fd99b89c03e313aa2086e8da4303701a09e1cf"
-
-[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,7 +167,7 @@ version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap",
@@ -184,7 +178,7 @@ name = "clap"
 version = "4.1.12"
 dependencies = [
  "backtrace",
- "bitflags 2.0.1",
+ "bitflags",
  "clap_derive",
  "clap_lex 0.3.3",
  "humantime",
@@ -753,7 +747,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ bench = false
 [dependencies]
 clap_derive = { path = "./clap_derive", version = "=4.1.12", optional = true }
 clap_lex = { path = "./clap_lex", version = "0.3.0" }
-bitflags = "2.0.0"
+bitflags = "1.2.0"
 unicase = { version = "2.6.0", optional = true }
 strsim = { version = "0.10.0",  optional = true }
 is-terminal = { version = "0.4.1",  optional = true }

--- a/src/builder/app_settings.rs
+++ b/src/builder/app_settings.rs
@@ -63,7 +63,6 @@ pub(crate) enum AppSettings {
 }
 
 bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     struct Flags: u64 {
         const SC_NEGATE_REQS                 = 1;
         const SC_REQUIRED                    = 1 << 1;

--- a/src/builder/arg_settings.rs
+++ b/src/builder/arg_settings.rs
@@ -49,7 +49,6 @@ pub(crate) enum ArgSettings {
 }
 
 bitflags! {
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     struct Flags: u32 {
         const REQUIRED         = 1;
         const GLOBAL           = 1 << 3;


### PR DESCRIPTION
This reverts commit 6878a1911b2509b1fb2afbaee616f6257758af41.

This was updated in #4771 but rustix is still on the old version, making us depend on
 two versions of bitflags.  Once rustix is updated, we can update.