### PR TITLE
fix(complete): Escape special characters properly for zsh

### DIFF
--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -426,6 +426,9 @@ fn escape_help(string: &str) -> String {
         .replace('\'', "'\\''")
         .replace('[', "\\[")
         .replace(']', "\\]")
+        .replace(':', "\\:")
+        .replace('$', "\\$")
+        .replace('`', "\\`")
 }
 
 /// Escape value string inside single quotes and parentheses
@@ -433,6 +436,11 @@ fn escape_value(string: &str) -> String {
     string
         .replace('\\', "\\\\")
         .replace('\'', "'\\''")
+        .replace('[', "\\[")
+        .replace(']', "\\]")
+        .replace(':', "\\:")
+        .replace('$', "\\$")
+        .replace('`', "\\`")
         .replace('(', "\\(")
         .replace(')', "\\)")
         .replace(' ', "\\ ")
@@ -687,4 +695,27 @@ fn write_positionals_of(p: &Command) -> String {
     }
 
     ret.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::shells::zsh::{escape_help, escape_value};
+
+    #[test]
+    fn test_escape_value() {
+        let raw_string = "\\ [foo]() `bar https://$PATH";
+        assert_eq!(
+            escape_value(raw_string),
+            "\\\\\\ \\[foo\\]\\(\\)\\ \\`bar\\ https\\://\\$PATH"
+        )
+    }
+
+    #[test]
+    fn test_escape_help() {
+        let raw_string = "\\ [foo]() `bar https://$PATH";
+        assert_eq!(
+            escape_help(raw_string),
+            "\\\\ \\[foo\\]() \\`bar https\\://\\$PATH"
+        )
+    }
 }

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -17,10 +17,10 @@ _my-app() {
     _arguments "${_arguments_options[@]}" \
 '--single-quotes[Can be '\''always'\'', '\''auto'\'', or '\''never'\'']' \
 '--double-quotes[Can be "always", "auto", or "never"]' \
-'--backticks[For more information see `echo test`]' \
+'--backticks[For more information see \`echo test\`]' \
 '--backslash[Avoid '\''\\n'\'']' \
 '--brackets[List packages \[filter\]]' \
-'--expansions[Execute the shell command with $SHELL]' \
+'--expansions[Execute the shell command with \$SHELL]' \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -124,10 +124,10 @@ _my-app_commands() {
     local commands; commands=(
 'cmd-single-quotes:Can be '\''always'\'', '\''auto'\'', or '\''never'\''' \
 'cmd-double-quotes:Can be "always", "auto", or "never"' \
-'cmd-backticks:For more information see `echo test`' \
+'cmd-backticks:For more information see \`echo test\`' \
 'cmd-backslash:Avoid '\''\\n'\''' \
 'cmd-brackets:List packages \[filter\]' \
-'cmd-expansions:Execute the shell command with $SHELL' \
+'cmd-expansions:Execute the shell command with \$SHELL' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'my-app commands' commands "$@"
@@ -197,10 +197,10 @@ _my-app__help_commands() {
     local commands; commands=(
 'cmd-single-quotes:Can be '\''always'\'', '\''auto'\'', or '\''never'\''' \
 'cmd-double-quotes:Can be "always", "auto", or "never"' \
-'cmd-backticks:For more information see `echo test`' \
+'cmd-backticks:For more information see \`echo test\`' \
 'cmd-backslash:Avoid '\''\\n'\''' \
 'cmd-brackets:List packages \[filter\]' \
-'cmd-expansions:Execute the shell command with $SHELL' \
+'cmd-expansions:Execute the shell command with \$SHELL' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'my-app help commands' commands "$@"


### PR DESCRIPTION
Closes #4751.

The original problem is because of unescaped colons, which is included in this PR. However, there are other characters that might cause similar issues, such as backticks and dollar signs. I don't think one would expect something like `$PATH` to be expanded when he or she puts it in a helper string.

Added a few test cases for unit testing. I think we should add integration tests for this, i.e., help strings from comments, but I'm not sure how to do it.