### PR TITLE
docs(clap_complete): clap_complete example documentation updated with corresponding file names

### DIFF
--- a/clap_complete/examples/completion-derive.rs
+++ b/clap_complete/examples/completion-derive.rs
@@ -2,15 +2,15 @@
 //!
 //! Usage with zsh:
 //! ```sh
-//! cargo run --example value_hints_derive -- --generate=zsh > /usr/local/share/zsh/site-functions/_value_hints_derive
+//! cargo run --example completion-derive -- --generate=zsh > /usr/local/share/zsh/site-functions/_completion_derive
 //! compinit
-//! ./target/debug/examples/value_hints_derive --<TAB>
+//! ./target/debug/examples/completion_derive --<TAB>
 //! ```
 //! fish:
 //! ```sh
-//! cargo run --example value_hints_derive -- --generate=fish > value_hints_derive.fish
-//! . ./value_hints_derive.fish
-//! ./target/debug/examples/value_hints_derive --<TAB>
+//! cargo run --example completion-derive -- --generate=fish > completion_derive.fish
+//! . ./completion_derive.fish
+//! ./target/debug/examples/completion_derive --<TAB>
 //! ```
 use clap::{Args, Command, CommandFactory, Parser, Subcommand, ValueHint};
 use clap_complete::{generate, Generator, Shell};

--- a/clap_complete/examples/completion.rs
+++ b/clap_complete/examples/completion.rs
@@ -2,15 +2,15 @@
 //!
 //! Usage with zsh:
 //! ```sh
-//! cargo run --example value_hints -- --generate=zsh > /usr/local/share/zsh/site-functions/_value_hints
+//! cargo run --example completion -- --generate=zsh > /usr/local/share/zsh/site-functions/_completion
 //! compinit
-//! ./target/debug/examples/value_hints --<TAB>
+//! ./target/debug/examples/completion --<TAB>
 //! ```
 //! fish:
 //! ```sh
-//! cargo run --example value_hints -- --generate=fish > value_hints.fish
-//! . ./value_hints.fish
-//! ./target/debug/examples/value_hints --<TAB>
+//! cargo run --example completion -- --generate=fish > completion.fish
+//! . ./completion.fish
+//! ./target/debug/examples/completion --<TAB>
 //! ```
 use clap::{value_parser, Arg, Command, ValueHint};
 use clap_complete::{generate, Generator, Shell};


### PR DESCRIPTION
Fixed wrong file names for comments in `clap_complete/examples/completion-derive.rs` and `clap_complete/examples/completion.rs`.


<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
