### PR TITLE
chore: Inline format args using clippy fix

### DIFF
--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -38,7 +38,7 @@ impl ErrorFormatter for KindFormatter {
         if let Some(msg) = error.kind().as_str() {
             styled.push_str(msg);
         } else if let Some(source) = error.inner.source.as_ref() {
-            let _ = write!(styled, "{}", source);
+            let _ = write!(styled, "{source}");
         } else {
             styled.push_str("unknown cause");
         }
@@ -68,7 +68,7 @@ impl ErrorFormatter for RichFormatter {
             if let Some(msg) = error.kind().as_str() {
                 styled.push_str(msg);
             } else if let Some(source) = error.inner.source.as_ref() {
-                let _ = write!(styled, "{}", source);
+                let _ = write!(styled, "{source}");
             } else {
                 styled.push_str("unknown cause");
             }
@@ -357,7 +357,7 @@ fn write_dynamic_context(
                     literal.render_reset(),
                 );
                 if let Some(source) = error.inner.source.as_deref() {
-                    let _ = write!(styled, ": {}", source);
+                    let _ = write!(styled, ": {source}");
                 }
                 true
             } else {

--- a/clap_builder/src/parser/matches/arg_matches.rs
+++ b/clap_builder/src/parser/matches/arg_matches.rs
@@ -143,10 +143,7 @@ impl ArgMatches {
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn get_count(&self, id: &str) -> u8 {
         *self.get_one::<u8>(id).unwrap_or_else(|| {
-            panic!(
-                "arg `{}`'s `ArgAction` should be `Count` which should provide a default",
-                id
-            )
+            panic!("arg `{id}`'s `ArgAction` should be `Count` which should provide a default")
         })
     }
 
@@ -182,8 +179,7 @@ impl ArgMatches {
             .get_one::<bool>(id)
             .unwrap_or_else(|| {
                 panic!(
-                    "arg `{}`'s `ArgAction` should be one of `SetTrue`, `SetFalse` which should provide a default",
-                    id
+                    "arg `{id}`'s `ArgAction` should be one of `SetTrue`, `SetFalse` which should provide a default"
                 )
             })
     }

--- a/clap_complete/src/shells/powershell.rs
+++ b/clap_complete/src/shells/powershell.rs
@@ -50,9 +50,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin_name}' -ScriptBlock {{
     $completions.Where{{ $_.CompletionText -like "$wordToComplete*" }} |
         Sort-Object -Property ListItemText
 }}
-"#,
-            bin_name = bin_name,
-            subcommands_cases = subcommands_cases
+"#
         );
 
         w!(buf, result.as_bytes());

