### PR TITLE
completion: Respect `ValueHint::Other` in Bash

### DIFF
--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -206,6 +206,8 @@ fn vals_for(o: &Arg) -> String {
                 .collect::<Vec<_>>()
                 .join(" ")
         )
+    } else if o.get_value_hint() == ValueHint::Other {
+        String::from("\"${cur}\"")
     } else {
         String::from("$(compgen -f \"${cur}\")")
     }

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -34,7 +34,7 @@ _my-app() {
                     return 0
                     ;;
                 --other)
-                    COMPREPLY=($(compgen -f "${cur}"))
+                    COMPREPLY=("${cur}")
                     return 0
                     ;;
                 --path)


### PR DESCRIPTION
The bash completion currently generates `compgen -f` by default, or `compgen -W ...` for exhaustive values. This checks for `ValueHint::Other` so that file completion can at least be disabled where inappropriate