### PR TITLE
fix: Fix fish shell completion bug that occurs when ValueEnum is the only one

### DIFF
--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -171,13 +171,13 @@ fn value_completion(option: &Arg) -> String {
                     // The help text after \t is wrapped in '' to make sure that the it is taken literally
                     // and there is no command substitution or variable expansion resulting in unexpected errors
                     Some(format!(
-                        "{}\t'{}'",
+                        "{}\t'{}',",
                         escape_string(value.get_name(), true).as_str(),
                         escape_string(&value.get_help().unwrap_or_default().to_string(), false)
                     ))
                 })
                 .collect::<Vec<_>>()
-                .join(",")
+                .join("")
         )
     } else {
         // NB! If you change this, please also update the table in `ValueHint` documentation.


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

# Bug to be fixed

This PR is about bug of fish shell completion.

Here is an example. The correct completion candidate is `hoge`, but `\{hoge` is actually completed.
```
$ example --action \{hoge       # extra left brace
```

This occurs when the ValueEnum has only one candidate.

## Code to reproduce the bug

```rust
use std::io;

use clap::{CommandFactory, Parser, ValueEnum};
use clap_complete::{self, generate, Shell};

#[derive(Parser)]
#[command(name = "example")]
struct Args {
    #[arg(long)]
    action: Option<Action>,
}

#[derive(ValueEnum, Clone)]
enum Action {
    Hoge,
}

fn main() {
    Args::parse();
    let mut cmd = Args::command();
    let name = cmd.get_name().to_string();
    generate(Shell::Fish, &mut cmd, name, &mut io::stdout());
}
```

- The symptom

```
$ example --action \{hoge       # extra left brace
```

- Generated completion file

```fish
complete -c example -l action -r -f -a "{hoge	''}"
complete -c example -s h -l help -d 'Print help'
```