--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -475,14 +475,7 @@ fn write_opts_of(p: &Command, p_global: Option<&Command>) -> String {
 
         if let Some(shorts) = o.get_short_and_visible_aliases() {
             for short in shorts {
-                let s = format!(
-                    "'{conflicts}{multiple}-{arg}+[{help}]{value_completion}' \\",
-                    conflicts = conflicts,
-                    multiple = multiple,
-                    arg = short,
-                    value_completion = vc,
-                    help = help
-                );
+                let s = format!("'{conflicts}{multiple}-{short}+[{help}]{vc}' \\");
 
                 debug!("write_opts_of:iter: Wrote...{}", &*s);
                 ret.push(s);
@@ -490,14 +483,7 @@ fn write_opts_of(p: &Command, p_global: Option<&Command>) -> String {
         }
         if let Some(longs) = o.get_long_and_visible_aliases() {
             for long in longs {
-                let l = format!(
-                    "'{conflicts}{multiple}--{arg}=[{help}]{value_completion}' \\",
-                    conflicts = conflicts,
-                    multiple = multiple,
-                    arg = long,
-                    value_completion = vc,
-                    help = help
-                );
+                let l = format!("'{conflicts}{multiple}--{long}=[{help}]{vc}' \\");
 
                 debug!("write_opts_of:iter: Wrote...{}", &*l);
                 ret.push(l);
@@ -564,13 +550,7 @@ fn write_flags_of(p: &Command, p_global: Option<&Command>) -> String {
         };
 
         if let Some(short) = f.get_short() {
-            let s = format!(
-                "'{conflicts}{multiple}-{arg}[{help}]' \\",
-                multiple = multiple,
-                conflicts = conflicts,
-                arg = short,
-                help = help
-            );
+            let s = format!("'{conflicts}{multiple}-{short}[{help}]' \\");
 
             debug!("write_flags_of:iter: Wrote...{}", &*s);
 
@@ -588,13 +568,7 @@ fn write_flags_of(p: &Command, p_global: Option<&Command>) -> String {
         }
 
         if let Some(long) = f.get_long() {
-            let l = format!(
-                "'{conflicts}{multiple}--{arg}[{help}]' \\",
-                conflicts = conflicts,
-                multiple = multiple,
-                arg = long,
-                help = help
-            );
+            let l = format!("'{conflicts}{multiple}--{long}[{help}]' \\");
 
             debug!("write_flags_of:iter: Wrote...{}", &*l);
 
@@ -602,13 +576,7 @@ fn write_flags_of(p: &Command, p_global: Option<&Command>) -> String {
 
             if let Some(aliases) = f.get_visible_aliases() {
                 for alias in aliases {
-                    let l = format!(
-                        "'{conflicts}{multiple}--{arg}[{help}]' \\",
-                        conflicts = conflicts,
-                        multiple = multiple,
-                        arg = alias,
-                        help = help
-                    );
+                    let l = format!("'{conflicts}{multiple}--{alias}[{help}]' \\");
 
                     debug!("write_flags_of:iter: Wrote...{}", &*l);
 

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -1247,8 +1247,8 @@ impl Method {
                     ident,
                     "cannot derive `{}` from Cargo.toml\n\n= note: {note}\n\n= help: {help}\n\n",
                     ident,
-                    note = format_args!("`{}` environment variable is not set", env_var),
-                    help = format_args!("use `{} = \"...\"` to set {} manually", ident, ident)
+                    note = format_args!("`{env_var}` environment variable is not set"),
+                    help = format_args!("use `{ident} = \"...\"` to set {ident} manually")
                 );
             }
         };

--- a/tests/builder/double_require.rs
+++ b/tests/builder/double_require.rs
@@ -51,7 +51,7 @@ fn help_text() {
     assert!(res.is_err());
     let err = res.unwrap_err();
     assert_eq!(err.kind(), ErrorKind::DisplayHelp);
-    println!("{}", err);
+    println!("{err}");
     assert_eq!(err.to_string(), HELP);
 }
 

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2650,8 +2650,7 @@ fn disable_help_flag_affects_help_subcommand() {
         .collect::<Vec<_>>();
     assert!(
         !args.contains(&"help"),
-        "`help` should not be present: {:?}",
-        args
+        "`help` should not be present: {args:?}"
     );
 }
 

--- a/tests/builder/ignore_errors.rs
+++ b/tests/builder/ignore_errors.rs
@@ -8,7 +8,7 @@ fn single_short_arg_without_value() {
 
     let r = cmd.try_get_matches_from(vec!["cmd", "-c" /* missing: , "config file" */]);
 
-    assert!(r.is_ok(), "unexpected error: {:?}", r);
+    assert!(r.is_ok(), "unexpected error: {r:?}");
     let m = r.unwrap();
     assert!(m.contains_id("config"));
 }
@@ -42,7 +42,7 @@ fn multiple_args_and_final_arg_without_value() {
         "cmd", "-c", "file", "-f", "-x", /* missing: , "some stuff" */
     ]);
 
-    assert!(r.is_ok(), "unexpected error: {:?}", r);
+    assert!(r.is_ok(), "unexpected error: {r:?}");
     let m = r.unwrap();
     assert_eq!(
         m.get_one::<String>("config").map(|v| v.as_str()),
@@ -69,7 +69,7 @@ fn multiple_args_and_intermittent_arg_without_value() {
         "-c", "file", "-f",
     ]);
 
-    assert!(r.is_ok(), "unexpected error: {:?}", r);
+    assert!(r.is_ok(), "unexpected error: {r:?}");
     let m = r.unwrap();
     assert_eq!(
         m.get_one::<String>("config").map(|v| v.as_str()),

--- a/tests/builder/opts.rs
+++ b/tests/builder/opts.rs
@@ -64,7 +64,7 @@ fn double_hyphen_as_value() {
                 .long("config"),
         )
         .try_get_matches_from(vec!["prog", "--config", "--"]);
-    assert!(res.is_ok(), "{:?}", res);
+    assert!(res.is_ok(), "{res:?}");
     assert_eq!(
         res.unwrap().get_one::<String>("cfg").map(|v| v.as_str()),
         Some("--")
@@ -428,7 +428,7 @@ fn leading_hyphen_with_only_pos_follows() {
         )
         .arg(arg!([arg] "some arg"))
         .try_get_matches_from(vec!["", "-o", "-2", "--", "val"]);
-    assert!(r.is_ok(), "{:?}", r);
+    assert!(r.is_ok(), "{r:?}");
     let m = r.unwrap();
     assert!(m.contains_id("o"));
     assert_eq!(

--- a/tests/builder/positionals.rs
+++ b/tests/builder/positionals.rs
@@ -27,7 +27,7 @@ fn issue_946() {
                 .help("filters to apply to output"),
         )
         .try_get_matches_from(vec!["compiletest", "--exact"]);
-    assert!(r.is_ok(), "{:#?}", r);
+    assert!(r.is_ok(), "{r:#?}");
     let matches = r.unwrap();
 
     assert!(*matches.get_one::<bool>("exact").expect("defaulted by clap"));
@@ -45,7 +45,7 @@ fn positional() {
             Arg::new("positional").index(1),
         ])
         .try_get_matches_from(vec!["", "-f", "test"]);
-    assert!(r.is_ok(), "{:#?}", r);
+    assert!(r.is_ok(), "{r:#?}");
     let m = r.unwrap();
     assert!(m.contains_id("positional"));
     assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
@@ -124,7 +124,7 @@ fn positional_multiple() {
                 .num_args(1..),
         ])
         .try_get_matches_from(vec!["", "-f", "test1", "test2", "test3"]);
-    assert!(r.is_ok(), "{:#?}", r);
+    assert!(r.is_ok(), "{r:#?}");
     let m = r.unwrap();
     assert!(m.contains_id("positional"));
     assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));
@@ -148,7 +148,7 @@ fn positional_multiple_3() {
                 .num_args(1..),
         ])
         .try_get_matches_from(vec!["", "test1", "test2", "test3", "--flag"]);
-    assert!(r.is_ok(), "{:#?}", r);
+    assert!(r.is_ok(), "{r:#?}");
     let m = r.unwrap();
     assert!(m.contains_id("positional"));
     assert!(*m.get_one::<bool>("flag").expect("defaulted by clap"));

--- a/tests/builder/tests.rs
+++ b/tests/builder/tests.rs
@@ -96,17 +96,17 @@ pub fn check_complex_output(args: &str, out: &str) {
             writeln!(w, "flag NOT present").unwrap();
         }
         n => {
-            writeln!(w, "flag present {} times", n).unwrap();
+            writeln!(w, "flag present {n} times").unwrap();
         }
     }
 
     if matches.contains_id("option") {
         if let Some(v) = matches.get_one::<String>("option").map(|v| v.as_str()) {
-            writeln!(w, "option present with value: {}", v).unwrap();
+            writeln!(w, "option present with value: {v}").unwrap();
         }
         if let Some(ov) = matches.get_many::<String>("option") {
             for o in ov {
-                writeln!(w, "An option: {}", o).unwrap();
+                writeln!(w, "An option: {o}").unwrap();
             }
         }
     } else {
@@ -114,7 +114,7 @@ pub fn check_complex_output(args: &str, out: &str) {
     }
 
     if let Some(p) = matches.get_one::<String>("positional").map(|v| v.as_str()) {
-        writeln!(w, "positional present with value: {}", p).unwrap();
+        writeln!(w, "positional present with value: {p}").unwrap();
     } else {
         writeln!(w, "positional NOT present").unwrap();
     }
@@ -183,11 +183,11 @@ pub fn check_complex_output(args: &str, out: &str) {
 
     if matches.contains_id("option") {
         if let Some(v) = matches.get_one::<String>("option").map(|v| v.as_str()) {
-            writeln!(w, "option present with value: {}", v).unwrap();
+            writeln!(w, "option present with value: {v}").unwrap();
         }
         if let Some(ov) = matches.get_many::<String>("option") {
             for o in ov {
-                writeln!(w, "An option: {}", o).unwrap();
+                writeln!(w, "An option: {o}").unwrap();
             }
         }
     } else {


### PR DESCRIPTION
This command cleaned up all the format args, making code significantly shorter and more readable.

```
cargo clippy --workspace --fix -- -A clippy::all -W clippy::uninlined_format_args
```
