### PR TITLE
docs(derive): Add a few notes to `default_value`

### DIFF
--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -238,6 +238,9 @@
 //! - `skip [= <expr>]`: Ignore this field, filling in with `<expr>`
 //!   - Without `<expr>`: fills the field with `Default::default()`
 //! - `default_value = <str>`: [`Arg::default_value`][crate::Arg::default_value] and [`Arg::required(false)`][crate::Arg::required]
+//!   - Sets the default by parsing a string, as if that string had been passed on the command line.
+//!   - For example, a value of `"123"` could be used with a `u32` arg, although `default_value_t = 123` would be a more idiomatic choice.
+//!   - This attribute is a good way to set the default value of a `String` arg.
 //! - `default_value_t [= <expr>]`: [`Arg::default_value`][crate::Arg::default_value] and [`Arg::required(false)`][crate::Arg::required]
 //!   - Requires `std::fmt::Display` that roundtrips correctly with the
 //!     [`Arg::value_parser`][crate::Arg::value_parser] or `#[arg(value_enum)]`


### PR DESCRIPTION
* Clarify that the value is parsed as if it had been passed via command line, not as Rust code like some other libraries (e.g. `argh`).

* Add an example for `u32`, but note that `default_value_t` is better for that type.

* Mention that this attribute is a good way to set the default value for `String` args. This should help avoid confusion with trying to use `default_value_t` for that purpose (see https://github.com/clap-rs/clap/discussions/4676 for example)

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
