### PR TITLE
Make FromStr::Err not need to be a `Send+Sync+'static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,6 +331,11 @@ path = "examples/tutorial_derive/04_02_parse.rs"
 required-features = ["derive"]
 
 [[example]]
+name = "04_02_01_parse_from_str"
+path = "examples/tutorial_derive/04_02_01_parse_from_str.rs"
+required-features = ["derive"]
+
+[[example]]
 name = "04_02_validate_derive"
 path = "examples/tutorial_derive/04_02_validate.rs"
 required-features = ["derive"]

--- a/clap_builder/src/builder/value_parser.rs
+++ b/clap_builder/src/builder/value_parser.rs
@@ -908,7 +908,7 @@ pub trait TypedValueParser: Clone + Send + Sync + 'static {
 impl<F, T, E> TypedValueParser for F
 where
     F: Fn(&str) -> Result<T, E> + Clone + Send + Sync + 'static,
-    E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    E: Into<Box<dyn std::error::Error>>,
     T: Send + Sync + Clone,
 {
     type Value = T;
@@ -2576,7 +2576,7 @@ pub mod via_prelude {
     impl<Parse> _ValueParserViaParse for _AutoValueParser<Parse>
     where
         Parse: std::str::FromStr + std::any::Any + Clone + Send + Sync + 'static,
-        <Parse as std::str::FromStr>::Err: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+        <Parse as std::str::FromStr>::Err: Into<Box<dyn std::error::Error>>,
     {
         fn value_parser(&self) -> _AnonymousValueParser {
             let func: fn(&str) -> Result<Parse, <Parse as std::str::FromStr>::Err> =
@@ -2688,7 +2688,7 @@ mod private {
     impl<Parse> _ValueParserViaParseSealed for _AutoValueParser<Parse>
     where
         Parse: std::str::FromStr + std::any::Any + Send + Sync + 'static,
-        <Parse as std::str::FromStr>::Err: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+        <Parse as std::str::FromStr>::Err: Into<Box<dyn std::error::Error>>,
     {
     }
 }

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -68,7 +68,7 @@ struct ErrorInner {
     #[cfg(feature = "error-context")]
     context: FlatMap<ContextKind, ContextValue>,
     message: Option<Message>,
-    source: Option<Box<dyn error::Error + Send + Sync>>,
+    source: Option<Box<dyn error::Error>>,
     help_flag: Option<&'static str>,
     styles: Styles,
     color_when: ColorChoice,
@@ -299,7 +299,7 @@ impl<F: ErrorFormatter> Error<F> {
         self
     }
 
-    pub(crate) fn set_source(mut self, source: Box<dyn error::Error + Send + Sync>) -> Self {
+    pub(crate) fn set_source(mut self, source: Box<dyn error::Error>) -> Self {
         self.inner.source = Some(source);
         self
     }
@@ -632,7 +632,7 @@ impl<F: ErrorFormatter> Error<F> {
     pub(crate) fn value_validation(
         arg: String,
         val: String,
-        err: Box<dyn error::Error + Send + Sync>,
+        err: Box<dyn error::Error>,
     ) -> Self {
         let mut err = Self::new(ErrorKind::ValueValidation).set_source(err);
 
@@ -919,5 +919,5 @@ impl Display for Backtrace {
 
 #[test]
 fn check_auto_traits() {
-    static_assertions::assert_impl_all!(Error: Send, Sync, Unpin);
+    static_assertions::assert_impl_all!(Error: Unpin);
 }

--- a/examples/tutorial_derive/04_02_01_parse_from_str.rs
+++ b/examples/tutorial_derive/04_02_01_parse_from_str.rs
@@ -1,0 +1,47 @@
+use std::fmt::{Display, Formatter};
+use std::marker::PhantomData;
+
+#[derive(Clone, Debug)]
+struct Foo {
+    v: u32
+}
+
+impl std::str::FromStr for Foo {
+    type Err = NotSendSyncError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s=="error" {
+            Err(NotSendSyncError{_pd: PhantomData })
+        } else {
+            Ok(Foo{v: 42})
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NotSendSyncError {
+    _pd: PhantomData<std::cell::RefCell<()>>,
+}
+
+impl Display for NotSendSyncError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for NotSendSyncError {
+
+}
+
+#[derive(clap::Parser, Debug, Clone)]
+#[structopt(name = "use FromStr")]
+struct Config {
+    //#[arg(long, value_parser=clap::value_parser!(Foo))]
+    #[arg(long)]
+    foo: Foo
+}
+
+fn main() {
+    let config = <Config as clap::Parser>::parse();
+    println!("foo.v={}", config.foo.v);
+}

--- a/examples/typed-derive.rs
+++ b/examples/typed-derive.rs
@@ -45,12 +45,12 @@ struct Args {
 }
 
 /// Parse a single key-value pair
-fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
+fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error>>
 where
     T: std::str::FromStr,
-    T::Err: Error + Send + Sync + 'static,
+    T::Err: Error,
     U: std::str::FromStr,
-    U::Err: Error + Send + Sync + 'static,
+    U::Err: Error,
 {
     let pos = s
         .find('=')


### PR DESCRIPTION
As far as I understand, standard rust library does not require error::Error to be a Send+Sync+'static, and (for example) `structopt` does not. But `clap` require. Thus, the library turns out to be incompatible with most parsing libraries that return `Box<dyn Error>` as an error.

This commit proposes to relax this requirement. This makes the library more backward-compatible with `structopt`. This will allow errors to be thrown from libraries that return errors, that not `Send` or `Sync`, for example `ssсanf`:

```
impl FromStr for MyConfigElement {
    type Err = sscanf::Error; // <<-- sscanf library return Box<dyn Error>, not Box<dyn Error+Send+Sync>
    // so sscanf::Error don't works with clap, but it's works in old 'structopt' crate

    fn from_str(s: &str) -> Result<Self, Self::Err> {

        #[derive(sscanf::FromScanf)]
        #[sscanf(format = "{foo}")]
        struct ParseHelper {
            foo: u32,
        }

	let result = sscanf::sscanf!(s, "{ParseHelper}")?;
	Ok(MyConfigElement::new(result.foo))
    }
}
```

A test+example of using such errors has also been added.

I know that a year ago there was a discussion about how the return Ok() result could also be !send+!sync+!clone (https://github.com/clap-rs/clap/discussions/3833), and I tried to do that - but it turned out that it required a lot of work.


