### PR TITLE
fix(help): Wrap long possible values correctly

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -701,32 +701,33 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 self.writer.push_str("Possible values:");
                 for pv in possible_vals.iter().filter(|pv| !pv.is_hide_set()) {
                     let name = pv.get_name();
+
+                    let mut descr = StyledStr::new();
                     let _ = write!(
-                        self.writer,
-                        "\n{:spaces$}- {}{name}{}",
-                        "",
+                        &mut descr,
+                        "{}{name}{}",
                         literal.render(),
                         literal.render_reset()
                     );
                     if let Some(help) = pv.get_help() {
                         debug!("HelpTemplate::help: Possible Value help");
-
                         // To align help messages
-                        let padding = longest - display_width(pv.get_name());
-                        let _ = write!(self.writer, ": {:padding$}", "");
-
-                        let avail_chars = if self.term_w > trailing_indent.len() {
-                            self.term_w - trailing_indent.len()
-                        } else {
-                            usize::MAX
-                        };
-
-                        let mut help = help.clone();
-                        help.replace_newline_var();
-                        help.wrap(avail_chars);
-                        help.indent("", &trailing_indent);
-                        self.writer.push_styled(&help);
+                        let padding = longest - display_width(name);
+                        let _ = write!(&mut descr, ": {:padding$}", "");
+                        descr.push_styled(help);
                     }
+
+                    let avail_chars = if self.term_w > trailing_indent.len() {
+                        self.term_w - trailing_indent.len()
+                    } else {
+                        usize::MAX
+                    };
+                    descr.replace_newline_var();
+                    descr.wrap(avail_chars);
+                    descr.indent("", &trailing_indent);
+
+                    let _ = write!(self.writer, "\n{:spaces$}- ", "",);
+                    self.writer.push_styled(&descr);
                 }
             }
         }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -449,13 +449,15 @@ Usage: test [OPTIONS]
 Options:
       --possible-values <possible_values>
           Possible values:
-          - short_name: Long enough help message, barely warrant wrapping
+          - short_name: Long enough help message, barely warrant
+            wrapping
           - second:     Short help gets handled the same
 
       --possible-values-with-new-line <possible_values_with_new_line>
           Possible values:
-          - long enough name to trigger new line: Really long enough help message to clearly warrant
-            wrapping believe me
+          - long enough name to trigger new line: Really long
+            enough help message to clearly warrant wrapping believe
+            me
           - second
 
       --possible-values-without-new-line <possible_values_without_new_line>


### PR DESCRIPTION
We weren't taking the name into account when determining the wrap width.

Fixes #5022

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
