### PR TITLE
fix(complete): Avoid use of -v in bash completion

### DIFF
--- a/clap_complete/src/shells/bash.rs
+++ b/clap_complete/src/shells/bash.rs
@@ -183,12 +183,12 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
                 if o.get_value_hint() == ValueHint::FilePath {
                     v.extend([
                         "local oldifs".to_string(),
-                        "if [[ -v IFS ]]; then".to_string(),
+                        r#"if [ -n "${IFS+x}" ]; then"#.to_string(),
                         r#"    oldifs="$IFS""#.to_string(),
                         "fi".to_string(),
                         r#"IFS=$'\n'"#.to_string(),
                         format!("COMPREPLY=({})", vals_for(o)),
-                        "if [[ -v oldifs ]]; then".to_string(),
+                        r#"if [ -n "${oldifs+x}" ]; then"#.to_string(),
                         r#"    IFS="$oldifs""#.to_string(),
                         "fi".to_string(),
                     ]);
@@ -216,12 +216,12 @@ fn option_details_for_path(cmd: &Command, path: &str) -> String {
                 if o.get_value_hint() == ValueHint::FilePath {
                     v.extend([
                         "local oldifs".to_string(),
-                        "if [[ -v IFS ]]; then".to_string(),
+                        r#"if [ -n "${IFS+x}" ]; then"#.to_string(),
                         r#"    oldifs="$IFS""#.to_string(),
                         "fi".to_string(),
                         r#"IFS=$'\n'"#.to_string(),
                         format!("COMPREPLY=({})", vals_for(o)),
-                        "if [[ -v oldifs ]]; then".to_string(),
+                        r#"if [ -n "${oldifs+x}" ]; then"#.to_string(),
                         r#"    IFS="$oldifs""#.to_string(),
                         "fi".to_string(),
                     ]);

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -557,12 +557,12 @@ _exhaustive() {
                     ;;
                 --file)
                     local oldifs
-                    if [[ -v IFS ]]; then
+                    if [ -n "${IFS+x}" ]; then
                         oldifs="$IFS"
                     fi
                     IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
-                    if [[ -v oldifs ]]; then
+                    if [ -n "${oldifs+x}" ]; then
                         IFS="$oldifs"
                     fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -572,12 +572,12 @@ _exhaustive() {
                     ;;
                 -f)
                     local oldifs
-                    if [[ -v IFS ]]; then
+                    if [ -n "${IFS+x}" ]; then
                         oldifs="$IFS"
                     fi
                     IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
-                    if [[ -v oldifs ]]; then
+                    if [ -n "${oldifs+x}" ]; then
                         IFS="$oldifs"
                     fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -50,12 +50,12 @@ _my-app() {
                     ;;
                 --file)
                     local oldifs
-                    if [[ -v IFS ]]; then
+                    if [ -n "${IFS+x}" ]; then
                         oldifs="$IFS"
                     fi
                     IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
-                    if [[ -v oldifs ]]; then
+                    if [ -n "${oldifs+x}" ]; then
                         IFS="$oldifs"
                     fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -65,12 +65,12 @@ _my-app() {
                     ;;
                 -f)
                     local oldifs
-                    if [[ -v IFS ]]; then
+                    if [ -n "${IFS+x}" ]; then
                         oldifs="$IFS"
                     fi
                     IFS=$'\n'
                     COMPREPLY=($(compgen -f "${cur}"))
-                    if [[ -v oldifs ]]; then
+                    if [ -n "${oldifs+x}" ]; then
                         IFS="$oldifs"
                     fi
                     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then


### PR DESCRIPTION
Fix #5430 