### PR TITLE
fix: Add missing clap::builder::OsStr impl

### DIFF
--- a/clap_builder/src/builder/os_str.rs
+++ b/clap_builder/src/builder/os_str.rs
@@ -64,16 +64,6 @@ impl From<Str> for OsStr {
     }
 }
 
-#[cfg(feature = "perf")]
-impl From<&'_ Str> for OsStr {
-    fn from(id: &'_ Str) -> Self {
-        match id.clone().into_inner() {
-            crate::builder::StrInner::Static(s) => Self::from_static_ref(std::ffi::OsStr::new(s)),
-            crate::builder::StrInner::Owned(s) => Self::from_ref(std::ffi::OsStr::new(s.as_ref())),
-        }
-    }
-}
-
 impl From<&'_ Str> for OsStr {
     fn from(id: &'_ Str) -> Self {
         id.clone().into()


### PR DESCRIPTION
Found via rust-lang/cargo#10554

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
