### PR TITLE
Add note about Command::disable_help_subcommand applying to children

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1260,6 +1260,8 @@ impl Command {
 
     /// Disables the `help` [`subcommand`].
     ///
+    /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
     /// # Examples
     ///
     /// ```rust


### PR DESCRIPTION
All the other `global_setting` setters have this note, I was confused about whether this one had to be manually applied until checking the source.