### PR TITLE
feat(help): Allow customizing terminal styling (unstable)

### DIFF
--- a/clap_builder/Cargo.toml
+++ b/clap_builder/Cargo.toml
@@ -35,8 +35,8 @@ debug = ["dep:backtrace"] # Enables debug messages
 unstable-doc = ["cargo", "wrap_help", "env", "unicode", "string"] # for docs.rs
 
 # Used in default
-std = [] # support for no_std in a backwards-compatible way
-color = ["dep:anstyle", "dep:anstream"]
+std = ["anstyle/std"] # support for no_std in a backwards-compatible way
+color = ["dep:anstream"]
 help = []
 usage = []
 error-context = []
@@ -62,7 +62,7 @@ bitflags = "1.2.0"
 unicase = { version = "2.6.0", optional = true }
 strsim = { version = "0.10.0",  optional = true }
 anstream = { version = "0.3.0", optional = true }
-anstyle = { version = "1.0.0", features = ["std"], optional = true }
+anstyle = "1.0.0"
 terminal_size = { version = "0.2.1", optional = true }
 backtrace = { version = "0.3.67", optional = true }
 unicode-width = { version = "0.1.9", optional = true }

--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4276,13 +4276,13 @@ impl Arg {
         let mut styled = StyledStr::new();
         // Write the name such --long or -l
         if let Some(l) = self.get_long() {
-            styled.stylize(Style::Literal, "--");
-            styled.stylize(Style::Literal, l);
+            styled.stylize(Style::Literal.as_style(), "--");
+            styled.stylize(Style::Literal.as_style(), l);
         } else if let Some(s) = self.get_short() {
-            styled.stylize(Style::Literal, "-");
+            styled.stylize(Style::Literal.as_style(), "-");
             let mut b = [0; 4];
             let s = s.encode_utf8(&mut b);
-            styled.stylize(Style::Literal, s);
+            styled.stylize(Style::Literal.as_style(), s);
         }
         styled.push_styled(&self.stylize_arg_suffix(required));
         styled
@@ -4297,26 +4297,26 @@ impl Arg {
             if self.is_require_equals_set() {
                 if is_optional_val {
                     need_closing_bracket = true;
-                    styled.stylize(Style::Placeholder, "[=");
+                    styled.stylize(Style::Placeholder.as_style(), "[=");
                 } else {
-                    styled.stylize(Style::Literal, "=");
+                    styled.stylize(Style::Literal.as_style(), "=");
                 }
             } else if is_optional_val {
                 need_closing_bracket = true;
-                styled.stylize(Style::Placeholder, " [");
+                styled.stylize(Style::Placeholder.as_style(), " [");
             } else {
-                styled.stylize(Style::Placeholder, " ");
+                styled.stylize(Style::Placeholder.as_style(), " ");
             }
         }
         if self.is_takes_value_set() || self.is_positional() {
             let required = required.unwrap_or_else(|| self.is_required_set());
             let arg_val = self.render_arg_val(required);
-            styled.stylize(Style::Placeholder, &arg_val);
+            styled.stylize(Style::Placeholder.as_style(), &arg_val);
         } else if matches!(*self.get_action(), ArgAction::Count) {
-            styled.stylize(Style::Placeholder, "...");
+            styled.stylize(Style::Placeholder.as_style(), "...");
         }
         if need_closing_bracket {
-            styled.stylize(Style::Placeholder, "]");
+            styled.stylize(Style::Placeholder.as_style(), "]");
         }
 
         styled

--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -16,6 +16,7 @@ use crate::builder::IntoResettable;
 use crate::builder::OsStr;
 use crate::builder::PossibleValue;
 use crate::builder::Str;
+use crate::builder::Style;
 use crate::builder::StyledStr;
 use crate::builder::ValueRange;
 use crate::util::AnyValueId;
@@ -4275,11 +4276,13 @@ impl Arg {
         let mut styled = StyledStr::new();
         // Write the name such --long or -l
         if let Some(l) = self.get_long() {
-            styled.literal("--");
-            styled.literal(l);
+            styled.stylize(Style::Literal, "--");
+            styled.stylize(Style::Literal, l);
         } else if let Some(s) = self.get_short() {
-            styled.literal("-");
-            styled.literal(s);
+            styled.stylize(Style::Literal, "-");
+            let mut b = [0; 4];
+            let s = s.encode_utf8(&mut b);
+            styled.stylize(Style::Literal, s);
         }
         styled.push_styled(&self.stylize_arg_suffix(required));
         styled
@@ -4294,26 +4297,26 @@ impl Arg {
             if self.is_require_equals_set() {
                 if is_optional_val {
                     need_closing_bracket = true;
-                    styled.placeholder("[=");
+                    styled.stylize(Style::Placeholder, "[=");
                 } else {
-                    styled.literal("=");
+                    styled.stylize(Style::Literal, "=");
                 }
             } else if is_optional_val {
                 need_closing_bracket = true;
-                styled.placeholder(" [");
+                styled.stylize(Style::Placeholder, " [");
             } else {
-                styled.placeholder(" ");
+                styled.stylize(Style::Placeholder, " ");
             }
         }
         if self.is_takes_value_set() || self.is_positional() {
             let required = required.unwrap_or_else(|| self.is_required_set());
             let arg_val = self.render_arg_val(required);
-            styled.placeholder(arg_val);
+            styled.stylize(Style::Placeholder, &arg_val);
         } else if matches!(*self.get_action(), ArgAction::Count) {
-            styled.placeholder("...");
+            styled.stylize(Style::Placeholder, "...");
         }
         if need_closing_bracket {
-            styled.placeholder("]");
+            styled.stylize(Style::Placeholder, "]");
         }
 
         styled

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -4321,9 +4321,9 @@ impl Command {
             .collect::<Vec<_>>()
             .join("|");
         let mut styled = StyledStr::new();
-        styled.none("<");
-        styled.none(g_string);
-        styled.none(">");
+        styled.push_str("<");
+        styled.push_string(g_string);
+        styled.push_str(">");
         styled
     }
 }

--- a/clap_builder/src/builder/mod.rs
+++ b/clap_builder/src/builder/mod.rs
@@ -59,3 +59,4 @@ pub use value_parser::_AnonymousValueParser;
 pub(crate) use self::str::Inner as StrInner;
 pub(crate) use action::CountType;
 pub(crate) use arg_settings::{ArgFlags, ArgSettings};
+pub(crate) use styled_str::Style;

--- a/clap_builder/src/builder/styled_str.rs
+++ b/clap_builder/src/builder/styled_str.rs
@@ -33,35 +33,19 @@ impl StyledStr {
         self.0.as_str()
     }
 
-    pub(crate) fn header(&mut self, msg: impl Into<String>) {
-        self.stylize(Style::Header, msg.into());
+    #[cfg(feature = "color")]
+    pub(crate) fn stylize(&mut self, style: Style, msg: &str) {
+        if !msg.is_empty() {
+            use std::fmt::Write as _;
+
+            let style = style.as_style();
+            let _ = write!(self.0, "{}{}{}", style.render(), msg, style.render_reset());
+        }
     }
 
-    pub(crate) fn literal(&mut self, msg: impl Into<String>) {
-        self.stylize(Style::Literal, msg.into());
-    }
-
-    pub(crate) fn placeholder(&mut self, msg: impl Into<String>) {
-        self.stylize(Style::Placeholder, msg.into());
-    }
-
-    #[cfg_attr(not(feature = "error-context"), allow(dead_code))]
-    pub(crate) fn good(&mut self, msg: impl Into<String>) {
-        self.stylize(Style::Good, msg.into());
-    }
-
-    #[cfg_attr(not(feature = "error-context"), allow(dead_code))]
-    pub(crate) fn warning(&mut self, msg: impl Into<String>) {
-        self.stylize(Style::Warning, msg.into());
-    }
-
-    pub(crate) fn error(&mut self, msg: impl Into<String>) {
-        self.stylize(Style::Error, msg.into());
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn hint(&mut self, msg: impl Into<String>) {
-        self.stylize(Style::Hint, msg.into());
+    #[cfg(not(feature = "color"))]
+    pub(crate) fn stylize(&mut self, _style: Style, msg: &str) {
+        self.0.push_str(msg);
     }
 
     pub(crate) fn none(&mut self, msg: impl Into<String>) {
@@ -120,21 +104,6 @@ impl StyledStr {
         new = new.trim_end().to_owned();
 
         self.0 = new;
-    }
-
-    #[cfg(feature = "color")]
-    fn stylize(&mut self, style: Style, msg: String) {
-        if !msg.is_empty() {
-            use std::fmt::Write as _;
-
-            let style = style.as_style();
-            let _ = write!(self.0, "{}{}{}", style.render(), msg, style.render_reset());
-        }
-    }
-
-    #[cfg(not(feature = "color"))]
-    fn stylize(&mut self, _style: Style, msg: String) {
-        self.0.push_str(&msg);
     }
 
     #[inline(never)]
@@ -240,12 +209,19 @@ impl std::fmt::Display for StyledStr {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Style {
+    #[allow(dead_code)]
     Header,
+    #[allow(dead_code)]
     Literal,
+    #[allow(dead_code)]
     Placeholder,
+    #[allow(dead_code)]
     Good,
+    #[allow(dead_code)]
     Warning,
+    #[allow(dead_code)]
     Error,
+    #[allow(dead_code)]
     Hint,
 }
 

--- a/clap_builder/src/builder/styled_str.rs
+++ b/clap_builder/src/builder/styled_str.rs
@@ -34,17 +34,16 @@ impl StyledStr {
     }
 
     #[cfg(feature = "color")]
-    pub(crate) fn stylize(&mut self, style: Style, msg: &str) {
+    pub(crate) fn stylize(&mut self, style: anstyle::Style, msg: &str) {
         if !msg.is_empty() {
             use std::fmt::Write as _;
 
-            let style = style.as_style();
             let _ = write!(self.0, "{}{}{}", style.render(), msg, style.render_reset());
         }
     }
 
     #[cfg(not(feature = "color"))]
-    pub(crate) fn stylize(&mut self, _style: Style, msg: &str) {
+    pub(crate) fn stylize(&mut self, _style: anstyle::Style, msg: &str) {
         self.0.push_str(msg);
     }
 
@@ -226,8 +225,7 @@ pub(crate) enum Style {
 }
 
 impl Style {
-    #[cfg(feature = "color")]
-    fn as_style(&self) -> anstyle::Style {
+    pub(crate) fn as_style(&self) -> anstyle::Style {
         match self {
             Style::Header => (anstyle::Effects::BOLD | anstyle::Effects::UNDERLINE).into(),
             Style::Literal => anstyle::Effects::BOLD.into(),

--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(feature = "error-context"), allow(unused_imports))]
 
 use crate::builder::Command;
+use crate::builder::Style;
 use crate::builder::StyledStr;
 #[cfg(feature = "error-context")]
 use crate::error::ContextKind;
@@ -99,7 +100,7 @@ impl ErrorFormatter for RichFormatter {
             for suggestion in suggestions {
                 styled.none("\n");
                 styled.none(TAB);
-                styled.good("tip: ");
+                styled.stylize(Style::Good, "tip: ");
                 styled.push_styled(suggestion);
             }
         }
@@ -116,7 +117,7 @@ impl ErrorFormatter for RichFormatter {
 }
 
 fn start_error(styled: &mut StyledStr) {
-    styled.error("error:");
+    styled.stylize(Style::Error, "error:");
     styled.none(" ");
 }
 
@@ -132,11 +133,11 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             {
                 if ContextValue::String(invalid_arg.clone()) == *prior_arg {
                     styled.none("the argument '");
-                    styled.warning(invalid_arg);
+                    styled.stylize(Style::Warning, invalid_arg);
                     styled.none("' cannot be used multiple times");
                 } else {
                     styled.none("the argument '");
-                    styled.warning(invalid_arg);
+                    styled.stylize(Style::Warning, invalid_arg);
                     styled.none("' cannot be used with");
 
                     match prior_arg {
@@ -145,12 +146,12 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                             for v in values {
                                 styled.none("\n");
                                 styled.none(TAB);
-                                styled.warning(&**v);
+                                styled.stylize(Style::Warning, &**v);
                             }
                         }
                         ContextValue::String(value) => {
                             styled.none(" '");
-                            styled.warning(value);
+                            styled.stylize(Style::Warning, value);
                             styled.none("'");
                         }
                         _ => {
@@ -167,7 +168,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_arg = error.get(ContextKind::InvalidArg);
             if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
                 styled.none("equal sign is needed when assigning values to '");
-                styled.warning(invalid_arg);
+                styled.stylize(Style::Warning, invalid_arg);
                 styled.none("'");
                 true
             } else {
@@ -184,13 +185,13 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             {
                 if invalid_value.is_empty() {
                     styled.none("a value is required for '");
-                    styled.warning(invalid_arg);
+                    styled.stylize(Style::Warning, invalid_arg);
                     styled.none("' but none was supplied");
                 } else {
                     styled.none("invalid value '");
                     styled.none(invalid_value);
                     styled.none("' for '");
-                    styled.warning(invalid_arg);
+                    styled.stylize(Style::Warning, invalid_arg);
                     styled.none("'");
                 }
 
@@ -202,10 +203,10 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                         styled.none("[possible values: ");
                         if let Some((last, elements)) = possible_values.split_last() {
                             for v in elements {
-                                styled.good(escape(v));
+                                styled.stylize(Style::Good, &escape(v));
                                 styled.none(", ");
                             }
-                            styled.good(escape(last));
+                            styled.stylize(Style::Good, &escape(last));
                         }
                         styled.none("]");
                     }
@@ -219,7 +220,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_sub = error.get(ContextKind::InvalidSubcommand);
             if let Some(ContextValue::String(invalid_sub)) = invalid_sub {
                 styled.none("unrecognized subcommand '");
-                styled.warning(invalid_sub);
+                styled.stylize(Style::Warning, invalid_sub);
                 styled.none("'");
                 true
             } else {
@@ -233,7 +234,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                 for v in invalid_arg {
                     styled.none("\n");
                     styled.none(TAB);
-                    styled.good(&**v);
+                    styled.stylize(Style::Good, &**v);
                 }
                 true
             } else {
@@ -244,7 +245,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_sub = error.get(ContextKind::InvalidSubcommand);
             if let Some(ContextValue::String(invalid_sub)) = invalid_sub {
                 styled.none("'");
-                styled.warning(invalid_sub);
+                styled.stylize(Style::Warning, invalid_sub);
                 styled.none("' requires a subcommand but one was not provided");
 
                 let possible_values = error.get(ContextKind::ValidSubcommand);
@@ -255,10 +256,10 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                         styled.none("[subcommands: ");
                         if let Some((last, elements)) = possible_values.split_last() {
                             for v in elements {
-                                styled.good(escape(v));
+                                styled.stylize(Style::Good, &escape(v));
                                 styled.none(", ");
                             }
-                            styled.good(escape(last));
+                            styled.stylize(Style::Good, &escape(last));
                         }
                         styled.none("]");
                     }
@@ -279,9 +280,9 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, invalid_value)
             {
                 styled.none("unexpected value '");
-                styled.warning(invalid_value);
+                styled.stylize(Style::Warning, invalid_value);
                 styled.none("' for '");
-                styled.warning(invalid_arg);
+                styled.stylize(Style::Warning, invalid_arg);
                 styled.none("' found; no more were expected");
                 true
             } else {
@@ -299,11 +300,11 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, actual_num_values, min_values)
             {
                 let were_provided = singular_or_plural(*actual_num_values as usize);
-                styled.warning(min_values.to_string());
+                styled.stylize(Style::Warning, &min_values.to_string());
                 styled.none(" more values required by '");
-                styled.warning(invalid_arg);
+                styled.stylize(Style::Warning, invalid_arg);
                 styled.none("'; only ");
-                styled.warning(actual_num_values.to_string());
+                styled.stylize(Style::Warning, &actual_num_values.to_string());
                 styled.none(were_provided);
                 true
             } else {
@@ -319,9 +320,9 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, invalid_value)
             {
                 styled.none("invalid value '");
-                styled.warning(invalid_value);
+                styled.stylize(Style::Warning, invalid_value);
                 styled.none("' for '");
-                styled.warning(invalid_arg);
+                styled.stylize(Style::Warning, invalid_arg);
                 if let Some(source) = error.inner.source.as_deref() {
                     styled.none("': ");
                     styled.none(source.to_string());
@@ -344,11 +345,11 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, actual_num_values, num_values)
             {
                 let were_provided = singular_or_plural(*actual_num_values as usize);
-                styled.warning(num_values.to_string());
+                styled.stylize(Style::Warning, &num_values.to_string());
                 styled.none(" values required for '");
-                styled.warning(invalid_arg);
+                styled.stylize(Style::Warning, invalid_arg);
                 styled.none("' but ");
-                styled.warning(actual_num_values.to_string());
+                styled.stylize(Style::Warning, &actual_num_values.to_string());
                 styled.none(were_provided);
                 true
             } else {
@@ -359,7 +360,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_arg = error.get(ContextKind::InvalidArg);
             if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
                 styled.none("unexpected argument '");
-                styled.warning(invalid_arg.to_string());
+                styled.stylize(Style::Warning, invalid_arg);
                 styled.none("' found");
                 true
             } else {
@@ -418,7 +419,7 @@ pub(crate) fn get_help_flag(cmd: &Command) -> Option<&'static str> {
 fn try_help(styled: &mut StyledStr, help: Option<&str>) {
     if let Some(help) = help {
         styled.none("\n\nFor more information, try '");
-        styled.literal(help.to_owned());
+        styled.stylize(Style::Literal, help);
         styled.none("'.\n");
     } else {
         styled.none("\n");
@@ -428,12 +429,12 @@ fn try_help(styled: &mut StyledStr, help: Option<&str>) {
 #[cfg(feature = "error-context")]
 fn did_you_mean(styled: &mut StyledStr, context: &str, valid: &ContextValue) {
     styled.none(TAB);
-    styled.good("tip:");
+    styled.stylize(Style::Good, "tip:");
     if let ContextValue::String(valid) = valid {
         styled.none(" a similar ");
         styled.none(context);
         styled.none(" exists: '");
-        styled.good(valid);
+        styled.stylize(Style::Good, valid);
         styled.none("'");
     } else if let ContextValue::Strings(valid) = valid {
         if valid.len() == 1 {
@@ -450,7 +451,7 @@ fn did_you_mean(styled: &mut StyledStr, context: &str, valid: &ContextValue) {
                 styled.none(", ");
             }
             styled.none("'");
-            styled.good(valid);
+            styled.stylize(Style::Good, valid);
             styled.none("'");
         }
     }

--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -100,7 +100,7 @@ impl ErrorFormatter for RichFormatter {
             for suggestion in suggestions {
                 styled.none("\n");
                 styled.none(TAB);
-                styled.stylize(Style::Good, "tip: ");
+                styled.stylize(Style::Good.as_style(), "tip: ");
                 styled.push_styled(suggestion);
             }
         }
@@ -117,7 +117,7 @@ impl ErrorFormatter for RichFormatter {
 }
 
 fn start_error(styled: &mut StyledStr) {
-    styled.stylize(Style::Error, "error:");
+    styled.stylize(Style::Error.as_style(), "error:");
     styled.none(" ");
 }
 
@@ -133,11 +133,11 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             {
                 if ContextValue::String(invalid_arg.clone()) == *prior_arg {
                     styled.none("the argument '");
-                    styled.stylize(Style::Warning, invalid_arg);
+                    styled.stylize(Style::Warning.as_style(), invalid_arg);
                     styled.none("' cannot be used multiple times");
                 } else {
                     styled.none("the argument '");
-                    styled.stylize(Style::Warning, invalid_arg);
+                    styled.stylize(Style::Warning.as_style(), invalid_arg);
                     styled.none("' cannot be used with");
 
                     match prior_arg {
@@ -146,12 +146,12 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                             for v in values {
                                 styled.none("\n");
                                 styled.none(TAB);
-                                styled.stylize(Style::Warning, &**v);
+                                styled.stylize(Style::Warning.as_style(), &**v);
                             }
                         }
                         ContextValue::String(value) => {
                             styled.none(" '");
-                            styled.stylize(Style::Warning, value);
+                            styled.stylize(Style::Warning.as_style(), value);
                             styled.none("'");
                         }
                         _ => {
@@ -168,7 +168,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_arg = error.get(ContextKind::InvalidArg);
             if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
                 styled.none("equal sign is needed when assigning values to '");
-                styled.stylize(Style::Warning, invalid_arg);
+                styled.stylize(Style::Warning.as_style(), invalid_arg);
                 styled.none("'");
                 true
             } else {
@@ -185,13 +185,13 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             {
                 if invalid_value.is_empty() {
                     styled.none("a value is required for '");
-                    styled.stylize(Style::Warning, invalid_arg);
+                    styled.stylize(Style::Warning.as_style(), invalid_arg);
                     styled.none("' but none was supplied");
                 } else {
                     styled.none("invalid value '");
                     styled.none(invalid_value);
                     styled.none("' for '");
-                    styled.stylize(Style::Warning, invalid_arg);
+                    styled.stylize(Style::Warning.as_style(), invalid_arg);
                     styled.none("'");
                 }
 
@@ -203,10 +203,10 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                         styled.none("[possible values: ");
                         if let Some((last, elements)) = possible_values.split_last() {
                             for v in elements {
-                                styled.stylize(Style::Good, &escape(v));
+                                styled.stylize(Style::Good.as_style(), &escape(v));
                                 styled.none(", ");
                             }
-                            styled.stylize(Style::Good, &escape(last));
+                            styled.stylize(Style::Good.as_style(), &escape(last));
                         }
                         styled.none("]");
                     }
@@ -220,7 +220,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_sub = error.get(ContextKind::InvalidSubcommand);
             if let Some(ContextValue::String(invalid_sub)) = invalid_sub {
                 styled.none("unrecognized subcommand '");
-                styled.stylize(Style::Warning, invalid_sub);
+                styled.stylize(Style::Warning.as_style(), invalid_sub);
                 styled.none("'");
                 true
             } else {
@@ -234,7 +234,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                 for v in invalid_arg {
                     styled.none("\n");
                     styled.none(TAB);
-                    styled.stylize(Style::Good, &**v);
+                    styled.stylize(Style::Good.as_style(), &**v);
                 }
                 true
             } else {
@@ -245,7 +245,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_sub = error.get(ContextKind::InvalidSubcommand);
             if let Some(ContextValue::String(invalid_sub)) = invalid_sub {
                 styled.none("'");
-                styled.stylize(Style::Warning, invalid_sub);
+                styled.stylize(Style::Warning.as_style(), invalid_sub);
                 styled.none("' requires a subcommand but one was not provided");
 
                 let possible_values = error.get(ContextKind::ValidSubcommand);
@@ -256,10 +256,10 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
                         styled.none("[subcommands: ");
                         if let Some((last, elements)) = possible_values.split_last() {
                             for v in elements {
-                                styled.stylize(Style::Good, &escape(v));
+                                styled.stylize(Style::Good.as_style(), &escape(v));
                                 styled.none(", ");
                             }
-                            styled.stylize(Style::Good, &escape(last));
+                            styled.stylize(Style::Good.as_style(), &escape(last));
                         }
                         styled.none("]");
                     }
@@ -280,9 +280,9 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, invalid_value)
             {
                 styled.none("unexpected value '");
-                styled.stylize(Style::Warning, invalid_value);
+                styled.stylize(Style::Warning.as_style(), invalid_value);
                 styled.none("' for '");
-                styled.stylize(Style::Warning, invalid_arg);
+                styled.stylize(Style::Warning.as_style(), invalid_arg);
                 styled.none("' found; no more were expected");
                 true
             } else {
@@ -300,11 +300,11 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, actual_num_values, min_values)
             {
                 let were_provided = singular_or_plural(*actual_num_values as usize);
-                styled.stylize(Style::Warning, &min_values.to_string());
+                styled.stylize(Style::Warning.as_style(), &min_values.to_string());
                 styled.none(" more values required by '");
-                styled.stylize(Style::Warning, invalid_arg);
+                styled.stylize(Style::Warning.as_style(), invalid_arg);
                 styled.none("'; only ");
-                styled.stylize(Style::Warning, &actual_num_values.to_string());
+                styled.stylize(Style::Warning.as_style(), &actual_num_values.to_string());
                 styled.none(were_provided);
                 true
             } else {
@@ -320,9 +320,9 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, invalid_value)
             {
                 styled.none("invalid value '");
-                styled.stylize(Style::Warning, invalid_value);
+                styled.stylize(Style::Warning.as_style(), invalid_value);
                 styled.none("' for '");
-                styled.stylize(Style::Warning, invalid_arg);
+                styled.stylize(Style::Warning.as_style(), invalid_arg);
                 if let Some(source) = error.inner.source.as_deref() {
                     styled.none("': ");
                     styled.none(source.to_string());
@@ -345,11 +345,11 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             ) = (invalid_arg, actual_num_values, num_values)
             {
                 let were_provided = singular_or_plural(*actual_num_values as usize);
-                styled.stylize(Style::Warning, &num_values.to_string());
+                styled.stylize(Style::Warning.as_style(), &num_values.to_string());
                 styled.none(" values required for '");
-                styled.stylize(Style::Warning, invalid_arg);
+                styled.stylize(Style::Warning.as_style(), invalid_arg);
                 styled.none("' but ");
-                styled.stylize(Style::Warning, &actual_num_values.to_string());
+                styled.stylize(Style::Warning.as_style(), &actual_num_values.to_string());
                 styled.none(were_provided);
                 true
             } else {
@@ -360,7 +360,7 @@ fn write_dynamic_context(error: &crate::error::Error, styled: &mut StyledStr) ->
             let invalid_arg = error.get(ContextKind::InvalidArg);
             if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
                 styled.none("unexpected argument '");
-                styled.stylize(Style::Warning, invalid_arg);
+                styled.stylize(Style::Warning.as_style(), invalid_arg);
                 styled.none("' found");
                 true
             } else {
@@ -419,7 +419,7 @@ pub(crate) fn get_help_flag(cmd: &Command) -> Option<&'static str> {
 fn try_help(styled: &mut StyledStr, help: Option<&str>) {
     if let Some(help) = help {
         styled.none("\n\nFor more information, try '");
-        styled.stylize(Style::Literal, help);
+        styled.stylize(Style::Literal.as_style(), help);
         styled.none("'.\n");
     } else {
         styled.none("\n");
@@ -429,12 +429,12 @@ fn try_help(styled: &mut StyledStr, help: Option<&str>) {
 #[cfg(feature = "error-context")]
 fn did_you_mean(styled: &mut StyledStr, context: &str, valid: &ContextValue) {
     styled.none(TAB);
-    styled.stylize(Style::Good, "tip:");
+    styled.stylize(Style::Good.as_style(), "tip:");
     if let ContextValue::String(valid) = valid {
         styled.none(" a similar ");
         styled.none(context);
         styled.none(" exists: '");
-        styled.stylize(Style::Good, valid);
+        styled.stylize(Style::Good.as_style(), valid);
         styled.none("'");
     } else if let ContextValue::Strings(valid) = valid {
         if valid.len() == 1 {
@@ -451,7 +451,7 @@ fn did_you_mean(styled: &mut StyledStr, context: &str, valid: &ContextValue) {
                 styled.none(", ");
             }
             styled.none("'");
-            styled.stylize(Style::Good, valid);
+            styled.stylize(Style::Good.as_style(), valid);
             styled.none("'");
         }
     }

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -435,18 +435,22 @@ impl<F: ErrorFormatter> Error<F> {
         name: String,
         usage: Option<StyledStr>,
     ) -> Self {
+        use std::fmt::Write as _;
+        let warning = Style::Warning.as_style();
+        let good = Style::Good.as_style();
         let mut err = Self::new(ErrorKind::InvalidSubcommand).with_cmd(cmd);
 
         #[cfg(feature = "error-context")]
         {
             let mut styled_suggestion = StyledStr::new();
-            styled_suggestion.none("to pass '");
-            styled_suggestion.stylize(Style::Warning.as_style(), &subcmd);
-            styled_suggestion.none("' as a value, use '");
-            styled_suggestion.stylize(Style::Good.as_style(), &name);
-            styled_suggestion.stylize(Style::Good.as_style(), " -- ");
-            styled_suggestion.stylize(Style::Good.as_style(), &subcmd);
-            styled_suggestion.none("'");
+            let _ = write!(
+                styled_suggestion,
+                "to pass '{}{subcmd}{}' as a value, use '{}{name} -- {subcmd}{}'",
+                warning.render(),
+                warning.render_reset(),
+                good.render(),
+                good.render_reset()
+            );
 
             err = err.extend_context_unchecked([
                 (ContextKind::InvalidSubcommand, ContextValue::String(subcmd)),
@@ -662,6 +666,9 @@ impl<F: ErrorFormatter> Error<F> {
         suggested_trailing_arg: bool,
         usage: Option<StyledStr>,
     ) -> Self {
+        use std::fmt::Write as _;
+        let warning = Style::Warning.as_style();
+        let good = Style::Good.as_style();
         let mut err = Self::new(ErrorKind::UnknownArgument).with_cmd(cmd);
 
         #[cfg(feature = "error-context")]
@@ -669,12 +676,14 @@ impl<F: ErrorFormatter> Error<F> {
             let mut suggestions = vec![];
             if suggested_trailing_arg {
                 let mut styled_suggestion = StyledStr::new();
-                styled_suggestion.none("to pass '");
-                styled_suggestion.stylize(Style::Warning.as_style(), &arg);
-                styled_suggestion.none("' as a value, use '");
-                styled_suggestion.stylize(Style::Good.as_style(), "-- ");
-                styled_suggestion.stylize(Style::Good.as_style(), &arg);
-                styled_suggestion.none("'");
+                let _ = write!(
+                    styled_suggestion,
+                    "to pass '{}{arg}{}' as a value, use '{}-- {arg}{}'",
+                    warning.render(),
+                    warning.render_reset(),
+                    good.render(),
+                    good.render_reset()
+                );
                 suggestions.push(styled_suggestion);
             }
 
@@ -687,12 +696,12 @@ impl<F: ErrorFormatter> Error<F> {
             match did_you_mean {
                 Some((flag, Some(sub))) => {
                     let mut styled_suggestion = StyledStr::new();
-                    styled_suggestion.none("'");
-                    styled_suggestion.stylize(Style::Good.as_style(), &sub);
-                    styled_suggestion.none(" ");
-                    styled_suggestion.stylize(Style::Good.as_style(), "--");
-                    styled_suggestion.stylize(Style::Good.as_style(), &flag);
-                    styled_suggestion.none("' exists");
+                    let _ = write!(
+                        styled_suggestion,
+                        "'{}{sub} --{flag}{}' exists",
+                        good.render(),
+                        good.render_reset()
+                    );
                     suggestions.push(styled_suggestion);
                 }
                 Some((flag, None)) => {
@@ -719,16 +728,22 @@ impl<F: ErrorFormatter> Error<F> {
         arg: String,
         usage: Option<StyledStr>,
     ) -> Self {
+        use std::fmt::Write as _;
+        let warning = Style::Warning.as_style();
+        let good = Style::Good.as_style();
         let mut err = Self::new(ErrorKind::UnknownArgument).with_cmd(cmd);
 
         #[cfg(feature = "error-context")]
         {
             let mut styled_suggestion = StyledStr::new();
-            styled_suggestion.none("subcommand '");
-            styled_suggestion.stylize(Style::Good.as_style(), &arg);
-            styled_suggestion.none("' exists; to use it, remove the '");
-            styled_suggestion.stylize(Style::Warning.as_style(), "--");
-            styled_suggestion.none("' before it");
+            let _ = write!(
+                styled_suggestion,
+                "subcommand '{}{arg}{}' exists; to use it, remove the '{}--{}' before it",
+                good.render(),
+                good.render_reset(),
+                warning.render(),
+                warning.render_reset()
+            );
 
             err = err.extend_context_unchecked([
                 (ContextKind::InvalidArg, ContextValue::String(arg)),

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -441,11 +441,11 @@ impl<F: ErrorFormatter> Error<F> {
         {
             let mut styled_suggestion = StyledStr::new();
             styled_suggestion.none("to pass '");
-            styled_suggestion.stylize(Style::Warning, &subcmd);
+            styled_suggestion.stylize(Style::Warning.as_style(), &subcmd);
             styled_suggestion.none("' as a value, use '");
-            styled_suggestion.stylize(Style::Good, &name);
-            styled_suggestion.stylize(Style::Good, " -- ");
-            styled_suggestion.stylize(Style::Good, &subcmd);
+            styled_suggestion.stylize(Style::Good.as_style(), &name);
+            styled_suggestion.stylize(Style::Good.as_style(), " -- ");
+            styled_suggestion.stylize(Style::Good.as_style(), &subcmd);
             styled_suggestion.none("'");
 
             err = err.extend_context_unchecked([
@@ -670,10 +670,10 @@ impl<F: ErrorFormatter> Error<F> {
             if suggested_trailing_arg {
                 let mut styled_suggestion = StyledStr::new();
                 styled_suggestion.none("to pass '");
-                styled_suggestion.stylize(Style::Warning, &arg);
+                styled_suggestion.stylize(Style::Warning.as_style(), &arg);
                 styled_suggestion.none("' as a value, use '");
-                styled_suggestion.stylize(Style::Good, "-- ");
-                styled_suggestion.stylize(Style::Good, &arg);
+                styled_suggestion.stylize(Style::Good.as_style(), "-- ");
+                styled_suggestion.stylize(Style::Good.as_style(), &arg);
                 styled_suggestion.none("'");
                 suggestions.push(styled_suggestion);
             }
@@ -688,10 +688,10 @@ impl<F: ErrorFormatter> Error<F> {
                 Some((flag, Some(sub))) => {
                     let mut styled_suggestion = StyledStr::new();
                     styled_suggestion.none("'");
-                    styled_suggestion.stylize(Style::Good, &sub);
+                    styled_suggestion.stylize(Style::Good.as_style(), &sub);
                     styled_suggestion.none(" ");
-                    styled_suggestion.stylize(Style::Good, "--");
-                    styled_suggestion.stylize(Style::Good, &flag);
+                    styled_suggestion.stylize(Style::Good.as_style(), "--");
+                    styled_suggestion.stylize(Style::Good.as_style(), &flag);
                     styled_suggestion.none("' exists");
                     suggestions.push(styled_suggestion);
                 }
@@ -725,9 +725,9 @@ impl<F: ErrorFormatter> Error<F> {
         {
             let mut styled_suggestion = StyledStr::new();
             styled_suggestion.none("subcommand '");
-            styled_suggestion.stylize(Style::Good, &arg);
+            styled_suggestion.stylize(Style::Good.as_style(), &arg);
             styled_suggestion.none("' exists; to use it, remove the '");
-            styled_suggestion.stylize(Style::Warning, "--");
+            styled_suggestion.stylize(Style::Warning.as_style(), "--");
             styled_suggestion.none("' before it");
 
             err = err.extend_context_unchecked([

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 // Internal
+use crate::builder::Style;
 use crate::builder::StyledStr;
 use crate::output::fmt::Colorizer;
 use crate::output::fmt::Stream;
@@ -440,11 +441,11 @@ impl<F: ErrorFormatter> Error<F> {
         {
             let mut styled_suggestion = StyledStr::new();
             styled_suggestion.none("to pass '");
-            styled_suggestion.warning(&subcmd);
+            styled_suggestion.stylize(Style::Warning, &subcmd);
             styled_suggestion.none("' as a value, use '");
-            styled_suggestion.good(name);
-            styled_suggestion.good(" -- ");
-            styled_suggestion.good(&subcmd);
+            styled_suggestion.stylize(Style::Good, &name);
+            styled_suggestion.stylize(Style::Good, " -- ");
+            styled_suggestion.stylize(Style::Good, &subcmd);
             styled_suggestion.none("'");
 
             err = err.extend_context_unchecked([
@@ -669,10 +670,10 @@ impl<F: ErrorFormatter> Error<F> {
             if suggested_trailing_arg {
                 let mut styled_suggestion = StyledStr::new();
                 styled_suggestion.none("to pass '");
-                styled_suggestion.warning(&arg);
+                styled_suggestion.stylize(Style::Warning, &arg);
                 styled_suggestion.none("' as a value, use '");
-                styled_suggestion.good("-- ");
-                styled_suggestion.good(&arg);
+                styled_suggestion.stylize(Style::Good, "-- ");
+                styled_suggestion.stylize(Style::Good, &arg);
                 styled_suggestion.none("'");
                 suggestions.push(styled_suggestion);
             }
@@ -687,10 +688,10 @@ impl<F: ErrorFormatter> Error<F> {
                 Some((flag, Some(sub))) => {
                     let mut styled_suggestion = StyledStr::new();
                     styled_suggestion.none("'");
-                    styled_suggestion.good(sub);
+                    styled_suggestion.stylize(Style::Good, &sub);
                     styled_suggestion.none(" ");
-                    styled_suggestion.good("--");
-                    styled_suggestion.good(flag);
+                    styled_suggestion.stylize(Style::Good, "--");
+                    styled_suggestion.stylize(Style::Good, &flag);
                     styled_suggestion.none("' exists");
                     suggestions.push(styled_suggestion);
                 }
@@ -724,9 +725,9 @@ impl<F: ErrorFormatter> Error<F> {
         {
             let mut styled_suggestion = StyledStr::new();
             styled_suggestion.none("subcommand '");
-            styled_suggestion.good(&arg);
+            styled_suggestion.stylize(Style::Good, &arg);
             styled_suggestion.none("' exists; to use it, remove the '");
-            styled_suggestion.warning("--");
+            styled_suggestion.stylize(Style::Warning, "--");
             styled_suggestion.none("' before it");
 
             err = err.extend_context_unchecked([

--- a/clap_builder/src/lib.rs
+++ b/clap_builder/src/lib.rs
@@ -16,6 +16,10 @@
     clippy::single_char_pattern
 )]
 #![forbid(unsafe_code)]
+// Wanting consistency in our calls
+#![allow(clippy::write_with_newline)]
+// Gets in the way of logging
+#![allow(clippy::let_and_return)]
 // HACK https://github.com/rust-lang/rust-clippy/issues/7290
 #![allow(clippy::single_component_path_imports)]
 #![allow(clippy::branches_sharing_code)]

--- a/clap_builder/src/macros.rs
+++ b/clap_builder/src/macros.rs
@@ -628,12 +628,13 @@ macro_rules! impl_settings {
 #[cfg(feature = "debug")]
 macro_rules! debug {
     ($($arg:tt)*) => ({
-        let prefix = format!("[{:>w$}] \t", module_path!(), w = 28);
+        use std::fmt::Write as _;
+        let hint = $crate::builder::Style::Hint.as_style();
+
+        let module_path = module_path!();
         let body = format!($($arg)*);
         let mut styled = $crate::builder::StyledStr::new();
-        styled.stylize($crate::builder::Style::Hint.as_style(), &prefix);
-        styled.stylize($crate::builder::Style::Hint.as_style(), &body);
-        styled.none("\n");
+        let _ = write!(styled, "{}[{module_path:>28}]{body}{}\n", hint.render(), hint.render_reset());
         let color = $crate::output::fmt::Colorizer::new($crate::output::fmt::Stream::Stderr, $crate::ColorChoice::Auto).with_content(styled);
         let _ = color.print();
     })

--- a/clap_builder/src/macros.rs
+++ b/clap_builder/src/macros.rs
@@ -631,8 +631,8 @@ macro_rules! debug {
         let prefix = format!("[{:>w$}] \t", module_path!(), w = 28);
         let body = format!($($arg)*);
         let mut styled = $crate::builder::StyledStr::new();
-        styled.hint(prefix);
-        styled.hint(body);
+        styled.stylize($crate::builder::Style::Hint, &prefix);
+        styled.stylize($crate::builder::Style::Hint, &body);
         styled.none("\n");
         let color = $crate::output::fmt::Colorizer::new($crate::output::fmt::Stream::Stderr, $crate::ColorChoice::Auto).with_content(styled);
         let _ = color.print();

--- a/clap_builder/src/macros.rs
+++ b/clap_builder/src/macros.rs
@@ -631,8 +631,8 @@ macro_rules! debug {
         let prefix = format!("[{:>w$}] \t", module_path!(), w = 28);
         let body = format!($($arg)*);
         let mut styled = $crate::builder::StyledStr::new();
-        styled.stylize($crate::builder::Style::Hint, &prefix);
-        styled.stylize($crate::builder::Style::Hint, &body);
+        styled.stylize($crate::builder::Style::Hint.as_style(), &prefix);
+        styled.stylize($crate::builder::Style::Hint.as_style(), &body);
         styled.none("\n");
         let color = $crate::output::fmt::Colorizer::new($crate::output::fmt::Stream::Stderr, $crate::ColorChoice::Auto).with_content(styled);
         let _ = color.print();

--- a/clap_builder/src/output/help.rs
+++ b/clap_builder/src/output/help.rs
@@ -33,5 +33,5 @@ pub(crate) fn write_help(writer: &mut StyledStr, cmd: &Command, usage: &Usage<'_
     // Remove any extra lines caused by book keeping
     writer.trim();
     // Ensure there is still a trailing newline
-    writer.none("\n");
+    writer.push_str("\n");
 }

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -127,10 +127,12 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     /// [`Command::help_template`]: Command::help_template()
     pub(crate) fn write_templated_help(&mut self, template: &str) {
         debug!("HelpTemplate::write_templated_help");
+        use std::fmt::Write as _;
+        let header = Style::Header.as_style();
 
         let mut parts = template.split('{');
         if let Some(first) = parts.next() {
-            self.none(first);
+            self.writer.push_str(first);
         }
         for part in parts {
             if let Some((tag, rest)) = part.split_once('}') {
@@ -164,7 +166,12 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                         self.write_about(true, true);
                     }
                     "usage-heading" => {
-                        self.header("Usage:");
+                        let _ = write!(
+                            self.writer,
+                            "{}Usage:{}",
+                            header.render(),
+                            header.render_reset()
+                        );
                     }
                     "usage" => {
                         self.writer.push_styled(
@@ -194,7 +201,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                         self.write_subcommands(self.cmd);
                     }
                     "tab" => {
-                        self.none(TAB);
+                        self.writer.push_str(TAB);
                     }
                     "after-help" => {
                         self.write_after_help();
@@ -203,12 +210,10 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                         self.write_before_help();
                     }
                     _ => {
-                        self.none("{");
-                        self.none(tag);
-                        self.none("}");
+                        let _ = write!(self.writer, "{{{tag}}}");
                     }
                 }
-                self.none(rest);
+                self.writer.push_str(rest);
             }
         }
     }
@@ -228,7 +233,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 .replace("{n}", "\n"),
             self.term_w,
         );
-        self.none(&display_name);
+        self.writer.push_string(display_name);
     }
 
     /// Writes binary name of a Parser Object to the wrapped stream.
@@ -246,7 +251,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         } else {
             wrap(&self.cmd.get_name().replace("{n}", "\n"), self.term_w)
         };
-        self.none(&bin_name);
+        self.writer.push_string(bin_name);
     }
 
     fn write_version(&mut self) {
@@ -255,18 +260,18 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             .get_version()
             .or_else(|| self.cmd.get_long_version());
         if let Some(output) = version {
-            self.none(wrap(output, self.term_w));
+            self.writer.push_string(wrap(output, self.term_w));
         }
     }
 
     fn write_author(&mut self, before_new_line: bool, after_new_line: bool) {
         if let Some(author) = self.cmd.get_author() {
             if before_new_line {
-                self.none("\n");
+                self.writer.push_str("\n");
             }
-            self.none(wrap(author, self.term_w));
+            self.writer.push_string(wrap(author, self.term_w));
             if after_new_line {
-                self.none("\n");
+                self.writer.push_str("\n");
             }
         }
     }
@@ -279,14 +284,14 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         };
         if let Some(output) = about {
             if before_new_line {
-                self.none("\n");
+                self.writer.push_str("\n");
             }
             let mut output = output.clone();
             output.replace_newline_var();
             output.wrap(self.term_w);
             self.writer.push_styled(&output);
             if after_new_line {
-                self.none("\n");
+                self.writer.push_str("\n");
             }
         }
     }
@@ -305,7 +310,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             output.replace_newline_var();
             output.wrap(self.term_w);
             self.writer.push_styled(&output);
-            self.none("\n\n");
+            self.writer.push_str("\n\n");
         }
     }
 
@@ -319,7 +324,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             self.cmd.get_after_help()
         };
         if let Some(output) = after_help {
-            self.none("\n\n");
+            self.writer.push_str("\n\n");
             let mut output = output.clone();
             output.replace_newline_var();
             output.wrap(self.term_w);
@@ -334,6 +339,9 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     /// including titles of a Parser Object to the wrapped stream.
     pub(crate) fn write_all_args(&mut self) {
         debug!("HelpTemplate::write_all_args");
+        use std::fmt::Write as _;
+        let header = Style::Header.as_style();
+
         let pos = self
             .cmd
             .get_positionals()
@@ -358,39 +366,52 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
 
         if subcmds {
             if !first {
-                self.none("\n\n");
+                self.writer.push_str("\n\n");
             }
             first = false;
             let default_help_heading = Str::from("Commands");
-            self.header(
-                self.cmd
-                    .get_subcommand_help_heading()
-                    .unwrap_or(&default_help_heading),
+            let help_heading = self
+                .cmd
+                .get_subcommand_help_heading()
+                .unwrap_or(&default_help_heading);
+            let _ = write!(
+                self.writer,
+                "{}{help_heading}:{}\n",
+                header.render(),
+                header.render_reset()
             );
-            self.header(":");
-            self.none("\n");
 
             self.write_subcommands(self.cmd);
         }
 
         if !pos.is_empty() {
             if !first {
-                self.none("\n\n");
+                self.writer.push_str("\n\n");
             }
             first = false;
             // Write positional args if any
-            self.header("Arguments:");
-            self.none("\n");
+            let help_heading = "Arguments";
+            let _ = write!(
+                self.writer,
+                "{}{help_heading}:{}\n",
+                header.render(),
+                header.render_reset()
+            );
             self.write_args(&pos, "Arguments", positional_sort_key);
         }
 
         if !non_pos.is_empty() {
             if !first {
-                self.none("\n\n");
+                self.writer.push_str("\n\n");
             }
             first = false;
-            self.header("Options:");
-            self.none("\n");
+            let help_heading = "Options";
+            let _ = write!(
+                self.writer,
+                "{}{help_heading}:{}\n",
+                header.render(),
+                header.render_reset()
+            );
             self.write_args(&non_pos, "Options", option_sort_key);
         }
         if !custom_headings.is_empty() {
@@ -409,12 +430,15 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
 
                 if !args.is_empty() {
                     if !first {
-                        self.none("\n\n");
+                        self.writer.push_str("\n\n");
                     }
                     first = false;
-                    self.header(heading);
-                    self.header(":");
-                    self.none("\n");
+                    let _ = write!(
+                        self.writer,
+                        "{}{heading}:{}\n",
+                        header.render(),
+                        header.render_reset()
+                    );
                     self.write_args(&args, heading, option_sort_key);
                 }
             }
@@ -452,9 +476,9 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
 
         for (i, (_, arg)) in ord_v.iter().enumerate() {
             if i != 0 {
-                self.none("\n");
+                self.writer.push_str("\n");
                 if next_line_help && self.use_long {
-                    self.none("\n");
+                    self.writer.push_str("\n");
                 }
             }
             self.write_arg(arg, next_line_help, longest);
@@ -465,7 +489,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     fn write_arg(&mut self, arg: &Arg, next_line_help: bool, longest: usize) {
         let spec_vals = &self.spec_vals(arg);
 
-        self.none(TAB);
+        self.writer.push_str(TAB);
         self.short(arg);
         self.long(arg);
         self.writer.push_styled(&arg.stylize_arg_suffix(None));
@@ -487,22 +511,37 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     /// Writes argument's short command to the wrapped stream.
     fn short(&mut self, arg: &Arg) {
         debug!("HelpTemplate::short");
+        use std::fmt::Write as _;
+        let literal = Style::Literal.as_style();
 
         if let Some(s) = arg.get_short() {
-            self.literal(format!("-{s}"));
+            let _ = write!(
+                self.writer,
+                "{}-{s}{}",
+                literal.render(),
+                literal.render_reset()
+            );
         } else if arg.get_long().is_some() {
-            self.none("    ");
+            self.writer.push_str("    ");
         }
     }
 
     /// Writes argument's long command to the wrapped stream.
     fn long(&mut self, arg: &Arg) {
         debug!("HelpTemplate::long");
+        use std::fmt::Write as _;
+        let literal = Style::Literal.as_style();
+
         if let Some(long) = arg.get_long() {
             if arg.get_short().is_some() {
-                self.none(", ");
+                self.writer.push_str(", ");
             }
-            self.literal(format!("--{long}"));
+            let _ = write!(
+                self.writer,
+                "{}--{long}{}",
+                literal.render(),
+                literal.render_reset()
+            );
         }
     }
 
@@ -514,9 +553,10 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             next_line_help,
             longest
         );
-        if self.use_long || next_line_help {
+        let padding = if self.use_long || next_line_help {
             // long help prints messages on the next line so it doesn't need to align text
             debug!("HelpTemplate::align_to_about: printing long help so skip alignment");
+            0
         } else if !arg.is_positional() {
             let self_len = display_width(&arg.to_string());
             // Since we're writing spaces from the tab point we first need to know if we
@@ -534,7 +574,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 self_len, spcs
             );
 
-            self.spaces(spcs);
+            spcs
         } else {
             let self_len = display_width(&arg.to_string());
             let padding = TAB_WIDTH;
@@ -544,8 +584,10 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 self_len, spcs
             );
 
-            self.spaces(spcs);
-        }
+            spcs
+        };
+
+        self.write_padding(padding);
     }
 
     /// Writes argument's help to the wrapped stream.
@@ -558,13 +600,15 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         longest: usize,
     ) {
         debug!("HelpTemplate::help");
+        use std::fmt::Write as _;
+        let literal = Style::Literal.as_style();
 
         // Is help on next line, if so then indent
         if next_line_help {
             debug!("HelpTemplate::help: Next Line...{:?}", next_line_help);
-            self.none("\n");
-            self.none(TAB);
-            self.none(NEXT_LINE_INDENT);
+            self.writer.push_str("\n");
+            self.writer.push_str(TAB);
+            self.writer.push_str(NEXT_LINE_INDENT);
         }
 
         let spaces = if next_line_help {
@@ -586,9 +630,9 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 } else {
                     " "
                 };
-                help.none(sep);
+                help.push_str(sep);
             }
-            help.none(spec_vals);
+            help.push_str(spec_vals);
         }
         let avail_chars = self.term_w.saturating_sub(spaces);
         debug!(
@@ -613,11 +657,6 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                     "HelpTemplate::help: Found possible vals...{:?}",
                     possible_vals
                 );
-                if !help_is_empty {
-                    self.none("\n\n");
-                    self.spaces(spaces);
-                }
-                self.none("Possible values:");
                 let longest = possible_vals
                     .iter()
                     .filter_map(|f| f.get_visible_quoted_name().map(|name| display_width(&name)))
@@ -642,21 +681,29 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 };
                 let trailing_indent = self.get_spaces(trailing_indent);
 
+                if !help_is_empty {
+                    let _ = write!(self.writer, "\n\n{:spaces$}", "");
+                }
+                self.writer.push_str("Possible values:");
                 for pv in possible_vals.iter().filter(|pv| !pv.is_hide_set()) {
-                    self.none("\n");
-                    self.spaces(spaces);
-                    self.none("- ");
-                    self.literal(pv.get_name());
+                    let name = pv.get_name();
+                    let _ = write!(
+                        self.writer,
+                        "\n{:spaces$}- {}{name}{}",
+                        "",
+                        literal.render(),
+                        literal.render_reset()
+                    );
                     if let Some(help) = pv.get_help() {
                         debug!("HelpTemplate::help: Possible Value help");
 
                         if possible_value_new_line {
-                            self.none(":\n");
-                            self.spaces(trailing_indent.len());
+                            let padding = trailing_indent.len();
+                            let _ = write!(self.writer, ":\n{:padding$}", "");
                         } else {
-                            self.none(": ");
                             // To align help messages
-                            self.spaces(longest - display_width(pv.get_name()));
+                            let padding = longest - display_width(pv.get_name());
+                            let _ = write!(self.writer, ": {:padding$}", "");
                         }
 
                         let avail_chars = if self.term_w > trailing_indent.len() {
@@ -802,24 +849,13 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         spec_vals.join(connector)
     }
 
-    fn header<T: AsRef<str>>(&mut self, msg: T) {
-        self.writer.stylize(Style::Header.as_style(), msg.as_ref());
-    }
-
-    fn literal<T: AsRef<str>>(&mut self, msg: T) {
-        self.writer.stylize(Style::Literal.as_style(), msg.as_ref());
-    }
-
-    fn none<T: Into<String>>(&mut self, msg: T) {
-        self.writer.none(msg);
-    }
-
     fn get_spaces(&self, n: usize) -> String {
         " ".repeat(n)
     }
 
-    fn spaces(&mut self, n: usize) {
-        self.none(self.get_spaces(n));
+    fn write_padding(&mut self, amount: usize) {
+        use std::fmt::Write as _;
+        let _ = write!(self.writer, "{:amount$}", "");
     }
 }
 
@@ -828,6 +864,9 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     /// Writes help for subcommands of a Parser Object to the wrapped stream.
     fn write_subcommands(&mut self, cmd: &Command) {
         debug!("HelpTemplate::write_subcommands");
+        use std::fmt::Write as _;
+        let literal = Style::Literal.as_style();
+
         // The shortest an arg can legally be is 2 (i.e. '-x')
         let mut longest = 2;
         let mut ord_v = Vec::new();
@@ -836,14 +875,28 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             .filter(|subcommand| should_show_subcommand(subcommand))
         {
             let mut styled = StyledStr::new();
-            styled.stylize(Style::Literal.as_style(), subcommand.get_name());
+            let name = subcommand.get_name();
+            let _ = write!(
+                styled,
+                "{}{name}{}",
+                literal.render(),
+                literal.render_reset()
+            );
             if let Some(short) = subcommand.get_short_flag() {
-                styled.none(", ");
-                styled.stylize(Style::Literal.as_style(), &format!("-{short}"));
+                let _ = write!(
+                    styled,
+                    ", {}-{short}{}",
+                    literal.render(),
+                    literal.render_reset()
+                );
             }
             if let Some(long) = subcommand.get_long_flag() {
-                styled.none(", ");
-                styled.stylize(Style::Literal.as_style(), &format!("--{long}"));
+                let _ = write!(
+                    styled,
+                    ", {}--{long}{}",
+                    literal.render(),
+                    literal.render_reset()
+                );
             }
             longest = longest.max(styled.display_width());
             ord_v.push((subcommand.get_display_order(), styled, subcommand));
@@ -859,7 +912,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             if first {
                 first = false;
             } else {
-                self.none("\n");
+                self.writer.push_str("\n");
             }
             self.write_subcommand(sc_str, sc, next_line_help, longest);
         }
@@ -943,12 +996,12 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
 
     /// Writes subcommand to the wrapped stream.
     fn subcmd(&mut self, sc_str: StyledStr, next_line_help: bool, longest: usize) {
-        let width = sc_str.display_width();
-
-        self.none(TAB);
+        self.writer.push_str(TAB);
         self.writer.push_styled(&sc_str);
         if !next_line_help {
-            self.spaces(longest + TAB_WIDTH - width);
+            let width = sc_str.display_width();
+            let padding = longest + TAB_WIDTH - width;
+            self.write_padding(padding);
         }
     }
 }

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -803,11 +803,11 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     }
 
     fn header<T: AsRef<str>>(&mut self, msg: T) {
-        self.writer.stylize(Style::Header, msg.as_ref());
+        self.writer.stylize(Style::Header.as_style(), msg.as_ref());
     }
 
     fn literal<T: AsRef<str>>(&mut self, msg: T) {
-        self.writer.stylize(Style::Literal, msg.as_ref());
+        self.writer.stylize(Style::Literal.as_style(), msg.as_ref());
     }
 
     fn none<T: Into<String>>(&mut self, msg: T) {
@@ -836,14 +836,14 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             .filter(|subcommand| should_show_subcommand(subcommand))
         {
             let mut styled = StyledStr::new();
-            styled.stylize(Style::Literal, subcommand.get_name());
+            styled.stylize(Style::Literal.as_style(), subcommand.get_name());
             if let Some(short) = subcommand.get_short_flag() {
                 styled.none(", ");
-                styled.stylize(Style::Literal, &format!("-{short}"));
+                styled.stylize(Style::Literal.as_style(), &format!("-{short}"));
             }
             if let Some(long) = subcommand.get_long_flag() {
                 styled.none(", ");
-                styled.stylize(Style::Literal, &format!("--{long}"));
+                styled.stylize(Style::Literal.as_style(), &format!("--{long}"));
             }
             longest = longest.max(styled.display_width());
             ord_v.push((subcommand.get_display_order(), styled, subcommand));

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -6,6 +6,7 @@ use std::usize;
 // Internal
 use crate::builder::PossibleValue;
 use crate::builder::Str;
+use crate::builder::Style;
 use crate::builder::StyledStr;
 use crate::builder::{Arg, Command};
 use crate::output::display_width;
@@ -801,12 +802,12 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         spec_vals.join(connector)
     }
 
-    fn header<T: Into<String>>(&mut self, msg: T) {
-        self.writer.header(msg);
+    fn header<T: AsRef<str>>(&mut self, msg: T) {
+        self.writer.stylize(Style::Header, msg.as_ref());
     }
 
-    fn literal<T: Into<String>>(&mut self, msg: T) {
-        self.writer.literal(msg);
+    fn literal<T: AsRef<str>>(&mut self, msg: T) {
+        self.writer.stylize(Style::Literal, msg.as_ref());
     }
 
     fn none<T: Into<String>>(&mut self, msg: T) {
@@ -835,14 +836,14 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             .filter(|subcommand| should_show_subcommand(subcommand))
         {
             let mut styled = StyledStr::new();
-            styled.literal(subcommand.get_name());
+            styled.stylize(Style::Literal, subcommand.get_name());
             if let Some(short) = subcommand.get_short_flag() {
                 styled.none(", ");
-                styled.literal(format!("-{short}"));
+                styled.stylize(Style::Literal, &format!("-{short}"));
             }
             if let Some(long) = subcommand.get_long_flag() {
                 styled.none(", ");
-                styled.literal(format!("--{long}"));
+                styled.stylize(Style::Literal, &format!("--{long}"));
             }
             longest = longest.max(styled.display_width());
             ord_v.push((subcommand.get_display_order(), styled, subcommand));

--- a/clap_builder/src/output/usage.rs
+++ b/clap_builder/src/output/usage.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(feature = "usage"), allow(dead_code))]
 
 // Internal
+use crate::builder::Style;
 use crate::builder::StyledStr;
 use crate::builder::{ArgPredicate, Command};
 use crate::parser::ArgMatcher;
@@ -38,7 +39,7 @@ impl<'cmd> Usage<'cmd> {
         let usage = some!(self.create_usage_no_title(used));
 
         let mut styled = StyledStr::new();
-        styled.header("Usage:");
+        styled.stylize(Style::Header, "Usage:");
         styled.none(" ");
         styled.push_styled(&usage);
         Some(styled)
@@ -78,10 +79,10 @@ impl<'cmd> Usage<'cmd> {
             .get_usage_name()
             .or_else(|| self.cmd.get_bin_name())
             .unwrap_or_else(|| self.cmd.get_name());
-        styled.literal(name);
+        styled.stylize(Style::Literal, name);
 
         if self.needs_options_tag() {
-            styled.placeholder(" [OPTIONS]");
+            styled.stylize(Style::Placeholder, " [OPTIONS]");
         }
 
         self.write_args(&[], !incl_reqs, &mut styled);
@@ -101,21 +102,21 @@ impl<'cmd> Usage<'cmd> {
                 styled.none("       ");
                 if self.cmd.is_args_conflicts_with_subcommands_set() {
                     // Short-circuit full usage creation since no args will be relevant
-                    styled.literal(name);
+                    styled.stylize(Style::Literal, name);
                 } else {
                     styled.push_styled(&self.create_help_usage(false));
                 }
-                styled.placeholder(" <");
-                styled.placeholder(placeholder);
-                styled.placeholder(">");
+                styled.stylize(Style::Placeholder, " <");
+                styled.stylize(Style::Placeholder, placeholder);
+                styled.stylize(Style::Placeholder, ">");
             } else if self.cmd.is_subcommand_required_set() {
-                styled.placeholder(" <");
-                styled.placeholder(placeholder);
-                styled.placeholder(">");
+                styled.stylize(Style::Placeholder, " <");
+                styled.stylize(Style::Placeholder, placeholder);
+                styled.stylize(Style::Placeholder, ">");
             } else {
-                styled.placeholder(" [");
-                styled.placeholder(placeholder);
-                styled.placeholder("]");
+                styled.stylize(Style::Placeholder, " [");
+                styled.stylize(Style::Placeholder, placeholder);
+                styled.stylize(Style::Placeholder, "]");
             }
         }
         styled.trim();
@@ -129,7 +130,8 @@ impl<'cmd> Usage<'cmd> {
         debug!("Usage::create_smart_usage");
         let mut styled = StyledStr::new();
 
-        styled.literal(
+        styled.stylize(
+            Style::Literal,
             self.cmd
                 .get_usage_name()
                 .or_else(|| self.cmd.get_bin_name())
@@ -139,13 +141,14 @@ impl<'cmd> Usage<'cmd> {
         self.write_args(used, false, &mut styled);
 
         if self.cmd.is_subcommand_required_set() {
-            styled.placeholder(" <");
-            styled.placeholder(
+            styled.stylize(Style::Placeholder, " <");
+            styled.stylize(
+                Style::Placeholder,
                 self.cmd
                     .get_subcommand_value_name()
                     .unwrap_or(DEFAULT_SUB_VALUE_NAME),
             );
-            styled.placeholder(">");
+            styled.stylize(Style::Placeholder, ">");
         }
         styled
     }
@@ -279,7 +282,7 @@ impl<'cmd> Usage<'cmd> {
                 if pos.is_last_set() {
                     let styled = required_positionals[index].take().unwrap();
                     let mut new = StyledStr::new();
-                    new.literal("-- ");
+                    new.stylize(Style::Literal, "-- ");
                     new.push_styled(&styled);
                     required_positionals[index] = Some(new);
                 }
@@ -287,9 +290,9 @@ impl<'cmd> Usage<'cmd> {
                 let mut styled;
                 if pos.is_last_set() {
                     styled = StyledStr::new();
-                    styled.literal("[-- ");
+                    styled.stylize(Style::Literal, "[-- ");
                     styled.push_styled(&pos.stylized(Some(true)));
-                    styled.literal("]");
+                    styled.stylize(Style::Literal, "]");
                 } else {
                     styled = pos.stylized(Some(false));
                 }

--- a/clap_builder/src/output/usage.rs
+++ b/clap_builder/src/output/usage.rs
@@ -39,7 +39,7 @@ impl<'cmd> Usage<'cmd> {
         let usage = some!(self.create_usage_no_title(used));
 
         let mut styled = StyledStr::new();
-        styled.stylize(Style::Header, "Usage:");
+        styled.stylize(Style::Header.as_style(), "Usage:");
         styled.none(" ");
         styled.push_styled(&usage);
         Some(styled)
@@ -79,10 +79,10 @@ impl<'cmd> Usage<'cmd> {
             .get_usage_name()
             .or_else(|| self.cmd.get_bin_name())
             .unwrap_or_else(|| self.cmd.get_name());
-        styled.stylize(Style::Literal, name);
+        styled.stylize(Style::Literal.as_style(), name);
 
         if self.needs_options_tag() {
-            styled.stylize(Style::Placeholder, " [OPTIONS]");
+            styled.stylize(Style::Placeholder.as_style(), " [OPTIONS]");
         }
 
         self.write_args(&[], !incl_reqs, &mut styled);
@@ -102,21 +102,21 @@ impl<'cmd> Usage<'cmd> {
                 styled.none("       ");
                 if self.cmd.is_args_conflicts_with_subcommands_set() {
                     // Short-circuit full usage creation since no args will be relevant
-                    styled.stylize(Style::Literal, name);
+                    styled.stylize(Style::Literal.as_style(), name);
                 } else {
                     styled.push_styled(&self.create_help_usage(false));
                 }
-                styled.stylize(Style::Placeholder, " <");
-                styled.stylize(Style::Placeholder, placeholder);
-                styled.stylize(Style::Placeholder, ">");
+                styled.stylize(Style::Placeholder.as_style(), " <");
+                styled.stylize(Style::Placeholder.as_style(), placeholder);
+                styled.stylize(Style::Placeholder.as_style(), ">");
             } else if self.cmd.is_subcommand_required_set() {
-                styled.stylize(Style::Placeholder, " <");
-                styled.stylize(Style::Placeholder, placeholder);
-                styled.stylize(Style::Placeholder, ">");
+                styled.stylize(Style::Placeholder.as_style(), " <");
+                styled.stylize(Style::Placeholder.as_style(), placeholder);
+                styled.stylize(Style::Placeholder.as_style(), ">");
             } else {
-                styled.stylize(Style::Placeholder, " [");
-                styled.stylize(Style::Placeholder, placeholder);
-                styled.stylize(Style::Placeholder, "]");
+                styled.stylize(Style::Placeholder.as_style(), " [");
+                styled.stylize(Style::Placeholder.as_style(), placeholder);
+                styled.stylize(Style::Placeholder.as_style(), "]");
             }
         }
         styled.trim();
@@ -131,7 +131,7 @@ impl<'cmd> Usage<'cmd> {
         let mut styled = StyledStr::new();
 
         styled.stylize(
-            Style::Literal,
+            Style::Literal.as_style(),
             self.cmd
                 .get_usage_name()
                 .or_else(|| self.cmd.get_bin_name())
@@ -141,14 +141,14 @@ impl<'cmd> Usage<'cmd> {
         self.write_args(used, false, &mut styled);
 
         if self.cmd.is_subcommand_required_set() {
-            styled.stylize(Style::Placeholder, " <");
+            styled.stylize(Style::Placeholder.as_style(), " <");
             styled.stylize(
-                Style::Placeholder,
+                Style::Placeholder.as_style(),
                 self.cmd
                     .get_subcommand_value_name()
                     .unwrap_or(DEFAULT_SUB_VALUE_NAME),
             );
-            styled.stylize(Style::Placeholder, ">");
+            styled.stylize(Style::Placeholder.as_style(), ">");
         }
         styled
     }
@@ -282,7 +282,7 @@ impl<'cmd> Usage<'cmd> {
                 if pos.is_last_set() {
                     let styled = required_positionals[index].take().unwrap();
                     let mut new = StyledStr::new();
-                    new.stylize(Style::Literal, "-- ");
+                    new.stylize(Style::Literal.as_style(), "-- ");
                     new.push_styled(&styled);
                     required_positionals[index] = Some(new);
                 }
@@ -290,9 +290,9 @@ impl<'cmd> Usage<'cmd> {
                 let mut styled;
                 if pos.is_last_set() {
                     styled = StyledStr::new();
-                    styled.stylize(Style::Literal, "[-- ");
+                    styled.stylize(Style::Literal.as_style(), "[-- ");
                     styled.push_styled(&pos.stylized(Some(true)));
-                    styled.stylize(Style::Literal, "]");
+                    styled.stylize(Style::Literal.as_style(), "]");
                 } else {
                     styled = pos.stylized(Some(false));
                 }


### PR DESCRIPTION
Code size
- `master`: 534.9KiB
- 38c857b:  534.9KiB
- fd195f2: 532.3KiB
- 816f1fb: 547.2KiB
- 5041814e: 542.4KiB

via `cargo bloat --release --features cargo --example cargo-example`