### PR TITLE
fix(derive): Allow `clippy::almost_swapped`

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -84,6 +84,7 @@ pub fn gen_for_struct(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         impl #impl_generics clap::Args for #struct_name #ty_generics #where_clause {
             fn augment_args<'b>(#app_var: clap::Command<'b>) -> clap::Command<'b> {
@@ -128,6 +129,7 @@ pub fn gen_from_arg_matches_for_struct(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         impl #impl_generics clap::FromArgMatches for #struct_name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {

--- a/clap_derive/src/derives/into_app.rs
+++ b/clap_derive/src/derives/into_app.rs
@@ -54,6 +54,7 @@ pub fn gen_for_struct(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         #[allow(deprecated)]
         impl #impl_generics clap::CommandFactory for #struct_name #ty_generics #where_clause {
@@ -99,6 +100,7 @@ pub fn gen_for_enum(enum_name: &Ident, generics: &Generics, attrs: &[Attribute])
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         impl #impl_generics clap::CommandFactory for #enum_name #ty_generics #where_clause {
             fn into_app<'b>() -> clap::Command<'b> {

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -72,6 +72,7 @@ pub fn gen_for_enum(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         impl #impl_generics clap::Subcommand for #enum_name #ty_generics #where_clause {
             fn augment_subcommands <'b>(__clap_app: clap::Command<'b>) -> clap::Command<'b> {
@@ -118,6 +119,7 @@ fn gen_from_arg_matches_for_enum(
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         impl #impl_generics clap::FromArgMatches for #name #ty_generics #where_clause {
             fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -59,6 +59,7 @@ pub fn gen_for_enum(name: &Ident, attrs: &[Attribute], e: &DataEnum) -> TokenStr
             clippy::nursery,
             clippy::cargo,
             clippy::suspicious_else_formatting,
+            clippy::almost_swapped,
         )]
         impl clap::ValueEnum for #name {
             #value_variants


### PR DESCRIPTION
As of Rust 1.69, the `clippy::almost_swapped` lint was enhanced and now
triggers on certain derive macros inside clap. To avoid the need for the
user to allow these lints outside of the macro (which generally requires
a module level `allow`), the allow was added to the generated code for
the v4 branch in #4735.

This change backports that fix the the `v3-master` branch.

Fixes: #4857