### PR TITLE
docs: Adjust how we approach `author`

### DIFF
--- a/examples/cargo-example-derive.rs
+++ b/examples/cargo-example-derive.rs
@@ -8,7 +8,7 @@ enum CargoCli {
 }
 
 #[derive(clap::Args)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct ExampleDeriveArgs {
     #[arg(long)]
     manifest_path: Option<std::path::PathBuf>,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 /// Simple program to greet a person
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Args {
     /// Name of the person to greet
     #[arg(short, long)]

--- a/examples/escaped-positional-derive.rs
+++ b/examples/escaped-positional-derive.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)] // requires `derive` feature
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     #[arg(short = 'f')]
     eff: bool,

--- a/examples/pacman.rs
+++ b/examples/pacman.rs
@@ -6,7 +6,6 @@ fn main() {
         .version("5.2.1")
         .subcommand_required(true)
         .arg_required_else_help(true)
-        .author("Pacman Development Team")
         // Query subcommand
         //
         // Only a few of its arguments are implemented below.

--- a/examples/tutorial_builder/02_apps.rs
+++ b/examples/tutorial_builder/02_apps.rs
@@ -3,7 +3,6 @@ use clap::{arg, Command};
 fn main() {
     let matches = Command::new("MyApp")
         .version("1.0")
-        .author("Kevin K. <kbknapp@gmail.com>")
         .about("Does awesome things")
         .arg(arg!(--two <VALUE>).required(true))
         .arg(arg!(--one <VALUE>).required(true))

--- a/examples/tutorial_derive/01_quick.rs
+++ b/examples/tutorial_derive/01_quick.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     /// Optional name to operate on
     name: Option<String>,

--- a/examples/tutorial_derive/02_app_settings.rs
+++ b/examples/tutorial_derive/02_app_settings.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 #[command(next_line_help = true)]
 struct Cli {
     #[arg(long)]

--- a/examples/tutorial_derive/02_apps.rs
+++ b/examples/tutorial_derive/02_apps.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 
 #[derive(Parser)]
 #[command(name = "MyApp")]
-#[command(author = "Kevin K. <kbknapp@gmail.com>")]
 #[command(version = "1.0")]
 #[command(about = "Does awesome things", long_about = None)]
 struct Cli {

--- a/examples/tutorial_derive/02_crate.rs
+++ b/examples/tutorial_derive/02_crate.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)] // Read from `Cargo.toml`
+#[command(version, about, long_about = None)] // Read from `Cargo.toml`
 struct Cli {
     #[arg(long)]
     two: String,

--- a/examples/tutorial_derive/03_01_flag_bool.rs
+++ b/examples/tutorial_derive/03_01_flag_bool.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     #[arg(short, long)]
     verbose: bool,

--- a/examples/tutorial_derive/03_01_flag_count.rs
+++ b/examples/tutorial_derive/03_01_flag_count.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,

--- a/examples/tutorial_derive/03_02_option.rs
+++ b/examples/tutorial_derive/03_02_option.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     #[arg(short, long)]
     name: Option<String>,

--- a/examples/tutorial_derive/03_02_option_mult.rs
+++ b/examples/tutorial_derive/03_02_option_mult.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     #[arg(short, long)]
     name: Vec<String>,

--- a/examples/tutorial_derive/03_03_positional.rs
+++ b/examples/tutorial_derive/03_03_positional.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     name: Option<String>,
 }

--- a/examples/tutorial_derive/03_03_positional_mult.rs
+++ b/examples/tutorial_derive/03_03_positional_mult.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     name: Vec<String>,
 }

--- a/examples/tutorial_derive/03_04_subcommands.rs
+++ b/examples/tutorial_derive/03_04_subcommands.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 #[command(propagate_version = true)]
 struct Cli {
     #[command(subcommand)]

--- a/examples/tutorial_derive/03_04_subcommands_alt.rs
+++ b/examples/tutorial_derive/03_04_subcommands_alt.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 #[command(propagate_version = true)]
 struct Cli {
     #[command(subcommand)]

--- a/examples/tutorial_derive/03_05_default_values.rs
+++ b/examples/tutorial_derive/03_05_default_values.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     #[arg(default_value_t = 2020)]
     port: u16,

--- a/examples/tutorial_derive/04_01_enum.rs
+++ b/examples/tutorial_derive/04_01_enum.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, ValueEnum};
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     /// What mode to run the program in
     #[arg(value_enum)]

--- a/examples/tutorial_derive/04_02_parse.rs
+++ b/examples/tutorial_derive/04_02_parse.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     /// Network port to use
     #[arg(value_parser = clap::value_parser!(u16).range(1..))]

--- a/examples/tutorial_derive/04_02_validate.rs
+++ b/examples/tutorial_derive/04_02_validate.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     /// Network port to use
     #[arg(value_parser = port_in_range)]

--- a/examples/tutorial_derive/04_03_relations.rs
+++ b/examples/tutorial_derive/04_03_relations.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Parser};
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     #[command(flatten)]
     vers: Vers,

--- a/examples/tutorial_derive/04_04_custom.rs
+++ b/examples/tutorial_derive/04_04_custom.rs
@@ -2,7 +2,7 @@ use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     /// set version manually
     #[arg(long, value_name = "VER")]

--- a/examples/tutorial_derive/05_01_assert.rs
+++ b/examples/tutorial_derive/05_01_assert.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(version, about, long_about = None)]
 struct Cli {
     /// Network port to use
     port: u16,

--- a/src/_derive/_tutorial/chapter_1.rs
+++ b/src/_derive/_tutorial/chapter_1.rs
@@ -8,7 +8,7 @@
 //!
 #![doc = include_str!("../../../examples/tutorial_derive/02_apps.md")]
 //!
-//! You can use [`#[command(author, version, about)]` attribute defaults][super#command-attributes] on the struct to fill these fields in from your `Cargo.toml` file.
+//! You can use [`#[command(version, about)]` attribute defaults][super#command-attributes] on the struct to fill these fields in from your `Cargo.toml` file.
 //!
 //! ```rust
 #![doc = include_str!("../../../examples/tutorial_derive/02_crate.rs")]

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -148,6 +148,7 @@
 //! - `author [= <expr>]`: [`Command::author`][crate::Command::author]
 //!   - When not present: no author set
 //!   - Without `<expr>`: defaults to [crate `authors`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field)
+//!   - **NOTE:** A custom [`help_template`][crate::Command::help_template] is needed for author to show up.
 //! - `about [= <expr>]`: [`Command::about`][crate::Command::about]
 //!   - When not present: [Doc comment summary](#doc-comments)
 //!   - Without `<expr>`: [crate `description`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-description-field) ([`Parser`][crate::Parser] container)


### PR DESCRIPTION
We've been getting questions like #5316 which shows that the discoverability of how to see that field is less than ideal.  In fact, it only is talked about for the sake of version migration and for `Command::author`.  Most derive users won't see that.

Steps
- Point derive users to `help_template,` like `Command::author` does
- Don't have useless `author` attributes that raise the question (rather than document it in the tutorial)

`command!` doesn't mention `author`, so I left it alone.