### PR TITLE
Correct title,name and synopsis in generated man pages for subcommands

### DIFF
--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -27,7 +27,7 @@ impl Man {
     /// Create a new manual page.
     pub fn new(mut cmd: clap::Command) -> Self {
         cmd.build();
-        let title = cmd.get_name().to_owned();
+        let title = cmd.get_display_name().unwrap_or_else(|| cmd.get_name()).to_owned();
         let section = "1".to_owned();
         let date = "".to_owned();
         let source = format!(

--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -27,7 +27,10 @@ impl Man {
     /// Create a new manual page.
     pub fn new(mut cmd: clap::Command) -> Self {
         cmd.build();
-        let title = cmd.get_display_name().unwrap_or_else(|| cmd.get_name()).to_owned();
+        let title = cmd
+            .get_display_name()
+            .unwrap_or_else(|| cmd.get_name())
+            .to_owned();
         let section = "1".to_owned();
         let date = "".to_owned();
         let source = format!(

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -9,9 +9,10 @@ pub(crate) fn subcommand_heading(cmd: &clap::Command) -> &str {
 }
 
 pub(crate) fn about(roff: &mut Roff, cmd: &clap::Command) {
+    let name = cmd.get_display_name().unwrap_or_else(|| cmd.get_name()).to_string();
     let s = match cmd.get_about().or_else(|| cmd.get_long_about()) {
-        Some(about) => format!("{} - {}", cmd.get_name(), about),
-        None => cmd.get_name().to_string(),
+        Some(about) => format!("{} - {}", name, about),
+        None => name,
     };
     roff.text([roman(s)]);
 }
@@ -29,7 +30,8 @@ pub(crate) fn description(roff: &mut Roff, cmd: &clap::Command) {
 }
 
 pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
-    let mut line = vec![bold(cmd.get_name()), roman(" ")];
+    let name = cmd.clone().render_usage().to_string();
+    let mut line = vec![bold(name), roman(" ")];
 
     for opt in cmd.get_arguments().filter(|i| !i.is_hide_set()) {
         let (lhs, rhs) = option_markers(opt);

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -9,10 +9,10 @@ pub(crate) fn subcommand_heading(cmd: &clap::Command) -> &str {
 }
 
 pub(crate) fn about(roff: &mut Roff, cmd: &clap::Command) {
-    let name = cmd.get_display_name().unwrap_or_else(|| cmd.get_name()).to_string();
+    let name = cmd.get_display_name().unwrap_or_else(|| cmd.get_name());
     let s = match cmd.get_about().or_else(|| cmd.get_long_about()) {
         Some(about) => format!("{} - {}", name, about),
-        None => name,
+        None => name.to_owned(),
     };
     roff.text([roman(s)]);
 }
@@ -30,7 +30,7 @@ pub(crate) fn description(roff: &mut Roff, cmd: &clap::Command) {
 }
 
 pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
-    let name = cmd.clone().render_usage().to_string();
+    let name = cmd.get_bin_name().unwrap_or_else(|| cmd.get_name());
     let mut line = vec![bold(name), roman(" ")];
 
     for opt in cmd.get_arguments().filter(|i| !i.is_hide_set()) {

--- a/clap_mangen/tests/snapshots/sub_subcommand_help.roff
+++ b/clap_mangen/tests/snapshots/sub_subcommand_help.roff
@@ -1,10 +1,10 @@
 .ie /n(.g .ds Aq /(aq
 .el .ds Aq '
-.TH help 1  "help " 
+.TH my-app-help 1  "help " 
 .SH NAME
-help /- Print this message or the help of the given subcommand(s)
+my/-app/-help /- Print this message or the help of the given subcommand(s)
 .SH SYNOPSIS
-/fBhelp/fR [/fIsubcommands/fR]
+/fBmy/-app help/fR [/fIsubcommands/fR]
 .SH DESCRIPTION
 Print this message or the help of the given subcommand(s)
 .SH SUBCOMMANDS


### PR DESCRIPTION
Print the "full" command in the name,title, and synopsis of subcommand man pages. Currently if clap was to generate a man page for `git add` the title and name would be simply `add`, not `git-add` like expected, and the synopsis would be `add <args>` not  `git add <args>`

- This PR changes this to obtain the title and name the same way as the subcommand names list in a man page, which was fixed by #4255 
- ~~To obtain the proper usage string (ex: `git add` not `git-add`) I believe we want [`Command.usage_name`](https://github.com/clap-rs/clap/blob/cbc9c9dd44fc4be25c196213d508b9d2a9c282f3/clap_builder/src/builder/command.rs#L92), but it is private and the only way I could find to obtain it is via `Command.render_usage()` which unfortunately forces an unnecessary clone. This also causes duplication of positional arguments (as can be seen below with `<COMMAND>` (the struct name) and `<subcommands>` both appearing in the synopsis. Suggestions on how to fix that are appreciated.~~ Fixed thanks to @EdJoPaTo suggestions :tada: 

Some minimal code to generate a cli with multiple sub (and subsub) commands to reproduce this can be found in my fork [here](https://github.com/Will-Shanks/clap/tree/mangen_subcommands)

Additional context can be found in #4231 

example (command = `mrc temp` from my linked test code)
Before:
```
temp(1)    General Commands Manual    temp(1)

NAME
       temp

SYNOPSIS
       temp [-h|--help] <subcommands>
```

After:
```
mrc-temp(1)    General Commands Manual    mrc-temp(1)

NAME
       mrc-temp

SYNOPSIS
       mrc temp [-h|--help] <subcommands>
```

