### PR TITLE
perf(derive): reduce amount of generated code

### DIFF
--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -703,7 +703,7 @@ fn gen_parsers(
         Ty::Other => {
             quote_spanned! { ty.span()=>
                 #arg_matches.#get_one(#id)
-                    .ok_or_else(|| clap::Error::raw(clap::error::ErrorKind::MissingRequiredArgument, format!("The following required argument was not provided: {}", #id)))?
+                    .ok_or_else(|| clap::Error::raw(clap::error::ErrorKind::MissingRequiredArgument, concat!("The following required argument was not provided: ", #id)))?
             }
         }
     };


### PR DESCRIPTION
Don't generate error string with `format!`, as there can be used `concat!`, reducing code size.

Example expanded code (from bindgen-cli) before:
```rust
                no_layout_tests: __clap_arg_matches
                    .remove_one::<bool>("no_layout_tests")
                    .ok_or_else(|| clap::Error::raw(
                        clap::error::ErrorKind::MissingRequiredArgument,
                        {
                            let res = ::alloc::fmt::format(
                                format_args!(
                                    "The following required argument was not provided: {0}",
                                    "no_layout_tests"
                                ),
                            );
                            res
                        },
                    ))?,
```

after:
```rust
                no_layout_tests: __clap_arg_matches
                    .remove_one::<bool>("no_layout_tests")
                    .ok_or_else(|| clap::Error::raw(
                        clap::error::ErrorKind::MissingRequiredArgument,
                        "The following required argument was not provided: no_layout_tests",
                    ))?,

```
This shave off ~10kb for bindgen-cli.