### PR TITLE
feat(clap_complete): Support flags with values `--flag bar`and `-f bar` in native completions

### DIFF
--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "unstable-dynamic")]
 
+use std::fs;
 use std::path::Path;
 
 use clap::{builder::PossibleValue, Command};
@@ -9,7 +10,7 @@ macro_rules! complete {
     ($cmd:expr, $input:expr$(, current_dir = $current_dir:expr)? $(,)?) => {
         {
             #[allow(unused)]
-            let current_dir = None;
+            let current_dir: Option<&Path> = None;
             $(let current_dir = $current_dir;)?
             complete(&mut $cmd, $input, current_dir)
         }
@@ -285,6 +286,156 @@ hello-world	Say hello to the world
 hello-moon
 goodbye-world
 "#]],
+    );
+}
+
+#[test]
+fn suggest_argument_value() {
+    let mut cmd = Command::new("dynamic")
+        .arg(
+            clap::Arg::new("input")
+                .long("input")
+                .short('i')
+                .value_hint(clap::ValueHint::FilePath),
+        )
+        .arg(
+            clap::Arg::new("format")
+                .long("format")
+                .short('F')
+                .value_parser(["json", "yaml", "toml"]),
+        )
+        .arg(
+            clap::Arg::new("count")
+                .long("count")
+                .short('c')
+                .action(clap::ArgAction::Count),
+        )
+        .arg(clap::Arg::new("positional").value_parser(["pos_a", "pos_b", "pos_c"]))
+        .args_conflicts_with_subcommands(true);
+
+    let testdir = snapbox::dir::DirRoot::mutable_temp().unwrap();
+    let testdir_path = testdir.path().unwrap();
+
+    fs::write(testdir_path.join("a_file"), "").unwrap();
+    fs::write(testdir_path.join("b_file"), "").unwrap();
+    fs::create_dir_all(testdir_path.join("c_dir")).unwrap();
+    fs::create_dir_all(testdir_path.join("d_dir")).unwrap();
+
+    assert_data_eq!(
+        complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![
+            "--input
+--format
+--count
+--help	Print help
+-i
+-F
+-c
+-h	Print help
+pos_a
+pos_b
+pos_c"
+        ],
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-i [TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![
+            "--input
+--format
+--count
+--help	Print help
+-i
+-F
+-c
+-h	Print help
+pos_a
+pos_b
+pos_c"
+        ],
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--input a[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![""],
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-i b[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![""],
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format [TAB]"),
+        snapbox::str![
+            "--input
+--format
+--count
+--help	Print help
+-i
+-F
+-c
+-h	Print help
+pos_a
+pos_b
+pos_c"
+        ],
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-F [TAB]"),
+        snapbox::str![
+            "--input
+--format
+--count
+--help	Print help
+-i
+-F
+-c
+-h	Print help
+pos_a
+pos_b
+pos_c"
+        ],
+    );
+
+    assert_data_eq!(complete!(cmd, "--format j[TAB]"), snapbox::str![""],);
+
+    assert_data_eq!(complete!(cmd, "-F j[TAB]"), snapbox::str![""],);
+
+    assert_data_eq!(complete!(cmd, "--format t[TAB]"), snapbox::str![""],);
+
+    assert_data_eq!(complete!(cmd, "-F t[TAB]"), snapbox::str![""],);
+
+    assert_data_eq!(
+        complete!(cmd, "-cccF [TAB]"),
+        snapbox::str![
+            "--input
+--format
+--count
+--help\tPrint help
+-i
+-F
+-c
+-h\tPrint help
+pos_a
+pos_b
+pos_c"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--input a_file [TAB]"),
+        snapbox::str![
+            "--input
+--format
+--count
+--help\tPrint help
+-i
+-F
+-c
+-h\tPrint help"
+        ]
     );
 }
 

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -324,103 +324,65 @@ fn suggest_argument_value() {
     assert_data_eq!(
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![
-            "--input
---format
---count
---help	Print help
--i
--F
--c
--h	Print help
-pos_a
-pos_b
-pos_c"
+            "a_file
+b_file
+c_dir/
+d_dir/"
         ],
     );
 
     assert_data_eq!(
         complete!(cmd, "-i [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![
-            "--input
---format
---count
---help	Print help
--i
--F
--c
--h	Print help
-pos_a
-pos_b
-pos_c"
+            "a_file
+b_file
+c_dir/
+d_dir/"
         ],
     );
 
     assert_data_eq!(
         complete!(cmd, "--input a[TAB]", current_dir = Some(testdir_path)),
-        snapbox::str![""],
+        snapbox::str!["a_file"],
     );
 
     assert_data_eq!(
         complete!(cmd, "-i b[TAB]", current_dir = Some(testdir_path)),
-        snapbox::str![""],
+        snapbox::str!["b_file"],
     );
 
     assert_data_eq!(
         complete!(cmd, "--format [TAB]"),
         snapbox::str![
-            "--input
---format
---count
---help	Print help
--i
--F
--c
--h	Print help
-pos_a
-pos_b
-pos_c"
+            "json
+yaml
+toml"
         ],
     );
 
     assert_data_eq!(
         complete!(cmd, "-F [TAB]"),
         snapbox::str![
-            "--input
---format
---count
---help	Print help
--i
--F
--c
--h	Print help
-pos_a
-pos_b
-pos_c"
+            "json
+yaml
+toml"
         ],
     );
 
-    assert_data_eq!(complete!(cmd, "--format j[TAB]"), snapbox::str![""],);
+    assert_data_eq!(complete!(cmd, "--format j[TAB]"), snapbox::str!["json"],);
 
-    assert_data_eq!(complete!(cmd, "-F j[TAB]"), snapbox::str![""],);
+    assert_data_eq!(complete!(cmd, "-F j[TAB]"), snapbox::str!["json"],);
 
-    assert_data_eq!(complete!(cmd, "--format t[TAB]"), snapbox::str![""],);
+    assert_data_eq!(complete!(cmd, "--format t[TAB]"), snapbox::str!["toml"],);
 
-    assert_data_eq!(complete!(cmd, "-F t[TAB]"), snapbox::str![""],);
+    assert_data_eq!(complete!(cmd, "-F t[TAB]"), snapbox::str!["toml"],);
 
     assert_data_eq!(
         complete!(cmd, "-cccF [TAB]"),
         snapbox::str![
-            "--input
---format
---count
---help\tPrint help
--i
--F
--c
--h\tPrint help
-pos_a
-pos_b
-pos_c"
+            "json
+yaml
+toml"
         ]
     );
 
@@ -434,7 +396,10 @@ pos_c"
 -i
 -F
 -c
--h\tPrint help"
+-h\tPrint help
+pos_a
+pos_b
+pos_c"
         ]
     );
 }


### PR DESCRIPTION
related issue: https://github.com/clap-rs/clap/issues/3920
what is left
- support `-fbar` and `-f=bar`
- error parsing for `--flag=bar` in bash
- `foo --bar\t` offering both `--bar <value>` and `--bare`