### PR TITLE
Exit without flushing stdout and stderr

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -23,7 +23,7 @@ use crate::output::fmt::Colorizer;
 use crate::output::fmt::Stream;
 use crate::parser::features::suggestions;
 use crate::util::FlatMap;
-use crate::util::{color::ColorChoice, safe_exit, SUCCESS_CODE, USAGE_CODE};
+use crate::util::{color::ColorChoice, SUCCESS_CODE, USAGE_CODE};
 use crate::Command;
 
 #[cfg(feature = "error-context")]
@@ -233,7 +233,7 @@ impl<F: ErrorFormatter> Error<F> {
     pub fn exit(&self) -> ! {
         // Swallow broken pipe errors
         let _ = self.print();
-        safe_exit(self.exit_code())
+        std::process::exit(self.exit_code());
     }
 
     /// Prints formatted and colored error to `stdout` or `stderr` according to its error kind

--- a/clap_builder/src/util/mod.rs
+++ b/clap_builder/src/util/mod.rs
@@ -29,15 +29,6 @@ pub(crate) const SUCCESS_CODE: i32 = 0;
 // - Python's `argparse` returns 2
 pub(crate) const USAGE_CODE: i32 = 2;
 
-pub(crate) fn safe_exit(code: i32) -> ! {
-    use std::io::Write;
-
-    let _ = std::io::stdout().lock().flush();
-    let _ = std::io::stderr().lock().flush();
-
-    std::process::exit(code)
-}
-
 #[cfg(not(feature = "unicode"))]
 pub(crate) fn eq_ignore_case(left: &str, right: &str) -> bool {
     left.eq_ignore_ascii_case(right)


### PR DESCRIPTION
I noticed the calls to flush standard out and err before calling `std::process:exit()` and I believe they aren't necessary.

Standard out is flushed when calling `std::process::exit()`:

- [std::process::exit()](https://github.com/rust-lang/rust/blob/3d5d7a24f76006b391d8a53d903ae64c1b4a52d2/library/std/src/process.rs#L2318)
- [std::rt::cleanup()](https://github.com/rust-lang/rust/blob/3d5d7a24f76006b391d8a53d903ae64c1b4a52d2/library/std/src/rt.rs#L105)
- [std::io::cleanup()](https://github.com/rust-lang/rust/blob/3d5d7a24f76006b391d8a53d903ae64c1b4a52d2/library/std/src/io/stdio.rs#L679)

And standard error is [unbuffered](https://github.com/rust-lang/rust/blob/3d5d7a24f76006b391d8a53d903ae64c1b4a52d2/library/std/src/io/stdio.rs#L919), and so doesn't need to be flushed.

I noticed this function was added in PR #1873, to fix issue #1871.

I checked out [4675070a](https://github.com/clap-rs/clap/commit/4675070a), the commit before #1873 was merged, and wasn't able to reproduce the issue in #1871, whose repro steps are to run `cargo run --example 09_auto_version -- --version` and not see any version output.

So I'm thinking it's likely that at some point, the rust stdlib changed to flush stdout before exiting.

Since `clap` has MSRV 1.74, I installed 1.74.0 and ran `cargo +1.74.0 run --example 09_auto_version -- --version` to make sure that things still worked with the oldest supported rust version.