### PR TITLE
Remove unused dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,10 +486,8 @@ dependencies = [
  "rustversion",
  "shlex",
  "snapbox",
- "static_assertions",
  "trybuild",
  "trycmd",
- "unic-emoji-char",
 ]
 
 [[package]]
@@ -521,15 +519,9 @@ dependencies = [
  "backtrace",
  "clap_lex 0.5.1",
  "color-print",
- "humantime",
- "rustversion",
- "shlex",
- "snapbox",
  "static_assertions",
  "strsim",
  "terminal_size 0.3.0",
- "trybuild",
- "trycmd",
  "unic-emoji-char",
  "unicase",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,6 @@ trycmd = { version = "0.14.18", default-features = false, features = ["color-aut
 humantime = "2.1.0"
 snapbox = "0.4.13"
 shlex = "1.2.0"
-static_assertions = "1.1.0"
-unic-emoji-char = "0.9.0"
 
 [[example]]
 name = "demo"

--- a/clap_builder/Cargo.toml
+++ b/clap_builder/Cargo.toml
@@ -68,13 +68,6 @@ backtrace = { version = "0.3.67", optional = true }
 unicode-width = { version = "0.1.9", optional = true }
 
 [dev-dependencies]
-trybuild = "1.0.85"
-rustversion = "1.0.14"
-# Cutting out `filesystem` feature
-trycmd = { version = "0.14.18", default-features = false, features = ["color-auto", "diff", "examples"] }
-humantime = "2.1.0"
-snapbox = "0.4.13"
-shlex = "1.2.0"
 static_assertions = "1.1.0"
 unic-emoji-char = "0.9.0"
 color-print = "0.3.5"


### PR DESCRIPTION
These dependencies are used elsewhere in clap, but not in these crates.
`cargo test` and `cargo check --examples` both still pass with these
dependencies removed.
