### PR TITLE
Update doctring for BoolishValueParser::new

### DIFF
--- a/clap_builder/src/builder/value_parser.rs
+++ b/clap_builder/src/builder/value_parser.rs
@@ -1913,7 +1913,7 @@ impl Default for FalseyValueParser {
 pub struct BoolishValueParser {}
 
 impl BoolishValueParser {
-    /// Parse bool-like string values, everything else is `true`
+    /// Parse bool-like string values, everything else is an error.
     pub fn new() -> Self {
         Self {}
     }


### PR DESCRIPTION
There seems to be an inconsistency between the docstring and the behavior of `BoolishValueParser::new()`. The docstring makes it seem as if a non-boolish value will default to `true`. This is not the case. Instead, an error occurs during parsing, which can be seen in the example code for `BoolishValueParser`.

Updating the docstring to align with current behavior.