### PR TITLE
feat: Allow referencing `TypedValueParser` in`ValueParserFactory` associated type

### DIFF
--- a/clap_builder/src/builder/mod.rs
+++ b/clap_builder/src/builder/mod.rs
@@ -57,6 +57,7 @@ pub use value_parser::PossibleValuesParser;
 pub use value_parser::RangedI64ValueParser;
 pub use value_parser::RangedU64ValueParser;
 pub use value_parser::StringValueParser;
+pub use value_parser::TryMapValueParser;
 pub use value_parser::TypedValueParser;
 pub use value_parser::ValueParser;
 pub use value_parser::ValueParserFactory;


### PR DESCRIPTION
When searching for relevant discussions and issues I happened upon #4362, which suggests using `TypedValueParser::try_map`. Unfortunately, this is not suitable for `ValueParserFactory` implementations that automatically register a `TypedValueParser` for a given type, as the `TryMapValueParser` type returned from try_map is not public.

Partial fix for #5065