### PR TITLE
fix(parser): Allow exclusive to override required_* 

### DIFF
--- a/clap_builder/src/parser/validator.rs
+++ b/clap_builder/src/parser/validator.rs
@@ -335,7 +335,7 @@ impl<'cmd> Validator<'cmd> {
                 required = true;
             }
 
-            if required {
+            if !is_exclusive_present && required {
                 missing_required.push(a.get_id().clone());
                 if !a.is_last_set() {
                     highest_index = highest_index.max(a.get_index().unwrap_or(0));

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -721,7 +721,7 @@ fn exclusive_with_required_unless_present() {
 
     cmd.clone()
         .try_get_matches_from(["bug", "--exclusive"])
-        .unwrap_err();
+        .unwrap();
 }
 
 #[test]
@@ -761,7 +761,7 @@ fn exclusive_with_required_unless_present_any() {
 
     cmd.clone()
         .try_get_matches_from(["bug", "--exclusive"])
-        .unwrap_err();
+        .unwrap();
 }
 
 #[test]
@@ -801,7 +801,7 @@ fn exclusive_with_required_unless_present_all() {
 
     cmd.clone()
         .try_get_matches_from(["bug", "--exclusive"])
-        .unwrap_err();
+        .unwrap();
 }
 
 #[test]

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -685,6 +685,126 @@ fn exclusive_with_required() {
 }
 
 #[test]
+fn exclusive_with_required_unless_present() {
+    let cmd = Command::new("bug")
+        .arg(
+            Arg::new("exclusive")
+                .long("exclusive")
+                .action(ArgAction::SetTrue)
+                .exclusive(true),
+        )
+        .arg(
+            Arg::new("required")
+                .long("required")
+                .action(ArgAction::SetTrue)
+                .required_unless_present("alternative"),
+        )
+        .arg(
+            Arg::new("alternative")
+                .long("alternative")
+                .action(ArgAction::SetTrue),
+        );
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--required"])
+        .unwrap();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--alternative"])
+        .unwrap();
+
+    cmd.clone().try_get_matches_from(["bug"]).unwrap_err();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--exclusive", "--required"])
+        .unwrap_err();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--exclusive"])
+        .unwrap_err();
+}
+
+#[test]
+fn exclusive_with_required_unless_present_any() {
+    let cmd = Command::new("bug")
+        .arg(
+            Arg::new("exclusive")
+                .long("exclusive")
+                .action(ArgAction::SetTrue)
+                .exclusive(true),
+        )
+        .arg(
+            Arg::new("required")
+                .long("required")
+                .action(ArgAction::SetTrue)
+                .required_unless_present_any(["alternative"]),
+        )
+        .arg(
+            Arg::new("alternative")
+                .long("alternative")
+                .action(ArgAction::SetTrue),
+        );
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--required"])
+        .unwrap();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--alternative"])
+        .unwrap();
+
+    cmd.clone().try_get_matches_from(["bug"]).unwrap_err();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--exclusive", "--required"])
+        .unwrap_err();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--exclusive"])
+        .unwrap_err();
+}
+
+#[test]
+fn exclusive_with_required_unless_present_all() {
+    let cmd = Command::new("bug")
+        .arg(
+            Arg::new("exclusive")
+                .long("exclusive")
+                .action(ArgAction::SetTrue)
+                .exclusive(true),
+        )
+        .arg(
+            Arg::new("required")
+                .long("required")
+                .action(ArgAction::SetTrue)
+                .required_unless_present_all(["alternative"]),
+        )
+        .arg(
+            Arg::new("alternative")
+                .long("alternative")
+                .action(ArgAction::SetTrue),
+        );
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--required"])
+        .unwrap();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--alternative"])
+        .unwrap();
+
+    cmd.clone().try_get_matches_from(["bug"]).unwrap_err();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--exclusive", "--required"])
+        .unwrap_err();
+
+    cmd.clone()
+        .try_get_matches_from(["bug", "--exclusive"])
+        .unwrap_err();
+}
+
+#[test]
 #[cfg(feature = "error-context")]
 fn option_conflicts_with_subcommand() {
     static CONFLICT_ERR: &str = "\


### PR DESCRIPTION
There are other cases for `required` that aren't being handled
- Groups
- Conflicts

I'm concerned there might be weird corner cases and didn't want the
analysis for that to block fixing this.

Fixes #5507