### PR TITLE
feat(complete): support command alias completions

### DIFF
--- a/clap_complete/src/generator/utils.rs
+++ b/clap_complete/src/generator/utils.rs
@@ -49,6 +49,10 @@ pub fn subcommands(p: &Command) -> Vec<(String, String)> {
         );
 
         subcmds.push((sc.get_name().to_string(), sc_bin_name.to_string()));
+
+        for a in sc.get_visible_aliases() {
+            subcmds.push((a.to_string(), sc_bin_name.to_string()));
+        }
     }
 
     subcmds


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Fixes #4265 

first time contributor here! this is probably very naive!

this might be a good temporary "hack" while we wait for #3951 and #3166. if that's a problem maybe a feature flag can be introduced, because tools with a lot of very common aliases (like [`jj`](https://github.com/martinvonz/jj)) barely get any completion support right now