### PR TITLE
perf(derive): Reduce the amount of generated code

### DIFF
--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -277,6 +277,10 @@ impl Item {
     }
 
     fn push_method(&mut self, kind: AttrKind, name: Ident, arg: impl ToTokens) {
+        self.push_method_(kind, name, arg.to_token_stream());
+    }
+
+    fn push_method_(&mut self, kind: AttrKind, name: Ident, arg: TokenStream) {
         if name == "id" {
             match kind {
                 AttrKind::Command | AttrKind::Value => {
@@ -293,7 +297,7 @@ impl Item {
                 }
                 AttrKind::Group | AttrKind::Arg | AttrKind::Clap | AttrKind::StructOpt => {}
             }
-            self.name = Name::Assigned(quote!(#arg));
+            self.name = Name::Assigned(arg);
         } else if name == "name" {
             match kind {
                 AttrKind::Arg => {
@@ -315,16 +319,16 @@ impl Item {
                 | AttrKind::Clap
                 | AttrKind::StructOpt => {}
             }
-            self.name = Name::Assigned(quote!(#arg));
+            self.name = Name::Assigned(arg);
         } else if name == "value_parser" {
-            self.value_parser = Some(ValueParser::Explicit(Method::new(name, quote!(#arg))));
+            self.value_parser = Some(ValueParser::Explicit(Method::new(name, arg)));
         } else if name == "action" {
-            self.action = Some(Action::Explicit(Method::new(name, quote!(#arg))));
+            self.action = Some(Action::Explicit(Method::new(name, arg)));
         } else {
             if name == "short" || name == "long" {
                 self.is_positional = false;
             }
-            self.methods.push(Method::new(name, quote!(#arg)));
+            self.methods.push(Method::new(name, arg));
         }
     }
 


### PR DESCRIPTION
Its a small win, dropping the number of copies and reducing the overhead from `quote` but enough of these could make a difference

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
