### PR TITLE
Add compilation error on invalid usage of boolean arg

### DIFF
--- a/clap_derive/src/utils/ty.rs
+++ b/clap_derive/src/utils/ty.rs
@@ -53,6 +53,11 @@ impl Ty {
             Self::Other => "...other...",
         }
     }
+
+    #[inline]
+    pub fn is_other(&self) -> bool {
+        matches!(self, Self::Other)
+    }
 }
 
 pub fn inner_type(field_ty: &syn::Type) -> &syn::Type {

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -297,6 +297,20 @@
 //! - `Option<Vec<T>>` will be `None` instead of `vec![]` if no arguments are provided.
 //!   - This gives the user some flexibility in designing their argument, like with `num_args(0..)`
 //!
+//! ### Positional bool
+//!
+//! Following is not allowed:
+//!
+//! ```rust,compile_fail
+//! use clap::Parser;
+//!
+//! #[derive(Parser, Debug)]
+//! struct RetardedArgs {
+//!     #[clap(value_parser)]
+//!     enabled: bool,
+//! }
+//! ```
+//!
 //! ## Doc Comments
 //!
 //! In clap, help messages for the whole binary can be specified


### PR DESCRIPTION
Compilation error for derive macro when encountering invalid usage of bool as described in #4467