### PR TITLE
fix(fish completions): quote short options too

### DIFF
--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -116,7 +116,13 @@ fn gen_fish_inner(
 
         if let Some(shorts) = flag.get_short_and_visible_aliases() {
             for short in shorts {
-                template.push_str(format!(" -s {short}").as_str());
+				match short {
+					'a'..='z' =>
+						template.push_str(format!(" -s {short}").as_str()),
+					_ => {
+						template.push_str(format!(" -s {}", escape_string(&short.to_string(), false)).as_str());
+					}
+				}
             }
         }
 


### PR DESCRIPTION
this should make things a bit easier for any programs that want to make '-?' an alias for '--help'

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
