### PR TITLE
Correct safety docs

### DIFF
--- a/clap_lex/src/ext.rs
+++ b/clap_lex/src/ext.rs
@@ -2,6 +2,9 @@ use std::ffi::OsStr;
 
 pub trait OsStrExt: private::Sealed {
     /// Converts to a string slice.
+    ///
+    /// The Utf8Error is guaranteed to have a valid UTF8 boundary
+    /// in its `valid_up_to()`
     fn try_str(&self) -> Result<&str, std::str::Utf8Error>;
     /// Returns `true` if the given pattern matches a sub-slice of
     /// this string slice.

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -463,7 +463,8 @@ fn split_nonutf8_once(b: &OsStr) -> (&str, Option<&OsStr>) {
     match b.try_str() {
         Ok(s) => (s, None),
         Err(err) => {
-            // SAFETY: `char_indices` ensures `index` is at a valid UTF-8 boundary
+            // SAFETY: `err.valid_up_to()`, which came from str::from_utf8(), is guaranteed
+            // to be a valid UTF8 boundary
             let (valid, after_valid) = unsafe { ext::split_at(b, err.valid_up_to()) };
             let valid = valid.try_str().unwrap();
             (valid, Some(after_valid))


### PR DESCRIPTION
They weren't referring to the right thing.
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->