### PR TITLE
docs: Fix typo (cio->clio)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //! - [clap_complete](https://crates.io/crates/clap_complete) for shell completion support
 //!
 //! CLI Helpers
-//! - [cio](https://crates.io/crates/clio) for reading/writing to files specified as arguments
+//! - [clio](https://crates.io/crates/clio) for reading/writing to files specified as arguments
 //! - [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag)
 //! - [clap-cargo](https://crates.io/crates/clap-cargo)
 //! - [concolor-clap](https://crates.io/crates/concolor-clap)


### PR DESCRIPTION
This fixes a trivial typo in the documentation.