### PR TITLE
fix: Resolve conflicting name inference if from aliases

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -544,19 +544,24 @@ impl<'cmd> Parser<'cmd> {
             if self.cmd.is_infer_subcommands_set() {
                 // For subcommand `test`, we accepts it's prefix: `t`, `te`,
                 // `tes` and `test`.
-                let v = self
-                    .cmd
-                    .all_subcommand_names()
-                    .filter(|s| s.starts_with(arg))
-                    .collect::<Vec<_>>();
+                let mut iter = self.cmd.get_subcommands().filter_map(|s| {
+                    if s.get_name().starts_with(arg) {
+                        return Some(s.get_name());
+                    }
 
-                if v.len() == 1 {
-                    return Some(v[0]);
+                    // Use find here instead of chaining the iterator because we want to accept
+                    // conflicts in aliases.
+                    s.get_all_aliases().find(|s| s.starts_with(arg))
+                });
+
+                if let name @ Some(_) = iter.next() {
+                    if iter.next().is_none() {
+                        return name;
+                    }
                 }
-
-                // If there is any ambiguity, fallback to non-infer subcommand
-                // search.
             }
+            // Don't use an else here because we want inference to support exact matching even if
+            // there are conflicts.
             if let Some(sc) = self.cmd.find_subcommand(arg) {
                 return Some(sc.get_name());
             }

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -264,7 +264,6 @@ fn infer_subcommands_pass_conflicting_aliases() {
 }
 
 #[test]
-#[should_panic(expected = "internal error")]
 fn infer_long_flag_pass_conflicting_aliases() {
     let m = Command::new("prog")
         .infer_subcommands(true)
@@ -273,12 +272,12 @@ fn infer_long_flag_pass_conflicting_aliases() {
                 .long_flag("test")
                 .long_flag_aliases(["testa", "t", "testb"]),
         )
-        .try_get_matches_from(vec!["prog", "--te"]);
-    assert!(m.is_err(), "{:#?}", m.unwrap());
+        .try_get_matches_from(vec!["prog", "--te"])
+        .unwrap();
+    assert_eq!(m.subcommand_name(), Some("c"));
 }
 
 #[test]
-#[should_panic(expected = "internal error")]
 fn infer_long_flag() {
     let m = Command::new("prog")
         .infer_subcommands(true)

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -258,8 +258,9 @@ fn infer_subcommands_pass_conflicting_aliases() {
     let m = Command::new("prog")
         .infer_subcommands(true)
         .subcommand(Command::new("test").aliases(["testa", "t", "testb"]))
-        .try_get_matches_from(vec!["prog", "te"]);
-    assert!(m.is_err(), "{:#?}", m.unwrap());
+        .try_get_matches_from(vec!["prog", "te"])
+        .unwrap();
+    assert_eq!(m.subcommand_name(), Some("test"));
 }
 
 #[test]

--- a/tests/builder/app_settings.rs
+++ b/tests/builder/app_settings.rs
@@ -1,8 +1,8 @@
 use std::ffi::OsString;
 
-use super::utils;
-
 use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
+
+use super::utils;
 
 static ALLOW_EXT_SC: &str = "\
 Usage: clap-test [COMMAND]
@@ -251,6 +251,51 @@ fn infer_subcommands_pass_exact_match() {
         .try_get_matches_from(vec!["prog", "test"])
         .unwrap();
     assert_eq!(m.subcommand_name(), Some("test"));
+}
+
+#[test]
+fn infer_subcommands_pass_conflicting_aliases() {
+    let m = Command::new("prog")
+        .infer_subcommands(true)
+        .subcommand(Command::new("test").aliases(["testa", "t", "testb"]))
+        .try_get_matches_from(vec!["prog", "te"]);
+    assert!(m.is_err(), "{:#?}", m.unwrap());
+}
+
+#[test]
+#[should_panic(expected = "internal error")]
+fn infer_long_flag_pass_conflicting_aliases() {
+    let m = Command::new("prog")
+        .infer_subcommands(true)
+        .subcommand(
+            Command::new("c")
+                .long_flag("test")
+                .long_flag_aliases(["testa", "t", "testb"]),
+        )
+        .try_get_matches_from(vec!["prog", "--te"]);
+    assert!(m.is_err(), "{:#?}", m.unwrap());
+}
+
+#[test]
+#[should_panic(expected = "internal error")]
+fn infer_long_flag() {
+    let m = Command::new("prog")
+        .infer_subcommands(true)
+        .subcommand(Command::new("test").long_flag("testa"))
+        .try_get_matches_from(vec!["prog", "--te"])
+        .unwrap();
+    assert_eq!(m.subcommand_name(), Some("test"));
+}
+
+#[test]
+fn infer_subcommands_long_flag_fail_with_args2() {
+    let m = Command::new("prog")
+        .infer_subcommands(true)
+        .subcommand(Command::new("a").long_flag("test"))
+        .subcommand(Command::new("b").long_flag("temp"))
+        .try_get_matches_from(vec!["prog", "--te"]);
+    assert!(m.is_err(), "{:#?}", m.unwrap());
+    assert_eq!(m.unwrap_err().kind(), ErrorKind::UnknownArgument);
 }
 
 #[cfg(feature = "suggestions")]


### PR DESCRIPTION
This fixes 3 behaviors with inferring subcommands
-  When name matches are for the same command, allow the match
- Don't panic when inferring long_flags because of a mix up between flag and name
-  When long flag matches are for the same command, allow the match

Testing of long flags was covered in #4971

Fixes #5021