### PR TITLE
Export error constructors

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -869,6 +869,14 @@ impl Arg {
         self.settings.unset(setting);
         self
     }
+
+    /// Display a potential argument. This matches up with the
+    /// [`crate::builder::TypedValueParser::parse_ref`] `arg` type and is used in the
+    /// [`crate::Error`] constructor methods.
+    pub(crate) fn display(arg: Option<&Arg>) -> String {
+        arg.map(ToString::to_string)
+            .unwrap_or_else(|| "...".to_owned())
+    }
 }
 
 /// # Value Handling

--- a/clap_builder/src/builder/value_parser.rs
+++ b/clap_builder/src/builder/value_parser.rs
@@ -854,9 +854,6 @@ where
             )
         }));
         let value = ok!((self)(value).map_err(|e| {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(arg, value.to_owned(), e.into()).with_cmd(cmd)
         }));
         Ok(value)
@@ -986,12 +983,7 @@ impl TypedValueParser for PathBufValueParser {
         value: std::ffi::OsString,
     ) -> Result<Self::Value, crate::Error> {
         if value.is_empty() {
-            return Err(crate::Error::empty_value(
-                cmd,
-                &[],
-                arg.map(ToString::to_string)
-                    .unwrap_or_else(|| "...".to_owned()),
-            ));
+            return Err(crate::Error::empty_value(cmd, &[], arg));
         }
         Ok(Self::Value::from(value))
     }
@@ -1078,8 +1070,7 @@ impl<E: crate::ValueEnum + Clone + Send + Sync + 'static> TypedValueParser for E
                 cmd,
                 value.to_string_lossy().into_owned(),
                 &possible_vals(),
-                arg.map(ToString::to_string)
-                    .unwrap_or_else(|| "...".to_owned()),
+                arg,
             )
         }));
         let value = ok!(E::value_variants()
@@ -1094,8 +1085,7 @@ impl<E: crate::ValueEnum + Clone + Send + Sync + 'static> TypedValueParser for E
                 cmd,
                 value.to_owned(),
                 &possible_vals(),
-                arg.map(ToString::to_string)
-                    .unwrap_or_else(|| "...".to_owned()),
+                arg,
             )
             }))
             .clone();
@@ -1204,13 +1194,7 @@ impl TypedValueParser for PossibleValuesParser {
                 .map(|v| v.get_name().to_owned())
                 .collect::<Vec<_>>();
 
-            Err(crate::Error::invalid_value(
-                cmd,
-                value,
-                &possible_vals,
-                arg.map(ToString::to_string)
-                    .unwrap_or_else(|| "...".to_owned()),
-            ))
+            Err(crate::Error::invalid_value(cmd, value, &possible_vals, arg))
         }
     }
 
