### PR TITLE
switch to correctly working Jaro implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,8 +535,8 @@ dependencies = [
  "backtrace",
  "clap_lex 0.6.0",
  "color-print",
+ "rapidfuzz",
  "static_assertions",
- "strsim",
  "terminal_size 0.3.0",
  "unic-emoji-char",
  "unicase",
@@ -2721,6 +2721,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rapidfuzz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "270e04e5ea61d40841942bb15e451c29ee1618637bcf97fc7ede5dd4a9b1601b"
 
 [[package]]
 name = "rayon"

--- a/clap_builder/Cargo.toml
+++ b/clap_builder/Cargo.toml
@@ -40,7 +40,7 @@ color = ["dep:anstream"]
 help = []
 usage = []
 error-context = []
-suggestions = ["dep:strsim", "error-context"]
+suggestions = ["dep:rapidfuzz", "error-context"]
 
 # Optional
 deprecated = [] # Guided experience to prepare for next breaking release (at different stages of development, this may become default)
@@ -60,7 +60,7 @@ bench = false
 [dependencies]
 clap_lex = { path = "../clap_lex", version = "0.6.0" }
 unicase = { version = "2.6.0", optional = true }
-strsim = { version = "0.10.0",  optional = true }
+rapidfuzz = { version = "0.5.0",  optional = true }
 anstream = { version = "0.6.0", optional = true }
 anstyle = "1.0.0"
 terminal_size = { version = "0.3.0", optional = true }


### PR DESCRIPTION
I noticed clap switched from Jaro-Winkler to Jaro similarity due to "a bug" in strsim. However the Jaro similarity in strsim is broken as well, since it doesn't calculate transpositions correctly (https://github.com/dguo/strsim-rs/issues/49).

This switches from strsim to rapidfuzz for string matching. Besides calculating the correct Jaro / Jaro-Winkler similarity, this should be faster. For the relatively short text lengths involved in commands the metric should be around 2-4x faster. Even though I doubt this matters a whole lot for this usage.

As a disclaimer: I am the author of rapidfuzz.