### PR TITLE
feat: add require no space to argument short version

### DIFF
--- a/clap_builder/src/builder/arg_settings.rs
+++ b/clap_builder/src/builder/arg_settings.rs
@@ -50,6 +50,7 @@ pub(crate) enum ArgSettings {
     AllowHyphenValues,
     AllowNegativeNumbers,
     RequireEquals,
+    RequireNoSpace,
     Last,
     TrailingVarArg,
     HideDefaultValue,

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -790,6 +790,13 @@ fn assert_arg(arg: &Arg) {
             arg.get_id(),
             num_vals
         );
+
+        assert!(
+            !arg.is_require_no_space_set(),
+            "Argument {}: cannot accept more than 1 arg (num_args={}) with require_no_space",
+            arg.get_id(),
+            num_vals
+        )
     }
 
     if num_vals == ValueRange::SINGLE {
@@ -827,6 +834,7 @@ fn assert_arg_flags(arg: &Arg) {
     checker!(is_allow_hyphen_values_set requires is_takes_value_set);
     checker!(is_allow_negative_numbers_set requires is_takes_value_set);
     checker!(is_require_equals_set requires is_takes_value_set);
+    checker!(is_require_no_space_set requires is_takes_value_set);
     checker!(is_last_set requires is_takes_value_set);
     checker!(is_hide_default_value_set requires is_takes_value_set);
     checker!(is_multiple_values_set requires is_takes_value_set);

--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -220,6 +220,20 @@ fn write_dynamic_context(
                 false
             }
         }
+        ErrorKind::SpaceFound => {
+            let invalid_arg = error.get(ContextKind::InvalidArg);
+            if let Some(ContextValue::String(invalid_arg)) = invalid_arg {
+                let _ = write!(
+                    styled,
+                    "no space is allowed when assigning values to '{}{invalid_arg}{}'",
+                    invalid.render(),
+                    invalid.render_reset()
+                );
+                true
+            } else {
+                false
+            }
+        }
         ErrorKind::InvalidValue => {
             let invalid_arg = error.get(ContextKind::InvalidArg);
             let invalid_value = error.get(ContextKind::InvalidValue);

--- a/clap_builder/src/error/kind.rs
+++ b/clap_builder/src/error/kind.rs
@@ -60,7 +60,7 @@ pub enum ErrorKind {
     /// [`UnknownArgument`]: ErrorKind::UnknownArgument
     InvalidSubcommand,
 
-    /// Occurs when the user doesn't use equals for an option that requires equal
+    /// Occurs when the user doesn't use equals for a long option that requires equal
     /// sign to provide values.
     ///
     /// ```rust
@@ -76,6 +76,23 @@ pub enum ErrorKind {
     /// assert_eq!(res.unwrap_err().kind(), ErrorKind::NoEquals);
     /// ```
     NoEquals,
+
+    /// Occurs when the user uses a space for a short option that requires no space
+    /// to provide values.
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, Arg, error::ErrorKind, ArgAction};
+    /// let res = Command::new("prog")
+    ///     .arg(Arg::new("color")
+    ///          .action(ArgAction::Set)
+    ///          .require_no_space(true)
+    ///          .short('c'))
+    ///     .try_get_matches_from(vec!["prog", "-c", "red"]);
+    /// assert!(res.is_err());
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::SpaceFound);
+    /// ```
+    SpaceFound,
 
     /// Occurs when the user provides a value for an argument with a custom validation and the
     /// value fails that validation.
@@ -338,6 +355,9 @@ impl ErrorKind {
             Self::UnknownArgument => Some("unexpected argument found"),
             Self::InvalidSubcommand => Some("unrecognized subcommand"),
             Self::NoEquals => Some("equal is needed when assigning values to one of the arguments"),
+            Self::SpaceFound => {
+                Some("no space is allowed when assigning values to one of the arguments")
+            }
             Self::ValueValidation => Some("invalid value for one of the arguments"),
             Self::TooManyValues => Some("unexpected value for an argument found"),
             Self::TooFewValues => Some("more values required for an argument"),

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -439,6 +439,22 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    pub(crate) fn space_found(cmd: &Command, arg: String, usage: Option<StyledStr>) -> Self {
+        let mut err = Self::new(ErrorKind::SpaceFound).with_cmd(cmd);
+
+        #[cfg(feature = "error-context")]
+        {
+            err = err
+                .extend_context_unchecked([(ContextKind::InvalidArg, ContextValue::String(arg))]);
+            if let Some(usage) = usage {
+                err = err
+                    .insert_context_unchecked(ContextKind::Usage, ContextValue::StyledStr(usage));
+            }
+        }
+
+        err
+    }
+
     pub(crate) fn invalid_value(
         cmd: &Command,
         bad_val: String,

--- a/clap_complete_fig/src/fig.rs
+++ b/clap_complete_fig/src/fig.rs
@@ -254,6 +254,16 @@ fn gen_options(cmd: &Command, indent: usize) -> String {
                 .unwrap();
             }
 
+            if option.is_require_no_space_set() {
+                write!(
+                    &mut buffer,
+                    "{:indent$}requiresNoSpace: true,\n",
+                    "",
+                    indent = indent + 4
+                )
+                .unwrap();
+            }
+
             write!(&mut buffer, "{:indent$}args: ", "", indent = indent + 4).unwrap();
 
             buffer.push_str(&gen_args(option, indent + 4));

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2004,6 +2004,121 @@ Options:
     utils::assert_output(cmd, "ctest -h", ISSUE_1487, false);
 }
 
+#[test]
+fn help_require_equals() {
+    static REQUIRE_EQUALS: &str = "\
+Usage: myapp [OPTIONS]
+
+Options:
+      --foo=<foo>  
+  -h, --help       Print help
+";
+    let cmd = Command::new("myapp").arg(
+        Arg::new("foo")
+            .long("foo")
+            .require_equals(true)
+            .action(ArgAction::Set),
+    );
+    utils::assert_output(cmd, "myapp -h", REQUIRE_EQUALS, false);
+}
+
+#[test]
+fn help_require_equals_short() {
+    static REQUIRE_EQUALS_SHORT: &str = "\
+Usage: myapp [OPTIONS]
+
+Options:
+  -f <foo>      
+  -h, --help    Print help
+";
+    let cmd = Command::new("myapp").arg(
+        Arg::new("foo")
+            .short('f')
+            .require_equals(true)
+            .action(ArgAction::Set),
+    );
+    utils::assert_output(cmd, "myapp -h", REQUIRE_EQUALS_SHORT, false);
+}
+
+#[test]
+fn help_require_no_space() {
+    static REQUIRE_NO_SPACE: &str = "\
+Usage: myapp [OPTIONS]
+
+Options:
+  -f<foo>      
+  -h, --help   Print help
+";
+    let cmd = Command::new("myapp").arg(
+        Arg::new("foo")
+            .short('f')
+            .require_no_space(true)
+            .action(ArgAction::Set),
+    );
+    utils::assert_output(cmd, "myapp -h", REQUIRE_NO_SPACE, false);
+}
+
+#[test]
+fn help_require_no_space_long() {
+    static REQUIRE_NO_SPACE_LONG: &str = "\
+Usage: myapp [OPTIONS]
+
+Options:
+      --foo <foo>  
+  -h, --help       Print help
+";
+    let cmd = Command::new("myapp").arg(
+        Arg::new("foo")
+            .long("foo")
+            .require_no_space(true)
+            .action(ArgAction::Set),
+    );
+    utils::assert_output(cmd, "myapp -h", REQUIRE_NO_SPACE_LONG, false);
+}
+
+#[test]
+fn help_require_equals_no_space() {
+    static REQUIRE_EQUALS_NO_SPACE: &str = "\
+Usage: myapp [OPTIONS]
+
+Options:
+  -f<foo>, --foo=<foo>  This is foo
+  -h, --help            Print help
+";
+    let cmd = Command::new("myapp").arg(
+        Arg::new("foo")
+            .long("foo")
+            .short('f')
+            .help("This is foo")
+            .require_equals(true)
+            .require_no_space(true)
+            .action(ArgAction::Set),
+    );
+    utils::assert_output(cmd, "myapp -h", REQUIRE_EQUALS_NO_SPACE, false);
+}
+
+#[test]
+fn help_require_equals_no_space_optional() {
+    static REQUIRE_EQUALS_NO_SPACE_OPTIONAL: &str = "\
+Usage: myapp [OPTIONS]
+
+Options:
+  -f[<foo>], --foo[=<foo>]  This is foo
+  -h, --help                Print help
+";
+    let cmd = Command::new("myapp").arg(
+        Arg::new("foo")
+            .long("foo")
+            .short('f')
+            .help("This is foo")
+            .num_args(0..=1)
+            .require_equals(true)
+            .require_no_space(true)
+            .action(ArgAction::Set),
+    );
+    utils::assert_output(cmd, "myapp -h", REQUIRE_EQUALS_NO_SPACE_OPTIONAL, false);
+}
+
 #[cfg(debug_assertions)]
 #[test]
 #[should_panic = "Command::help_expected is enabled for the Command"]


### PR DESCRIPTION
Fix #3030.

This PR enables restricting the short option to the `-oval` syntax with the `require_no_space` argument setting, and changes `require_equals` to only affect the long option `--option=val` (**BREAKING CHANGE**). This will allow compliance with the POSIX and GNU conventions as mentioned in the issue by setting both `require_no_space` and `require_equals` to true:

> In clap terms, these are saying we should only allow
> 
> - `--long`
> - `--long=value`
> - `-s`
> - `-svalue`

Here is an example help message that demonstrates this:

```
Usage: myapp [OPTIONS]

Options:
  -f[<foo>], --foo[=<foo>]  This is foo
  -h, --help                Print help
```

A specific real-world application that has motivated this is [uutils/coreutils](https://github.com/uutils/coreutils) which aims to mirror the GNU version as closely as possible. However, their `date -I/--iso-8601` implementation, for example, accepts values that are not considered valid (e.g. `date -I seconds` and `date -I=seconds`), and there is no possible workaround.

The changes made to `require_equals` may break current applications that take a positional argument after an optional option-argument, e.g.

```
Command::new("prog")
    .arg(
        Arg::new("cfg")
            .action(ArgAction::Set)
            .require_equals(true)
            .num_args(0..)
            .short('c'),
    )
    .arg(Arg::new("cmd"))
    .try_get_matches_from(vec!["prog", "-c", "cmd"]);
```
Currently `cmd` would be treated as the second argument, but after the PR where `require_equals` no longer works on short option, it will become the associated value to the first. 

Migration to the new major version (if this is merged) should complement `require_equals` with `require_no_space` and replace `-o=val` usage with `-oval`, otherwise the associated value would become `=val` as `=` is parsed as part of the value.