### PR TITLE
fix: Allow position-sensitive flags

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4078,7 +4078,9 @@ impl Arg {
     }
 
     pub(crate) fn is_takes_value_set(&self) -> bool {
-        self.get_action().takes_values()
+        self.get_num_args()
+            .unwrap_or_else(|| 1.into())
+            .takes_values()
     }
 
     /// Report whether [`Arg::allow_hyphen_values`] is set

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -704,13 +704,14 @@ fn assert_arg(arg: &Arg) {
         arg.get_id(),
     );
 
-    assert_eq!(
-        arg.get_action().takes_values(),
-        arg.is_takes_value_set(),
-        "Argument `{}`'s selected action {:?} contradicts `takes_value`",
-        arg.get_id(),
-        arg.get_action()
-    );
+    if arg.is_takes_value_set() {
+        assert!(
+            arg.get_action().takes_values(),
+            "Argument `{}`'s selected action {:?} contradicts `takes_value`",
+            arg.get_id(),
+            arg.get_action()
+        );
+    }
     if let Some(action_type_id) = arg.get_action().value_type_id() {
         assert_eq!(
             action_type_id,

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -775,13 +775,6 @@ fn assert_arg(arg: &Arg) {
     }
 
     assert_eq!(
-        num_vals.takes_values(),
-        arg.is_takes_value_set(),
-        "Argument {}: mismatch between `num_args` ({}) and `takes_value`",
-        arg.get_id(),
-        num_vals,
-    );
-    assert_eq!(
         num_vals.is_multiple(),
         arg.is_multiple_values_set(),
         "Argument {}: mismatch between `num_args` ({}) and `multiple_values`",

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -99,7 +99,7 @@ pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
             (None, None) => vec![],
         };
 
-        if opt.get_action().takes_values() {
+        if opt.get_num_args().expect("built").takes_values() {
             if let Some(value) = &opt.get_value_names() {
                 header.push(roman("="));
                 header.push(italic(value.join(" ")));
@@ -288,7 +288,7 @@ fn option_environment(opt: &clap::Arg) -> Option<Vec<Inline>> {
 }
 
 fn option_default_values(opt: &clap::Arg) -> Option<String> {
-    if opt.is_hide_default_value_set() || !opt.get_action().takes_values() {
+    if opt.is_hide_default_value_set() || !opt.get_num_args().expect("built").takes_values() {
         return None;
     } else if !opt.get_default_values().is_empty() {
         let values = opt

--- a/examples/find.md
+++ b/examples/find.md
@@ -11,13 +11,15 @@ Options:
   -V, --version  Print version
 
 TESTS:
-      --empty        File is empty and is either a regular file or a directory
-      --name <NAME>  Base of file name (the path with the leading directories removed) matches shell
-                     pattern pattern
+      --empty [<empty>]  File is empty and is either a regular file or a directory [default: false]
+                         [possible values: true, false]
+      --name <name>      Base of file name (the path with the leading directories removed) matches
+                         shell pattern pattern
 
 OPERATORS:
-  -o, --or   expr2 is not evaluate if exp1 is true
-  -a, --and  Same as `expr1 expr1`
+  -o, --or [<or>]    expr2 is not evaluate if exp1 is true [default: false] [possible values: true,
+                     false]
+  -a, --and [<and>]  Same as `expr1 expr1` [default: false] [possible values: true, false]
 
 $ find --empty -o --name .keep
 [
@@ -42,12 +44,38 @@ $ find --empty -o --name .keep
 ]
 
 $ find --empty -o --name .keep -o --name foo
-? 2
-error: the argument '--or' cannot be used multiple times
-
-Usage: find [OPTIONS]
-
-For more information, try '--help'.
+[
+    (
+        "empty",
+        Bool(
+            true,
+        ),
+    ),
+    (
+        "or",
+        Bool(
+            true,
+        ),
+    ),
+    (
+        "name",
+        String(
+            ".keep",
+        ),
+    ),
+    (
+        "or",
+        Bool(
+            true,
+        ),
+    ),
+    (
+        "name",
+        String(
+            "foo",
+        ),
+    ),
+]
 
 ```
 

--- a/examples/find.md
+++ b/examples/find.md
@@ -11,15 +11,13 @@ Options:
   -V, --version  Print version
 
 TESTS:
-      --empty [<empty>]  File is empty and is either a regular file or a directory [default: false]
-                         [possible values: true, false]
-      --name <name>      Base of file name (the path with the leading directories removed) matches
-                         shell pattern pattern
+      --empty        File is empty and is either a regular file or a directory
+      --name <name>  Base of file name (the path with the leading directories removed) matches shell
+                     pattern pattern
 
 OPERATORS:
-  -o, --or [<or>]    expr2 is not evaluate if exp1 is true [default: false] [possible values: true,
-                     false]
-  -a, --and [<and>]  Same as `expr1 expr1` [default: false] [possible values: true, false]
+  -o, --or   expr2 is not evaluate if exp1 is true
+  -a, --and  Same as `expr1 expr1`
 
 $ find --empty -o --name .keep
 [

--- a/examples/find.md
+++ b/examples/find.md
@@ -41,5 +41,13 @@ $ find --empty -o --name .keep
     ),
 ]
 
+$ find --empty -o --name .keep -o --name foo
+? 2
+error: the argument '--or' cannot be used multiple times
+
+Usage: find [OPTIONS]
+
+For more information, try '--help'.
+
 ```
 

--- a/examples/find.rs
+++ b/examples/find.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use clap::{arg, command, ArgGroup, ArgMatches, Command};
+use clap::{command, value_parser, Arg, ArgAction, ArgGroup, ArgMatches, Command};
 
 fn main() {
     let matches = cli().get_matches();
@@ -13,14 +13,44 @@ fn cli() -> Command {
         .group(ArgGroup::new("tests").multiple(true))
         .next_help_heading("TESTS")
         .args([
-            arg!(--empty "File is empty and is either a regular file or a directory").group("tests"),
-            arg!(--name <NAME> "Base of file name (the path with the leading directories removed) matches shell pattern pattern").group("tests"),
+            Arg::new("empty")
+                .long("empty")
+                .num_args(0)
+                .value_parser(value_parser!(bool))
+                .default_missing_value("true")
+                .default_value("false")
+                .action(ArgAction::Append)
+                .help("File is empty and is either a regular file or a directory")
+                .group("tests"),
+            Arg::new("name")
+                .long("name")
+                .action(ArgAction::Append)
+                .help("Base of file name (the path with the leading directories removed) matches shell pattern pattern")
+                .group("tests")
         ])
         .group(ArgGroup::new("operators").multiple(true))
         .next_help_heading("OPERATORS")
         .args([
-            arg!(-o - -or "expr2 is not evaluate if exp1 is true").group("operators"),
-            arg!(-a - -and "Same as `expr1 expr1`").group("operators"),
+            Arg::new("or")
+                .short('o')
+                .long("or")
+                .num_args(0)
+                .value_parser(value_parser!(bool))
+                .default_missing_value("true")
+                .default_value("false")
+                .action(ArgAction::Append)
+                .help("expr2 is not evaluate if exp1 is true")
+                .group("operators"),
+            Arg::new("and")
+                .short('a')
+                .long("and")
+                .num_args(0)
+                .value_parser(value_parser!(bool))
+                .default_missing_value("true")
+                .default_value("false")
+                .action(ArgAction::Append)
+                .help("Same as `expr1 expr1`")
+                .group("operators"),
         ])
 }
 

--- a/examples/find.rs
+++ b/examples/find.rs
@@ -13,12 +13,8 @@ fn cli() -> Command {
         .group(ArgGroup::new("tests").multiple(true))
         .next_help_heading("TESTS")
         .args([
-            Arg::new("empty")
+            position_sensitive_flag(Arg::new("empty"))
                 .long("empty")
-                .num_args(0)
-                .value_parser(value_parser!(bool))
-                .default_missing_value("true")
-                .default_value("false")
                 .action(ArgAction::Append)
                 .help("File is empty and is either a regular file or a directory")
                 .group("tests"),
@@ -31,27 +27,28 @@ fn cli() -> Command {
         .group(ArgGroup::new("operators").multiple(true))
         .next_help_heading("OPERATORS")
         .args([
-            Arg::new("or")
+            position_sensitive_flag(Arg::new("or"))
                 .short('o')
                 .long("or")
-                .num_args(0)
-                .value_parser(value_parser!(bool))
-                .default_missing_value("true")
-                .default_value("false")
                 .action(ArgAction::Append)
                 .help("expr2 is not evaluate if exp1 is true")
                 .group("operators"),
-            Arg::new("and")
+            position_sensitive_flag(Arg::new("and"))
                 .short('a')
                 .long("and")
-                .num_args(0)
-                .value_parser(value_parser!(bool))
-                .default_missing_value("true")
-                .default_value("false")
                 .action(ArgAction::Append)
                 .help("Same as `expr1 expr1`")
                 .group("operators"),
         ])
+}
+
+fn position_sensitive_flag(arg: Arg) -> Arg {
+    // Flags don't track the position of each occurrence, so we need to emulate flags with
+    // value-less options to get the same result
+    arg.num_args(0)
+        .value_parser(value_parser!(bool))
+        .default_missing_value("true")
+        .default_value("false")
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
In writing up a reply to #5287, I tested our `find` example and realized it had the bug they were trying to workaround.  This PR adds support for options to act like flags.  We were already half-way there with `num_args(0..=1)`.  Not the most elegant solution for the user (elegant architecturally in clap) but it at least unblocks users.