### PR TITLE
Extract/add public method `Error.exit_code`

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -214,21 +214,26 @@ impl<F: ErrorFormatter> Error<F> {
         }
     }
 
+    /// Returns the exit code that `.exit` will exit the process with.
+    ///
+    /// When the error's kind would print to `stderr` this returns `2`,
+    /// else it returns `0`.
+    pub fn exit_code(&self) -> i32 {
+        if self.use_stderr() {
+            USAGE_CODE
+        } else {
+            SUCCESS_CODE
+        }
+    }
+
     /// Prints the error and exits.
     ///
     /// Depending on the error kind, this either prints to `stderr` and exits with a status of `2`
     /// or prints to `stdout` and exits with a status of `0`.
     pub fn exit(&self) -> ! {
-        if self.use_stderr() {
-            // Swallow broken pipe errors
-            let _ = self.print();
-
-            safe_exit(USAGE_CODE);
-        }
-
         // Swallow broken pipe errors
         let _ = self.print();
-        safe_exit(SUCCESS_CODE)
+        safe_exit(self.exit_code())
     }
 
     /// Prints formatted and colored error to `stdout` or `stderr` according to its error kind


### PR DESCRIPTION
… and simplifies method `Error.exit` as a side effect.

<details>
<summary>
The motivation for this pull request was to allow simplification of the code below (click to expand) where marked with <code>XXX</code> with future releases of clap.
</summary>

```rust
// Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
// SPDX-License-Identifier: MIT

// ..snip..

// Matches the two internal constants from [clap_builder-4.3.1]/src/util/mod.rs  // XXX
const SUCCESS_CODE: i32 = 0;                                                     // XXX
const USAGE_CODE: i32 = 2;                                                       // XXX

fn main() {
    exit(middle_main(args_os()));
}

fn middle_main<I, T>(argv: I) -> i32
where
    // to match clap::Command.get_matches_from
    I: IntoIterator<Item = T>,
    T: Into<OsString> + Clone,
{
    let clap_result = command_line_parser::command().try_get_matches_from(argv);
    match clap_result {
        Ok(matches) => innermost_main(matches),
        Err(e) => {
            // This mimics clap::Error.exit minus the call to safe_exit
            let _ = e.print();
            if e.use_stderr() {                                                  // XXX
                USAGE_CODE                                                       // XXX
            } else {                                                             // XXX
                SUCCESS_CODE                                                     // XXX
            }                                                                    // XXX
        }
    }
}

fn innermost_main(matches: ArgMatches) -> i32 {
    // ..snip..
}
```
</details>

What do you think?