### PR TITLE
test(help): Remove redundant test

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4793,15 +4793,4 @@ mod test {
 
         assert_eq!(p.to_string(), "<file1> <file2>");
     }
-
-    #[test]
-    fn positional_display_val_names_req() {
-        let mut p = Arg::new("pos")
-            .index(1)
-            .required(true)
-            .value_names(["file1", "file2"]);
-        p._build();
-
-        assert_eq!(p.to_string(), "<file1> <file2>");
-    }
 }


### PR DESCRIPTION
The tests `positional_display_val_names_required` and `positional_display_val_names_req` are equivalent.

`positional_display_val_names_required` was added in Aug 2022 in https://github.com/clap-rs/clap/commit/02db3043e2bfc6658ad7a4a4d69dadd73e813dfd#diff-f1b965dbd6b694e7419437ace420b4fac5e8e0366848860ce5e63523fd7b835fR4430-L4438.

Keep `positional_display_val_names_required` and remove `positional_display_val_names_req`.