### PR TITLE
chore(git): Lengthen commit summary length

### DIFF
--- a/committed.toml
+++ b/committed.toml
@@ -1,3 +1,4 @@
 style="conventional"
 ignore_author_re="(dependabot|renovate)"
 merge_commit = false
+subject_length = 72


### PR DESCRIPTION
The default is 50, which is too short.
github wrap around commit summary as 72 chars.
And more blogs suggest that:
* https://matklad.github.io/2023/12/31/git-things.html#Git-Things
* https://news.ycombinator.com/item?id=38831630
* https://www.kernel.org/doc/html/v4.10/process/submitting-patches.html#the-canonical-patch-format

Bitten by the commit lint with a35f03eb62167ab370e8deb9f99814ed3dc44582 in #5547.