### PR TITLE
fix(error): Include -- in more cases 

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -1570,10 +1570,16 @@ impl<'cmd> Parser<'cmd> {
             .collect();
 
         // `did_you_mean` is a lot more likely and should cause us to skip the `--` suggestion
+        // with the one exception being that the CLI is trying to capture arguments
         //
         // In theory, this is only called for `--long`s, so we don't need to check
-        let suggested_trailing_arg =
-            did_you_mean.is_none() && !trailing_values && self.cmd.has_positionals();
+        let suggested_trailing_arg = (did_you_mean.is_none()
+            || self
+                .cmd
+                .get_positionals()
+                .any(|arg| arg.is_last_set() || arg.is_trailing_var_arg_set()))
+            && !trailing_values
+            && self.cmd.has_positionals();
         ClapError::unknown_argument(
             self.cmd,
             format!("--{arg}"),

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -165,6 +165,7 @@ fn suggest_trailing_last() {
 error: unexpected argument '--ignored' found
 
   tip: a similar argument exists: '--ignore-rust-version'
+  tip: to pass '--ignored' as a value, use '-- --ignored'
 
 Usage: cargo --ignore-rust-version [-- <TESTNAME>]
 

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -152,6 +152,29 @@ For more information, try '--help'.
 
 #[test]
 #[cfg(feature = "error-context")]
+fn suggest_trailing_last() {
+    let cmd = Command::new("cargo")
+        .arg(arg!([TESTNAME]).last(true))
+        .arg(arg!(--"ignore-rust-version"));
+
+    let res = cmd.try_get_matches_from(["cargo", "--ignored"]);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    let expected_kind = ErrorKind::UnknownArgument;
+    static MESSAGE: &str = "\
+error: unexpected argument '--ignored' found
+
+  tip: a similar argument exists: '--ignore-rust-version'
+
+Usage: cargo --ignore-rust-version [-- <TESTNAME>]
+
+For more information, try '--help'.
+";
+    assert_error(err, expected_kind, MESSAGE, true);
+}
+
+#[test]
+#[cfg(feature = "error-context")]
 fn trailing_already_in_use() {
     let cmd = Command::new("rg").arg(arg!([PATTERN]));
 


### PR DESCRIPTION
Inspired by rust-lang/cargo#12494.
Part of this is that our "did you mean" does prefix checks so it can be
overly aggressive in providing suggestions.
To avoid providing needless suggestions I limited this change to `last`
/ `trailing_var_arg` as those convey that `--` is more likely a valid
suggestion.