### PR TITLE
feat: Allow deferred initialization of subcommands

### DIFF
--- a/tests/builder/propagate_globals.rs
+++ b/tests/builder/propagate_globals.rs
@@ -17,7 +17,7 @@ fn get_app() -> Command {
                 .global(true)
                 .action(ArgAction::Count),
         )
-        .subcommand(Command::new("outer").subcommand(Command::new("inner")))
+        .subcommand(Command::new("outer").defer(|cmd| cmd.subcommand(Command::new("inner"))))
 }
 
 fn get_matches(cmd: Command, argv: &'static str) -> ArgMatches {

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -5,15 +5,15 @@ use super::utils;
 #[test]
 fn subcommand() {
     let m = Command::new("test")
-        .subcommand(
-            Command::new("some").arg(
+        .subcommand(Command::new("some").defer(|cmd| {
+            cmd.arg(
                 Arg::new("test")
                     .short('t')
                     .long("test")
                     .action(ArgAction::Set)
                     .help("testing testing"),
-            ),
-        )
+            )
+        }))
         .arg(Arg::new("other").long("other"))
         .try_get_matches_from(vec!["myprog", "some", "--test", "testing"])
         .unwrap();
@@ -30,15 +30,15 @@ fn subcommand() {
 #[test]
 fn subcommand_none_given() {
     let m = Command::new("test")
-        .subcommand(
-            Command::new("some").arg(
+        .subcommand(Command::new("some").defer(|cmd| {
+            cmd.arg(
                 Arg::new("test")
                     .short('t')
                     .long("test")
                     .action(ArgAction::Set)
                     .help("testing testing"),
-            ),
-        )
+            )
+        }))
         .arg(Arg::new("other").long("other"))
         .try_get_matches_from(vec![""])
         .unwrap();
@@ -50,14 +50,16 @@ fn subcommand_none_given() {
 fn subcommand_multiple() {
     let m = Command::new("test")
         .subcommands(vec![
-            Command::new("some").arg(
-                Arg::new("test")
-                    .short('t')
-                    .long("test")
-                    .action(ArgAction::Set)
-                    .help("testing testing"),
-            ),
-            Command::new("add").arg(Arg::new("roster").short('r')),
+            Command::new("some").defer(|cmd| {
+                cmd.arg(
+                    Arg::new("test")
+                        .short('t')
+                        .long("test")
+                        .action(ArgAction::Set)
+                        .help("testing testing"),
+                )
+            }),
+            Command::new("add").defer(|cmd| cmd.arg(Arg::new("roster").short('r'))),
         ])
         .arg(Arg::new("other").long("other"))
         .try_get_matches_from(vec!["myprog", "some", "--test", "testing"])
@@ -148,8 +150,9 @@ Usage: dym [COMMAND]
 For more information, try '--help'.
 ";
 
-    let cmd = Command::new("dym")
-        .subcommand(Command::new("subcmd").arg(arg!(-s --subcmdarg <subcmdarg> "tests")));
+    let cmd = Command::new("dym").subcommand(
+        Command::new("subcmd").defer(|cmd| cmd.arg(arg!(-s --subcmdarg <subcmdarg> "tests"))),
+    );
 
     utils::assert_output(cmd, "dym --subcmarg subcmd", EXPECTED, true);
 }
@@ -166,8 +169,9 @@ Usage: dym [COMMAND]
 For more information, try '--help'.
 ";
 
-    let cmd = Command::new("dym")
-        .subcommand(Command::new("subcmd").arg(arg!(-s --subcmdarg <subcmdarg> "tests")));
+    let cmd = Command::new("dym").subcommand(
+        Command::new("subcmd").defer(|cmd| cmd.arg(arg!(-s --subcmdarg <subcmdarg> "tests"))),
+    );
 
     utils::assert_output(cmd, "dym --subcmarg foo", EXPECTED, true);
 }
@@ -427,7 +431,7 @@ fn busybox_like_multicall() {
     }
     let cmd = Command::new("busybox")
         .multicall(true)
-        .subcommand(Command::new("busybox").subcommands(applet_commands()))
+        .subcommand(Command::new("busybox").defer(|cmd| cmd.subcommands(applet_commands())))
         .subcommands(applet_commands());
 
     let m = cmd
@@ -553,7 +557,9 @@ Options:
         .version("1.0.0")
         .propagate_version(true)
         .multicall(true)
-        .subcommand(Command::new("foo").subcommand(Command::new("bar").arg(Arg::new("value"))));
+        .subcommand(Command::new("foo").defer(|cmd| {
+            cmd.subcommand(Command::new("bar").defer(|cmd| cmd.arg(Arg::new("value"))))
+        }));
     utils::assert_output(cmd, "foo bar --help", EXPECTED, false);
 }
 
@@ -573,7 +579,10 @@ Options:
         .version("1.0.0")
         .propagate_version(true)
         .multicall(true)
-        .subcommand(Command::new("foo").subcommand(Command::new("bar").arg(Arg::new("value"))));
+        .subcommand(
+            Command::new("foo")
+                .defer(|cmd| cmd.subcommand(Command::new("bar").arg(Arg::new("value")))),
+        );
     utils::assert_output(cmd, "help foo bar", EXPECTED, false);
 }
 
@@ -593,7 +602,10 @@ Options:
         .version("1.0.0")
         .propagate_version(true)
         .multicall(true)
-        .subcommand(Command::new("foo").subcommand(Command::new("bar").arg(Arg::new("value"))));
+        .subcommand(
+            Command::new("foo")
+                .defer(|cmd| cmd.subcommand(Command::new("bar").arg(Arg::new("value")))),
+        );
     cmd.build();
     let subcmd = cmd.find_subcommand_mut("foo").unwrap();
     let subcmd = subcmd.find_subcommand_mut("bar").unwrap();

--- a/tests/builder/version.rs
+++ b/tests/builder/version.rs
@@ -19,7 +19,7 @@ fn with_both() -> Command {
 }
 
 fn with_subcommand() -> Command {
-    with_version().subcommand(Command::new("bar").subcommand(Command::new("baz")))
+    with_version().subcommand(Command::new("bar").defer(|cmd| cmd.subcommand(Command::new("baz"))))
 }
 
 #[test]


### PR DESCRIPTION
This is mostly targeted at reducing startup time for no-op commands
within *very* large applications, like deno (see clap-rs#4774).

This comes at the cost of 1.1 KiB of binary size