### PR TITLE
feat(mangen): generate filename and files

### DIFF
--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -95,6 +95,51 @@ impl Man {
     }
 }
 
+/// Handle [`Man`] in relation to files
+impl Man {
+    /// Generate the filename of the manual page
+    #[must_use]
+    pub fn get_filename(&self) -> String {
+        format!(
+            "{}.{}",
+            self.cmd
+                .get_display_name()
+                .unwrap_or_else(|| self.cmd.get_name()),
+            self.section
+        )
+    }
+
+    /// [Renders](Man::render) the manual page and writes it to a file
+    pub fn generate_to<Dir>(&self, out_dir: Dir) -> Result<std::path::PathBuf, std::io::Error>
+    where
+        Dir: AsRef<std::path::Path>,
+    {
+        let filepath = out_dir.as_ref().join(self.get_filename());
+        let mut file = std::fs::File::create(&filepath)?;
+        self.render(&mut file)?;
+        file.flush()?;
+        Ok(filepath)
+    }
+}
+
+/// Generate manual page files for the command with all subcommands
+pub fn generate_to<Dir>(cmd: clap::Command, out_dir: Dir) -> Result<(), std::io::Error>
+where
+    Dir: AsRef<std::path::Path>,
+{
+    fn generate(cmd: clap::Command, out_dir: &std::path::Path) -> Result<(), std::io::Error> {
+        for cmd in cmd.get_subcommands().cloned() {
+            generate(cmd, out_dir)?;
+        }
+        Man::new(cmd).generate_to(out_dir)?;
+        Ok(())
+    }
+
+    let mut cmd = cmd.disable_help_subcommand(true);
+    cmd.build();
+    generate(cmd, out_dir.as_ref())
+}
+
 /// Generate ROFF output
 impl Man {
     /// Render a full manual page into the writer.

--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -110,10 +110,10 @@ impl Man {
     }
 
     /// [Renders](Man::render) the manual page and writes it to a file
-    pub fn generate_to<Dir>(&self, out_dir: Dir) -> Result<std::path::PathBuf, std::io::Error>
-    where
-        Dir: AsRef<std::path::Path>,
-    {
+    pub fn generate_to(
+        &self,
+        out_dir: impl AsRef<std::path::Path>,
+    ) -> Result<std::path::PathBuf, std::io::Error> {
         let filepath = out_dir.as_ref().join(self.get_filename());
         let mut file = std::fs::File::create(&filepath)?;
         self.render(&mut file)?;
@@ -123,10 +123,10 @@ impl Man {
 }
 
 /// Generate manual page files for the command with all subcommands
-pub fn generate_to<Dir>(cmd: clap::Command, out_dir: Dir) -> Result<(), std::io::Error>
-where
-    Dir: AsRef<std::path::Path>,
-{
+pub fn generate_to(
+    cmd: clap::Command,
+    out_dir: impl AsRef<std::path::Path>,
+) -> Result<(), std::io::Error> {
     fn generate(cmd: clap::Command, out_dir: &std::path::Path) -> Result<(), std::io::Error> {
         for cmd in cmd.get_subcommands().cloned() {
             generate(cmd, out_dir)?;


### PR DESCRIPTION
The API is inspired by clap_complete. Similar code is already used by other people like in #4231. Not everyone should write the same code again.

In order to correctly create the man pages of the subcommands #5301 is also needed.