### PR TITLE
refactor: clap_complete behind feature in clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,7 @@ name = "clap"
 version = "4.3.1"
 dependencies = [
  "clap_builder 4.3.1",
+ "clap_complete",
  "clap_derive",
  "humantime",
  "once_cell",
@@ -540,6 +541,8 @@ name = "clap_complete"
 version = "4.3.1"
 dependencies = [
  "clap 4.3.1",
+ "clap_builder 4.3.1",
+ "clap_derive",
  "clap_lex 0.5.0",
  "is_executable",
  "pathdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ wrap_help = ["clap_builder/wrap_help"]
 env = ["clap_builder/env"] # Use environment variables during arg parsing
 unicode = ["clap_builder/unicode"]  # Support for unicode characters in arguments and help messages
 string = ["clap_builder/string"]  # Allow runtime generated strings
+complete = ["dep:clap_complete"]
 
 # In-work features
 unstable-v5 = ["clap_builder/unstable-v5", "clap_derive?/unstable-v5", "deprecated"]
@@ -103,6 +104,7 @@ bench = false
 [dependencies]
 clap_builder = { path = "./clap_builder", version = "=4.3.1", default-features = false }
 clap_derive = { path = "./clap_derive", version = "=4.3.1", optional = true }
+clap_complete = { path = "./clap_complete", version = "=4.3.1", optional = true }
 once_cell = { version = "1.12.0", optional = true }
 
 [dev-dependencies]

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -32,7 +32,8 @@ pre-release-replacements = [
 bench = false
 
 [dependencies]
-clap = { path = "../", version = "4.1.0", default-features = false, features = ["std"] }
+clap_builder = { path = "../clap_builder", default-features = false, features = ["std"] }
+clap_derive = { path = "../clap_derive", version = "4.3.1", optional = true }
 clap_lex = { path = "../clap_lex", version = "0.5.0", optional = true }
 is_executable = { version = "1.0.1", optional = true }
 pathdiff = { version = "0.2.1", optional = true }
@@ -43,7 +44,7 @@ unicode-xid = { version = "0.2.2", optional = true }
 snapbox = { version = "0.4.11", features = ["diff"] }
 # Cutting out `filesystem` feature
 trycmd = { version = "0.14.16", default-features = false, features = ["color-auto", "diff", "examples"] }
-clap = { path = "../", version = "4.0.0", default-features = false, features = ["std", "derive", "help"] }
+clap = { path = "../", default-features = false, features = ["std", "derive", "help"] }
 
 [[example]]
 name = "dynamic"
@@ -51,5 +52,5 @@ required-features = ["unstable-dynamic"]
 
 [features]
 default = []
-unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:unicode-xid", "clap/derive", "dep:is_executable", "dep:pathdiff"]
-debug = ["clap/debug"]
+unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:unicode-xid", "clap_derive", "dep:is_executable", "dep:pathdiff"]
+debug = ["clap_builder/debug"]

--- a/clap_complete/src/dynamic.rs
+++ b/clap_complete/src/dynamic.rs
@@ -6,10 +6,12 @@ pub mod bash {
     use std::ffi::OsString;
     use std::io::Write;
 
+    use clap_builder as clap;
+    use clap_derive::{self, *};
     use clap_lex::OsStrExt as _;
     use unicode_xid::UnicodeXID;
 
-    #[derive(clap::Subcommand)]
+    #[derive(clap_derive::Subcommand)]
     #[command(hide = true)]
     #[allow(missing_docs)]
     #[derive(Clone, Debug)]
@@ -18,8 +20,8 @@ pub mod bash {
         Complete(CompleteArgs),
     }
 
-    #[derive(clap::Args)]
-    #[command(group = clap::ArgGroup::new("complete").multiple(true).conflicts_with("register"))]
+    #[derive(Args)]
+    #[command(group = clap_builder::ArgGroup::new("complete").multiple(true).conflicts_with("register"))]
     #[allow(missing_docs)]
     #[derive(Clone, Debug)]
     pub struct CompleteArgs {
@@ -64,13 +66,16 @@ pub mod bash {
 
     impl CompleteCommand {
         /// Process the completion request
-        pub fn complete(&self, cmd: &mut clap::Command) -> std::convert::Infallible {
+        pub fn complete(&self, cmd: &mut clap_builder::Command) -> std::convert::Infallible {
             self.try_complete(cmd).unwrap_or_else(|e| e.exit());
             std::process::exit(0)
         }
 
         /// Process the completion request
-        pub fn try_complete(&self, cmd: &mut clap::Command) -> clap::error::Result<()> {
+        pub fn try_complete(
+            &self,
+            cmd: &mut clap_builder::Command,
+        ) -> clap_builder::error::Result<()> {
             debug!("CompleteCommand::try_complete: {self:?}");
             let CompleteCommand::Complete(args) = self;
             if let Some(out_path) = args.register.as_deref() {
@@ -220,7 +225,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
         Menu,
     }
 
-    impl clap::ValueEnum for CompType {
+    impl clap_builder::ValueEnum for CompType {
         fn value_variants<'a>() -> &'a [Self] {
             &[
                 Self::Normal,
@@ -230,13 +235,13 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                 Self::Menu,
             ]
         }
-        fn to_possible_value(&self) -> ::std::option::Option<clap::builder::PossibleValue> {
+        fn to_possible_value(&self) -> ::std::option::Option<clap_builder::builder::PossibleValue> {
             match self {
                 Self::Normal => {
                     let value = "9";
                     debug_assert_eq!(b'\t'.to_string(), value);
                     Some(
-                        clap::builder::PossibleValue::new(value)
+                        clap_builder::builder::PossibleValue::new(value)
                             .alias("normal")
                             .help("Normal completion"),
                     )
@@ -245,7 +250,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                     let value = "63";
                     debug_assert_eq!(b'?'.to_string(), value);
                     Some(
-                        clap::builder::PossibleValue::new(value)
+                        clap_builder::builder::PossibleValue::new(value)
                             .alias("successive")
                             .help("List completions after successive tabs"),
                     )
@@ -254,7 +259,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                     let value = "33";
                     debug_assert_eq!(b'!'.to_string(), value);
                     Some(
-                        clap::builder::PossibleValue::new(value)
+                        clap_builder::builder::PossibleValue::new(value)
                             .alias("alternatives")
                             .help("List alternatives on partial word completion"),
                     )
@@ -263,7 +268,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                     let value = "64";
                     debug_assert_eq!(b'@'.to_string(), value);
                     Some(
-                        clap::builder::PossibleValue::new(value)
+                        clap_builder::builder::PossibleValue::new(value)
                             .alias("unmodified")
                             .help("List completions if the word is not unmodified"),
                     )
@@ -272,7 +277,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                     let value = "37";
                     debug_assert_eq!(b'%'.to_string(), value);
                     Some(
-                        clap::builder::PossibleValue::new(value)
+                        clap_builder::builder::PossibleValue::new(value)
                             .alias("menu")
                             .help("Menu completion"),
                     )
@@ -289,7 +294,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
 
     /// Complete the command specified
     pub fn complete(
-        cmd: &mut clap::Command,
+        cmd: &mut clap_builder::Command,
         args: Vec<std::ffi::OsString>,
         arg_index: usize,
         _comp_type: CompType,
@@ -350,7 +355,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
 
     fn complete_arg(
         arg: &clap_lex::ParsedArg<'_>,
-        cmd: &clap::Command,
+        cmd: &clap_builder::Command,
         current_dir: Option<&std::path::Path>,
         pos_index: usize,
         is_escaped: bool,
@@ -426,7 +431,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
 
     fn complete_arg_value(
         value: Result<&str, &OsStr>,
-        arg: &clap::Arg,
+        arg: &clap_builder::Arg,
         current_dir: Option<&std::path::Path>,
     ) -> Vec<OsString> {
         let mut values = Vec::new();
@@ -445,29 +450,29 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
                 Err(value_os) => value_os,
             };
             match arg.get_value_hint() {
-                clap::ValueHint::Other => {
+                clap_builder::ValueHint::Other => {
                     // Should not complete
                 }
-                clap::ValueHint::Unknown | clap::ValueHint::AnyPath => {
+                clap_builder::ValueHint::Unknown | clap_builder::ValueHint::AnyPath => {
                     values.extend(complete_path(value_os, current_dir, |_| true));
                 }
-                clap::ValueHint::FilePath => {
+                clap_builder::ValueHint::FilePath => {
                     values.extend(complete_path(value_os, current_dir, |p| p.is_file()));
                 }
-                clap::ValueHint::DirPath => {
+                clap_builder::ValueHint::DirPath => {
                     values.extend(complete_path(value_os, current_dir, |p| p.is_dir()));
                 }
-                clap::ValueHint::ExecutablePath => {
+                clap_builder::ValueHint::ExecutablePath => {
                     use is_executable::IsExecutable;
                     values.extend(complete_path(value_os, current_dir, |p| p.is_executable()));
                 }
-                clap::ValueHint::CommandName
-                | clap::ValueHint::CommandString
-                | clap::ValueHint::CommandWithArguments
-                | clap::ValueHint::Username
-                | clap::ValueHint::Hostname
-                | clap::ValueHint::Url
-                | clap::ValueHint::EmailAddress => {
+                clap_builder::ValueHint::CommandName
+                | clap_builder::ValueHint::CommandString
+                | clap_builder::ValueHint::CommandWithArguments
+                | clap_builder::ValueHint::Username
+                | clap_builder::ValueHint::Hostname
+                | clap_builder::ValueHint::Url
+                | clap_builder::ValueHint::EmailAddress => {
                     // No completion implementation
                 }
                 _ => {
@@ -530,7 +535,7 @@ complete OPTIONS -F _clap_complete_NAME EXECUTABLES
         completions
     }
 
-    fn complete_subcommand(value: &str, cmd: &clap::Command) -> Vec<OsString> {
+    fn complete_subcommand(value: &str, cmd: &clap_builder::Command) -> Vec<OsString> {
         debug!(
             "complete_subcommand: cmd={:?}, value={:?}",
             cmd.get_name(),

--- a/clap_complete/src/generator/mod.rs
+++ b/clap_complete/src/generator/mod.rs
@@ -8,7 +8,7 @@ use std::io::Error;
 use std::io::Write;
 use std::path::PathBuf;
 
-use clap::Command;
+use clap_builder::Command;
 
 /// Generator trait which can be used to write generators
 pub trait Generator {

--- a/clap_complete/src/generator/utils.rs
+++ b/clap_complete/src/generator/utils.rs
@@ -1,6 +1,6 @@
 //! Helpers for writing generators
 
-use clap::{Arg, Command};
+use clap_builder::{Arg, Command};
 
 /// Gets all subcommands including child subcommands in the form of `("name", "bin_name")`.
 ///
@@ -120,7 +120,7 @@ pub fn flags(p: &Command) -> Vec<Arg> {
 }
 
 /// Get the possible values for completion
-pub fn possible_values(a: &Arg) -> Option<Vec<clap::builder::PossibleValue>> {
+pub fn possible_values(a: &Arg) -> Option<Vec<clap_builder::builder::PossibleValue>> {
     if !a.get_num_args().expect("built").takes_values() {
         None
     } else {
@@ -133,8 +133,8 @@ pub fn possible_values(a: &Arg) -> Option<Vec<clap::builder::PossibleValue>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Arg;
-    use clap::ArgAction;
+    use clap_builder::Arg;
+    use clap_builder::ArgAction;
 
     fn common_app() -> Command {
         Command::new("myapp")

--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Write as _, io::Write};
 
-use clap::*;
+use clap_builder::*;
 
 use crate::generator::{utils, Generator};
 

--- a/clap_complete/src/shells/elvish.rs
+++ b/clap_complete/src/shells/elvish.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
-use clap::builder::StyledStr;
-use clap::*;
+use clap_builder::builder::StyledStr;
+use clap_builder::*;
 
 use crate::generator::{utils, Generator};
 use crate::INTERNAL_ERROR_MSG;

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use clap::*;
+use clap_builder::*;
 
 use crate::generator::{utils, Generator};
 

--- a/clap_complete/src/shells/powershell.rs
+++ b/clap_complete/src/shells/powershell.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
-use clap::builder::StyledStr;
-use clap::*;
+use clap_builder::builder::StyledStr;
+use clap_builder::*;
 
 use crate::generator::{utils, Generator};
 use crate::INTERNAL_ERROR_MSG;

--- a/clap_complete/src/shells/shell.rs
+++ b/clap_complete/src/shells/shell.rs
@@ -2,8 +2,8 @@ use std::fmt::Display;
 use std::path::Path;
 use std::str::FromStr;
 
-use clap::builder::PossibleValue;
-use clap::ValueEnum;
+use clap_builder::builder::PossibleValue;
+use clap_builder::ValueEnum;
 
 use crate::shells;
 use crate::Generator;
@@ -80,7 +80,7 @@ impl Generator for Shell {
         }
     }
 
-    fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::Write) {
+    fn generate(&self, cmd: &clap_builder::Command, buf: &mut dyn std::io::Write) {
         match self {
             Shell::Bash => shells::Bash.generate(cmd, buf),
             Shell::Elvish => shells::Elvish.generate(cmd, buf),

--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use clap::*;
+use clap_builder::*;
 
 use crate::generator::{utils, Generator};
 use crate::INTERNAL_ERROR_MSG;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,11 @@ pub use clap_builder::*;
 #[doc(hidden)]
 pub use clap_derive::{self, *};
 
+#[cfg(feature = "complete")]
+pub mod complete {
+    pub use clap_complete::*;
+}
+
 #[cfg(feature = "unstable-doc")]
 pub mod _cookbook;
 #[cfg(feature = "unstable-doc")]


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
https://github.com/clap-rs/clap/issues/4949

This adds a `clap::complete` module behind the `complete` feature flag. To avoid circular dependency issues, `clap_complete` now depends directly on `clap_builder` rather than the top-level crate.

These are minimal changes to get everything building and testing, I'll be happy to sync up docs if there is interest in this.