### PR TITLE
Improve colorchoice enum

### DIFF
--- a/clap_builder/src/util/color.rs
+++ b/clap_builder/src/util/color.rs
@@ -64,6 +64,15 @@ pub enum ColorChoice {
     Never,
 }
 
+impl ColorChoice {
+    /// Report all `possible_values`
+    pub fn possible_values() -> impl Iterator<Item = PossibleValue> {
+        Self::value_variants()
+            .iter()
+            .filter_map(ValueEnum::to_possible_value)
+    }
+}
+
 impl Default for ColorChoice {
     fn default() -> Self {
         Self::Auto
@@ -99,11 +108,9 @@ impl ValueEnum for ColorChoice {
 
     fn to_possible_value(&self) -> Option<PossibleValue> {
         Some(match self {
-            Self::Auto => {
-                PossibleValue::new("auto").help("Use colored output if writing to a terminal/TTY")
-            }
-            Self::Always => PossibleValue::new("always").help("Always use colored output"),
-            Self::Never => PossibleValue::new("never").help("Never use colored output"),
+            Self::Auto => PossibleValue::new("auto"),
+            Self::Always => PossibleValue::new("always"),
+            Self::Never => PossibleValue::new("never"),
         })
     }
 }


### PR DESCRIPTION
This is done because of the decisions made in discussion for `colorchoice_clap` crate, see rust-cli/anstyle#102.

`ColorChoice::possible_values` is a convenience for builder users.

As for `ValueEnum::to_possible_value`, it was originally written this way to mimic ripgrep's `--help` output.  However, this forces short/long help distinction when there might not be otherwise.  Looking at other programs, like `git`, there doesn't seem to be a longer description of the values (an "always ansi" makes things more complicated).