### PR TITLE
fix(parser): Don't panic with conflicts and groups

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -514,7 +514,7 @@ impl<'cmd> Parser<'cmd> {
                     arg_os.display().to_string(),
                     matcher
                         .arg_ids()
-                        .map(|id| self.cmd.find(id).unwrap().to_string())
+                        .filter_map(|id| self.cmd.find(id).map(|a| a.to_string()))
                         .collect(),
                     Usage::new(self.cmd).create_usage_with_title(&[]),
                 );


### PR DESCRIPTION
With #5298, I had overlooked that `matcher.arg_ids()` includes `ArgGroup`s.  I had assumed I could always find a present `id` among `Arg`s and `unwrap`ed.

I skipped a test for this because the use case is a bit strange that the long term value for the test would likely be low.
If/when we add derive support for `args_conflicts_with_subcommands`, it will then cover this case.

Fixes #5304

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
