### PR TITLE
fix(zsh): Separate options from _arguments options

### DIFF
--- a/clap_complete/src/shells/zsh.rs
+++ b/clap_complete/src/shells/zsh.rs
@@ -322,7 +322,7 @@ fn parser_of<'cmd>(parent: &'cmd Command, bin_name: &str) -> Option<&'cmd Comman
 fn get_args_of(parent: &Command, p_global: Option<&Command>) -> String {
     debug!("get_args_of");
 
-    let mut segments = vec![String::from("_arguments \"${_arguments_options[@]}\" \\")];
+    let mut segments = vec![String::from("_arguments \"${_arguments_options[@]}\" : \\")];
     let opts = write_opts_of(parent, p_global);
     let flags = write_flags_of(parent, p_global);
     let positionals = write_positionals_of(parent);

--- a/clap_complete/tests/snapshots/aliases.zsh
+++ b/clap_complete/tests/snapshots/aliases.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-o+[cmd option]: : ' \
 '-O+[cmd option]: : ' \
 '--option=[cmd option]: : ' \

--- a/clap_complete/tests/snapshots/basic.zsh
+++ b/clap_complete/tests/snapshots/basic.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-c[]' \
 '(-c)-v[]' \
 '-h[Print help]' \
@@ -29,7 +29,7 @@ _my-app() {
         curcontext="${curcontext%:*:*}:my-app-command-$line[1]:"
         case $line[1] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '*-d[]' \
 '-c[]' \
 '-h[Print help]' \
@@ -37,7 +37,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -49,11 +49,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-help-command-$line[1]:"
         case $line[1] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/custom_bin_name.zsh
+++ b/clap_complete/tests/snapshots/custom_bin_name.zsh
@@ -14,7 +14,7 @@ _bin-name() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-c[]' \
 '(-c)-v[]' \
 '-h[Print help]' \
@@ -29,7 +29,7 @@ _bin-name() {
         curcontext="${curcontext%:*:*}:bin-name-command-$line[1]:"
         case $line[1] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '*-d[]' \
 '-c[]' \
 '-h[Print help]' \
@@ -37,7 +37,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_bin-name__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -49,11 +49,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:bin-name-help-command-$line[1]:"
         case $line[1] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '*-c[some config file]' \
 '*-C[some config file]' \
 '*--config[some config file]' \
@@ -35,7 +35,7 @@ _my-app() {
         curcontext="${curcontext%:*:*}:my-app-command-$line[3]:"
         case $line[3] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--case=[the case to test]: : ' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -44,7 +44,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -56,11 +56,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-help-command-$line[1]:"
         case $line[1] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
@@ -14,7 +14,7 @@ _exhaustive() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '--generate=[generate]:SHELL:(bash elvish fish powershell zsh)' \
 '--global[everywhere]' \
 '-h[Print help]' \
@@ -31,7 +31,7 @@ _exhaustive() {
         curcontext="${curcontext%:*:*}:exhaustive-command-$line[1]:"
         case $line[1] in
             (action)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--set=[value]: : ' \
 '--choice=[enum]: :(first second)' \
 '--set-true[bool]' \
@@ -44,7 +44,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (quote)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--choice=[]: :((bash\:"bash (shell)"
 fish\:"fish shell"
 zsh\:"zsh shell"))' \
@@ -70,7 +70,7 @@ zsh\:"zsh shell"))' \
         curcontext="${curcontext%:*:*}:exhaustive-quote-command-$line[1]:"
         case $line[1] in
             (cmd-single-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -79,7 +79,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (cmd-double-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -88,7 +88,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (cmd-backticks)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -97,7 +97,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (cmd-backslash)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -106,7 +106,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (cmd-brackets)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -115,7 +115,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (cmd-expansions)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -124,7 +124,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (escape-help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -133,7 +133,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_exhaustive__quote__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -145,35 +145,35 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:exhaustive-quote-help-command-$line[1]:"
         case $line[1] in
             (cmd-single-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-double-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-backticks)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-backslash)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-brackets)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-expansions)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (escape-help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac
@@ -185,7 +185,7 @@ esac
 esac
 ;;
 (value)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--delim=[]: : ' \
 '--tuple=[]: : : : ' \
 '--require-eq=[]: : ' \
@@ -198,7 +198,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (pacman)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -215,7 +215,7 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:exhaustive-pacman-command-$line[1]:"
         case $line[1] in
             (one)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -224,7 +224,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (two)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -233,7 +233,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_exhaustive__pacman__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -245,15 +245,15 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:exhaustive-pacman-help-command-$line[1]:"
         case $line[1] in
             (one)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (two)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac
@@ -265,7 +265,7 @@ esac
 esac
 ;;
 (last)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--global[everywhere]' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -276,7 +276,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (alias)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-o+[cmd option]: : ' \
 '-O+[cmd option]: : ' \
 '--option=[cmd option]: : ' \
@@ -294,7 +294,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (hint)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--choice=[]: :(bash fish zsh)' \
 '--unknown=[]: : ' \
 '--other=[]: :( )' \
@@ -324,7 +324,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (complete)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--shell=[Specify shell to complete for]:SHELL:(bash fish)' \
 '--register=[Path to write completion-registration to]:REGISTER:_files' \
 '--global[everywhere]' \
@@ -336,7 +336,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_exhaustive__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -348,11 +348,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:exhaustive-help-command-$line[1]:"
         case $line[1] in
             (action)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (quote)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_exhaustive__help__quote_commands" \
 "*::: :->quote" \
 && ret=0
@@ -364,31 +364,31 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:exhaustive-help-quote-command-$line[1]:"
         case $line[1] in
             (cmd-single-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-double-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-backticks)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-backslash)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-brackets)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-expansions)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (escape-help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac
@@ -396,11 +396,11 @@ _arguments "${_arguments_options[@]}" \
 esac
 ;;
 (value)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (pacman)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_exhaustive__help__pacman_commands" \
 "*::: :->pacman" \
 && ret=0
@@ -412,11 +412,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:exhaustive-help-pacman-command-$line[1]:"
         case $line[1] in
             (one)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (two)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac
@@ -424,23 +424,23 @@ _arguments "${_arguments_options[@]}" \
 esac
 ;;
 (last)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (alias)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (hint)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (complete)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '--single-quotes[Can be '\''always'\'', '\''auto'\'', or '\''never'\'']' \
 '--double-quotes[Can be "always", "auto", or "never"]' \
 '--backticks[For more information see \`echo test\`]' \
@@ -35,43 +35,43 @@ _my-app() {
         curcontext="${curcontext%:*:*}:my-app-command-$line[1]:"
         case $line[1] in
             (cmd-single-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (cmd-double-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (cmd-backticks)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (cmd-backslash)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (cmd-brackets)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (cmd-expansions)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -83,31 +83,31 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-help-command-$line[1]:"
         case $line[1] in
             (cmd-single-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-double-quotes)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-backticks)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-backslash)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-brackets)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (cmd-expansions)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '*-c[some config file]' \
 '*-C[some config file]' \
 '*--config[some config file]' \
@@ -35,7 +35,7 @@ _my-app() {
         curcontext="${curcontext%:*:*}:my-app-command-$line[3]:"
         case $line[3] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--case=[the case to test]: : ' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -44,7 +44,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (some_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--config=[the other case to test]: : ' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -54,7 +54,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (some-cmd-with-hyphens)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -62,7 +62,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (some-hidden-cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -70,7 +70,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -82,23 +82,23 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-help-command-$line[1]:"
         case $line[1] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (some_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (some-cmd-with-hyphens)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (some-hidden-cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '*-c[some config file]' \
 '*-C[some config file]' \
 '*--config[some config file]' \
@@ -35,7 +35,7 @@ _my-app() {
         curcontext="${curcontext%:*:*}:my-app-command-$line[3]:"
         case $line[3] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--case=[the case to test]: : ' \
 '-h[Print help]' \
 '--help[Print help]' \
@@ -44,7 +44,7 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (some_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -60,7 +60,7 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-some_cmd-command-$line[1]:"
         case $line[1] in
             (sub_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--config=[the other case to test]: :((Lest\ quotes,\ aren'\''t\ escaped.\:"help,with,comma"
 Second\ to\ trigger\ display\ of\ options\:""))' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -70,7 +70,7 @@ Second\ to\ trigger\ display\ of\ options\:""))' \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__some_cmd__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -82,11 +82,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-some_cmd-help-command-$line[1]:"
         case $line[1] in
             (sub_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac
@@ -98,7 +98,7 @@ esac
 esac
 ;;
 (some_cmd_alias)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '-V[Print version]' \
@@ -114,7 +114,7 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-some_cmd-command-$line[1]:"
         case $line[1] in
             (sub_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '--config=[the other case to test]: :((Lest\ quotes,\ aren'\''t\ escaped.\:"help,with,comma"
 Second\ to\ trigger\ display\ of\ options\:""))' \
 '-h[Print help (see more with '\''--help'\'')]' \
@@ -124,7 +124,7 @@ Second\ to\ trigger\ display\ of\ options\:""))' \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__some_cmd__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -136,11 +136,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-some_cmd-help-command-$line[1]:"
         case $line[1] in
             (sub_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac
@@ -152,7 +152,7 @@ esac
 esac
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -164,11 +164,11 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-help-command-$line[1]:"
         case $line[1] in
             (test)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (some_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__help__some_cmd_commands" \
 "*::: :->some_cmd" \
 && ret=0
@@ -180,7 +180,7 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-help-some_cmd-command-$line[1]:"
         case $line[1] in
             (sub_cmd)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac
@@ -188,7 +188,7 @@ _arguments "${_arguments_options[@]}" \
 esac
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/subcommand_last.zsh
+++ b/clap_complete/tests/snapshots/subcommand_last.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '::free:' \
@@ -28,19 +28,19 @@ _my-app() {
         curcontext="${curcontext%:*:*}:my-app-command-$line[2]:"
         case $line[2] in
             (foo)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (bar)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 ":: :_my-app__help_commands" \
 "*::: :->help" \
 && ret=0
@@ -52,15 +52,15 @@ _arguments "${_arguments_options[@]}" \
         curcontext="${curcontext%:*:*}:my-app-help-command-$line[1]:"
         case $line[1] in
             (foo)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (bar)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
 (help)
-_arguments "${_arguments_options[@]}" \
+_arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
         esac

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.zsh
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '*::first -- first multi-valued argument:' \

--- a/clap_complete/tests/snapshots/value_hint.zsh
+++ b/clap_complete/tests/snapshots/value_hint.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '--choice=[]: :(bash fish zsh)' \
 '--unknown=[]: : ' \
 '--other=[]: :( )' \

--- a/clap_complete/tests/snapshots/value_terminator.zsh
+++ b/clap_complete/tests/snapshots/value_terminator.zsh
@@ -14,7 +14,7 @@ _my-app() {
     fi
 
     local context curcontext="$curcontext" state line
-    _arguments "${_arguments_options[@]}" \
+    _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
 '*;::arguments -- multi-valued argument with a value terminator:' \


### PR DESCRIPTION
This PR resolves #5521 

The zsh _arguments completion function has the following syntax:

```
_arguments [ARGUMENTS_OPTIONS] [:] COMMAND_ARG...
```
Where the optional colon is used to disambiguate options consumed by the `_arguments` function itself.

If this colon is missing and the first `COMMAND_ARG` conflicts with one of the options supported by `_arguments`, then it is misinterpreted resulting in missing options or the "unknown match specification character" seen above.