### PR TITLE
docs(tutorial): Expand the default_value_t example

### DIFF
--- a/examples/tutorial_derive/03_05_default_values.md
+++ b/examples/tutorial_derive/03_05_default_values.md
@@ -2,19 +2,31 @@
 $ 03_05_default_values_derive --help
 A simple to use, efficient, and full-featured Command Line Argument Parser
 
-Usage: 03_05_default_values_derive[EXE] [PORT]
-
-Arguments:
-  [PORT]  [default: 2020]
+Usage: 03_05_default_values_derive[EXE] [OPTIONS]
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+      --port <PORT>      [default: 2020]
+      --host <HOST>      [default: example.com]
+      --config <CONFIG>  [default: config.json]
+      --seed <SEED>      [default: 1 2 3]
+      --source <SOURCE>  [default: a b]
+  -h, --help             Print help
+  -V, --version          Print version
 
 $ 03_05_default_values_derive
-port: 2020
-
-$ 03_05_default_values_derive 22
-port: 22
+Cli {
+    port: 2020,
+    host: "example.com",
+    config: "config.json",
+    seed: [
+        1,
+        2,
+        3,
+    ],
+    source: [
+        "a",
+        "b",
+    ],
+}
 
 ```

--- a/examples/tutorial_derive/03_05_default_values.rs
+++ b/examples/tutorial_derive/03_05_default_values.rs
@@ -1,14 +1,27 @@
 use clap::Parser;
+use std::path::PathBuf;
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(default_value_t = 2020)]
+    #[arg(long, default_value_t = 2020)]
     port: u16,
+
+    #[arg(long, default_value = "example.com")]
+    host: String,
+
+    #[arg(long, default_value_os_t = PathBuf::from("config.json"))]
+    config: PathBuf,
+
+    #[arg(long, default_values_t = [1, 2, 3])]
+    seed: Vec<u32>,
+
+    #[arg(long, default_values_os_t = [PathBuf::from("a"), PathBuf::from("b")])]
+    source: Vec<PathBuf>,
 }
 
 fn main() {
     let cli = Cli::parse();
 
-    println!("port: {:?}", cli.port);
+    println!("{:#?}", cli);
 }

--- a/src/_derive/_tutorial.rs
+++ b/src/_derive/_tutorial.rs
@@ -145,7 +145,7 @@
 //!
 //! We've previously showed that arguments can be [`required`][crate::Arg::required] or optional.
 //! When optional, you work with a `Option` and can `unwrap_or`.  Alternatively, you can
-//! set `#[arg(default_value_t)]`.
+//! set `#[arg(default_value_t)]` or one of the related attributes.
 //!
 //! ```rust
 #![doc = include_str!("../../examples/tutorial_derive/03_05_default_values.rs")]


### PR DESCRIPTION
There are a lot of attributes for setting defaults, and it may not be immediately obvious how to set defaults for types like `String` and `PathBuf`. Update the example to show each of the attributes for setting defaults.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
