### PR TITLE
fix: Remove strict linting from generated code

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -85,7 +85,6 @@ pub fn gen_for_struct(
             clippy::cargo,
             clippy::suspicious_else_formatting,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::Args for #struct_name #ty_generics #where_clause {
             fn augment_args<'b>(#app_var: clap::Command<'b>) -> clap::Command<'b> {
                 #augmentation
@@ -130,7 +129,6 @@ pub fn gen_from_arg_matches_for_struct(
             clippy::cargo,
             clippy::suspicious_else_formatting,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #struct_name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -55,7 +55,6 @@ pub fn gen_for_struct(
             clippy::cargo,
             clippy::suspicious_else_formatting,
         )]
-        #[deny(clippy::correctness)]
         #[allow(deprecated)]
         impl #impl_generics clap::CommandFactory for #struct_name #ty_generics #where_clause {
             fn into_app<'b>() -> clap::Command<'b> {
@@ -101,7 +100,6 @@ pub fn gen_for_enum(enum_name: &Ident, generics: &Generics, attrs: &[Attribute])
             clippy::cargo,
             clippy::suspicious_else_formatting,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::CommandFactory for #enum_name #ty_generics #where_clause {
             fn into_app<'b>() -> clap::Command<'b> {
                 #[allow(deprecated)]

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -73,7 +73,6 @@ pub fn gen_for_enum(
             clippy::cargo,
             clippy::suspicious_else_formatting,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::Subcommand for #enum_name #ty_generics #where_clause {
             fn augment_subcommands <'b>(__clap_app: clap::Command<'b>) -> clap::Command<'b> {
                 #augmentation
@@ -120,7 +119,6 @@ fn gen_from_arg_matches_for_enum(
             clippy::cargo,
             clippy::suspicious_else_formatting,
         )]
-        #[deny(clippy::correctness)]
         impl #impl_generics clap::FromArgMatches for #name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -60,7 +60,6 @@ pub fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStr
             clippy::cargo,
             clippy::suspicious_else_formatting,
         )]
-        #[deny(clippy::correctness)]
         impl clap::ValueEnum for #name {
             #value_variants
             #to_possible_value


### PR DESCRIPTION
The `#[deny(correctness)]` attribute is inside some generated code (such
as the `Subcommand` derive macro). As of Rust 1.69.0, this is triggering
a clippy error in some uses. Due to the placement of the `deny`, it is
not possible for a user of clap to override it.

This change removes all the instances of this `deny` attribute. The same
was done on the `master` branch in #4739.

Fixes: #4857