### PR TITLE
docs(examples): Add examples of same names multiple options.

### DIFF
--- a/examples/tutorial_builder/03_02_option_mult.md
+++ b/examples/tutorial_builder/03_02_option_mult.md
@@ -10,21 +10,15 @@ Options:
   -V, --version      Print version
 
 $ 03_02_option_mult
-name: None
+names: []
 
 $ 03_02_option_mult --name bob
-name: Some("bob")
+names: ["bob"]
 
-$ 03_02_option_mult --name=bob
-name: Some("bob")
+$ 03_02_option_mult --name bob --name john
+names: ["bob", "john"]
 
-$ 03_02_option_mult -n bob
-name: Some("bob")
-
-$ 03_02_option_mult -n=bob
-name: Some("bob")
-
-$ 03_02_option_mult -nbob
-name: Some("bob")
+$ 03_02_option_mult_derive --name bob --name=john -n tom -n=chris -nsteve
+name: ["bob", "john", "tom", "chris", "steve"]
 
 ```

--- a/examples/tutorial_builder/03_02_option_mult.rs
+++ b/examples/tutorial_builder/03_02_option_mult.rs
@@ -10,5 +10,11 @@ fn main() {
         )
         .get_matches();
 
-    println!("name: {:?}", matches.get_one::<String>("name"));
+    let args = matches
+        .get_many::<String>("name")
+        .unwrap_or_default()
+        .map(|v| v.as_str())
+        .collect::<Vec<_>>();
+
+    println!("names: {:?}", &args);
 }

--- a/examples/tutorial_derive/03_02_option_mult.md
+++ b/examples/tutorial_derive/03_02_option_mult.md
@@ -18,18 +18,6 @@ name: ["bob"]
 $ 03_02_option_mult_derive --name bob --name john
 name: ["bob", "john"]
 
-$ 03_02_option_mult_derive --name=bob
-name: ["bob"]
-
-$ 03_02_option_mult_derive -n bob
-name: ["bob"]
-
-$ 03_02_option_mult_derive -n=bob
-name: ["bob"]
-
-$ 03_02_option_mult_derive -nbob
-name: ["bob"]
-
 $ 03_02_option_mult_derive --name bob --name=john -n tom -n=chris -nsteve
 name: ["bob", "john", "tom", "chris", "steve"]
 

--- a/examples/tutorial_derive/03_02_option_mult.md
+++ b/examples/tutorial_derive/03_02_option_mult.md
@@ -15,6 +15,9 @@ name: []
 $ 03_02_option_mult_derive --name bob
 name: ["bob"]
 
+$ 03_02_option_mult_derive --name bob --name john
+name: ["bob", "john"]
+
 $ 03_02_option_mult_derive --name=bob
 name: ["bob"]
 
@@ -26,5 +29,8 @@ name: ["bob"]
 
 $ 03_02_option_mult_derive -nbob
 name: ["bob"]
+
+$ 03_02_option_mult_derive --name bob --name=john -n tom -n=chris -nsteve
+name: ["bob", "john", "tom", "chris", "steve"]
 
 ```


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
The examples `03_02_option_mult_derive` in https://docs.rs/clap/latest/clap/_derive/_tutorial/chapter_2/index.html#options did not include a case where the same option name is specified multiple times.
This PR adds such examples.