### PR TITLE
fix: use SCREAMING_SNAKE_CASE for static variable `authors`

### DIFF
--- a/clap_builder/src/macros.rs
+++ b/clap_builder/src/macros.rs
@@ -42,14 +42,14 @@ macro_rules! crate_version {
 #[macro_export]
 macro_rules! crate_authors {
     ($sep:expr) => {{
-        static authors: &str = env!("CARGO_PKG_AUTHORS");
-        if authors.contains(':') {
+        static AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
+        if AUTHORS.contains(':') {
             static CACHED: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-            let s = CACHED.get_or_init(|| authors.replace(':', $sep));
+            let s = CACHED.get_or_init(|| AUTHORS.replace(':', $sep));
             let s: &'static str = &*s;
             s
         } else {
-            authors
+            AUTHORS
         }
     }};
     () => {


### PR DESCRIPTION
This just quiets an annoying clippy warning :)

![image](https://github.com/clap-rs/clap/assets/29718261/26494cbd-256f-4e69-8754-2e900db5428c)
