### PR TITLE
Update linux-raw-sys to 0.3.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,13 +402,13 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -516,14 +516,14 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -573,9 +573,9 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -793,16 +793,16 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -956,12 +956,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR aims to fix a compile issue for LoongArch by updating `linux-raw-sys`.

```
error[E0433]: failed to resolve: use of undeclared crate or module `general`
  --> /home/hev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/linux-raw-sys-0.1.3/src/lib.rs:67:20
   |
67 | impl PartialEq for general::__kernel_timespec {
   |                    ^^^^^^^ use of undeclared crate or module `general`

error[E0433]: failed to resolve: use of undeclared crate or module `general`
  --> /home/hev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/linux-raw-sys-0.1.3/src/lib.rs:79:13
   |
79 | impl Eq for general::__kernel_timespec {}
   |             ^^^^^^^ use of undeclared crate or module `general`
```
```bash
cargo update -p is-terminal -p terminal_size
```

```
    Updating crates.io index
    Updating errno v0.2.8 -> v0.3.1
    Updating is-terminal v0.4.4 -> v0.4.7
    Updating linux-raw-sys v0.1.3 -> v0.3.8
    Updating rustix v0.36.4 -> v0.37.3
    Updating terminal_size v0.2.3 -> v0.2.6
```
