### PR TITLE
chore: Inline format args 2 (mixed cases)

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,8 +1,13 @@
 msrv = "1.64.0"  # MSRV
+
 warn-on-all-wildcard-imports = true
-allow-expect-in-tests = true
-allow-unwrap-in-tests = true
+
 allow-dbg-in-tests = true
+allow-expect-in-tests = true
+## TODO: This parameter requires clippy v1.67+. Uncomment once MSRV is bumped.
+# allow-mixed-uninlined-format-args = false
+allow-unwrap-in-tests = true
+
 disallowed-methods = [
     { path = "std::option::Option::map_or", reason = "use `map(..).unwrap_or(..)`" },
     { path = "std::option::Option::map_or_else", reason = "use `map(..).unwrap_or_else(..)`" },

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -3984,8 +3984,7 @@ impl Command {
                 self.display_name.as_deref().unwrap_or(&self.name)
             };
             let display_name = format!(
-                "{}{}{}",
-                self_display_name,
+                "{self_display_name}{}{}",
                 if !self_display_name.is_empty() {
                     "-"
                 } else {
@@ -4068,8 +4067,7 @@ impl Command {
 
                 if sc.bin_name.is_none() {
                     let bin_name = format!(
-                        "{}{}{}",
-                        self_bin_name,
+                        "{self_bin_name}{}{}",
                         if !self_bin_name.is_empty() { " " } else { "" },
                         &*sc.name
                     );
@@ -4092,8 +4090,7 @@ impl Command {
                         self.display_name.as_deref().unwrap_or(&self.name)
                     };
                     let display_name = format!(
-                        "{}{}{}",
-                        self_display_name,
+                        "{self_display_name}{}{}",
                         if !self_display_name.is_empty() {
                             "-"
                         } else {

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -48,7 +48,7 @@ pub(crate) fn assert_app(cmd: &Command) {
         }
 
         if let Some(l) = sc.get_long_flag().as_ref() {
-            assert!(!l.starts_with('-'), "Command {}: long_flag {:?} must not start with a `-`, that will be handled by the parser", sc.get_name(), l);
+            assert!(!l.starts_with('-'), "Command {}: long_flag {l:?} must not start with a `-`, that will be handled by the parser", sc.get_name());
             long_flags.push(Flag::Command(format!("--{l}"), sc.get_name()));
         }
 
@@ -76,7 +76,7 @@ pub(crate) fn assert_app(cmd: &Command) {
         }
 
         if let Some(l) = arg.get_long() {
-            assert!(!l.starts_with('-'), "Argument {}: long {:?} must not start with a `-`, that will be handled by the parser", arg.get_id(), l);
+            assert!(!l.starts_with('-'), "Argument {}: long {l:?} must not start with a `-`, that will be handled by the parser", arg.get_id());
             long_flags.push(Flag::Arg(format!("--{l}"), arg.get_id().as_str()));
         }
 
@@ -99,9 +99,8 @@ pub(crate) fn assert_app(cmd: &Command) {
             if let Some((first, second)) = cmd.two_args_of(|x| x.get_long() == Some(l)) {
                 panic!(
                     "Command {}: Long option names must be unique for each argument, \
-                            but '--{}' is in use by both '{}' and '{}'{}",
+                            but '--{l}' is in use by both '{}' and '{}'{}",
                     cmd.get_name(),
-                    l,
                     first.get_id(),
                     second.get_id(),
                     duplicate_tip(cmd, first, second)
@@ -114,9 +113,8 @@ pub(crate) fn assert_app(cmd: &Command) {
             if let Some((first, second)) = cmd.two_args_of(|x| x.get_short() == Some(s)) {
                 panic!(
                     "Command {}: Short option names must be unique for each argument, \
-                            but '-{}' is in use by both '{}' and '{}'{}",
+                            but '-{s}' is in use by both '{}' and '{}'{}",
                     cmd.get_name(),
-                    s,
                     first.get_id(),
                     second.get_id(),
                     duplicate_tip(cmd, first, second),
@@ -190,9 +188,8 @@ pub(crate) fn assert_app(cmd: &Command) {
             );
             assert!(
                 cmd.id_exists(req),
-                "Command {}: Argument or group '{}' specified in 'required_unless*' for '{}' does not exist",
+                "Command {}: Argument or group '{req}' specified in 'required_unless*' for '{}' does not exist",
                     cmd.get_name(),
-                req,
                 arg.get_id(),
             );
         }
@@ -205,9 +202,8 @@ pub(crate) fn assert_app(cmd: &Command) {
             );
             assert!(
                 cmd.id_exists(req),
-                "Command {}: Argument or group '{}' specified in 'required_unless*' for '{}' does not exist",
+                "Command {}: Argument or group '{req}' specified in 'required_unless*' for '{}' does not exist",
                     cmd.get_name(),
-                req,
                 arg.get_id(),
             );
         }
@@ -216,9 +212,8 @@ pub(crate) fn assert_app(cmd: &Command) {
         for req in &arg.blacklist {
             assert!(
                 cmd.id_exists(req),
-                "Command {}: Argument or group '{}' specified in 'conflicts_with*' for '{}' does not exist",
+                "Command {}: Argument or group '{req}' specified in 'conflicts_with*' for '{}' does not exist",
                     cmd.get_name(),
-                req,
                 arg.get_id(),
             );
         }
@@ -227,9 +222,8 @@ pub(crate) fn assert_app(cmd: &Command) {
         for req in &arg.overrides {
             assert!(
                 cmd.id_exists(req),
-                "Command {}: Argument or group '{}' specified in 'overrides_with*' for '{}' does not exist",
+                "Command {}: Argument or group '{req}' specified in 'overrides_with*' for '{}' does not exist",
                     cmd.get_name(),
-                req,
                 arg.get_id(),
             );
         }
@@ -294,10 +288,9 @@ pub(crate) fn assert_app(cmd: &Command) {
             // Args listed inside groups should exist
             assert!(
                 cmd.get_arguments().any(|x| x.get_id() == arg),
-                "Command {}: Argument group '{}' contains non-existent argument '{}'",
+                "Command {}: Argument group '{}' contains non-existent argument '{arg}'",
                 cmd.get_name(),
-                group.get_id(),
-                arg
+                group.get_id()
             );
         }
 
@@ -305,10 +298,9 @@ pub(crate) fn assert_app(cmd: &Command) {
             // Args listed inside groups should exist
             assert!(
                 cmd.id_exists(arg),
-                "Command {}: Argument group '{}' requires non-existent '{}' id",
+                "Command {}: Argument group '{}' requires non-existent '{arg}' id",
                 cmd.get_name(),
-                group.get_id(),
-                arg
+                group.get_id()
             );
         }
 
@@ -316,10 +308,9 @@ pub(crate) fn assert_app(cmd: &Command) {
             // Args listed inside groups should exist
             assert!(
                 cmd.id_exists(arg),
-                "Command {}: Argument group '{}' conflicts with non-existent '{}' id",
+                "Command {}: Argument group '{}' conflicts with non-existent '{arg}' id",
                 cmd.get_name(),
-                group.get_id(),
-                arg
+                group.get_id()
             );
         }
     }
@@ -343,10 +334,9 @@ pub(crate) fn assert_app(cmd: &Command) {
         for alias in sc.get_all_aliases() {
             assert!(
                 subs.insert(alias),
-                "Command {}: command `{}` alias `{}` is duplicated",
+                "Command {}: command `{}` alias `{alias}` is duplicated",
                 cmd.get_name(),
-                sc.get_name(),
-                alias
+                sc.get_name()
             );
         }
     }
@@ -768,10 +758,8 @@ fn assert_arg(arg: &Arg) {
         let num_val_names = arg.get_value_names().unwrap_or(&[]).len();
         if num_vals.max_values() < num_val_names {
             panic!(
-                "Argument {}: Too many value names ({}) compared to `num_args` ({})",
-                arg.get_id(),
-                num_val_names,
-                num_vals
+                "Argument {}: Too many value names ({num_val_names}) compared to `num_args` ({num_vals})",
+                arg.get_id()
             );
         }
     }
@@ -779,24 +767,21 @@ fn assert_arg(arg: &Arg) {
     assert_eq!(
         num_vals.takes_values(),
         arg.is_takes_value_set(),
-        "Argument {}: mismatch between `num_args` ({}) and `takes_value`",
+        "Argument {}: mismatch between `num_args` ({num_vals}) and `takes_value`",
         arg.get_id(),
-        num_vals,
     );
     assert_eq!(
         num_vals.is_multiple(),
         arg.is_multiple_values_set(),
-        "Argument {}: mismatch between `num_args` ({}) and `multiple_values`",
+        "Argument {}: mismatch between `num_args` ({num_vals}) and `multiple_values`",
         arg.get_id(),
-        num_vals,
     );
 
     if 1 < num_vals.min_values() {
         assert!(
             !arg.is_require_equals_set(),
-            "Argument {}: cannot accept more than 1 arg (num_args={}) with require_equals",
-            arg.get_id(),
-            num_vals
+            "Argument {}: cannot accept more than 1 arg (num_args={num_vals}) with require_equals",
+            arg.get_id()
         );
     }
 
@@ -869,21 +854,16 @@ fn assert_defaults<'d>(
             for part in default_os.split(val_delim) {
                 if let Err(err) = value_parser.parse_ref(&assert_cmd, Some(arg), part) {
                     panic!(
-                        "Argument `{}`'s {}={:?} failed validation: {}",
+                        "Argument `{}`'s {field}={:?} failed validation: {err}",
                         arg.get_id(),
-                        field,
-                        part.to_string_lossy(),
-                        err
+                        part.to_string_lossy()
                     );
                 }
             }
         } else if let Err(err) = value_parser.parse_ref(&assert_cmd, Some(arg), default_os) {
             panic!(
-                "Argument `{}`'s {}={:?} failed validation: {}",
-                arg.get_id(),
-                field,
-                default_os,
-                err
+                "Argument `{}`'s {field}={default_os:?} failed validation: {err}",
+                arg.get_id()
             );
         }
     }

--- a/clap_builder/src/builder/value_parser.rs
+++ b/clap_builder/src/builder/value_parser.rs
@@ -1292,19 +1292,13 @@ impl<T: std::convert::TryFrom<i64> + Clone + Send + Sync> RangedI64ValueParser<T
         // - Make it convenient to limit the range like with `..10`
         let start = match range.start_bound() {
             l @ std::ops::Bound::Included(i) => {
-                debug_assert!(
-                    self.bounds.contains(i),
-                    "{} must be in {:?}",
-                    i,
-                    self.bounds
-                );
+                debug_assert!(self.bounds.contains(i), "{i} must be in {:?}", self.bounds);
                 l.cloned()
             }
             l @ std::ops::Bound::Excluded(i) => {
                 debug_assert!(
                     self.bounds.contains(&i.saturating_add(1)),
-                    "{} must be in {:?}",
-                    i,
+                    "{i} must be in {:?}",
                     self.bounds
                 );
                 l.cloned()
@@ -1313,19 +1307,13 @@ impl<T: std::convert::TryFrom<i64> + Clone + Send + Sync> RangedI64ValueParser<T
         };
         let end = match range.end_bound() {
             l @ std::ops::Bound::Included(i) => {
-                debug_assert!(
-                    self.bounds.contains(i),
-                    "{} must be in {:?}",
-                    i,
-                    self.bounds
-                );
+                debug_assert!(self.bounds.contains(i), "{i} must be in {:?}", self.bounds);
                 l.cloned()
             }
             l @ std::ops::Bound::Excluded(i) => {
                 debug_assert!(
                     self.bounds.contains(&i.saturating_sub(1)),
-                    "{} must be in {:?}",
-                    i,
+                    "{i} must be in {:?}",
                     self.bounds
                 );
                 l.cloned()
@@ -1396,7 +1384,7 @@ where
             return Err(crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
-                format!("{} is not in {}", value, self.format_bounds()).into(),
+                format!("{value} is not in {}", self.format_bounds()).into(),
             )
             .with_cmd(cmd));
         }
@@ -1492,19 +1480,13 @@ impl<T: std::convert::TryFrom<u64>> RangedU64ValueParser<T> {
         // - Make it convenient to limit the range like with `..10`
         let start = match range.start_bound() {
             l @ std::ops::Bound::Included(i) => {
-                debug_assert!(
-                    self.bounds.contains(i),
-                    "{} must be in {:?}",
-                    i,
-                    self.bounds
-                );
+                debug_assert!(self.bounds.contains(i), "{i} must be in {:?}", self.bounds);
                 l.cloned()
             }
             l @ std::ops::Bound::Excluded(i) => {
                 debug_assert!(
                     self.bounds.contains(&i.saturating_add(1)),
-                    "{} must be in {:?}",
-                    i,
+                    "{i} must be in {:?}",
                     self.bounds
                 );
                 l.cloned()
@@ -1513,19 +1495,13 @@ impl<T: std::convert::TryFrom<u64>> RangedU64ValueParser<T> {
         };
         let end = match range.end_bound() {
             l @ std::ops::Bound::Included(i) => {
-                debug_assert!(
-                    self.bounds.contains(i),
-                    "{} must be in {:?}",
-                    i,
-                    self.bounds
-                );
+                debug_assert!(self.bounds.contains(i), "{i} must be in {:?}", self.bounds);
                 l.cloned()
             }
             l @ std::ops::Bound::Excluded(i) => {
                 debug_assert!(
                     self.bounds.contains(&i.saturating_sub(1)),
-                    "{} must be in {:?}",
-                    i,
+                    "{i} must be in {:?}",
                     self.bounds
                 );
                 l.cloned()
@@ -1596,7 +1572,7 @@ where
             return Err(crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
-                format!("{} is not in {}", value, self.format_bounds()).into(),
+                format!("{value} is not in {}", self.format_bounds()).into(),
             )
             .with_cmd(cmd));
         }

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -761,7 +761,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 } else {
                     Default::default()
                 };
-                let env_info = format!("[env: {}{}]", env.0.to_string_lossy(), env_val);
+                let env_info = format!("[env: {}{env_val}]", env.0.to_string_lossy());
                 spec_vals.push(env_info);
             }
         }

--- a/clap_builder/src/output/textwrap/core.rs
+++ b/clap_builder/src/output/textwrap/core.rs
@@ -99,10 +99,10 @@ mod tests {
         // characters such as '#' and '©'.
         for ch in '\u{1}'..'\u{FF}' {
             if is_emoji(ch) {
-                let desc = format!("{:?} U+{:04X}", ch, ch as u32);
+                let desc = format!("{ch:?} U+{:04X}", ch as u32);
 
                 #[cfg(feature = "unicode")]
-                assert_eq!(ch.width().unwrap(), 1, "char: {}", desc);
+                assert_eq!(ch.width().unwrap(), 1, "char: {desc}");
 
                 #[cfg(not(feature = "unicode"))]
                 assert_eq!(ch_width(ch), 1, "char: {desc}");
@@ -117,10 +117,10 @@ mod tests {
         // emojis such as 😊.
         for ch in '\u{FF}'..'\u{2FFFF}' {
             if is_emoji(ch) {
-                let desc = format!("{:?} U+{:04X}", ch, ch as u32);
+                let desc = format!("{ch:?} U+{:04X}", ch as u32);
 
                 #[cfg(feature = "unicode")]
-                assert!(ch.width().unwrap() <= 2, "char: {}", desc);
+                assert!(ch.width().unwrap() <= 2, "char: {desc}");
 
                 #[cfg(not(feature = "unicode"))]
                 assert_eq!(ch_width(ch), 1, "char: {desc}");

--- a/clap_complete/examples/dynamic.rs
+++ b/clap_complete/examples/dynamic.rs
@@ -27,7 +27,7 @@ fn main() {
     {
         completions.complete(&mut command());
     } else {
-        println!("{:#?}", matches);
+        println!("{matches:#?}");
     }
 }
 

--- a/clap_complete/src/dynamic.rs
+++ b/clap_complete/src/dynamic.rs
@@ -124,7 +124,7 @@ pub mod bash {
 
     /// The recommended file name for the registration code
     pub fn file_name(name: &str) -> String {
-        format!("{}.bash", name)
+        format!("{name}.bash")
     }
 
     /// Define the completion behavior
@@ -154,8 +154,7 @@ pub mod bash {
         let escaped_name = name.replace('-', "_");
         debug_assert!(
             escaped_name.chars().all(|c| c.is_xid_continue()),
-            "`name` must be an identifier, got `{}`",
-            escaped_name
+            "`name` must be an identifier, got `{escaped_name}`"
         );
         let mut upper_name = escaped_name.clone();
         upper_name.make_ascii_uppercase();
@@ -201,7 +200,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
         .replace("COMPLETER", &completer)
         .replace("UPPER", &upper_name);
 
-        writeln!(buf, "{}", script)?;
+        writeln!(buf, "{script}")?;
         Ok(())
     }
 
@@ -377,7 +376,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                                     .into_iter()
                                     .map(|os| {
                                         // HACK: Need better `OsStr` manipulation
-                                        format!("--{}={}", flag, os.to_string_lossy()).into()
+                                        format!("--{flag}={}", os.to_string_lossy()).into()
                                     }),
                             )
                         }
@@ -386,7 +385,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                             crate::generator::utils::longs_and_visible_aliases(cmd)
                                 .into_iter()
                                 .filter_map(|f| {
-                                    f.starts_with(flag).then(|| format!("--{}", f).into())
+                                    f.starts_with(flag).then(|| format!("--{f}").into())
                                 }),
                         );
                     }
@@ -396,7 +395,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                 completions.extend(
                     crate::generator::utils::longs_and_visible_aliases(cmd)
                         .into_iter()
-                        .map(|f| format!("--{}", f).into()),
+                        .map(|f| format!("--{f}").into()),
                 );
             }
 
@@ -406,7 +405,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                     crate::generator::utils::shorts_and_visible_aliases(cmd)
                         .into_iter()
                         // HACK: Need better `OsStr` manipulation
-                        .map(|f| format!("{}{}", arg.to_value_os().to_string_lossy(), f).into()),
+                        .map(|f| format!("{}{f}", arg.to_value_os().to_string_lossy()).into()),
                 );
             }
         }

--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -21,7 +21,7 @@ impl Generator for Bash {
         w!(
             buf,
             format!(
-                "_{name}() {{
+                "_{bin_name}() {{
     local i cur prev opts cmd
     COMPREPLY=()
     cur=\"${{COMP_WORDS[COMP_CWORD]}}\"
@@ -58,9 +58,8 @@ impl Generator for Bash {
     esac
 }}
 
-complete -F _{name} -o bashdefault -o default {name}
+complete -F _{bin_name} -o bashdefault -o default {bin_name}
 ",
-                name = bin_name,
                 cmd = bin_name.replace('-', "__"),
                 name_opts = all_options_for_path(cmd, bin_name),
                 name_opts_details = option_details_for_path(cmd, bin_name),
@@ -82,7 +81,6 @@ fn all_subcommands(cmd: &Command) -> String {
     ) {
         let fn_name = format!(
             "{parent_fn_name}__{cmd_name}",
-            parent_fn_name = parent_fn_name,
             cmd_name = cmd.get_name().to_string().replace('-', "__")
         );
         subcmds.push((
@@ -167,11 +165,10 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
         if let Some(longs) = o.get_long_and_visible_aliases() {
             opts.extend(longs.iter().map(|long| {
                 format!(
-                    "--{})
+                    "--{long})
                     COMPREPLY=({})
                     return 0
                     ;;",
-                    long,
                     vals_for(o)
                 )
             }));
@@ -180,11 +177,10 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
         if let Some(shorts) = o.get_short_and_visible_aliases() {
             opts.extend(shorts.iter().map(|short| {
                 format!(
-                    "-{})
+                    "-{short})
                     COMPREPLY=({})
                     return 0
                     ;;",
-                    short,
                     vals_for(o)
                 )
             }));

--- a/clap_complete/src/shells/elvish.rs
+++ b/clap_complete/src/shells/elvish.rs
@@ -70,7 +70,7 @@ fn generate_inner(p: &Command, previous_command_name: &str) -> String {
     let command_name = if previous_command_name.is_empty() {
         p.get_bin_name().expect(INTERNAL_ERROR_MSG).to_string()
     } else {
-        format!("{};{}", previous_command_name, &p.get_name())
+        format!("{previous_command_name};{}", &p.get_name())
     };
 
     let mut completions = String::new();
@@ -122,9 +122,9 @@ fn generate_inner(p: &Command, previous_command_name: &str) -> String {
 
     let mut subcommands_cases = format!(
         r"
-        &'{}'= {{{}
+        &'{}'= {{{completions}
         }}",
-        &command_name, completions
+        &command_name
     );
 
     for subcommand in p.get_subcommands() {

--- a/clap_complete/src/shells/powershell.rs
+++ b/clap_complete/src/shells/powershell.rs
@@ -75,7 +75,7 @@ fn generate_inner(p: &Command, previous_command_name: &str) -> String {
     let command_name = if previous_command_name.is_empty() {
         p.get_bin_name().expect(INTERNAL_ERROR_MSG).to_string()
     } else {
-        format!("{};{}", previous_command_name, &p.get_name())
+        format!("{previous_command_name};{}", &p.get_name())
     };
 
     let mut completions = String::new();
@@ -96,8 +96,8 @@ fn generate_inner(p: &Command, previous_command_name: &str) -> String {
         completions.push_str(&preamble);
         completions.push_str(
             format!(
-                "'{}', '{}', {}, '{}')",
-                data, data, "[CompletionResultType]::ParameterValue", tooltip
+                "'{data}', '{data}', {}, '{tooltip}')",
+                "[CompletionResultType]::ParameterValue"
             )
             .as_str(),
         );
@@ -105,10 +105,10 @@ fn generate_inner(p: &Command, previous_command_name: &str) -> String {
 
     let mut subcommands_cases = format!(
         r"
-        '{}' {{{}
+        '{}' {{{completions}
             break
         }}",
-        &command_name, completions
+        &command_name
     );
 
     for subcommand in p.get_subcommands() {

--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -22,11 +22,11 @@ impl Generator for Zsh {
         w!(
             buf,
             format!(
-                "#compdef {name}
+                "#compdef {bin_name}
 
 autoload -U is-at-least
 
-_{name}() {{
+_{bin_name}() {{
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -43,13 +43,12 @@ _{name}() {{
 
 {subcommand_details}
 
-if [ \"$funcstack[1]\" = \"_{name}\" ]; then
-    _{name} \"$@\"
+if [ \"$funcstack[1]\" = \"_{bin_name}\" ]; then
+    _{bin_name} \"$@\"
 else
-    compdef _{name} {name}
+    compdef _{bin_name} {bin_name}
 fi
 ",
-                name = bin_name,
                 initial_args = get_args_of(cmd, None),
                 subcommands = get_subcommands_of(cmd),
                 subcommand_details = subcommand_details(cmd)
@@ -104,7 +103,6 @@ _{bin_name_underscore}_commands() {{
     _describe -t commands '{bin_name} commands' commands \"$@\"
 }}",
         bin_name_underscore = bin_name.replace(' ', "__"),
-        bin_name = bin_name,
         subcommands_and_args = subcommands_of(p)
     );
     ret.push(parent_text);
@@ -126,7 +124,6 @@ _{bin_name_underscore}_commands() {{
     _describe -t commands '{bin_name} commands' commands \"$@\"
 }}",
             bin_name_underscore = bin_name.replace(' ', "__"),
-            bin_name = bin_name,
             subcommands_and_args =
                 subcommands_of(parser_of(p, bin_name).expect(INTERNAL_ERROR_MSG))
         ));
@@ -156,7 +153,6 @@ fn subcommands_of(p: &Command) -> String {
 
         let text = format!(
             "'{name}:{help}' \\",
-            name = name,
             help = escape_help(&subcommand.get_about().unwrap_or_default().to_string())
         );
 
@@ -643,7 +639,6 @@ fn write_positionals_of(p: &Command) -> String {
 
         let a = format!(
             "'{cardinality}:{name}{help}:{value_completion}' \\",
-            cardinality = cardinality,
             name = arg.get_id(),
             help = arg
                 .get_help()

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -53,7 +53,7 @@ fn escape_string(string: &str) -> String {
 
 fn gen_fig_inner(parent_commands: &[&str], indent: usize, cmd: &Command, buffer: &mut String) {
     if cmd.has_subcommands() {
-        write!(buffer, "{:indent$}subcommands: [\n", "", indent = indent).unwrap();
+        write!(buffer, "{:indent$}subcommands: [\n", "").unwrap();
         // generate subcommands
         for subcommand in cmd.get_subcommands() {
             let mut aliases: Vec<&str> = subcommand.get_all_aliases().collect();
@@ -111,7 +111,7 @@ fn gen_fig_inner(parent_commands: &[&str], indent: usize, cmd: &Command, buffer:
 
             write!(buffer, "{:indent$}}},\n", "", indent = indent + 2).unwrap();
         }
-        write!(buffer, "{:indent$}],\n", "", indent = indent).unwrap();
+        write!(buffer, "{:indent$}],\n", "").unwrap();
     }
 
     buffer.push_str(&gen_options(cmd, indent));
@@ -121,17 +121,17 @@ fn gen_fig_inner(parent_commands: &[&str], indent: usize, cmd: &Command, buffer:
     match args.len() {
         0 => {}
         1 => {
-            write!(buffer, "{:indent$}args: ", "", indent = indent).unwrap();
+            write!(buffer, "{:indent$}args: ", "").unwrap();
 
             buffer.push_str(&gen_args(args[0], indent));
         }
         _ => {
-            write!(buffer, "{:indent$}args: [\n", "", indent = indent).unwrap();
+            write!(buffer, "{:indent$}args: [\n", "").unwrap();
             for arg in args {
                 write!(buffer, "{:indent$}", "", indent = indent + 2).unwrap();
                 buffer.push_str(&gen_args(arg, indent + 2));
             }
-            write!(buffer, "{:indent$}]\n", "", indent = indent).unwrap();
+            write!(buffer, "{:indent$}]\n", "").unwrap();
         }
     };
 }
@@ -142,7 +142,7 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
     let flags = generator::utils::flags(cmd);
 
     if cmd.get_opts().next().is_some() || !flags.is_empty() {
-        write!(&mut buffer, "{:indent$}options: [\n", "", indent = indent).unwrap();
+        write!(&mut buffer, "{:indent$}options: [\n", "").unwrap();
 
         for option in cmd.get_opts() {
             write!(&mut buffer, "{:indent$}{{\n", "", indent = indent + 2).unwrap();
@@ -346,7 +346,7 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
             write!(&mut buffer, "{:indent$}}},\n", "", indent = indent + 2).unwrap();
         }
 
-        write!(&mut buffer, "{:indent$}],\n", "", indent = indent).unwrap();
+        write!(&mut buffer, "{:indent$}],\n", "").unwrap();
     }
 
     buffer
@@ -363,8 +363,7 @@ fn gen_args(arg: &Arg, indent: usize) -> String {
         &mut buffer,
         "{{\n{:indent$}  name: \"{}\",\n",
         "",
-        escape_string(arg.get_id().as_str()),
-        indent = indent
+        escape_string(arg.get_id().as_str())
     )
     .unwrap();
 
@@ -467,7 +466,7 @@ fn gen_args(arg: &Arg, indent: usize) -> String {
         };
     };
 
-    write!(&mut buffer, "{:indent$}}},\n", "", indent = indent).unwrap();
+    write!(&mut buffer, "{:indent$}}},\n", "").unwrap();
 
     buffer
 }

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -10,7 +10,7 @@ pub(crate) fn subcommand_heading(cmd: &clap::Command) -> &str {
 
 pub(crate) fn about(roff: &mut Roff, cmd: &clap::Command) {
     let s = match cmd.get_about().or_else(|| cmd.get_long_about()) {
-        Some(about) => format!("{} - {}", cmd.get_name(), about),
+        Some(about) => format!("{} - {about}", cmd.get_name()),
         None => cmd.get_name().to_string(),
     };
     roff.text([roman(s)]);
@@ -203,10 +203,9 @@ pub(crate) fn subcommands(roff: &mut Roff, cmd: &clap::Command, section: &str) {
         roff.control("TP", []);
 
         let name = format!(
-            "{}-{}({})",
+            "{}-{}({section})",
             cmd.get_display_name().unwrap_or_else(|| cmd.get_name()),
-            sub.get_name(),
-            section
+            sub.get_name()
         );
         roff.text([roman(name)]);
 

--- a/examples/cargo-example.rs
+++ b/examples/cargo-example.rs
@@ -14,5 +14,5 @@ fn main() {
         _ => unreachable!("clap should ensure we don't get here"),
     };
     let manifest_path = matches.get_one::<std::path::PathBuf>("manifest-path");
-    println!("{:?}", manifest_path);
+    println!("{manifest_path:?}");
 }

--- a/examples/find.rs
+++ b/examples/find.rs
@@ -5,7 +5,7 @@ use clap::{arg, command, ArgGroup, ArgMatches, Command};
 fn main() {
     let matches = cli().get_matches();
     let values = Value::from_matches(&matches);
-    println!("{:#?}", values);
+    println!("{values:#?}");
 }
 
 fn cli() -> Command {

--- a/examples/git-derive.rs
+++ b/examples/git-derive.rs
@@ -128,11 +128,8 @@ fn main() {
                 .unwrap_or("worktree");
             let path = path.as_deref().unwrap_or_else(|| OsStr::new(""));
             println!(
-                "Diffing {}..{} {} (color={})",
-                base,
-                head,
-                path.to_string_lossy(),
-                color
+                "Diffing {base}..{head} {} (color={color})",
+                path.to_string_lossy()
             );
         }
         Commands::Push { remote } => {

--- a/examples/tutorial_builder/01_quick.rs
+++ b/examples/tutorial_builder/01_quick.rs
@@ -25,7 +25,7 @@ fn main() {
 
     // You can check the value provided by positional arguments, or option arguments
     if let Some(name) = matches.get_one::<String>("name") {
-        println!("Value for name: {}", name);
+        println!("Value for name: {name}");
     }
 
     if let Some(config_path) = matches.get_one::<PathBuf>("config") {

--- a/examples/tutorial_builder/04_01_enum.rs
+++ b/examples/tutorial_builder/04_01_enum.rs
@@ -38,7 +38,7 @@ impl std::str::FromStr for Mode {
                 return Ok(*variant);
             }
         }
-        Err(format!("invalid variant: {}", s))
+        Err(format!("invalid variant: {s}"))
     }
 }
 

--- a/examples/tutorial_builder/04_02_parse.rs
+++ b/examples/tutorial_builder/04_02_parse.rs
@@ -13,5 +13,5 @@ fn main() {
     let port: u16 = *matches
         .get_one::<u16>("PORT")
         .expect("'PORT' is required and parsing will fail if its missing");
-    println!("PORT = {}", port);
+    println!("PORT = {port}");
 }

--- a/examples/tutorial_builder/04_02_validate.rs
+++ b/examples/tutorial_builder/04_02_validate.rs
@@ -15,7 +15,7 @@ fn main() {
     let port: u16 = *matches
         .get_one::<u16>("PORT")
         .expect("'PORT' is required and parsing will fail if its missing");
-    println!("PORT = {}", port);
+    println!("PORT = {port}");
 }
 
 const PORT_RANGE: RangeInclusive<usize> = 1..=65535;
@@ -23,7 +23,7 @@ const PORT_RANGE: RangeInclusive<usize> = 1..=65535;
 fn port_in_range(s: &str) -> Result<u16, String> {
     let port: usize = s
         .parse()
-        .map_err(|_| format!("`{}` isn't a port number", s))?;
+        .map_err(|_| format!("`{s}` isn't a port number"))?;
     if PORT_RANGE.contains(&port) {
         Ok(port as u16)
     } else {

--- a/examples/tutorial_builder/04_03_relations.rs
+++ b/examples/tutorial_builder/04_03_relations.rs
@@ -58,10 +58,10 @@ fn main() {
             (_, _, true) => patch += 1,
             _ => unreachable!(),
         };
-        format!("{}.{}.{}", major, minor, patch)
+        format!("{major}.{minor}.{patch}")
     };
 
-    println!("Version: {}", version);
+    println!("Version: {version}");
 
     // Check for usage of -c
     if matches.contains_id("config") {
@@ -70,8 +70,7 @@ fn main() {
             .unwrap_or_else(|| matches.get_one::<PathBuf>("spec-in").unwrap())
             .display();
         println!(
-            "Doing work using input {} and config {}",
-            input,
+            "Doing work using input {input} and config {}",
             matches.get_one::<PathBuf>("config").unwrap().display()
         );
     }

--- a/examples/tutorial_builder/04_04_custom.rs
+++ b/examples/tutorial_builder/04_04_custom.rs
@@ -57,10 +57,10 @@ fn main() {
                 .exit();
             }
         };
-        format!("{}.{}.{}", major, minor, patch)
+        format!("{major}.{minor}.{patch}")
     };
 
-    println!("Version: {}", version);
+    println!("Version: {version}");
 
     // Check for usage of -c
     if matches.contains_id("config") {
@@ -76,8 +76,7 @@ fn main() {
             })
             .display();
         println!(
-            "Doing work using input {} and config {}",
-            input,
+            "Doing work using input {input} and config {}",
             matches.get_one::<PathBuf>("config").unwrap().display()
         );
     }

--- a/examples/tutorial_builder/05_01_assert.rs
+++ b/examples/tutorial_builder/05_01_assert.rs
@@ -7,7 +7,7 @@ fn main() {
     let port: usize = *matches
         .get_one::<usize>("PORT")
         .expect("'PORT' is required and parsing will fail if its missing");
-    println!("PORT = {}", port);
+    println!("PORT = {port}");
 }
 
 fn cmd() -> clap::Command {

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -595,12 +595,7 @@ fn assert_trailing_var_args(
             .allow_hyphen_values(true),
     );
     let m = cmd.try_get_matches_from(input);
-    assert!(
-        m.is_ok(),
-        "failed with args {:?}: {}",
-        input,
-        m.unwrap_err()
-    );
+    assert!(m.is_ok(), "failed with args {input:?}: {}", m.unwrap_err());
     let m = m.unwrap();
 
     let actual_var_args = m

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -121,17 +121,17 @@ fn arg_conflicts_with_group() {
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--other"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--flag"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 }
 
@@ -149,17 +149,17 @@ fn arg_conflicts_with_group_with_multiple_sources() {
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "-f"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--some", "usb1"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--some", "usb1", "--other", "40"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "-f", "--some", "usb1"]);
@@ -192,17 +192,17 @@ fn group_conflicts_with_arg() {
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--other"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--flag"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 }
 
@@ -226,12 +226,12 @@ fn arg_conflicts_with_required_group() {
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--other"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 }
 
@@ -255,12 +255,12 @@ fn arg_conflicts_with_group_with_required_memeber() {
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--flag"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 }
 
@@ -290,12 +290,12 @@ fn required_group_conflicts_with_arg() {
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--some"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 
     let result = cmd.try_get_matches_from_mut(vec!["myprog", "--other"]);
     if let Err(err) = result {
-        panic!("{}", err);
+        panic!("{err}");
     }
 }
 

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -13,8 +13,7 @@ fn assert_error<F: clap::error::ErrorFormatter>(
     assert_eq!(
         stderr,
         err.use_stderr(),
-        "Should Use STDERR failed. Should be {} but is {}",
-        stderr,
+        "Should Use STDERR failed. Should be {stderr} but is {}",
         err.use_stderr()
     );
     assert_eq!(expected_kind, err.kind());

--- a/tests/builder/utils.rs
+++ b/tests/builder/utils.rs
@@ -34,8 +34,7 @@ pub fn assert_output(l: Command, args: &str, expected: &str, stderr: bool) {
     assert_eq!(
         stderr,
         err.use_stderr(),
-        "Should Use STDERR failed. Should be {} but is {}",
-        stderr,
+        "Should Use STDERR failed. Should be {stderr} but is {}",
         err.use_stderr()
     );
     assert_eq(expected, actual)

--- a/tests/derive/utils.rs
+++ b/tests/derive/utils.rs
@@ -56,8 +56,7 @@ pub fn assert_output<P: clap::Parser + std::fmt::Debug>(args: &str, expected: &s
     assert_eq!(
         stderr,
         err.use_stderr(),
-        "Should Use STDERR failed. Should be {} but is {}",
-        stderr,
+        "Should Use STDERR failed. Should be {stderr} but is {}",
         err.use_stderr()
     );
     snapbox::assert_eq(expected, actual)


### PR DESCRIPTION
Add allow-mixed-uninlined-format-args to clippy config (sorted),
 and run the same command:

 ```
 cargo clippy --workspace --fix -- -A clippy::all -W clippy::uninlined_format_args
 ```
