### PR TITLE
Improve did-you-mean suggestions by detecting swapped words

### DIFF
--- a/clap_builder/src/parser/features/suggestions.rs
+++ b/clap_builder/src/parser/features/suggestions.rs
@@ -124,6 +124,22 @@ mod test {
     }
 
     #[test]
+    fn swapped_words_1() {
+        assert_eq!(
+            did_you_mean("write-lock", ["lock-write", "no-lock"].iter()),
+            vec!["no-lock"]
+        );
+    }
+
+    #[test]
+    fn swapped_words_2() {
+        assert_eq!(
+            did_you_mean("features-all", ["all-features", "features"].iter()),
+            vec!["all-features", "features"]
+        );
+    }
+
+    #[test]
     fn flag_missing_letter() {
         let p_vals = ["test", "possible", "values"];
         assert_eq!(


### PR DESCRIPTION
While using the `deno` CLI (which uses clap) I experienced the following:

```
$ deno check --write-lock
error: unexpected argument '--write-lock' found

  tip: a similar argument exists: '--no-lock'
```

The option I wanted was `--lock-write`.

Resolves #5029.