### PR TITLE
fix(assert): Allow stateful value parsers

### DIFF
--- a/tests/builder/default_missing_vals.rs
+++ b/tests/builder/default_missing_vals.rs
@@ -258,38 +258,6 @@ fn delimited_missing_value() {
     );
 }
 
-#[cfg(debug_assertions)]
-#[test]
-#[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_missing_value=\"value\" failed validation: error: invalid value 'value' for '[arg]'"]
-fn default_missing_values_are_possible_values() {
-    use clap::{Arg, Command};
-
-    let _ = Command::new("test")
-        .arg(
-            Arg::new("arg")
-                .value_parser(["one", "two"])
-                .default_missing_value("value"),
-        )
-        .try_get_matches();
-}
-
-#[cfg(debug_assertions)]
-#[test]
-#[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_missing_value=\"value\" failed validation: error: invalid value 'value' for '[arg]"]
-fn default_missing_values_are_valid() {
-    use clap::{Arg, Command};
-
-    let _ = Command::new("test")
-        .arg(
-            Arg::new("arg")
-                .value_parser(clap::value_parser!(u32))
-                .default_missing_value("value"),
-        )
-        .try_get_matches();
-}
-
 #[test]
 fn valid_index() {
     let m = Command::new("df")

--- a/tests/builder/default_vals.rs
+++ b/tests/builder/default_vals.rs
@@ -793,38 +793,6 @@ fn required_args_with_default_values() {
     assert!(m.contains_id("arg"));
 }
 
-#[cfg(debug_assertions)]
-#[test]
-#[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_value=\"value\" failed validation: error: invalid value 'value' for '[arg]'"]
-fn default_values_are_possible_values() {
-    use clap::{Arg, Command};
-
-    let _ = Command::new("test")
-        .arg(
-            Arg::new("arg")
-                .value_parser(["one", "two"])
-                .default_value("value"),
-        )
-        .try_get_matches();
-}
-
-#[cfg(debug_assertions)]
-#[test]
-#[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_value=\"one\" failed validation: error: invalid value 'one' for '[arg]"]
-fn invalid_default_values() {
-    use clap::{Arg, Command};
-
-    let _ = Command::new("test")
-        .arg(
-            Arg::new("arg")
-                .value_parser(clap::value_parser!(u32))
-                .default_value("one"),
-        )
-        .try_get_matches();
-}
-
 #[test]
 fn valid_delimited_default_values() {
     use clap::{Arg, Command};
@@ -835,23 +803,6 @@ fn valid_delimited_default_values() {
                 .value_parser(clap::value_parser!(u32))
                 .value_delimiter(',')
                 .default_value("1,2,3"),
-        )
-        .debug_assert();
-}
-
-#[cfg(debug_assertions)]
-#[test]
-#[cfg(feature = "error-context")]
-#[should_panic = "Argument `arg`'s default_value=\"one\" failed validation: error: invalid value 'one' for '[arg]"]
-fn invalid_delimited_default_values() {
-    use clap::{Arg, Command};
-
-    Command::new("test")
-        .arg(
-            Arg::new("arg")
-                .value_parser(clap::value_parser!(u32))
-                .value_delimiter(',')
-                .default_value("one,two"),
         )
         .debug_assert();
 }


### PR DESCRIPTION
We'll need to re-evaluate how to solve #3202.

Fixes #4643

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
