### PR TITLE
fix: Don't silently ignore complete tests when missing installed shells on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
-    - uses: taiki-e/install-action@cargo-hack
+    - name: Install shells
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y elvish fish zsh
     - name: Build
       run: make build-${{matrix.features}}
     - name: Test

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -65,6 +65,9 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
+    - name: Install shells
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y elvish fish zsh
     - name: Build
       run: make build-${{matrix.features}}
     - name: Test
@@ -96,6 +99,9 @@ jobs:
         toolchain: stable
     - uses: Swatinem/rust-cache@v2
     - uses: taiki-e/install-action@cargo-hack
+    - name: Install shells
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y elvish fish zsh
     - name: Update dependencues
       run: cargo update
     - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,9 +571,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "completest"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8229e041ca8f8130ad7f0ce1afb9cfdb3033de7fd548e6422dbb2f4f12184f41"
+checksum = "e6cda99a94266124c2cce3d239973ef8ce3160c83a3f426a314285d9bf6422d1"
 
 [[package]]
 name = "completest-nu"
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "completest-pty"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6d1272e27f608f97616be67a2aed03ed8d73910b5df9a7f4a50c4ffd59d185"
+checksum = "ee700748da7d34de4bbe0296d3153e8ef5217233d814d23fb68106c110dd9bc5"
 dependencies = [
  "completest",
  "ptyprocess",

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -45,8 +45,8 @@ unicode-xid = { version = "0.2.2", optional = true }
 snapbox = { version = "0.6.0", features = ["diff", "dir", "examples"] }
 # Cutting out `filesystem` feature
 trycmd = { version = "0.15.1", default-features = false, features = ["color-auto", "diff", "examples"] }
-completest = "0.4.0"
-completest-pty = "0.5.0"
+completest = "0.4.1"
+completest-pty = "0.5.2"
 clap = { path = "../", version = "4.0.0", default-features = false, features = ["std", "derive", "help"] }
 automod = "1.0.14"
 

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.inputrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.inputrc
@@ -1,0 +1,1 @@
+# expected empty file to disable loading ~/.inputrc

--- a/clap_complete/tests/snapshots/home/static/exhaustive/zsh/.zshenv
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/zsh/.zshenv
@@ -1,5 +1,5 @@
 fpath=($fpath $ZDOTDIR/zsh)
-autoload -U +X compinit && compinit
+autoload -U +X compinit && compinit -u # bypass compaudit security checking
 precmd_functions=""  # avoid the prompt being overwritten
 PS1='%% '
 PROMPT='%% '

--- a/clap_complete/tests/testsuite/common.rs
+++ b/clap_complete/tests/testsuite/common.rs
@@ -430,7 +430,7 @@ pub(crate) fn has_command(command: &str) -> bool {
         Ok(output) => output,
         Err(e) => {
             // CI is expected to support all of the commands
-            if is_ci() && cfg!(linux) {
+            if is_ci() && cfg!(target_os = "linux") {
                 panic!(
                     "expected command `{}` to be somewhere in PATH: {}",
                     command, e

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -23,14 +23,11 @@ fn suggest_subcommand_subset() {
         .subcommand(Command::new("hello-moon"))
         .subcommand(Command::new("goodbye-world"));
 
-    assert_data_eq!(
-        complete!(cmd, "he"),
-        snapbox::str![
-            "hello-moon
+    assert_data_eq!(complete!(cmd, "he"), snapbox::str![[r#"
+hello-moon
 hello-world
-help\tPrint this message or the help of the given subcommand(s)"
-        ],
-    );
+help	Print this message or the help of the given subcommand(s)
+"#]],);
 }
 
 #[test]
@@ -52,14 +49,11 @@ fn suggest_long_flag_subset() {
                 .action(clap::ArgAction::Count),
         );
 
-    assert_data_eq!(
-        complete!(cmd, "--he"),
-        snapbox::str![
-            "--hello-world
+    assert_data_eq!(complete!(cmd, "--he"), snapbox::str![[r#"
+--hello-world
 --hello-moon
---help\tPrint help"
-        ],
-    );
+--help	Print help
+"#]],);
 }
 
 #[test]
@@ -71,13 +65,10 @@ fn suggest_possible_value_subset() {
         "goodbye-world".into(),
     ]));
 
-    assert_data_eq!(
-        complete!(cmd, "hello"),
-        snapbox::str![
-            "hello-world\tSay hello to the world
-hello-moon"
-        ],
-    );
+    assert_data_eq!(complete!(cmd, "hello"), snapbox::str![[r#"
+hello-world	Say hello to the world
+hello-moon
+"#]],);
 }
 
 #[test]
@@ -99,15 +90,12 @@ fn suggest_additional_short_flags() {
                 .action(clap::ArgAction::Count),
         );
 
-    assert_data_eq!(
-        complete!(cmd, "-a"),
-        snapbox::str![
-            "-aa
+    assert_data_eq!(complete!(cmd, "-a"), snapbox::str![[r#"
+-aa
 -ab
 -ac
--ah\tPrint help"
-        ],
-    );
+-ah	Print help
+"#]],);
 }
 
 #[test]
@@ -120,16 +108,13 @@ fn suggest_subcommand_positional() {
         ]),
     ));
 
-    assert_data_eq!(
-        complete!(cmd, "hello-world [TAB]"),
-        snapbox::str![
-            "--help\tPrint help (see more with '--help')
--h\tPrint help (see more with '--help')
-hello-world\tSay hello to the world
+    assert_data_eq!(complete!(cmd, "hello-world [TAB]"), snapbox::str![[r#"
+--help	Print help (see more with '--help')
+-h	Print help (see more with '--help')
+hello-world	Say hello to the world
 hello-moon
-goodbye-world"
-        ],
-    );
+goodbye-world
+"#]],);
 }
 
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {

--- a/clap_complete/tests/testsuite/elvish.rs
+++ b/clap_complete/tests/testsuite/elvish.rs
@@ -152,8 +152,8 @@ fn complete() {
         common::load_runtime::<completest_pty::ElvishRuntimeBuilder>("static", "exhaustive");
 
     let input = "exhaustive \t";
-    let expected = snapbox::str![
-        r#"% exhaustive --generate
+    let expected = snapbox::str![[r#"
+% exhaustive --generate
  COMPLETING argument  
 --generate     generate                                                 
 --global       everywhere                                               
@@ -169,8 +169,8 @@ hint           hint
 last           last                                                     
 pacman         pacman                                                   
 quote          quote                                                    
-value          value                                                    "#
-    ];
+value          value                                                    
+"#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }

--- a/clap_complete/tests/testsuite/fish.rs
+++ b/clap_complete/tests/testsuite/fish.rs
@@ -182,9 +182,9 @@ fn complete_dynamic() {
     let mut runtime =
         common::load_runtime::<completest_pty::FishRuntimeBuilder>("dynamic", "exhaustive");
 
-    let input = "exhaustive \t";
+    let input = "exhaustive \t\t";
     let expected = snapbox::str![[r#"
-% exhaustive 
+% exhaustive action 
 action                                                             last              -V         (Print version)
 alias                                                              pacman            --generate      (generate)
 complete            (Register shell completions for this program)  quote             --global      (everywhere)
@@ -194,14 +194,29 @@ hint                                                               -h  (Print he
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
-    let input = "exhaustive quote \t";
+    let input = "exhaustive quote \t\t";
     let expected = snapbox::str![[r#"
 % exhaustive quote 
 cmd-backslash                                        (Avoid '/n')
 cmd-backticks              (For more information see `echo test`)
 cmd-brackets                             (List packages [filter])
 cmd-double-quotes           (Can be "always", "auto", or "never")
-…and 16 more rows
+cmd-expansions            (Execute the shell command with $SHELL)
+cmd-single-quotes           (Can be 'always', 'auto', or 'never')
+escape-help                                             (/tab "')
+help  (Print this message or the help of the given subcommand(s))
+-h                          (Print help (see more with '--help'))
+-V                                                (Print version)
+--backslash                                          (Avoid '/n')
+--backticks                (For more information see `echo test`)
+--brackets                               (List packages [filter])
+--choice                                                         
+--double-quotes             (Can be "always", "auto", or "never")
+--expansions              (Execute the shell command with $SHELL)
+--global                                             (everywhere)
+--help                      (Print help (see more with '--help'))
+--single-quotes             (Can be 'always', 'auto', or 'never')
+--version                                         (Print version)
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);

--- a/clap_complete/tests/testsuite/fish.rs
+++ b/clap_complete/tests/testsuite/fish.rs
@@ -183,40 +183,26 @@ fn complete_dynamic() {
         common::load_runtime::<completest_pty::FishRuntimeBuilder>("dynamic", "exhaustive");
 
     let input = "exhaustive \t";
-    let expected = snapbox::str![
-        r#"% exhaustive
+    let expected = snapbox::str![[r#"
+% exhaustive 
 action                                                             last              -V         (Print version)
 alias                                                              pacman            --generate      (generate)
 complete            (Register shell completions for this program)  quote             --global      (everywhere)
 help  (Print this message or the help of the given subcommand(s))  value             --help        (Print help)
-hint                                                               -h  (Print help)  --version  (Print version)"#
-    ];
+hint                                                               -h  (Print help)  --version  (Print version)
+"#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
     let input = "exhaustive quote \t";
-    let expected = snapbox::str![
-        r#"% exhaustive quote
-cmd-backslash                                        (Avoid '\n')
+    let expected = snapbox::str![[r#"
+% exhaustive quote 
+cmd-backslash                                        (Avoid '/n')
 cmd-backticks              (For more information see `echo test`)
 cmd-brackets                             (List packages [filter])
 cmd-double-quotes           (Can be "always", "auto", or "never")
-cmd-expansions            (Execute the shell command with $SHELL)
-cmd-single-quotes           (Can be 'always', 'auto', or 'never')
-escape-help                                             (\tab "')
-help  (Print this message or the help of the given subcommand(s))
--h                                                   (Print help)
--V                                                (Print version)
---backslash                                          (Avoid '\n')
---backticks                (For more information see `echo test`)
---brackets                               (List packages [filter])
---double-quotes             (Can be "always", "auto", or "never")
---expansions              (Execute the shell command with $SHELL)
---global                                             (everywhere)
---help                                               (Print help)
---single-quotes             (Can be 'always', 'auto', or 'never')
---version                                         (Print version)"#
-    ];
+…and 16 more rows
+"#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -153,12 +153,12 @@ fn complete() {
         common::load_runtime::<completest_pty::ZshRuntimeBuilder>("static", "exhaustive");
 
     let input = "exhaustive \t";
-    let expected = snapbox::str![
-        r#"% exhaustive
+    let expected = snapbox::str![[r#"
+% exhaustive
 complete                                           -- Register shell completions for this program                     
 help                                               -- Print this message or the help of the given subcommand(s)       
-pacman    action  alias  value  quote  hint  last  --                                                                 "#
-    ];
+pacman    action  alias  value  quote  hint  last  --                                                                 
+"#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }

--- a/clap_complete_nushell/tests/common.rs
+++ b/clap_complete_nushell/tests/common.rs
@@ -374,7 +374,7 @@ pub(crate) fn has_command(command: &str) -> bool {
         Ok(output) => output,
         Err(e) => {
             // CI is expected to support all of the commands
-            if is_ci() && cfg!(linux) {
+            if is_ci() && cfg!(target_os = "linux") {
                 panic!(
                     "expected command `{}` to be somewhere in PATH: {}",
                     command, e


### PR DESCRIPTION
They was not run on CI, so they're siliencely falling for a long time.

Close #5540.