### PR TITLE
dynamic completions filter options

### DIFF
--- a/clap_complete/src/dynamic/shells/bash.rs
+++ b/clap_complete/src/dynamic/shells/bash.rs
@@ -1,5 +1,7 @@
 use unicode_xid::UnicodeXID as _;
 
+use crate::dynamic::ShowOptions;
+
 /// Bash completions
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Bash;
@@ -71,7 +73,8 @@ complete -o nospace -o bashdefault -F _clap_complete_NAME BIN
             .ok()
             .and_then(|i| i.parse().ok());
         let ifs: Option<String> = std::env::var("IFS").ok().and_then(|i| i.parse().ok());
-        let completions = crate::dynamic::complete(cmd, args, index, current_dir)?;
+        let completions =
+            crate::dynamic::complete(cmd, args, index, current_dir, ShowOptions::Always)?;
 
         for (i, completion) in completions.iter().enumerate() {
             if i != 0 {

--- a/clap_complete/src/dynamic/shells/fish.rs
+++ b/clap_complete/src/dynamic/shells/fish.rs
@@ -1,3 +1,5 @@
+use crate::dynamic::ShowOptions;
+
 /// Fish completions
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Fish;
@@ -28,7 +30,8 @@ impl crate::dynamic::Completer for Fish {
         buf: &mut dyn std::io::Write,
     ) -> Result<(), std::io::Error> {
         let index = args.len() - 1;
-        let completions = crate::dynamic::complete(cmd, args, index, current_dir)?;
+        let completions =
+            crate::dynamic::complete(cmd, args, index, current_dir, ShowOptions::ExactDash)?;
 
         for completion in completions {
             writeln!(buf, "{}", completion.to_string_lossy())?;

--- a/clap_complete/src/dynamic/shells/fish.rs
+++ b/clap_complete/src/dynamic/shells/fish.rs
@@ -1,0 +1,38 @@
+/// Fish completions
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Fish;
+
+impl crate::dynamic::Completer for Fish {
+    fn file_name(&self, name: &str) -> String {
+        format!("{name}.fish")
+    }
+    fn write_registration(
+        &self,
+        _name: &str,
+        bin: &str,
+        completer: &str,
+        buf: &mut dyn std::io::Write,
+    ) -> Result<(), std::io::Error> {
+        let bin = shlex::quote(bin);
+        let completer = shlex::quote(completer);
+        writeln!(
+            buf,
+            r#"complete -x -c {bin} -a "("'{completer}'" complete --shell fish -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))""#
+        )
+    }
+    fn write_complete(
+        &self,
+        cmd: &mut clap::Command,
+        args: Vec<std::ffi::OsString>,
+        current_dir: Option<&std::path::Path>,
+        buf: &mut dyn std::io::Write,
+    ) -> Result<(), std::io::Error> {
+        let index = args.len() - 1;
+        let completions = crate::dynamic::complete(cmd, args, index, current_dir)?;
+
+        for completion in completions {
+            writeln!(buf, "{}", completion.to_string_lossy())?;
+        }
+        Ok(())
+    }
+}

--- a/clap_complete/src/dynamic/shells/mod.rs
+++ b/clap_complete/src/dynamic/shells/mod.rs
@@ -1,9 +1,11 @@
 //! Shell support
 
 mod bash;
+mod fish;
 mod shell;
 
 pub use bash::*;
+pub use fish::*;
 pub use shell::*;
 
 use std::ffi::OsString;

--- a/clap_complete/src/dynamic/shells/shell.rs
+++ b/clap_complete/src/dynamic/shells/shell.rs
@@ -10,6 +10,8 @@ use clap::ValueEnum;
 pub enum Shell {
     /// Bourne Again SHell (bash)
     Bash,
+    /// Friendly Interactive SHell (fish)
+    Fish,
 }
 
 impl Display for Shell {
@@ -37,12 +39,13 @@ impl FromStr for Shell {
 // Hand-rolled so it can work even when `derive` feature is disabled
 impl ValueEnum for Shell {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Shell::Bash]
+        &[Shell::Bash, Shell::Fish]
     }
 
     fn to_possible_value<'a>(&self) -> Option<PossibleValue> {
         Some(match self {
             Shell::Bash => PossibleValue::new("bash"),
+            Shell::Fish => PossibleValue::new("fish"),
         })
     }
 }
@@ -51,6 +54,7 @@ impl Shell {
     fn completer(&self) -> &dyn crate::dynamic::Completer {
         match self {
             Self::Bash => &super::Bash,
+            Self::Fish => &super::Fish,
         }
     }
 }

--- a/clap_complete/tests/snapshots/home/dynamic/exhaustive/fish/fish/completions/exhaustive.fish
+++ b/clap_complete/tests/snapshots/home/dynamic/exhaustive/fish/fish/completions/exhaustive.fish
@@ -1,0 +1,1 @@
+complete -x -c exhaustive -a "("'exhaustive'" complete --shell fish -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"

--- a/clap_complete/tests/snapshots/home/dynamic/exhaustive/fish/fish/config.fish
+++ b/clap_complete/tests/snapshots/home/dynamic/exhaustive/fish/fish/config.fish
@@ -1,0 +1,7 @@
+set -U fish_greeting ""
+set -U fish_autosuggestion_enabled 0
+function fish_title
+end
+function fish_prompt
+    printf '%% '
+end;

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -236,7 +236,7 @@ _exhaustive() {
             fi
             case "${prev}" in
                 --shell)
-                    COMPREPLY=($(compgen -W "bash" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish" -- "${cur}"))
                     return 0
                     ;;
                 --register)

--- a/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
@@ -104,7 +104,7 @@ complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l email -r -f
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l global -d 'everywhere'
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s h -l help -d 'Print help'
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l shell -d 'Specify shell to complete for' -r -f -a "{bash	}"
+complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l shell -d 'Specify shell to complete for' -r -f -a "{bash	,fish	}"
 complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l register -d 'Path to write completion-registration to' -r -F
 complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l global -d 'everywhere'
 complete -c exhaustive -n "__fish_seen_subcommand_from complete" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
@@ -309,7 +309,7 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (complete)
 _arguments "${_arguments_options[@]}" \
-'--shell=[Specify shell to complete for]:SHELL:(bash)' \
+'--shell=[Specify shell to complete for]:SHELL:(bash fish)' \
 '--register=[Path to write completion-registration to]:REGISTER:_files' \
 '--global[everywhere]' \
 '-h[Print help (see more with '\''--help'\'')]' \

--- a/clap_complete/tests/snapshots/register_dynamic.fish
+++ b/clap_complete/tests/snapshots/register_dynamic.fish
@@ -1,0 +1,1 @@
+complete -x -c my-app -a 'my-app'" complete --shell fish -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token)"

--- a/clap_complete/tests/testsuite/fish.rs
+++ b/clap_complete/tests/testsuite/fish.rs
@@ -162,9 +162,8 @@ fn complete_dynamic() {
 
     let input = "exhaustive \t";
     let expected = r#"% exhaustive
-action    help  pacman  -h          --global
-alias     hint  quote   -V          --help
-complete  last  value   --generate  --version"#;
+action  complete  hint  pacman  value
+alias   help      last  quote"#;
     let actual = runtime.complete(input, &term).unwrap();
     snapbox::assert_eq(expected, actual);
 }

--- a/clap_complete/tests/testsuite/fish.rs
+++ b/clap_complete/tests/testsuite/fish.rs
@@ -143,3 +143,28 @@ alias   help  (Print this message or the help of the given subcommand(s))  last 
     let actual = runtime.complete(input, &term).unwrap();
     snapbox::assert_eq(expected, actual);
 }
+
+#[cfg(feature = "unstable-dynamic")]
+#[test]
+fn register_dynamic() {
+    common::register_example("dynamic", "exhaustive", completest::Shell::Fish);
+}
+
+#[test]
+#[cfg(all(unix, feature = "unstable-dynamic"))]
+fn complete_dynamic() {
+    if !common::has_command("fish") {
+        return;
+    }
+
+    let term = completest::Term::new();
+    let mut runtime = common::load_runtime("dynamic", "exhaustive", completest::Shell::Fish);
+
+    let input = "exhaustive \t";
+    let expected = r#"% exhaustive
+action    help  pacman  -h          --global
+alias     hint  quote   -V          --help
+complete  last  value   --generate  --version"#;
+    let actual = runtime.complete(input, &term).unwrap();
+    snapbox::assert_eq(expected, actual);
+}


### PR DESCRIPTION
based on #5048

Allows dynamic completions to only show option completions when the dashes (`-`) match.

I.e., only show them when either one `-` or two `--` are already present.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
