### PR TITLE
fix(help): Preserve block indent when wrapping

### DIFF
--- a/clap_builder/src/output/textwrap/mod.rs
+++ b/clap_builder/src/output/textwrap/mod.rs
@@ -83,7 +83,7 @@ mod test {
 
     #[test]
     fn leading_whitespace() {
-        assert_eq!(wrap("  foo bar", 6), vec!["  foo", "bar"]);
+        assert_eq!(wrap("  foo bar", 6), vec!["  foo", "  bar"]);
     }
 
     #[test]
@@ -92,7 +92,7 @@ mod test {
         // will be empty. This is because the string is split into
         // words like [" ", "foobar ", "baz"], which puts "foobar " on
         // the second line. We never output trailing whitespace
-        assert_eq!(wrap(" foobar baz", 6), vec!["", "foobar", "baz"]);
+        assert_eq!(wrap(" foobar baz", 6), vec!["", " foobar", " baz"]);
     }
 
     #[test]

--- a/clap_builder/src/output/textwrap/word_separators.rs
+++ b/clap_builder/src/output/textwrap/word_separators.rs
@@ -5,14 +5,15 @@ pub(crate) fn find_words_ascii_space(line: &str) -> impl Iterator<Item = &'_ str
 
     std::iter::from_fn(move || {
         for (idx, ch) in char_indices.by_ref() {
-            if in_whitespace && ch != ' ' {
+            let next_whitespace = ch == ' ';
+            if in_whitespace && !next_whitespace {
                 let word = &line[start..idx];
                 start = idx;
-                in_whitespace = ch == ' ';
+                in_whitespace = next_whitespace;
                 return Some(word);
             }
 
-            in_whitespace = ch == ' ';
+            in_whitespace = next_whitespace;
         }
 
         if start < line.len() {

--- a/clap_builder/src/output/textwrap/wrap_algorithms.rs
+++ b/clap_builder/src/output/textwrap/wrap_algorithms.rs
@@ -1,24 +1,37 @@
 use super::core::display_width;
 
 #[derive(Debug)]
-pub(crate) struct LineWrapper {
-    line_width: usize,
+pub(crate) struct LineWrapper<'w> {
     hard_width: usize,
+    line_width: usize,
+    carryover: Option<&'w str>,
 }
 
-impl LineWrapper {
+impl<'w> LineWrapper<'w> {
     pub(crate) fn new(hard_width: usize) -> Self {
         Self {
-            line_width: 0,
             hard_width,
+            line_width: 0,
+            carryover: None,
         }
     }
 
     pub(crate) fn reset(&mut self) {
         self.line_width = 0;
+        self.carryover = None;
     }
 
-    pub(crate) fn wrap<'w>(&mut self, mut words: Vec<&'w str>) -> Vec<&'w str> {
+    pub(crate) fn wrap(&mut self, mut words: Vec<&'w str>) -> Vec<&'w str> {
+        if self.carryover.is_none() {
+            if let Some(word) = words.first() {
+                if word.trim().is_empty() {
+                    self.carryover = Some(*word);
+                } else {
+                    self.carryover = Some("");
+                }
+            }
+        }
+
         let mut i = 0;
         while i < words.len() {
             let word = &words[i];
@@ -31,9 +44,15 @@ impl LineWrapper {
                     let trimmed = words[last].trim_end();
                     words[last] = trimmed;
                 }
+
+                self.line_width = 0;
                 words.insert(i, "\n");
                 i += 1;
-                self.reset();
+                if let Some(carryover) = self.carryover {
+                    words.insert(i, carryover);
+                    self.line_width += carryover.len();
+                    i += 1;
+                }
             }
             self.line_width += word_width + trimmed_delta;
 

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -801,6 +801,35 @@ Options:
 
 #[test]
 #[cfg(feature = "wrap_help")]
+fn wrapped_indentation() {
+    static HELP: &str = "\
+Usage: ctest [mode]
+
+Arguments:
+  [mode]  Some values:
+            - l, long           Copy-friendly, 14
+          characters, contains symbols.
+            - m, med, medium    Copy-friendly, 8 characters,
+          contains symbols.
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("ctest")
+        .version("0.1")
+        .term_width(60)
+        .arg(Arg::new("mode").help(
+            "Some values:
+  - l, long           Copy-friendly, 14 characters, contains symbols.
+  - m, med, medium    Copy-friendly, 8 characters, contains symbols.",
+        ));
+    utils::assert_output(cmd, "ctest --help", HELP, false);
+}
+
+#[test]
+#[cfg(feature = "wrap_help")]
 fn wrapping_newline_variables() {
     static WRAPPING_NEWLINE_CHARS: &str = "\
 Usage: ctest [mode]

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -808,9 +808,9 @@ Usage: ctest [mode]
 Arguments:
   [mode]  Some values:
             - l, long           Copy-friendly, 14
-          characters, contains symbols.
+            characters, contains symbols.
             - m, med, medium    Copy-friendly, 8 characters,
-          contains symbols.
+            contains symbols.
 
 Options:
   -h, --help     Print help


### PR DESCRIPTION
Besides improving the styling, my hope is that I can build on this to generalize parts of help rendering and save some compile time / binary size.

The main risk is if the indentation is too much for whats being wrapped but that seems like a whole other issue.