### PR TITLE
fix: ArgGroup::is_multiple does not require &mut self

### DIFF
--- a/clap_builder/src/builder/arg_group.rs
+++ b/clap_builder/src/builder/arg_group.rs
@@ -280,7 +280,7 @@ impl ArgGroup {
     ///
     /// assert!(group.is_multiple());
     /// ```
-    pub fn is_multiple(&mut self) -> bool {
+    pub fn is_multiple(&self) -> bool {
         self.multiple
     }
 


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
