### PR TITLE
docs(builder): Avoid creating link to now-undocumented method

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1126,7 +1126,7 @@ impl Command {
         }
     }
 
-    /// Disables the automatic delimiting of values after `--` or when [`Command::trailing_var_arg`]
+    /// Disables the automatic delimiting of values after `--` or when [`Arg::trailing_var_arg`]
     /// was used.
     ///
     /// **NOTE:** The same thing can be done manually by setting the final positional argument to


### PR DESCRIPTION
(This is an obvious bug or documentation fix, so that's why I skip the issue creation process.)

Currently, the method [`Command::dont_delimit_trailing_values`](https://docs.rs/clap/latest/clap/struct.Command.html#method.dont_delimit_trailing_values) contains a link to `Command::trailing_var_arg`, but that link is dead, as the method is not documented ([anymore](https://github.com/clap-rs/clap/commit/bffce7f57a278d6e9026491c1d47933b987c61f2#diff-0ec4d4c3449555af0c6e9991c62e6d12d3b5d7a09e412f90b7b2b4e865007899R2003)).

Therefore, the documentation for this method should link to `Arg::trailing_var_arg` instead, which is exactly what this PR does.

Note that there are a few more questionable uses of `Command::trailing_var_arg`, which I didn't dare to touch:
```console
$ git grep -Firn 'nd::trailing_var'
clap_builder/src/builder/value_hint.rs:52:    /// [`.num_args(1..)`] and Command must use [`Command::trailing_var_arg(true)`]. The result is that the
clap_builder/src/builder/value_hint.rs:56:    /// [`Command::trailing_var_arg(true)`]: crate::Command::trailing_var_arg
clap_complete/examples/completion-derive.rs:56:    // Command::trailing_var_ar is required to use ValueHint::CommandWithArguments
```

The first two may or may not be outdated; the last one might be outdated, and is a typo in any case. But I'm not sure enough to fix either of them.

Bonus points if someone writes a linter that automatically checks whether documentation-internal links point to `#[doc(hidden)]` items. :-)