@@ -1379,9 +1363,6 @@ where
             )
         }));
         let value = ok!(value.parse::<i64>().map_err(|err| {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
@@ -1390,9 +1371,6 @@ where
             .with_cmd(cmd)
         }));
         if !self.bounds.contains(&value) {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             return Err(crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
@@ -1403,9 +1381,6 @@ where
 
         let value: Result<Self::Value, _> = value.try_into();
         let value = ok!(value.map_err(|err| {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
@@ -1579,9 +1554,6 @@ where
             )
         }));
         let value = ok!(value.parse::<u64>().map_err(|err| {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
@@ -1590,9 +1562,6 @@ where
             .with_cmd(cmd)
         }));
         if !self.bounds.contains(&value) {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             return Err(crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
@@ -1603,9 +1572,6 @@ where
 
         let value: Result<Self::Value, _> = value.try_into();
         let value = ok!(value.map_err(|err| {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(
                 arg,
                 raw_value.to_string_lossy().into_owned(),
@@ -1677,8 +1643,7 @@ impl TypedValueParser for BoolValueParser {
                 cmd,
                 value.to_string_lossy().into_owned(),
                 &possible_vals,
-                arg.map(ToString::to_string)
-                    .unwrap_or_else(|| "...".to_owned()),
+                arg,
             ));
         };
         Ok(value)
@@ -1871,9 +1836,6 @@ impl TypedValueParser for BoolishValueParser {
             )
         }));
         let value = ok!(crate::util::str_to_bool(value).ok_or_else(|| {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(arg, value.to_owned(), "value was not a boolean".into())
                 .with_cmd(cmd)
         }));
@@ -1948,12 +1910,7 @@ impl TypedValueParser for NonEmptyStringValueParser {
         value: &std::ffi::OsStr,
     ) -> Result<Self::Value, crate::Error> {
         if value.is_empty() {
-            return Err(crate::Error::empty_value(
-                cmd,
-                &[],
-                arg.map(ToString::to_string)
-                    .unwrap_or_else(|| "...".to_owned()),
-            ));
+            return Err(crate::Error::empty_value(cmd, &[], arg));
         }
         let value = ok!(value.to_str().ok_or_else(|| {
             crate::Error::invalid_utf8(
@@ -2070,9 +2027,6 @@ where
     ) -> Result<Self::Value, crate::Error> {
         let mid_value = ok!(self.parser.parse_ref(cmd, arg, value));
         let value = ok!((self.func)(mid_value).map_err(|e| {
-            let arg = arg
-                .map(|a| a.to_string())
-                .unwrap_or_else(|| "...".to_owned());
             crate::Error::value_validation(arg, value.to_string_lossy().into_owned(), e.into())
                 .with_cmd(cmd)
         }));

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -391,7 +391,15 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
-    pub(crate) fn empty_value(cmd: &Command, good_vals: &[String], arg: String) -> Self {
+    /// Create an error for an invalid empty value.
+    ///
+    /// # Arguments
+    ///
+    /// * `cmd`: The command which failed to validate.
+    /// * `good_vals`: If non-empty, a list of valid values for the given argument, used for
+    ///   generating suggestions.
+    /// * `arg`: The argument which failed to validate, if any.
+    pub fn empty_value(cmd: &Command, good_vals: &[String], arg: Option<&crate::Arg>) -> Self {
         Self::invalid_value(cmd, "".to_owned(), good_vals, arg)
     }
 
@@ -411,12 +419,22 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
-    pub(crate) fn invalid_value(
+    /// Create an error for an invalid value.
+    ///
+    /// # Arguments
+    ///
+    /// * `cmd`: The command which failed to validate.
+    /// * `bad_val`: The invalid value.
+    /// * `good_vals`: If non-empty, a list of valid values for the given argument, used for
+    ///   generating suggestions.
+    /// * `arg`: The argument which failed to validate, if any.
+    pub fn invalid_value(
         cmd: &Command,
         bad_val: String,
         good_vals: &[String],
-        arg: String,
+        arg: Option<&crate::Arg>,
     ) -> Self {
+        let arg = crate::Arg::display(arg);
         let suggestion = suggestions::did_you_mean(&bad_val, good_vals.iter()).pop();
         let mut err = Self::new(ErrorKind::InvalidValue).with_cmd(cmd);
 
@@ -629,11 +647,19 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
-    pub(crate) fn value_validation(
-        arg: String,
+    /// Create a value validation error.
+    ///
+    /// # Arguments
+    ///
+    /// * `arg`: The argument which failed to validate, if any.
+    /// * `val`: The invalid value.
+    /// * `err`: The error message.
+    pub fn value_validation(
+        arg: Option<&crate::Arg>,
         val: String,
         err: Box<dyn error::Error + Send + Sync>,
     ) -> Self {
+        let arg = crate::Arg::display(arg);
         let mut err = Self::new(ErrorKind::ValueValidation).set_source(err);
 
         #[cfg(feature = "error-context")]

--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -1287,7 +1287,7 @@ impl<'cmd> Parser<'cmd> {
                     .filter(|pv| !pv.is_hide_set())
                     .map(|n| n.get_name().to_owned())
                     .collect::<Vec<_>>(),
-                arg.to_string(),
+                Some(arg),
             ));
         } else if let Some(expected) = expected.num_values() {
             if expected != actual {

--- a/clap_builder/src/parser/validator.rs
+++ b/clap_builder/src/parser/validator.rs
@@ -47,7 +47,7 @@ impl<'cmd> Validator<'cmd> {
                         .filter(|pv| !pv.is_hide_set())
                         .map(|n| n.get_name().to_owned())
                         .collect::<Vec<_>>(),
-                    o.to_string(),
+                    Some(o),
                 ));
             }
         }


### PR DESCRIPTION
Fix for #5065. This exports the following `Error` constructors to improve diagnostic generation for `TypedValueParser` implementors:

- `Error::empty_value`
- `Error::invalid_value`
- `Error::value_validation`

Additionally, this exports `Error::set_source` to provide a mechanism for custom error messages while still taking advantage of the `context` formatting.

## Future work

Perhaps we should consider making public `Error::invalid_subcommand`, though I have no use for it at the moment.