### PR TITLE
feat(nu): Make the completion scripts more general 

### DIFF
--- a/clap_complete_nushell/src/lib.rs
+++ b/clap_complete_nushell/src/lib.rs
@@ -42,7 +42,7 @@ impl Generator for Nushell {
         }
 
         completions.push_str("}\n\n");
-        completions.push_str("use completions *\n");
+        completions.push_str("export use completions *\n");
 
         buf.write_all(completions.as_bytes())
             .expect("Failed to write to generated file")

--- a/clap_complete_nushell/tests/snapshots/aliases.nu
+++ b/clap_complete_nushell/tests/snapshots/aliases.nu
@@ -15,4 +15,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *

--- a/clap_complete_nushell/tests/snapshots/basic.nu
+++ b/clap_complete_nushell/tests/snapshots/basic.nu
@@ -27,4 +27,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *

--- a/clap_complete_nushell/tests/snapshots/feature_sample.nu
+++ b/clap_complete_nushell/tests/snapshots/feature_sample.nu
@@ -36,4 +36,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *

--- a/clap_complete_nushell/tests/snapshots/home/test/nu/.config/nushell/completions/test.nu
+++ b/clap_complete_nushell/tests/snapshots/home/test/nu/.config/nushell/completions/test.nu
@@ -255,4 +255,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *

--- a/clap_complete_nushell/tests/snapshots/quoting.nu
+++ b/clap_complete_nushell/tests/snapshots/quoting.nu
@@ -75,4 +75,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *

--- a/clap_complete_nushell/tests/snapshots/special_commands.nu
+++ b/clap_complete_nushell/tests/snapshots/special_commands.nu
@@ -64,4 +64,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *

--- a/clap_complete_nushell/tests/snapshots/sub_subcommands.nu
+++ b/clap_complete_nushell/tests/snapshots/sub_subcommands.nu
@@ -73,4 +73,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *

--- a/clap_complete_nushell/tests/snapshots/value_hint.nu
+++ b/clap_complete_nushell/tests/snapshots/value_hint.nu
@@ -24,4 +24,4 @@ module completions {
 
 }
 
-use completions *
+export use completions *


### PR DESCRIPTION
The generated scripts can be used as script, module and overlay.

* script `source completion_script.nu`

* module `use completion_script.nu *`

* overlay `overlay use completion_script.nu`

Closes #5117 