### PR TITLE
fix(parser): Allow multiple value terminated positionals

### DIFF
--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -603,6 +603,7 @@ fn _verify_positionals(cmd: &Command) -> bool {
             .get_positionals()
             .filter(|p| {
                 p.is_multiple_values_set()
+                    && p.get_value_terminator().is_none()
                     && !p.get_num_args().expect(INTERNAL_ERROR_MSG).is_fixed()
             })
             .count();

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1412,6 +1412,37 @@ fn multiple_vals_with_hyphen() {
 }
 
 #[test]
+#[should_panic]
+fn multiple_positional_multiple_values() {
+    let _ = Command::new("do")
+        .arg(
+            Arg::new("cmd1")
+                .action(ArgAction::Set)
+                .num_args(1..)
+                .allow_hyphen_values(true)
+                .value_terminator(";"),
+        )
+        .arg(
+            Arg::new("cmd2")
+                .action(ArgAction::Set)
+                .num_args(1..)
+                .allow_hyphen_values(true)
+                .value_terminator(";"),
+        )
+        .try_get_matches_from(vec![
+            "do",
+            "find",
+            "-type",
+            "f",
+            "-name",
+            "special",
+            ";",
+            "/home/clap",
+            "foo",
+        ]);
+}
+
+#[test]
 fn issue_1480_max_values_consumes_extra_arg_1() {
     let res = Command::new("prog")
         .arg(Arg::new("field").num_args(..=1).long("field"))

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1412,9 +1412,8 @@ fn multiple_vals_with_hyphen() {
 }
 
 #[test]
-#[should_panic]
 fn multiple_positional_multiple_values() {
-    let _ = Command::new("do")
+    let res = Command::new("do")
         .arg(
             Arg::new("cmd1")
                 .action(ArgAction::Set)
@@ -1440,6 +1439,24 @@ fn multiple_positional_multiple_values() {
             "/home/clap",
             "foo",
         ]);
+    assert!(res.is_ok(), "{:?}", res.unwrap_err().kind());
+
+    let m = res.unwrap();
+    let cmd1: Vec<_> = m
+        .get_many::<String>("cmd1")
+        .unwrap()
+        .map(|v| v.as_str())
+        .collect();
+    assert_eq!(
+        &cmd1,
+        &["find", "-type", "f", "-name", "special", "/home/clap"]
+    );
+    let cmd2: Vec<_> = m
+        .get_many::<String>("cmd2")
+        .unwrap()
+        .map(|v| v.as_str())
+        .collect();
+    assert_eq!(&cmd2, &["foo"]);
 }
 
 #[test]

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1447,16 +1447,13 @@ fn multiple_positional_multiple_values() {
         .unwrap()
         .map(|v| v.as_str())
         .collect();
-    assert_eq!(
-        &cmd1,
-        &["find", "-type", "f", "-name", "special", "/home/clap"]
-    );
+    assert_eq!(&cmd1, &["find", "-type", "f", "-name", "special"]);
     let cmd2: Vec<_> = m
         .get_many::<String>("cmd2")
         .unwrap()
         .map(|v| v.as_str())
         .collect();
-    assert_eq!(&cmd2, &["foo"]);
+    assert_eq!(&cmd2, &["/home/clap", "foo"]);
 }
 
 #[test]


### PR DESCRIPTION
While this doesn't directly address #4919, this fixes problems around it
- One value terminated positional was allowed, but a second would hit asserts relate to `last`
- The parser didn't correctly update the state when multiple were present (yet somehow it worked when followed by a single value)