### PR TITLE
fix(help): Don't use next-line-help on long-help for subcommands

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -963,7 +963,8 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     }
 
     fn subcommand_next_line_help(&self, cmd: &Command, spec_vals: &str, longest: usize) -> bool {
-        if self.next_line_help | self.use_long {
+        // Ignore `self.use_long` since subcommands are only shown as short help
+        if self.next_line_help {
             // setting_next_line
             true
         } else {

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -5,10 +5,8 @@ stdout = """
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
 Commands:
-  more
-          
-  help
-          Print this message or the help of the given subcommand(s)
+  more  
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
       --verbose

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -5,10 +5,8 @@ stdout = """
 Usage: stdio-fixture[EXE] [OPTIONS] [COMMAND]
 
 Commands:
-  more
-          
-  help
-          Print this message or the help of the given subcommand(s)
+  more  
+  help  Print this message or the help of the given subcommand(s)
 
 Options:
       --verbose


### PR DESCRIPTION
Subcommands don't switch their behavior on `--help`, so let's not switch to next-line-help based on `--help`.

Fixes #4897

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
