### PR TITLE
fix(parser): Allow help and version command 

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -3810,7 +3810,7 @@ impl Command {
         // do the real parsing
         let mut parser = Parser::new(self);
         if let Err(error) = parser.get_matches_with(&mut matcher, raw_args, args_cursor) {
-            if self.is_set(AppSettings::IgnoreErrors) {
+            if self.is_set(AppSettings::IgnoreErrors) && error.use_stderr() {
                 debug!("Command::_do_parse: ignoring error: {error}");
             } else {
                 return Err(error);

--- a/tests/builder/ignore_errors.rs
+++ b/tests/builder/ignore_errors.rs
@@ -128,7 +128,6 @@ fn subcommand() {
 }
 
 #[test]
-#[should_panic(expected = "`Result::unwrap_err()` on an `Ok` value")]
 fn help_command() {
     static HELP: &str = "\
 Usage: test
@@ -143,7 +142,6 @@ Options:
 }
 
 #[test]
-#[should_panic(expected = "`Result::unwrap_err()` on an `Ok` value")]
 fn version_command() {
     let cmd = Command::new("test").ignore_errors(true).version("0.1");
 


### PR DESCRIPTION
Fixes https://github.com/clap-rs/clap/issues/4392

## Context
The help and version command are considered errors, though they are not "true" ones (I'm curious to know why they're considered errors to begin with :thinking: )
- https://github.com/clap-rs/clap/blob/1f71fd9e992c2d39a187c6bd1f015bdfe77dbadf/clap_builder/src/error/kind.rs#L259-L277
-  https://github.com/clap-rs/clap/blob/1f71fd9e992c2d39a187c6bd1f015bdfe77dbadf/clap_builder/src/error/kind.rs#L303-L317

As a result, when `ignore_errors` is true, the output from the help and version commands are ignored.

## Changes in this PR

This PR adds an explicit check so that only "true" errors are ignored