### PR TITLE
Add support for completing `--flag value<TAB>`, `-fbar<TAB>`, `-f=bar<TAB>` and `-f bar<TAB>`

### DIFF
--- a/clap_complete/src/dynamic/completer.rs
+++ b/clap_complete/src/dynamic/completer.rs
@@ -145,7 +145,7 @@ pub fn complete(
             } else if arg.is_short() {
                 if let Some(short) = arg.to_short() {
                     let mut short = short.clone();
-                    // HACK: Not consider `-fhg` now. During parsing, we assume that ShortFlags are in the format of `-fbar` or `-f=bar`.
+                    // HACK: During completion parsing, we assume that ShortFlags are in the format of `-fbar` or `-f=bar`.
                     let opt = short.next_flag();
                     state = if let Some(opt) = opt {
                         if let Ok(opt) = opt {
@@ -243,7 +243,7 @@ fn complete_arg(
             );
         } else if arg.is_negative_number() {
         } else if arg.is_short() {
-            // HACK: Assuming knowledge of -f<TAB>` and `-f=<TAB>` to complete the value of `-f`
+            // HACK: Assuming knowledge of -f<TAB>` and `-f=<TAB>` to complete the value of `-f`, and `-f<TAB>` to complete another short flag of cmd.
             if let Some(short) = arg.to_short() {
                 let mut short = short.clone();
                 let opt = short.next_flag();
@@ -274,6 +274,13 @@ fn complete_arg(
                         }
                     }
                 }
+
+                completions.extend(
+                    shorts_and_visible_aliases(cmd)
+                        .into_iter()
+                        .map(|(f, help)| (format!("{}{}", arg.to_value_os().to_string_lossy(), f).into(), help)),
+                );
+
             }
         } else if arg.is_stdio() {
             // HACK: Assuming knowledge of is_stdio
@@ -289,7 +296,18 @@ fn complete_arg(
                     .map(|(f, help)| (format!("-{}", f).into(), help)),
             );
         } else if arg.is_empty() {
-            // NOTE: Do nothing for empty arg.
+            // Complete all the long and short flag of current command.
+            completions.extend(
+                longs_and_visible_aliases(cmd)
+                    .into_iter()
+                    .map(|(f, help)| (format!("--{f}").into(), help)),
+            );
+
+            completions.extend(
+                shorts_and_visible_aliases(cmd)
+                    .into_iter()
+                    .map(|(f, help)| (format!("-{}", f).into(), help)),
+            );
         }
     }
 

--- a/clap_complete/src/dynamic/completer.rs
+++ b/clap_complete/src/dynamic/completer.rs
@@ -251,9 +251,11 @@ fn complete_arg(
                     if let Ok(opt) = opt {
                         if let Some(arg) = cmd.get_arguments().find(|a| a.get_short() == Some(opt))
                         {
+                            let mut equal_char = "";
                             if let Some(equal) = short.peek_next_flag() {
                                 if let Ok(equal) = equal {
                                     if equal == '=' {
+                                        equal_char = "=";
                                         short.next_flag();
                                     }
                                 }
@@ -267,7 +269,7 @@ fn complete_arg(
                                     )
                                     .into_iter()
                                     .map(|(f, help)| {
-                                        (format!("-{}{}", opt, f.to_string_lossy()).into(), help)
+                                        (format!("-{}{}{}", opt, equal_char, f.to_string_lossy()).into(), help)
                                     }),
                                 )
                             }

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -305,6 +305,11 @@ impl<'s> ParsedArg<'s> {
         self.inner == "--"
     }
 
+    /// Does the argument look like an equal sign (`=`)
+    pub fn is_equal(&self) -> bool {
+        self.inner == "="
+    }
+
     /// Does the argument look like a negative number?
     ///
     /// This won't parse the number in full but attempts to see if this looks
@@ -419,6 +424,13 @@ impl<'s> ShortFlags<'s> {
     /// Ideally call this before doing any iterator
     pub fn is_negative_number(&self) -> bool {
         self.invalid_suffix.is_none() && is_number(self.utf8_prefix.as_str())
+    }
+
+    /// Peek the next short flag
+    /// 
+    /// On error, returns a None
+    pub fn peek_next_flag(&self) -> Option<Result<char, &'s OsStr>> {
+        self.utf8_prefix.clone().next().map(|(_, c)| Ok(c))
     }
 
     /// Advance the iterator, returning the next short flag on success


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Related issues:
- https://github.com/clap-rs/clap/issues/3920
- https://github.com/clap-rs/clap/issues/3166

In this PR, I modified some logic in the complete function:
- Added `CompletionState` to record the current parsing state during completion parsing. When completion is triggered with `target_cursor` equal to `cursor`, the completion function will be chosen based on the `CompletionState`.
- Modified the priority handling in the `complete` function for arg over subcommand, optional long flag, escape, negative number, optional short flag, stdio, and empty.
- Modified the priority handling in `complete_arg` for `arg`, with the same priority as above.

There are some TODOs in this PR that I will implement later, including:
- Long flag, short flag, and alias completion for subcommand
- Support for `args_conflicts_with_subcommands`
- Support for `subcommand_precedence_over_arg`
- Support for `multicall`

