### PR TITLE
Improve bash completion with compopt

### DIFF
--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -168,29 +168,48 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
     let mut opts = vec![String::new()];
 
     for o in p.get_opts() {
+        let compopt = match o.get_value_hint() {
+            ValueHint::FilePath => Some("compopt -o filenames"),
+            _ => None,
+        };
+
         if let Some(longs) = o.get_long_and_visible_aliases() {
             opts.extend(longs.iter().map(|long| {
-                format!(
-                    "--{})
-                    COMPREPLY=({})
-                    return 0
-                    ;;",
-                    long,
-                    vals_for(o)
-                )
+                let mut v = vec![
+                    format!("--{})", long),
+                    format!("COMPREPLY=({})", vals_for(o)),
+                ];
+
+                if let Some(copt) = compopt {
+                    v.extend([
+                        r#"if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then"#.to_string(),
+                        format!("    {}", copt),
+                        "fi".to_string(),
+                    ]);
+                }
+
+                v.extend(["return 0", ";;"].iter().map(|s| s.to_string()));
+                v.join("\n                    ")
             }));
         }
 
         if let Some(shorts) = o.get_short_and_visible_aliases() {
             opts.extend(shorts.iter().map(|short| {
-                format!(
-                    "-{})
-                    COMPREPLY=({})
-                    return 0
-                    ;;",
-                    short,
-                    vals_for(o)
-                )
+                let mut v = vec![
+                    format!("-{})", short),
+                    format!("COMPREPLY=({})", vals_for(o)),
+                ];
+
+                if let Some(copt) = compopt {
+                    v.extend([
+                        r#"if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then"#.to_string(),
+                        format!("    {}", copt),
+                        "fi".to_string(),
+                    ]);
+                }
+
+                v.extend(["return 0", ";;"].iter().map(|s| s.to_string()));
+                v.join("\n                    ")
             }));
         }
     }

--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -171,6 +171,7 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
         let compopt = match o.get_value_hint() {
             ValueHint::FilePath => Some("compopt -o filenames"),
             ValueHint::DirPath => Some("compopt -o plusdirs"),
+            ValueHint::Other => Some("compopt -o nospace"),
             _ => None,
         };
 

--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -170,6 +170,7 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
     for o in p.get_opts() {
         let compopt = match o.get_value_hint() {
             ValueHint::FilePath => Some("compopt -o filenames"),
+            ValueHint::DirPath => Some("compopt -o plusdirs"),
             _ => None,
         };
 
@@ -229,6 +230,8 @@ fn vals_for(o: &Arg) -> String {
                 .collect::<Vec<_>>()
                 .join(" ")
         )
+    } else if o.get_value_hint() == ValueHint::DirPath {
+        String::from("") // should be empty to avoid duplicate candidates
     } else if o.get_value_hint() == ValueHint::Other {
         String::from("\"${cur}\"")
     } else {

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -542,6 +542,9 @@ _exhaustive() {
                     ;;
                 --other)
                     COMPREPLY=("${cur}")
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o nospace
+                    fi
                     return 0
                     ;;
                 --path)

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -554,10 +554,16 @@ _exhaustive() {
                     ;;
                 --file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
                     return 0
                     ;;
                 -f)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
                     return 0
                     ;;
                 --dir)

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -567,11 +567,17 @@ _exhaustive() {
                     return 0
                     ;;
                 --dir)
-                    COMPREPLY=($(compgen -f "${cur}"))
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
                     return 0
                     ;;
                 -d)
-                    COMPREPLY=($(compgen -f "${cur}"))
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
                     return 0
                     ;;
                 --exe)

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -60,11 +60,17 @@ _my-app() {
                     return 0
                     ;;
                 --dir)
-                    COMPREPLY=($(compgen -f "${cur}"))
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
                     return 0
                     ;;
                 -d)
-                    COMPREPLY=($(compgen -f "${cur}"))
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
                     return 0
                     ;;
                 --exe)

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -47,10 +47,16 @@ _my-app() {
                     ;;
                 --file)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
                     return 0
                     ;;
                 -f)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
                     return 0
                     ;;
                 --dir)

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -35,6 +35,9 @@ _my-app() {
                     ;;
                 --other)
                     COMPREPLY=("${cur}")
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o nospace
+                    fi
                     return 0
                     ;;
                 --path)

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -210,7 +210,7 @@ fn complete() {
     }
 
     let input = "exhaustive hint --other \t";
-    let expected = "exhaustive hint --other         % exhaustive hint --other  ";
+    let expected = "exhaustive hint --other         % exhaustive hint --other ";
     let actual = runtime.complete(input, &term).unwrap();
     snapbox::assert_eq(expected, actual);
 }

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -164,7 +164,7 @@ fn complete() {
 
     // Issue 5239 (https://github.com/clap-rs/clap/issues/5239)
     let input = "exhaustive hint --file test\t";
-    let expected = "exhaustive hint --file test     % exhaustive hint --file tests ";
+    let expected = "exhaustive hint --file test     % exhaustive hint --file tests/";
     let actual = runtime.complete(input, &term).unwrap();
     snapbox::assert_eq(expected, actual);
 

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -200,8 +200,8 @@ fn complete() {
         );
         let actual = runtime.complete(input.as_str(), &term).unwrap();
         assert!(
-            actual.contains("a_file")
-                && actual.contains("b_file")
+            !actual.contains("a_file")
+                && !actual.contains("b_file")
                 && actual.contains("c_dir")
                 && actual.contains("d_dir"),
             "Actual output:\n{}",


### PR DESCRIPTION
This PR tries to improve bash completion support.

* Fix #5239
* Add support for `ValueHint::DirPath`
* Suppress a useless space appended during completion for `ValueHint::Other`