### PR TITLE
fix(error): Change from neutral 'note' to helpful 'tip'

### DIFF
--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -99,7 +99,7 @@ impl ErrorFormatter for RichFormatter {
             for suggestion in suggestions {
                 styled.none("\n");
                 styled.none(TAB);
-                styled.good("note: ");
+                styled.good("tip: ");
                 styled.push_styled(suggestion);
             }
         }
@@ -429,14 +429,14 @@ fn try_help(styled: &mut StyledStr, help: Option<&str>) {
 fn did_you_mean(styled: &mut StyledStr, context: &str, valid: &ContextValue) {
     if let ContextValue::String(valid) = valid {
         styled.none(TAB);
-        styled.good("note: ");
+        styled.good("tip: ");
         styled.none(context);
         styled.none(" '");
         styled.good(valid);
         styled.none("' exists");
     } else if let ContextValue::Strings(valid) = valid {
         styled.none(TAB);
-        styled.good("note: ");
+        styled.good("tip: ");
         styled.none(context);
         if valid.len() > 1 {
             styled.none("s");

--- a/examples/derive_ref/interop_tests.md
+++ b/examples/derive_ref/interop_tests.md
@@ -142,7 +142,7 @@ $ interop_hand_subcommand add --unknown
 ? failed
 error: unexpected argument '--unknown' found
 
-  note: to pass '--unknown' as a value, use '-- --unknown'
+  tip: to pass '--unknown' as a value, use '-- --unknown'
 
 Usage: interop_hand_subcommand[EXE] add [NAME]...
 

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -141,7 +141,7 @@ fn suggest_trailing() {
     static MESSAGE: &str = "\
 error: unexpected argument '--foo' found
 
-  note: to pass '--foo' as a value, use '-- --foo'
+  tip: to pass '--foo' as a value, use '-- --foo'
 
 Usage: rg [PATTERN]
 

--- a/tests/builder/flags.rs
+++ b/tests/builder/flags.rs
@@ -160,7 +160,7 @@ fn issue_1284_argument_in_flag_style() {
     const USE_FLAG_AS_ARGUMENT: &str = "\
 error: unexpected argument '--another-flag' found
 
-  note: to pass '--another-flag' as a value, use '-- --another-flag'
+  tip: to pass '--another-flag' as a value, use '-- --another-flag'
 
 Usage: mycat [OPTIONS] [filename]
 
@@ -204,7 +204,7 @@ fn issue_2308_multiple_dashes() {
     static MULTIPLE_DASHES: &str = "\
 error: unexpected argument '-----' found
 
-  note: to pass '-----' as a value, use '-- -----'
+  tip: to pass '-----' as a value, use '-- -----'
 
 Usage: test <arg>
 

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -448,7 +448,7 @@ fn did_you_mean() {
     static DYM: &str = "\
 error: unexpected argument '--optio' found
 
-  note: argument '--option' exists
+  tip: argument '--option' exists
 
 Usage: clap-test --option <opt>... [positional] [positional2] [positional3]...
 
@@ -546,7 +546,7 @@ fn issue_1073_suboptimal_flag_suggestion() {
     static DYM_ISSUE_1073: &str = "\
 error: unexpected argument '--files-without-matches' found
 
-  note: argument '--files-without-match' exists
+  tip: argument '--files-without-match' exists
 
 Usage: ripgrep-616 --files-without-match
 

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -181,7 +181,7 @@ fn possible_values_output() {
 error: invalid value 'slo' for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-  note: value 'slow' exists
+  tip: value 'slow' exists
 
 For more information, try '--help'.
 ";
@@ -215,7 +215,7 @@ fn possible_values_alias_output() {
 error: invalid value 'slo' for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-  note: value 'slow' exists
+  tip: value 'slow' exists
 
 For more information, try '--help'.
 ";
@@ -253,7 +253,7 @@ fn possible_values_hidden_output() {
 error: invalid value 'slo' for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-  note: value 'slow' exists
+  tip: value 'slow' exists
 
 For more information, try '--help'.
 ";
@@ -292,7 +292,7 @@ fn escaped_possible_values_output() {
 error: invalid value 'ludicrous' for '-O <option>'
   [possible values: slow, fast, \"ludicrous speed\"]
 
-  note: value 'ludicrous speed' exists
+  tip: value 'ludicrous speed' exists
 
 For more information, try '--help'.
 ";

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -100,8 +100,8 @@ fn subcmd_did_you_mean_output() {
     static DYM_SUBCMD: &str = "\
 error: unrecognized subcommand 'subcm'
 
-  note: subcommand 'subcmd' exists
-  note: to pass 'subcm' as a value, use 'dym -- subcm'
+  tip: subcommand 'subcmd' exists
+  tip: to pass 'subcm' as a value, use 'dym -- subcm'
 
 Usage: dym [COMMAND]
 
@@ -120,8 +120,8 @@ fn subcmd_did_you_mean_output_ambiguous() {
     static DYM_SUBCMD_AMBIGUOUS: &str = "\
 error: unrecognized subcommand 'te'
 
-  note: subcommands 'test', 'temp' exist
-  note: to pass 'te' as a value, use 'dym -- te'
+  tip: subcommands 'test', 'temp' exist
+  tip: to pass 'te' as a value, use 'dym -- te'
 
 Usage: dym [COMMAND]
 
@@ -141,7 +141,7 @@ fn subcmd_did_you_mean_output_arg() {
     static EXPECTED: &str = "\
 error: unexpected argument '--subcmarg' found
 
-  note: 'subcmd --subcmdarg' exists
+  tip: 'subcmd --subcmdarg' exists
 
 Usage: dym [COMMAND]
 
@@ -353,7 +353,7 @@ fn subcommand_used_after_double_dash() {
     static SUBCMD_AFTER_DOUBLE_DASH: &str = "\
 error: unexpected argument 'subcmd' found
 
-  note: subcommand 'subcmd' exists; to use it, remove the '--' before it
+  tip: subcommand 'subcmd' exists; to use it, remove the '--' before it
 
 Usage: cmd [COMMAND]
 
@@ -517,8 +517,8 @@ For more information, try 'help'.
         static BAZ_EXPECTED: &str = "\
 error: unrecognized subcommand 'baz'
 
-  note: subcommand 'bar' exists
-  note: to pass 'baz' as a value, use ' -- baz'
+  tip: subcommand 'bar' exists
+  tip: to pass 'baz' as a value, use ' -- baz'
 
 Usage: <COMMAND>
 


### PR DESCRIPTION
This also has the advantage of aligning with `error:`

This is a small part of #4638

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
