### PR TITLE
impl Eq<std::any::TypeId> for clap_builder::util::AnyValueId

### DIFF
--- a/clap_builder/src/util/any_value.rs
+++ b/clap_builder/src/util/any_value.rs
@@ -69,6 +69,12 @@ impl PartialOrd for AnyValueId {
     }
 }
 
+impl PartialEq<std::any::TypeId> for AnyValueId {
+    fn eq(&self, other: &std::any::TypeId) -> bool {
+        self.type_id == *other
+    }
+}
+
 impl Ord for AnyValueId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.type_id.cmp(&other.type_id)
@@ -108,5 +114,14 @@ mod test {
         use super::*;
 
         assert_eq!(format!("{:?}", AnyValue::new(5)), "AnyValue { inner: i32 }");
+    }
+
+    #[test]
+    fn eq_to_type_id() {
+        use super::*;
+
+        let any_value_id = AnyValueId::of::<i32>();
+        let type_id = std::any::TypeId::of::<i32>();
+        assert_eq!(any_value_id, type_id);
     }
 }


### PR DESCRIPTION
Allow equality comparison for AnyValueId and TypeId.

**Background**:
I am trying to write a schema command for my CLI. I am using the type_id method on the ValueParser to get the data type for an argument but cannot actually compare it to anything without this implementation.
