### PR TITLE
docs: Update mut_arg docs on help + version flags 

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -209,8 +209,6 @@ impl Command {
 
     /// Allows one to mutate an [`Arg`] after it's been added to a [`Command`].
     ///
-    /// This can be useful for modifying the auto-generated help or version arguments.
-    ///
     /// # Panics
     ///
     /// If the argument is undefined


### PR DESCRIPTION
I was recently migrating from clap 3 to 4, and one of the things pointed out as a big change [here](https://epage.github.io/blog/2022/09/clap4/#removing-implicit-version-help-behavior) was that `mut_args` no longer works for pre-defined `help` and `version` flags.

However, in docs.rs, [for `mut_arg`, it still states](https://docs.rs/clap/latest/clap/struct.Command.html#method.mut_arg):

> This can be useful for modifying the auto-generated help or version arguments.

Which might be confusing, since if you try that, you'll get something like:

```bash
thread 'main' panicked at 'Argument `help` is undefined'
```

This just removes that line since IMO it'll just lead to confusion with the newer behaviour.