### PR TITLE
feat(clap_complete): Dynamic Completion: Support hiding possible values, flags, and subcommands by default

### DIFF
--- a/clap_complete/examples/dynamic.rs
+++ b/clap_complete/examples/dynamic.rs
@@ -1,3 +1,4 @@
+use clap::builder::PossibleValue;
 use clap::FromArgMatches;
 use clap::Subcommand;
 
@@ -13,7 +14,11 @@ fn command() -> clap::Command {
             clap::Arg::new("format")
                 .long("format")
                 .short('F')
-                .value_parser(["json", "yaml", "toml"]),
+                .value_parser([
+                    PossibleValue::new("json"),
+                    PossibleValue::new("yaml"),
+                    PossibleValue::new("toml").hide(true),
+                ]),
         )
         .args_conflicts_with_subcommands(true);
     clap_complete::dynamic::shells::CompleteCommand::augment_subcommands(cmd)

--- a/clap_complete/examples/dynamic.rs
+++ b/clap_complete/examples/dynamic.rs
@@ -4,6 +4,11 @@ use clap::Subcommand;
 
 fn command() -> clap::Command {
     let cmd = clap::Command::new("dynamic")
+        .subcommand(
+            clap::Command::new("hidden")
+                .about("Hidden subcommand")
+                .hide(true),
+        )
         .arg(
             clap::Arg::new("input")
                 .long("input")

--- a/clap_complete/examples/dynamic.rs
+++ b/clap_complete/examples/dynamic.rs
@@ -11,6 +11,13 @@ fn command() -> clap::Command {
                 .value_hint(clap::ValueHint::FilePath),
         )
         .arg(
+            clap::Arg::new("output")
+                .long("output")
+                .short('o')
+                .hide(true)
+                .value_hint(clap::ValueHint::FilePath),
+        )
+        .arg(
             clap::Arg::new("format")
                 .long("format")
                 .short('F')

--- a/clap_complete/src/dynamic/completer.rs
+++ b/clap_complete/src/dynamic/completer.rs
@@ -171,11 +171,16 @@ fn complete_arg_value(
 
     if let Some(possible_values) = possible_values(arg) {
         if let Ok(value) = value {
-            values.extend(possible_values.into_iter().filter_map(|p| {
-                let name = p.get_name();
-                name.starts_with(value)
-                    .then(|| (name.into(), p.get_help().cloned()))
-            }));
+            values.extend(
+                possible_values
+                    .into_iter()
+                    .filter(|p| value != "" || !p.is_hide_set())
+                    .filter_map(|p| {
+                        let name = p.get_name();
+                        name.starts_with(value)
+                            .then(|| (name.into(), p.get_help().cloned()))
+                    }),
+            );
         }
     } else {
         let value_os = match value {

--- a/clap_complete/src/dynamic/completer.rs
+++ b/clap_complete/src/dynamic/completer.rs
@@ -286,8 +286,8 @@ fn complete_subcommand(value: &str, cmd: &clap::Command) -> Vec<(OsString, Optio
 
     let mut scs = subcommands(cmd)
         .into_iter()
-        .filter(|x| x.0.starts_with(value))
-        .map(|x| (OsString::from(&x.0), x.1))
+        .filter(|(n, sc)| n.starts_with(value) && (value != "" || !sc.is_hide_set()))
+        .map(|(n, sc)| (OsString::from(&n), sc.get_about().cloned()))
         .collect::<Vec<_>>();
     scs.sort();
     scs.dedup();
@@ -338,11 +338,11 @@ fn possible_values(a: &clap::Arg) -> Option<Vec<clap::builder::PossibleValue>> {
 ///
 /// Subcommand `rustup toolchain install` would be converted to
 /// `("install", "rustup toolchain install")`.
-fn subcommands(p: &clap::Command) -> Vec<(String, Option<StyledStr>)> {
+fn subcommands(p: &clap::Command) -> Vec<(String, &clap::Command)> {
     debug!("subcommands: name={}", p.get_name());
     debug!("subcommands: Has subcommands...{:?}", p.has_subcommands());
 
     p.get_subcommands()
-        .map(|sc| (sc.get_name().to_string(), sc.get_about().cloned()))
+        .map(|sc| (sc.get_name().to_string(), sc))
         .collect()
 }

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -41,7 +41,8 @@ fn suggest_long_flag_subset() {
         .arg(
             clap::Arg::new("hello-moon")
                 .long("hello-moon")
-                .action(clap::ArgAction::Count),
+                .action(clap::ArgAction::Count)
+                .hide(true),
         )
         .arg(
             clap::Arg::new("goodbye-world")
@@ -54,6 +55,14 @@ fn suggest_long_flag_subset() {
 --hello-moon
 --help\tPrint help",
         complete!(cmd, "--he"),
+    );
+
+    snapbox::assert_eq(
+        "--hello-world
+--goodbye-world
+--help\tPrint help
+-h\tPrint help",
+        complete!(cmd, " "),
     );
 }
 

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -19,7 +19,7 @@ macro_rules! complete {
 fn suggest_subcommand_subset() {
     let mut cmd = Command::new("exhaustive")
         .subcommand(Command::new("hello-world"))
-        .subcommand(Command::new("hello-moon"))
+        .subcommand(Command::new("hello-moon").hide(true))
         .subcommand(Command::new("goodbye-world"));
 
     snapbox::assert_eq(
@@ -27,6 +27,15 @@ fn suggest_subcommand_subset() {
 hello-world
 help\tPrint this message or the help of the given subcommand(s)",
         complete!(cmd, "he"),
+    );
+
+    snapbox::assert_eq(
+        "--help\tPrint help
+-h\tPrint help
+goodbye-world
+hello-world
+help\tPrint this message or the help of the given subcommand(s)",
+        complete!(cmd, " "),
     );
 }
 

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -62,7 +62,7 @@ fn suggest_possible_value_subset() {
     let name = "exhaustive";
     let mut cmd = Command::new(name).arg(clap::Arg::new("hello-world").value_parser([
         PossibleValue::new("hello-world").help("Say hello to the world"),
-        "hello-moon".into(),
+        PossibleValue::new("hello-moon").hide(true),
         "goodbye-world".into(),
     ]));
 
@@ -70,6 +70,14 @@ fn suggest_possible_value_subset() {
         "hello-world\tSay hello to the world
 hello-moon",
         complete!(cmd, "hello"),
+    );
+
+    snapbox::assert_eq(
+        "--help\tPrint help (see more with '--help')
+-h\tPrint help (see more with '--help')
+hello-world\tSay hello to the world
+goodbye-world",
+        complete!(cmd, " "),
     );
 }
 


### PR DESCRIPTION
Closes #3951

For example, `--output` is hidden on listing all possible flags...

<img width="533" alt="image" src="https://github.com/clap-rs/clap/assets/12772118/868daa4f-5bf0-4753-b8d4-890bc2ff945d">

And it is visible when I type `--o`.

<img width="538" alt="image" src="https://github.com/clap-rs/clap/assets/12772118/ab4b2cc5-3cf7-484d-8ae1-507fb7748d19">
