### PR TITLE
fix(help): Defaulting max_term_width instead of max_term_width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Breaking Changes
 
 - Made `ArgPredicate` `non_exhaustive`
+- *(help)* Change default `Command::term_width` to "source format"
+- *(help)* Change default `Command::max_term_width` to 100
 - *(derive)* `Vec<Vec<T>>` types are now assuming to capture occurrences
 
 ### Features

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1158,7 +1158,7 @@ impl Command {
     /// This only applies when [`term_width`][Command::term_width] is unset so that the current
     /// terminal's width will be used.  See [`Command::term_width`] for more details.
     ///
-    /// Using `0` will ignore terminal widths and use source formatting (default).
+    /// Using `0` will ignore this, always respecting [`Command::term_width`] (default).
     ///
     /// **NOTE:** This setting applies globally and *not* on a per-command basis.
     ///

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1132,6 +1132,9 @@ impl Command {
     /// Defaults to current terminal width when `wrap_help` feature flag is enabled.  If current
     /// width cannot be determined, the default is 100.
     ///
+    /// **`unstable-v5` feature**: Defaults to unbound, being subject to
+    /// [`Command::max_term_width`].
+    ///
     /// **NOTE:** This setting applies globally and *not* on a per-command basis.
     ///
     /// **NOTE:** This requires the `wrap_help` feature
@@ -1159,6 +1162,8 @@ impl Command {
     /// terminal's width will be used.  See [`Command::term_width`] for more details.
     ///
     /// Using `0` will ignore this, always respecting [`Command::term_width`] (default).
+    ///
+    /// **`unstable-v5` feature**: Defaults to 100.
     ///
     /// **NOTE:** This setting applies globally and *not* on a per-command basis.
     ///

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -115,6 +115,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         }
     }
 
+    #[cfg(not(feature = "unstable-v5"))]
     fn term_w(cmd: &'cmd Command) -> usize {
         match cmd.get_term_width() {
             Some(0) => usize::MAX,
@@ -129,6 +130,26 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 cmp::min(current_width, max_width)
             }
         }
+    }
+
+    #[cfg(feature = "unstable-v5")]
+    fn term_w(cmd: &'cmd Command) -> usize {
+        let term_w = match cmd.get_term_width() {
+            Some(0) => usize::MAX,
+            Some(w) => w,
+            None => {
+                let (current_width, _h) = dimensions();
+                current_width.unwrap_or(usize::MAX)
+            }
+        };
+
+        let max_term_w = match cmd.get_max_term_width() {
+            Some(0) => usize::MAX,
+            Some(mw) => mw,
+            None => 100,
+        };
+
+        cmp::min(term_w, max_term_w)
     }
 
     /// Write help to stream for the parser in the format defined by the template.

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -101,7 +101,22 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             cmd.get_name(),
             use_long
         );
-        let term_w = match cmd.get_term_width() {
+        let term_w = Self::term_w(cmd);
+        let next_line_help = cmd.is_next_line_help_set();
+
+        HelpTemplate {
+            writer,
+            cmd,
+            styles: cmd.get_styles(),
+            usage,
+            next_line_help,
+            term_w,
+            use_long,
+        }
+    }
+
+    fn term_w(cmd: &'cmd Command) -> usize {
+        match cmd.get_term_width() {
             Some(0) => usize::MAX,
             Some(w) => w,
             None => {
@@ -113,17 +128,6 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 };
                 cmp::min(current_width, max_width)
             }
-        };
-        let next_line_help = cmd.is_next_line_help_set();
-
-        HelpTemplate {
-            writer,
-            cmd,
-            styles: cmd.get_styles(),
-            usage,
-            next_line_help,
-            term_w,
-            use_long,
         }
     }
 

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -916,6 +916,7 @@ fn old_newline_variables() {
 #[test]
 #[cfg(feature = "wrap_help")]
 fn issue_688_hide_pos_vals() {
+    #[cfg(not(feature = "unstable-v5"))]
     static ISSUE_688: &str = "\
 Usage: ctest [OPTIONS]
 
@@ -923,6 +924,18 @@ Options:
       --filter <filter>  Sets the filter, or sampling method, to use for interpolation when resizing the particle
                          images. The default is Linear (Bilinear). [possible values: Nearest, Linear, Cubic, Gaussian,
                          Lanczos3]
+  -h, --help             Print help
+  -V, --version          Print version
+";
+
+    #[cfg(feature = "unstable-v5")]
+    static ISSUE_688: &str = "\
+Usage: ctest [OPTIONS]
+
+Options:
+      --filter <filter>  Sets the filter, or sampling method, to use for interpolation when resizing
+                         the particle images. The default is Linear (Bilinear). [possible values:
+                         Nearest, Linear, Cubic, Gaussian, Lanczos3]
   -h, --help             Print help
   -V, --version          Print version
 ";
@@ -1511,12 +1524,24 @@ fn hide_default_val() {
 #[test]
 #[cfg(feature = "wrap_help")]
 fn escaped_whitespace_values() {
+    #[cfg(not(feature = "unstable-v5"))]
     static ESCAPED_DEFAULT_VAL: &str = "\
 Usage: default [OPTIONS]
 
 Options:
       --arg <argument>  Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \" \", \"\\n\", \"\\t\",
                         other]
+  -h, --help            Print help
+  -V, --version         Print version
+";
+
+    #[cfg(feature = "unstable-v5")]
+    static ESCAPED_DEFAULT_VAL: &str = "\
+Usage: default [OPTIONS]
+
+Options:
+      --arg <argument>  Pass an argument to the program. [default: \"\\n\"] [possible values: normal, \"
+                        \", \"\\n\", \"\\t\", other]
   -h, --help            Print help
   -V, --version         Print version
 ";


### PR DESCRIPTION
This is gated behind `unstable-v5` feature flag

Fixes #4295