### PR TITLE
bump terminal_size to 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
  "snapbox",
  "static_assertions",
  "strsim",
- "terminal_size 0.2.3",
+ "terminal_size 0.2.6",
  "trybuild",
  "trycmd",
  "unic-emoji-char",
@@ -2075,7 +2075,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tabled",
- "terminal_size 0.2.3",
+ "terminal_size 0.2.6",
  "thiserror",
  "titlecase",
  "toml",
@@ -2124,7 +2124,7 @@ dependencies = [
  "nu-table",
  "nu-utils",
  "strip-ansi-escapes",
- "terminal_size 0.2.3",
+ "terminal_size 0.2.6",
  "tui",
 ]
 
@@ -3461,12 +3461,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix 0.36.4",
- "windows-sys 0.42.0",
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/clap_builder/Cargo.toml
+++ b/clap_builder/Cargo.toml
@@ -63,7 +63,7 @@ unicase = { version = "2.6.0", optional = true }
 strsim = { version = "0.10.0",  optional = true }
 anstream = { version = "0.3.0", optional = true }
 anstyle = "1.0.0"
-terminal_size = { version = "0.2.1", optional = true }
+terminal_size = { version = "0.2.6", optional = true }
 backtrace = { version = "0.3.67", optional = true }
 unicode-width = { version = "0.1.9", optional = true }
 once_cell = { version = "1.12.0", optional = true }


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Bumping terminal_size because it was transitively pulling in an older rustix version that caused some re-compilation that is [purportedly fixed in a newer version of rustix](https://github.com/bytecodealliance/rustix/issues/575)
