### PR TITLE
Reduce code size of testing tokens if they're a number

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -643,7 +643,7 @@ impl<'cmd> Parser<'cmd> {
 
         if self.cmd[current_positional.get_id()].is_allow_hyphen_values_set()
             || (self.cmd[current_positional.get_id()].is_allow_negative_numbers_set()
-                && next.is_number())
+                && next.is_negative_number())
         {
             // If allow hyphen, this isn't a new arg.
             debug!("Parser::is_new_arg: Allow hyphen");
@@ -841,7 +841,7 @@ impl<'cmd> Parser<'cmd> {
 
         #[allow(clippy::blocks_in_if_conditions)]
         if matches!(parse_state, ParseState::Opt(opt) | ParseState::Pos(opt)
-                if self.cmd[opt].is_allow_hyphen_values_set() || (self.cmd[opt].is_allow_negative_numbers_set() && short_arg.is_number()))
+                if self.cmd[opt].is_allow_hyphen_values_set() || (self.cmd[opt].is_allow_negative_numbers_set() && short_arg.is_negative_number()))
         {
             debug!("Parser::parse_short_args: prior arg accepts hyphenated values",);
             return Ok(ParseResult::MaybeHyphenValue);
@@ -851,7 +851,7 @@ impl<'cmd> Parser<'cmd> {
             .get(&pos_counter)
             .map(|arg| arg.is_allow_negative_numbers_set())
             .unwrap_or_default()
-            && short_arg.is_number()
+            && short_arg.is_negative_number()
         {
             debug!("Parser::parse_short_arg: negative number");
             return Ok(ParseResult::MaybeHyphenValue);

--- a/clap_lex/tests/parsed.rs
+++ b/clap_lex/tests/parsed.rs
@@ -120,12 +120,14 @@ fn to_short() {
 
 #[test]
 fn is_negative_number() {
-    let raw = clap_lex::RawArgs::new(["bin", "-10.0"]);
-    let mut cursor = raw.cursor();
-    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
-    let next = raw.next(&mut cursor).unwrap();
+    for number in ["-10.0", "-1", "-100", "-3.5", "-1e10", "-1.3e10"] {
+        let raw = clap_lex::RawArgs::new(["bin", number]);
+        let mut cursor = raw.cursor();
+        assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+        let next = raw.next(&mut cursor).unwrap();
 
-    assert!(next.is_number());
+        assert!(next.is_negative_number());
+    }
 }
 
 #[test]
@@ -135,17 +137,22 @@ fn is_positive_number() {
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
 
-    assert!(next.is_number());
+    assert!(!next.is_negative_number());
 }
 
 #[test]
 fn is_not_number() {
-    let raw = clap_lex::RawArgs::new(["bin", "--10.0"]);
-    let mut cursor = raw.cursor();
-    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
-    let next = raw.next(&mut cursor).unwrap();
+    for number in ["--10.0", "-..", "-2..", "-e", "-1e", "-1e10.2", "-.2"] {
+        let raw = clap_lex::RawArgs::new(["bin", number]);
+        let mut cursor = raw.cursor();
+        assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+        let next = raw.next(&mut cursor).unwrap();
 
-    assert!(!next.is_number());
+        assert!(
+            !next.is_negative_number(),
+            "`{number}` is mistakenly classified as a number"
+        );
+    }
 }
 
 #[test]

--- a/clap_lex/tests/shorts.rs
+++ b/clap_lex/tests/shorts.rs
@@ -151,23 +151,23 @@ fn is_exhausted_empty() {
 }
 
 #[test]
-fn is_number() {
+fn is_negative_number() {
     let raw = clap_lex::RawArgs::new(["bin", "-1.0"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
     let shorts = next.to_short().unwrap();
 
-    assert!(shorts.is_number());
+    assert!(shorts.is_negative_number());
 }
 
 #[test]
-fn is_not_number() {
+fn is_not_negaitve_number() {
     let raw = clap_lex::RawArgs::new(["bin", "-hello"]);
     let mut cursor = raw.cursor();
     assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
     let next = raw.next(&mut cursor).unwrap();
     let shorts = next.to_short().unwrap();
 
-    assert!(!shorts.is_number());
+    assert!(!shorts.is_negative_number());
 }


### PR DESCRIPTION
This commit is a tiny win in compiled code size of a final binary including `clap` which shaves off 19k of compiled code locally. Previously tokens were checked if they were a number by using `.parse::<f64>().is_ok()`, but parsing floats is relatively heavyweight in terms of code size. This replaces the check with a more naive "does this string have lots of ascii digits" check where the compiled size of this check should be much smaller.

I'll note that this is not a critical optimization at all and is one I'm mostly curious if it's of interest. There's other various edge cases that were previously classified as numbers which will no longer be classified as numbers such as `nan`, `inf`, `+1`, `1e10`, etc. That would mean that this is technically a breaking change, and if that's not acceptable then this is most definitely not worth it.