### PR TITLE
fix(complete): Prevent filenames splitting in bash completion

### DIFF
--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -178,10 +178,23 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
 
         if let Some(longs) = o.get_long_and_visible_aliases() {
             opts.extend(longs.iter().map(|long| {
-                let mut v = vec![
-                    format!("--{})", long),
-                    format!("COMPREPLY=({})", vals_for(o)),
-                ];
+                let mut v = vec![format!("--{})", long)];
+
+                if o.get_value_hint() == ValueHint::FilePath {
+                    v.extend([
+                        "local oldifs".to_string(),
+                        "if [[ -v IFS ]]; then".to_string(),
+                        r#"    oldifs="$IFS""#.to_string(),
+                        "fi".to_string(),
+                        r#"IFS=$'\n'"#.to_string(),
+                        format!("COMPREPLY=({})", vals_for(o)),
+                        "if [[ -v oldifs ]]; then".to_string(),
+                        r#"    IFS="$oldifs""#.to_string(),
+                        "fi".to_string(),
+                    ]);
+                } else {
+                    v.push(format!("COMPREPLY=({})", vals_for(o)));
+                }
 
                 if let Some(copt) = compopt {
                     v.extend([
@@ -198,10 +211,23 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
 
         if let Some(shorts) = o.get_short_and_visible_aliases() {
             opts.extend(shorts.iter().map(|short| {
-                let mut v = vec![
-                    format!("-{})", short),
-                    format!("COMPREPLY=({})", vals_for(o)),
-                ];
+                let mut v = vec![format!("-{})", short)];
+
+                if o.get_value_hint() == ValueHint::FilePath {
+                    v.extend([
+                        "local oldifs".to_string(),
+                        "if [[ -v IFS ]]; then".to_string(),
+                        r#"    oldifs="$IFS""#.to_string(),
+                        "fi".to_string(),
+                        r#"IFS=$'\n'"#.to_string(),
+                        format!("COMPREPLY=({})", vals_for(o)),
+                        "if [[ -v oldifs ]]; then".to_string(),
+                        r#"    IFS="$oldifs""#.to_string(),
+                        "fi".to_string(),
+                    ]);
+                } else {
+                    v.push(format!("COMPREPLY=({})", vals_for(o)));
+                }
 
                 if let Some(copt) = compopt {
                     v.extend([

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -556,14 +556,30 @@ _exhaustive() {
                     return 0
                     ;;
                 --file)
+                    local oldifs
+                    if [[ -v IFS ]]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ -v oldifs ]]; then
+                        IFS="$oldifs"
+                    fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o filenames
                     fi
                     return 0
                     ;;
                 -f)
+                    local oldifs
+                    if [[ -v IFS ]]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ -v oldifs ]]; then
+                        IFS="$oldifs"
+                    fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o filenames
                     fi

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -49,14 +49,30 @@ _my-app() {
                     return 0
                     ;;
                 --file)
+                    local oldifs
+                    if [[ -v IFS ]]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ -v oldifs ]]; then
+                        IFS="$oldifs"
+                    fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o filenames
                     fi
                     return 0
                     ;;
                 -f)
+                    local oldifs
+                    if [[ -v IFS ]]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
+                    if [[ -v oldifs ]]; then
+                        IFS="$oldifs"
+                    fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
                         compopt -o filenames
                     fi

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -222,6 +222,27 @@ fn complete() {
         );
     }
 
+    // Issue 5313 (https://github.com/clap-rs/clap/issues/5313)
+    {
+        use std::fs::File;
+        use std::path::Path;
+
+        let testdir = snapbox::path::PathFixture::mutable_temp().unwrap();
+        let testdir_path = testdir.path().unwrap();
+
+        File::create(Path::new(testdir_path).join("foo bar.txt")).unwrap();
+        File::create(Path::new(testdir_path).join("baz\tqux.txt")).unwrap();
+
+        let input = format!(
+            "exhaustive hint --file {}/\t\t",
+            testdir_path.to_string_lossy()
+        );
+        let expected = r#"% 
+foo      bar.txt  baz      qux.txt  "#;
+        let actual = runtime.complete(input.as_str(), &term).unwrap();
+        snapbox::assert_eq(expected, actual);
+    }
+
     let input = "exhaustive hint --other \t";
     let expected = "exhaustive hint --other         % exhaustive hint --other ";
     let actual = runtime.complete(input, &term).unwrap();

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -238,7 +238,7 @@ fn complete() {
             testdir_path.to_string_lossy()
         );
         let expected = r#"% 
-foo      bar.txt  baz      qux.txt  "#;
+foo bar.txt   baz^Iqux.txt  "#;
         let actual = runtime.complete(input.as_str(), &term).unwrap();
         snapbox::assert_eq(expected, actual);
     }


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Fix #5313 (and continuation of #5240)

The root cause is field splitting by bash.
It is erroneously performed when processing `compgen` output.
The delimiters used for field splitting are defined in `IFS` environment variable, which is `$' \t\n'` (space, tab, newline) by default. If the output of `compgen` contains these characters, they are split out.

This patch (partially) fixes that by restricting `IFS` to newline.
Now we can handle filenames with spaces and/or tabs, but not newlines because we cannot distinguish "newline as a delimiter" from "newline contained in filename".

Handling newlines would be more difficult than handling spaces. It seems that other completion scripts cannot handle this.
I think this should be a separate issue if we really try to fix this.