### PR TITLE
perf: avoid retrieving possible_values unless they're used

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -684,57 +684,56 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         let help_is_empty = help.is_empty();
         self.writer.push_styled(&help);
         if let Some(arg) = arg {
-            const DASH_SPACE: usize = "- ".len();
-            let possible_vals = arg.get_possible_values();
-            if !possible_vals.is_empty()
-                && !arg.is_hide_possible_values_set()
-                && self.use_long_pv(arg)
-            {
-                debug!("HelpTemplate::help: Found possible vals...{possible_vals:?}");
-                let longest = possible_vals
-                    .iter()
-                    .filter(|f| !f.is_hide_set())
-                    .map(|f| display_width(f.get_name()))
-                    .max()
-                    .expect("Only called with possible value");
+            if !arg.is_hide_possible_values_set() && self.use_long_pv(arg) {
+                const DASH_SPACE: usize = "- ".len();
+                let possible_vals = arg.get_possible_values();
+                if !possible_vals.is_empty() {
+                    debug!("HelpTemplate::help: Found possible vals...{possible_vals:?}");
+                    let longest = possible_vals
+                        .iter()
+                        .filter(|f| !f.is_hide_set())
+                        .map(|f| display_width(f.get_name()))
+                        .max()
+                        .expect("Only called with possible value");
 
-                let spaces = spaces + TAB_WIDTH - DASH_SPACE;
-                let trailing_indent = spaces + DASH_SPACE;
-                let trailing_indent = self.get_spaces(trailing_indent);
+                    let spaces = spaces + TAB_WIDTH - DASH_SPACE;
+                    let trailing_indent = spaces + DASH_SPACE;
+                    let trailing_indent = self.get_spaces(trailing_indent);
 
-                if !help_is_empty {
-                    let _ = write!(self.writer, "\n\n{:spaces$}", "");
-                }
-                self.writer.push_str("Possible values:");
-                for pv in possible_vals.iter().filter(|pv| !pv.is_hide_set()) {
-                    let name = pv.get_name();
-
-                    let mut descr = StyledStr::new();
-                    let _ = write!(
-                        &mut descr,
-                        "{}{name}{}",
-                        literal.render(),
-                        literal.render_reset()
-                    );
-                    if let Some(help) = pv.get_help() {
-                        debug!("HelpTemplate::help: Possible Value help");
-                        // To align help messages
-                        let padding = longest - display_width(name);
-                        let _ = write!(&mut descr, ": {:padding$}", "");
-                        descr.push_styled(help);
+                    if !help_is_empty {
+                        let _ = write!(self.writer, "\n\n{:spaces$}", "");
                     }
+                    self.writer.push_str("Possible values:");
+                    for pv in possible_vals.iter().filter(|pv| !pv.is_hide_set()) {
+                        let name = pv.get_name();
 
-                    let avail_chars = if self.term_w > trailing_indent.len() {
-                        self.term_w - trailing_indent.len()
-                    } else {
-                        usize::MAX
-                    };
-                    descr.replace_newline_var();
-                    descr.wrap(avail_chars);
-                    descr.indent("", &trailing_indent);
+                        let mut descr = StyledStr::new();
+                        let _ = write!(
+                            &mut descr,
+                            "{}{name}{}",
+                            literal.render(),
+                            literal.render_reset()
+                        );
+                        if let Some(help) = pv.get_help() {
+                            debug!("HelpTemplate::help: Possible Value help");
+                            // To align help messages
+                            let padding = longest - display_width(name);
+                            let _ = write!(&mut descr, ": {:padding$}", "");
+                            descr.push_styled(help);
+                        }
 
-                    let _ = write!(self.writer, "\n{:spaces$}- ", "",);
-                    self.writer.push_styled(&descr);
+                        let avail_chars = if self.term_w > trailing_indent.len() {
+                            self.term_w - trailing_indent.len()
+                        } else {
+                            usize::MAX
+                        };
+                        descr.replace_newline_var();
+                        descr.wrap(avail_chars);
+                        descr.indent("", &trailing_indent);
+
+                        let _ = write!(self.writer, "\n{:spaces$}- ", "",);
+                        self.writer.push_styled(&descr);
+                    }
                 }
             }
         }
@@ -844,17 +843,19 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             spec_vals.push(format!("[short aliases: {als}]"));
         }
 
-        let possible_vals = a.get_possible_values();
-        if !possible_vals.is_empty() && !a.is_hide_possible_values_set() && !self.use_long_pv(a) {
-            debug!("HelpTemplate::spec_vals: Found possible vals...{possible_vals:?}");
+        if !a.is_hide_possible_values_set() && !self.use_long_pv(a) {
+            let possible_vals = a.get_possible_values();
+            if !possible_vals.is_empty() {
+                debug!("HelpTemplate::spec_vals: Found possible vals...{possible_vals:?}");
 
-            let pvs = possible_vals
-                .iter()
-                .filter_map(PossibleValue::get_visible_quoted_name)
-                .collect::<Vec<_>>()
-                .join(", ");
+                let pvs = possible_vals
+                    .iter()
+                    .filter_map(PossibleValue::get_visible_quoted_name)
+                    .collect::<Vec<_>>()
+                    .join(", ");
 
-            spec_vals.push(format!("[possible values: {pvs}]"));
+                spec_vals.push(format!("[possible values: {pvs}]"));
+            }
         }
         let connector = if self.use_long { "\n" } else { " " };
         spec_vals.join(connector)

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -305,11 +305,15 @@ fn option_default_values(opt: &clap::Arg) -> Option<String> {
 }
 
 fn get_possible_values(arg: &clap::Arg) -> Option<(Vec<String>, bool)> {
+    if arg.is_hide_possible_values_set() {
+        return None;
+    }
+
     let possibles = &arg.get_possible_values();
     let possibles: Vec<&clap::builder::PossibleValue> =
         possibles.iter().filter(|pos| !pos.is_hide_set()).collect();
 
-    if !(possibles.is_empty() || arg.is_hide_possible_values_set()) {
+    if !possibles.is_empty() {
         return Some(format_possible_values(&possibles));
     }
     None


### PR DESCRIPTION
In some sophisticated situations, these may be expensive to calculate. One example might be a '--branch' option accepting any single Git branch that exists on the remote -- in such a case, the remote would need to be queried for all possible_values. The cost is ultimately unavoidable at runtime since this validation has to happen eventually, but there's no need to pay it when generating help text if `is_hide_possible_values_set`.

To keep '-h' fast, avoid collecting `possible_values` during '-h' unless we're actually going to use the values in display.

This optimization is repeated for the manpage renderer.

This is trivially based on the short-circuiting logic at `clap_builder/src/builder/command.rs:long_help_exists_`, which at least supports the idea that actually consuming the iterator is not generally-guaranteed behavior when `hide_possible_values` is set.

---

This seems like an obvious bug 'to me', but I recognize that there might be some angle to this that warrants discussion. If so, let me know and we can put this PR on ice while discussion happens in a tracking issue.