### PR TITLE
chore: Update terminal_size to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
  "snapbox",
  "static_assertions",
  "strsim",
- "terminal_size 0.2.3",
+ "terminal_size 0.3.0",
  "trybuild",
  "trycmd",
  "unic-emoji-char",
@@ -2051,7 +2051,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tabled",
- "terminal_size 0.2.3",
+ "terminal_size 0.2.6",
  "titlecase",
  "toml",
  "umask",
@@ -2097,7 +2097,7 @@ dependencies = [
  "nu-utils",
  "ratatui",
  "strip-ansi-escapes",
- "terminal_size 0.2.3",
+ "terminal_size 0.2.6",
 ]
 
 [[package]]
@@ -3438,12 +3438,22 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
- "rustix 0.36.4",
- "windows-sys 0.42.0",
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.8",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/clap_builder/Cargo.toml
+++ b/clap_builder/Cargo.toml
@@ -63,7 +63,7 @@ unicase = { version = "2.6.0", optional = true }
 strsim = { version = "0.10.0",  optional = true }
 anstream = { version = "0.5.0", optional = true }
 anstyle = "1.0.0"
-terminal_size = { version = "0.2.1", optional = true }
+terminal_size = { version = "0.3.0", optional = true }
 backtrace = { version = "0.3.67", optional = true }
 unicode-width = { version = "0.1.9", optional = true }
 


### PR DESCRIPTION
For some reason, terminal_size bumped semver recently; they also bumped the rustix version to 0.38.

I'd like to reduce the number of copies of OS integration crates (rustix and nix) in my dependency chain.  By updating terminal_size to 0.3.x we allow builders to keep then number of dependencies to a minimum

(Now honestly, given terminal_size boils down to basically
 *one function* I have no idea why they bumped semver, the
 API appears to be the same because we continue to build
 with both, as you'd expect)
