### PR TITLE
fix(complete): Don't panic on broken pipe

### DIFF
--- a/clap_complete/src/macros.rs
+++ b/clap_complete/src/macros.rs
@@ -2,7 +2,13 @@ macro_rules! w {
     ($buf:expr, $to_w:expr) => {
         match $buf.write_all($to_w) {
             Ok(..) => (),
-            Err(..) => panic!("Failed to write to generated file"),
+            Err(err) if err.kind() == std::io::ErrorKind::BrokenPipe => {
+                // Is there a better exit code for this?
+                std::process::exit(1);
+            }
+            Err(err) => {
+                panic!("Failed to write to generated file: {0}", err);
+            }
         }
     };
 }


### PR DESCRIPTION
If the completion is piped to another command, for example into `less`, and that program stops before reading everything, the write fails and the program panics. Make it exit gracefully instead.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
