### PR TITLE
Remove a part of derive/tutorial/chapter_2 that appears twice.

### DIFF
--- a/src/_derive/_tutorial/chapter_2.rs
+++ b/src/_derive/_tutorial/chapter_2.rs
@@ -18,7 +18,7 @@
 #![doc = include_str!("../../../examples/tutorial_derive/03_03_positional.md")]
 //!
 //! Note that the [default `ArgAction` is `Set`][super#arg-types].  To
-//! accept multiple values, override the [action][Arg::action] with [`Append`][crate::ArgAction::Append] via `Vec`:
+//! accept multiple occurrences, override the [action][Arg::action] with [`Append`][crate::ArgAction::Append] via `Vec`:
 //! ```rust
 #![doc = include_str!("../../../examples/tutorial_derive/03_03_positional_mult.rs")]
 //! ```
@@ -39,13 +39,6 @@
 #![doc = include_str!("../../../examples/tutorial_derive/03_02_option.rs")]
 //! ```
 #![doc = include_str!("../../../examples/tutorial_derive/03_02_option.md")]
-//!
-//! Note that the [default `ArgAction` is `Set`][super#arg-types].  To
-//! accept multiple occurrences, override the [action][Arg::action] with [`Append`][crate::ArgAction::Append] via `Vec`:
-//! ```rust
-#![doc = include_str!("../../../examples/tutorial_derive/03_02_option_mult.rs")]
-//! ```
-#![doc = include_str!("../../../examples/tutorial_derive/03_02_option_mult.md")]
 //!
 //! ### Flags
 //!


### PR DESCRIPTION
The offending section is here https://github.com/clap-rs/clap/blob/master/src/_derive/_tutorial/chapter_2.rs#L20-L25 which is repeated here https://github.com/clap-rs/clap/blob/master/src/_derive/_tutorial/chapter_2.rs#L43-L48. This PR removes the second occurrence as the position of the first is (in my opinion) a more appropriate place for it. This PR also changes the wording of the first occurrence to be more like the second as it is (again, in my opinion,) very slightly more clear.