### PR TITLE
Link to exit code info

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -588,7 +588,7 @@ impl Command {
         Error::raw(kind, message).format(self)
     }
 
-    /// Parse [`env::args_os`], exiting on failure.
+    /// Parse [`env::args_os`], [exiting][Error::exit] on failure.
     ///
     /// # Panics
     ///
@@ -610,7 +610,7 @@ impl Command {
         self.get_matches_from(env::args_os())
     }
 
-    /// Parse [`env::args_os`], exiting on failure.
+    /// Parse [`env::args_os`], [exiting][Error::exit] on failure.
     ///
     /// Like [`Command::get_matches`] but doesn't consume the `Command`.
     ///
@@ -670,7 +670,7 @@ impl Command {
         self.try_get_matches_from(env::args_os())
     }
 
-    /// Parse the specified arguments, exiting on failure.
+    /// Parse the specified arguments, [exiting][Error::exit] on failure.
     ///
     /// **NOTE:** The first argument will be parsed as the binary name unless
     /// [`Command::no_binary_name`] is used.

--- a/clap_builder/src/derive.rs
+++ b/clap_builder/src/derive.rs
@@ -22,7 +22,7 @@ use std::ffi::OsString;
 ///
 /// **NOTE:** Deriving requires the `derive` feature flag
 pub trait Parser: FromArgMatches + CommandFactory + Sized {
-    /// Parse from `std::env::args_os()`, exit on error
+    /// Parse from `std::env::args_os()`, [exit][Error::exit] on error.
     fn parse() -> Self {
         let mut matches = <Self as CommandFactory>::command().get_matches();
         let res = <Self as FromArgMatches>::from_arg_matches_mut(&mut matches)
@@ -43,7 +43,7 @@ pub trait Parser: FromArgMatches + CommandFactory + Sized {
         <Self as FromArgMatches>::from_arg_matches_mut(&mut matches).map_err(format_error::<Self>)
     }
 
-    /// Parse from iterator, exit on error
+    /// Parse from iterator, [exit][Error::exit] on error.
     fn parse_from<I, T>(itr: I) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -72,7 +72,7 @@ pub trait Parser: FromArgMatches + CommandFactory + Sized {
         <Self as FromArgMatches>::from_arg_matches_mut(&mut matches).map_err(format_error::<Self>)
     }
 
-    /// Update from iterator, exit on error
+    /// Update from iterator, [exit][Error::exit] on error.
     fn update_from<I, T>(&mut self, itr: I)
     where
         I: IntoIterator<Item = T>,


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Clap's default exit code has changed over time, and although it's documented it's a bit hard to find. This adds hyperlinks to the docs to make it easier to discover.

This follows on from #1653, #1327, #3426
