### PR TITLE
clap_derive: remove syn's full feature

### DIFF
--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro = true
 bench = false
 
 [dependencies]
-syn = { version = "2.0.8", features = ["full"] }
+syn = "2.0.8"
 quote = "1.0.9"
 proc-macro2 = "1.0.42"
 heck = "0.4.0"


### PR DESCRIPTION
Removes unused (at least no test fail) `syn`s `full` feature, reducing build time.