### PR TITLE
chore: add VSCode DevContainer specification file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+	"name": "Rust",
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/apt-packages": {
+			"packages": "curl,ca-certificates,wget,net-tools,bash-completion"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"mhutchie.git-graph",
+				"rust-lang.rust-analyzer",
+				"mutantdino.resourcemonitor",
+				"GitHub.vscode-pull-request-github",
+				"GitHub.vscode-github-actions",
+				"bierner.markdown-preview-github-styles",
+				"me-dutour-mathieu.vscode-github-actions"
+			]
+		}
+	}
+}


### PR DESCRIPTION
This allows for one-click setup of a development environment with the
Rust compiler and a few useful VSCode extensions (as long as the host
machine has a container runtime available and functioning)

fixes #5295

Signed-off-by: ccap2 <58476525+ccap2@users.noreply.github.com>
