### PR TITLE
style: fish: escaping tab as \t for more readibility

### DIFF
--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -178,7 +178,7 @@ fn value_completion(option: &Arg) -> String {
                     // The help text after \t is wrapped in '' to make sure that the it is taken literally
                     // and there is no command substitution or variable expansion resulting in unexpected errors
                     Some(format!(
-                        "{}\t'{}'",
+                        "{}\\t'{}'",
                         escape_string(value.get_name(), true).as_str(),
                         escape_help(value.get_help().unwrap_or_default())
                     ))

--- a/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
@@ -1,4 +1,4 @@
-complete -c exhaustive -n "__fish_use_subcommand" -l generate -d 'generate' -r -f -a "{bash	'',elvish	'',fish	'',powershell	'',zsh	''}"
+complete -c exhaustive -n "__fish_use_subcommand" -l generate -d 'generate' -r -f -a "{bash\t'',elvish\t'',fish\t'',powershell\t'',zsh\t''}"
 complete -c exhaustive -n "__fish_use_subcommand" -l global -d 'everywhere'
 complete -c exhaustive -n "__fish_use_subcommand" -s h -l help -d 'Print help'
 complete -c exhaustive -n "__fish_use_subcommand" -s V -l version -d 'Print version'
@@ -12,13 +12,13 @@ complete -c exhaustive -n "__fish_use_subcommand" -f -a "hint"
 complete -c exhaustive -n "__fish_use_subcommand" -f -a "complete" -d 'Register shell completions for this program'
 complete -c exhaustive -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c exhaustive -n "__fish_seen_subcommand_from action" -l set -d 'value' -r
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -l choice -d 'enum' -r -f -a "{first	'',second	''}"
+complete -c exhaustive -n "__fish_seen_subcommand_from action" -l choice -d 'enum' -r -f -a "{first\t'',second\t''}"
 complete -c exhaustive -n "__fish_seen_subcommand_from action" -l set-true -d 'bool'
 complete -c exhaustive -n "__fish_seen_subcommand_from action" -l count -d 'number'
 complete -c exhaustive -n "__fish_seen_subcommand_from action" -l global -d 'everywhere'
 complete -c exhaustive -n "__fish_seen_subcommand_from action" -s h -l help -d 'Print help'
 complete -c exhaustive -n "__fish_seen_subcommand_from action" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes; and not __fish_seen_subcommand_from cmd-double-quotes; and not __fish_seen_subcommand_from cmd-backticks; and not __fish_seen_subcommand_from cmd-backslash; and not __fish_seen_subcommand_from cmd-brackets; and not __fish_seen_subcommand_from cmd-expansions; and not __fish_seen_subcommand_from escape-help; and not __fish_seen_subcommand_from help" -l choice -r -f -a "{bash	'bash (shell)',fish	'fish shell',zsh	'zsh shell'}"
+complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes; and not __fish_seen_subcommand_from cmd-double-quotes; and not __fish_seen_subcommand_from cmd-backticks; and not __fish_seen_subcommand_from cmd-backslash; and not __fish_seen_subcommand_from cmd-brackets; and not __fish_seen_subcommand_from cmd-expansions; and not __fish_seen_subcommand_from escape-help; and not __fish_seen_subcommand_from help" -l choice -r -f -a "{bash\t'bash (shell)',fish\t'fish shell',zsh\t'zsh shell'}"
 complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes; and not __fish_seen_subcommand_from cmd-double-quotes; and not __fish_seen_subcommand_from cmd-backticks; and not __fish_seen_subcommand_from cmd-backslash; and not __fish_seen_subcommand_from cmd-brackets; and not __fish_seen_subcommand_from cmd-expansions; and not __fish_seen_subcommand_from escape-help; and not __fish_seen_subcommand_from help" -l single-quotes -d 'Can be \'always\', \'auto\', or \'never\''
 complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes; and not __fish_seen_subcommand_from cmd-double-quotes; and not __fish_seen_subcommand_from cmd-backticks; and not __fish_seen_subcommand_from cmd-backslash; and not __fish_seen_subcommand_from cmd-brackets; and not __fish_seen_subcommand_from cmd-expansions; and not __fish_seen_subcommand_from escape-help; and not __fish_seen_subcommand_from help" -l double-quotes -d 'Can be "always", "auto", or "never"'
 complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes; and not __fish_seen_subcommand_from cmd-double-quotes; and not __fish_seen_subcommand_from cmd-backticks; and not __fish_seen_subcommand_from cmd-backslash; and not __fish_seen_subcommand_from cmd-brackets; and not __fish_seen_subcommand_from cmd-expansions; and not __fish_seen_subcommand_from escape-help; and not __fish_seen_subcommand_from help" -l backticks -d 'For more information see `echo test`'
@@ -94,7 +94,7 @@ complete -c exhaustive -n "__fish_seen_subcommand_from alias" -s f -s F -l flag 
 complete -c exhaustive -n "__fish_seen_subcommand_from alias" -l global -d 'everywhere'
 complete -c exhaustive -n "__fish_seen_subcommand_from alias" -s h -l help -d 'Print help'
 complete -c exhaustive -n "__fish_seen_subcommand_from alias" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l choice -r -f -a "{bash	'',fish	'',zsh	''}"
+complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l choice -r -f -a "{bash\t'',fish\t'',zsh\t''}"
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l unknown -r
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l other -r -f
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s p -l path -r -F
@@ -110,7 +110,7 @@ complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l email -r -f
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l global -d 'everywhere'
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s h -l help -d 'Print help'
 complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l shell -d 'Specify shell to complete for' -r -f -a "{bash	'',fish	''}"
+complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l shell -d 'Specify shell to complete for' -r -f -a "{bash\t'',fish\t''}"
 complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l register -d 'Path to write completion-registration to' -r -F
 complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l global -d 'everywhere'
 complete -c exhaustive -n "__fish_seen_subcommand_from complete" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/clap_complete/tests/snapshots/sub_subcommands.fish
+++ b/clap_complete/tests/snapshots/sub_subcommands.fish
@@ -12,7 +12,7 @@ complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -s V -l version -d 'Print version'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.	'help,with,comma',Second to trigger display of options	''}"
+complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.\t'help,with,comma',Second to trigger display of options\t''}"
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
@@ -21,7 +21,7 @@ complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fis
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -s V -l version -d 'Print version'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.	'help,with,comma',Second to trigger display of options	''}"
+complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.\t'help,with,comma',Second to trigger display of options\t''}"
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version'
 complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and __fish_seen_subcommand_from help; and not __fish_seen_subcommand_from sub_cmd; and not __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'

--- a/clap_complete/tests/snapshots/value_hint.fish
+++ b/clap_complete/tests/snapshots/value_hint.fish
@@ -1,4 +1,4 @@
-complete -c my-app -l choice -r -f -a "{bash	'',fish	'',zsh	''}"
+complete -c my-app -l choice -r -f -a "{bash\t'',fish\t'',zsh\t''}"
 complete -c my-app -l unknown -r
 complete -c my-app -l other -r -f
 complete -c my-app -s p -l path -r -F


### PR DESCRIPTION
It seems that fish [prefers \t over literal tab character][1].

[1]: https://github.com/fish-shell/fish-shell/blob/4d7ef1fad82986b8e5210979ab91fc424a645c87/share/completions/ls.fish#L61-L71