### PR TITLE
fix: Don't silently ignore complete tests when missing installed shells on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
+  TERM: xterm
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-hack
+    - name: Install shells
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y elvish fish zsh
     - name: Build
       run: make build-${{matrix.features}}
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   CLICOLOR: 1
-  TERM: xterm
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,9 +571,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "completest"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8229e041ca8f8130ad7f0ce1afb9cfdb3033de7fd548e6422dbb2f4f12184f41"
+checksum = "e6cda99a94266124c2cce3d239973ef8ce3160c83a3f426a314285d9bf6422d1"
 
 [[package]]
 name = "completest-nu"
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "completest-pty"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6d1272e27f608f97616be67a2aed03ed8d73910b5df9a7f4a50c4ffd59d185"
+checksum = "ee700748da7d34de4bbe0296d3153e8ef5217233d814d23fb68106c110dd9bc5"
 dependencies = [
  "completest",
  "ptyprocess",

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.inputrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.inputrc
@@ -1,0 +1,1 @@
+# expected empty file to disable loading ~/.inputrc

--- a/clap_complete/tests/snapshots/home/static/exhaustive/zsh/.zshenv
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/zsh/.zshenv
@@ -1,5 +1,5 @@
 fpath=($fpath $ZDOTDIR/zsh)
-autoload -U +X compinit && compinit
+autoload -U +X compinit && compinit -u # bypass compaudit security checking
 precmd_functions=""  # avoid the prompt being overwritten
 PS1='%% '
 PROMPT='%% '

--- a/clap_complete/tests/testsuite/common.rs
+++ b/clap_complete/tests/testsuite/common.rs
@@ -430,7 +430,7 @@ pub(crate) fn has_command(command: &str) -> bool {
         Ok(output) => output,
         Err(e) => {
             // CI is expected to support all of the commands
-            if is_ci() && cfg!(linux) {
+            if is_ci() && cfg!(target_os = "linux") {
                 panic!(
                     "expected command `{}` to be somewhere in PATH: {}",
                     command, e

--- a/clap_complete/tests/testsuite/fish.rs
+++ b/clap_complete/tests/testsuite/fish.rs
@@ -184,7 +184,7 @@ fn complete_dynamic() {
 
     let input = "exhaustive \t";
     let expected = snapbox::str![
-        r#"% exhaustive
+        r#"% exhaustive 
 action                                                             last              -V         (Print version)
 alias                                                              pacman            --generate      (generate)
 complete            (Register shell completions for this program)  quote             --global      (everywhere)
@@ -194,26 +194,27 @@ hint                                                               -h  (Print he
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
-    let input = "exhaustive quote \t";
+    let input = "exhaustive quote \t\t";
     let expected = snapbox::str![
-        r#"% exhaustive quote
-cmd-backslash                                        (Avoid '\n')
+        r#"% exhaustive quote 
+cmd-backslash                                        (Avoid '/n')
 cmd-backticks              (For more information see `echo test`)
 cmd-brackets                             (List packages [filter])
 cmd-double-quotes           (Can be "always", "auto", or "never")
 cmd-expansions            (Execute the shell command with $SHELL)
 cmd-single-quotes           (Can be 'always', 'auto', or 'never')
-escape-help                                             (\tab "')
+escape-help                                             (/tab "')
 help  (Print this message or the help of the given subcommand(s))
--h                                                   (Print help)
+-h                          (Print help (see more with '--help'))
 -V                                                (Print version)
---backslash                                          (Avoid '\n')
+--backslash                                          (Avoid '/n')
 --backticks                (For more information see `echo test`)
 --brackets                               (List packages [filter])
+--choice [..]
 --double-quotes             (Can be "always", "auto", or "never")
 --expansions              (Execute the shell command with $SHELL)
 --global                                             (everywhere)
---help                                               (Print help)
+--help                      (Print help (see more with '--help'))
 --single-quotes             (Can be 'always', 'auto', or 'never')
 --version                                         (Print version)"#
     ];

--- a/clap_complete_nushell/tests/common.rs
+++ b/clap_complete_nushell/tests/common.rs
@@ -374,7 +374,7 @@ pub(crate) fn has_command(command: &str) -> bool {
         Ok(output) => output,
         Err(e) => {
             // CI is expected to support all of the commands
-            if is_ci() && cfg!(linux) {
+            if is_ci() && cfg!(target_os = "linux") {
                 panic!(
                     "expected command `{}` to be somewhere in PATH: {}",
                     command, e


### PR DESCRIPTION
They was not run on CI, so they're siliencely falling for a long time.

Close #5540.