### PR TITLE
fix(parser): Value terminator has higher precedence than later multiple values

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -302,6 +302,13 @@ impl<'cmd> Parser<'cmd> {
                         .map(|p_name| !p_name.is_last_set())
                         .unwrap_or_default();
 
+                let is_terminated = self
+                    .cmd
+                    .get_keymap()
+                    .get(&pos_counter)
+                    .map(|a| a.get_value_terminator().is_some())
+                    .unwrap_or_default();
+
                 let missing_pos = self.cmd.is_allow_missing_positional_set()
                     && is_second_to_last
                     && !trailing_values;
@@ -309,7 +316,7 @@ impl<'cmd> Parser<'cmd> {
                 debug!("Parser::get_matches_with: Positional counter...{pos_counter}");
                 debug!("Parser::get_matches_with: Low index multiples...{low_index_mults:?}");
 
-                if low_index_mults || missing_pos {
+                if (low_index_mults || missing_pos) && !is_terminated {
                     let skip_current = if let Some(n) = raw_args.peek(&args_cursor) {
                         if let Some(arg) = self
                             .cmd

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1376,6 +1376,39 @@ fn multiple_value_terminator_option_other_arg() {
 }
 
 #[test]
+fn all_multiple_value_terminator() {
+    let m = Command::new("lip")
+        .arg(
+            Arg::new("files")
+                .value_terminator(";")
+                .action(ArgAction::Set)
+                .num_args(0..),
+        )
+        .arg(Arg::new("other").num_args(0..))
+        .try_get_matches_from(vec!["test", "value", ";"]);
+
+    assert!(m.is_ok(), "{:?}", m.unwrap_err().kind());
+    let m = m.unwrap();
+
+    assert!(m.contains_id("files"));
+    assert!(m.contains_id("other"));
+    assert_eq!(
+        m.get_many::<String>("files")
+            .unwrap()
+            .map(|v| v.as_str())
+            .collect::<Vec<_>>(),
+        ["value".to_owned()],
+    );
+    assert_eq!(
+        m.get_many::<String>("other")
+            .unwrap()
+            .map(|v| v.as_str())
+            .collect::<Vec<_>>(),
+        [";".to_owned()],
+    );
+}
+
+#[test]
 fn multiple_vals_with_hyphen() {
     let res = Command::new("do")
         .arg(

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1391,20 +1391,13 @@ fn all_multiple_value_terminator() {
     let m = m.unwrap();
 
     assert!(m.contains_id("files"));
-    assert!(m.contains_id("other"));
+    assert!(!m.contains_id("other"));
     assert_eq!(
         m.get_many::<String>("files")
             .unwrap()
             .map(|v| v.as_str())
             .collect::<Vec<_>>(),
         ["value".to_owned()],
-    );
-    assert_eq!(
-        m.get_many::<String>("other")
-            .unwrap()
-            .map(|v| v.as_str())
-            .collect::<Vec<_>>(),
-        [";".to_owned()],
     );
 }
 


### PR DESCRIPTION
This is one of several bugs found when looking at #4960.