### PR TITLE
fish/complete: Generate helper functions to check for subcommands

### DIFF
--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -121,15 +121,9 @@ fn gen_fish_inner(
             [command, subcommand] => out.push_str(&format!(
                 " {command}; and __fish_seen_subcommand_from {subcommand}"
             )),
-            [command, "help", _subcommand] => {
-                out.push_str(&format!(" {command}; and __fish_seen_subcommand_from help"));
-            }
-            ["help", command, _subcommand] => {
-                out.push_str(&format!(" help; and __fish_seen_subcommand_from {command}"));
-            }
-            _ => unimplemented!(
-                "subcommand should be nested less than 3 levels: {parent_commands:?}"
-            ),
+            // Subcommand should be nested less than 3 levels to be practical
+            // `rustup toolchain help install` cannot receive any flags to it.
+            _ => return,
         }
         basic_template.push_str(format!(" -n \"{out}\"").as_str());
     }

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -20,8 +20,38 @@ impl Generator for Fish {
             .get_bin_name()
             .expect("crate::generate should have set the bin_name");
 
+        let has_global_flags = {
+            let n_args = cmd.get_arguments().filter(|a| !a.is_positional()).count();
+            // `-h` and `-v` behaves as command, not regular flags/options that modifies subcommand behaviors.
+            match (
+                cmd.is_disable_help_flag_set(),
+                cmd.is_disable_version_flag_set(),
+            ) {
+                (false, false) => n_args > 2,
+                (true, true) => n_args > 0,
+                _ => n_args > 1,
+            }
+        };
+
+        let name = escape_name(bin_name);
+        let mut needs_fn_name = &format!("__fish_{name}_needs_command")[..];
+        let mut using_fn_name = &format!("__fish_{name}_using_subcommand")[..];
+        if has_global_flags {
+            gen_subcommand_helpers(&name, cmd, buf, needs_fn_name, using_fn_name);
+        } else {
+            needs_fn_name = "__fish_use_subcommand";
+            using_fn_name = "__fish_seen_subcommand_from";
+        }
+
         let mut buffer = String::new();
-        gen_fish_inner(bin_name, &[], cmd, &mut buffer);
+        gen_fish_inner(
+            bin_name,
+            &[],
+            cmd,
+            &mut buffer,
+            needs_fn_name,
+            using_fn_name,
+        );
         w!(buf, buffer.as_bytes());
     }
 }
@@ -40,11 +70,17 @@ fn escape_help(help: &builder::StyledStr) -> String {
     escape_string(&help.to_string().replace('\n', " "), false)
 }
 
+fn escape_name(name: &str) -> String {
+    name.replace('-', "_")
+}
+
 fn gen_fish_inner(
     root_command: &str,
     parent_commands: &[&str],
     cmd: &Command,
     buffer: &mut String,
+    needs_fn_name: &str,
+    using_fn_name: &str,
 ) {
     debug!("gen_fish_inner");
     // example :
@@ -57,31 +93,43 @@ fn gen_fish_inner(
     //      -a "{possible_arguments}"
     //      -r # if require parameter
     //      -f # don't use file completion
-    //      -n "__fish_use_subcommand"               # complete for command "myprog"
-    //      -n "__fish_seen_subcommand_from subcmd1" # complete for command "myprog subcmd1"
+    //      -n "{needs_fn_name}"            # complete for command "myprog"
+    //      -n "{using_fn_name} subcmd1"    # complete for command "myprog subcmd1"
 
     let mut basic_template = format!("complete -c {root_command}");
 
     if parent_commands.is_empty() {
         if cmd.has_subcommands() {
-            basic_template.push_str(" -n \"__fish_use_subcommand\"");
+            basic_template.push_str(&format!(" -n \"{needs_fn_name}\""));
         }
     } else {
-        let mut out = String::from("__fish_seen_subcommand_from");
-        for &command in parent_commands {
-            out.push(' ');
-            out.push_str(command);
-        }
-        let subcommands: Vec<&str> = cmd
-            .get_subcommands()
-            .flat_map(Command::get_name_and_visible_aliases)
-            .collect();
-        if !subcommands.is_empty() {
-            out.push_str("; and not __fish_seen_subcommand_from");
-        }
-        for name in subcommands {
-            out.push(' ');
-            out.push_str(name);
+        let mut out = String::from(using_fn_name);
+        match parent_commands {
+            [] => unreachable!(),
+            [command] => {
+                out.push_str(&format!(" {command}"));
+                if cmd.has_subcommands() {
+                    out.push_str("; and not __fish_seen_subcommand_from");
+                }
+                let subcommands = cmd
+                    .get_subcommands()
+                    .flat_map(Command::get_name_and_visible_aliases);
+                for name in subcommands {
+                    out.push_str(&format!(" {name}"));
+                }
+            }
+            [command, subcommand] => out.push_str(&format!(
+                " {command}; and __fish_seen_subcommand_from {subcommand}"
+            )),
+            [command, "help", _subcommand] => {
+                out.push_str(&format!(" {command}; and __fish_seen_subcommand_from help"));
+            }
+            ["help", command, _subcommand] => {
+                out.push_str(&format!(" help; and __fish_seen_subcommand_from {command}"));
+            }
+            _ => unimplemented!(
+                "subcommand should be nested less than 3 levels: {parent_commands:?}"
+            ),
         }
         basic_template.push_str(format!(" -n \"{out}\"").as_str());
     }
@@ -160,9 +208,76 @@ fn gen_fish_inner(
         for subcommand_name in subcommand.get_name_and_visible_aliases() {
             let mut parent_commands: Vec<_> = parent_commands.into();
             parent_commands.push(subcommand_name);
-            gen_fish_inner(root_command, &parent_commands, subcommand, buffer);
+            gen_fish_inner(
+                root_command,
+                &parent_commands,
+                subcommand,
+                buffer,
+                needs_fn_name,
+                using_fn_name,
+            );
         }
     }
+}
+
+/// Print fish's helpers for easy handling subcommands.
+fn gen_subcommand_helpers(
+    bin_name: &str,
+    cmd: &Command,
+    buf: &mut dyn Write,
+    needs_fn_name: &str,
+    using_fn_name: &str,
+) {
+    if !cmd.has_subcommands() {
+        return;
+    }
+    let mut optspecs = String::new();
+    let cmd_opts = cmd.get_arguments().filter(|a| !a.is_positional());
+    for option in cmd_opts {
+        optspecs.push(' ');
+        let mut has_short = false;
+        if let Some(short) = option.get_short() {
+            has_short = true;
+            optspecs.push(short);
+        }
+
+        if let Some(long) = option.get_long() {
+            if has_short {
+                optspecs.push('/');
+            }
+            optspecs.push_str(&escape_string(long, false));
+        }
+        if option.is_required_set() {
+            optspecs.push('=');
+        }
+    }
+    let optspecs_fn_name = format!("__fish_{bin_name}_global_optspecs");
+    let template = format!("\
+        # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.\n\
+        function {optspecs_fn_name}\n\
+        \tstring join \\n{optspecs}\n\
+        end\n\n\
+        function {needs_fn_name}\n\
+        \t# Figure out if the current invocation already has a command.\n\
+        \tset -l cmd (commandline -opc)\n\
+        \tset -e cmd[1]\n\
+        \targparse -s ({optspecs_fn_name}) -- $cmd 2>/dev/null\n\
+        \tor return\n\
+        \tif set -q argv[1]\n\
+        \t\t# Also print the command, so this can be used to figure out what it is.\n\
+        \t\techo $argv[1]\n\
+        \t\treturn 1\n\
+        \tend\n\
+        \treturn 0\n\
+        end\n\n\
+        function {using_fn_name}\n\
+        \tset -l cmd ({needs_fn_name})\n\
+        \ttest -z \"$cmd\"\n\
+        \tand return 1\n\
+        \tcontains -- $cmd[1] $argv\n\
+        end\n\n\
+    ");
+    w!(buf, template.as_bytes());
 }
 
 fn value_completion(option: &Arg) -> String {

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -114,8 +114,10 @@ fn gen_fish_inner(
             [command, subcommand] => out.push_str(&format!(
                 " {command}; and __fish_seen_subcommand_from {subcommand}"
             )),
-            // Subcommand should be nested less than 3 levels to be practical
-            // `rustup toolchain help install` cannot receive any flags to it.
+            // HACK: Assuming subcommands are only nested less than 3 levels as more than that is
+            // unwieldy and takes more effort to support.
+            // For example, `rustup toolchain help install` is the longest valid command line of `rustup`
+            // that uses nested subcommands, and it cannot receive any flags to it.
             _ => return,
         }
         basic_template.push_str(format!(" -n \"{out}\"").as_str());

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use clap::{builder, Arg, Command, ValueHint};
+use clap::{builder, Arg, ArgAction, Command, ValueHint};
 
 use crate::generator::{utils, Generator};
 
@@ -16,7 +16,6 @@ impl Generator for Fish {
     }
 
     fn generate(&self, cmd: &Command, buf: &mut dyn Write) {
-        use clap::ArgAction::{Help, HelpLong, HelpShort, Version};
         let bin_name = cmd
             .get_bin_name()
             .expect("crate::generate should have set the bin_name");
@@ -26,7 +25,14 @@ impl Generator for Fish {
         // However, we prefer to fallback to the old behavior when there are no regular flags. `-h` and `-v` is not
         // a regular flag and it behaves like a command. E.g., `rustup --version toolchain` is not a valid command line.
         let has_global_flags = cmd.get_arguments().any(|a| {
-            !a.is_positional() && !matches!(a.get_action(), Help | HelpShort | HelpLong | Version)
+            !a.is_positional()
+                && !matches!(
+                    a.get_action(),
+                    ArgAction::Help
+                        | ArgAction::HelpShort
+                        | ArgAction::HelpLong
+                        | ArgAction::Version
+                )
         });
 
         let name = escape_name(bin_name);

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -21,7 +21,10 @@ impl Generator for Fish {
             .get_bin_name()
             .expect("crate::generate should have set the bin_name");
 
-        // `-h` and `-v` behaves as command, not regular flags/options that modifies subcommand behaviors.
+        // If there is any regular flags, we may have complicated cases, e.g. `git --git-dir somedir status`. Using normal
+        // `__fish_seen_subcommand_from` won't help us find out the real subcommand is `status`, and not `somedir`.
+        // However, we prefer to fallback to the old behavior when there are no regular flags. `-h` and `-v` is not
+        // a regular flag and it behaves like a command. E.g., `rustup --version toolchain` is not a valid command line.
         let has_global_flags = cmd.get_arguments().any(|a| {
             !a.is_positional() && !matches!(a.get_action(), Help | HelpShort | HelpLong | Version)
         });

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -231,7 +231,12 @@ fn gen_subcommand_helpers(
             }
             optspecs.push_str(&escape_string(long, false));
         }
-        if option.is_required_set() {
+
+        let is_an_option = option
+            .get_num_args()
+            .map(|r| r.takes_values())
+            .unwrap_or(true);
+        if is_an_option {
             optspecs.push('=');
         }
     }

--- a/clap_complete/src/shells/fish.rs
+++ b/clap_complete/src/shells/fish.rs
@@ -29,7 +29,7 @@ impl Generator for Fish {
         let name = escape_name(bin_name);
         let mut needs_fn_name = &format!("__fish_{name}_needs_command")[..];
         let mut using_fn_name = &format!("__fish_{name}_using_subcommand")[..];
-        if has_global_flags {
+        if has_global_flags && cmd.has_subcommands() {
             gen_subcommand_helpers(&name, cmd, buf, needs_fn_name, using_fn_name);
         } else {
             needs_fn_name = "__fish_use_subcommand";
@@ -215,9 +215,6 @@ fn gen_subcommand_helpers(
     needs_fn_name: &str,
     using_fn_name: &str,
 ) {
-    if !cmd.has_subcommands() {
-        return;
-    }
     let mut optspecs = String::new();
     let cmd_opts = cmd.get_arguments().filter(|a| !a.is_positional());
     for option in cmd_opts {

--- a/clap_complete/tests/snapshots/basic.fish
+++ b/clap_complete/tests/snapshots/basic.fish
@@ -1,10 +1,36 @@
-complete -c my-app -n "__fish_use_subcommand" -s c
-complete -c my-app -n "__fish_use_subcommand" -s v
-complete -c my-app -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_use_subcommand" -f -a "test" -d 'Subcommand with a second line'
-complete -c my-app -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from test" -s d
-complete -c my-app -n "__fish_seen_subcommand_from test" -s c
-complete -c my-app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test help" -f -a "test" -d 'Subcommand with a second line'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_my_app_global_optspecs
+	string join \n c v h/help
+end
+
+function __fish_my_app_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_my_app_using_subcommand
+	set -l cmd (__fish_my_app_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c my-app -n "__fish_my_app_needs_command" -s c
+complete -c my-app -n "__fish_my_app_needs_command" -s v
+complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "test" -d 'Subcommand with a second line'
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s d
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s c
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test help" -f -a "test" -d 'Subcommand with a second line'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/clap_complete/tests/snapshots/custom_bin_name.fish
+++ b/clap_complete/tests/snapshots/custom_bin_name.fish
@@ -1,10 +1,36 @@
-complete -c bin-name -n "__fish_use_subcommand" -s c
-complete -c bin-name -n "__fish_use_subcommand" -s v
-complete -c bin-name -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c bin-name -n "__fish_use_subcommand" -f -a "test" -d 'Subcommand with a second line'
-complete -c bin-name -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c bin-name -n "__fish_seen_subcommand_from test" -s d
-complete -c bin-name -n "__fish_seen_subcommand_from test" -s c
-complete -c bin-name -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help'
-complete -c bin-name -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test help" -f -a "test" -d 'Subcommand with a second line'
-complete -c bin-name -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_bin_name_global_optspecs
+	string join \n c v h/help
+end
+
+function __fish_bin_name_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_bin_name_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_bin_name_using_subcommand
+	set -l cmd (__fish_bin_name_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c bin-name -n "__fish_bin_name_needs_command" -s c
+complete -c bin-name -n "__fish_bin_name_needs_command" -s v
+complete -c bin-name -n "__fish_bin_name_needs_command" -s h -l help -d 'Print help'
+complete -c bin-name -n "__fish_bin_name_needs_command" -f -a "test" -d 'Subcommand with a second line'
+complete -c bin-name -n "__fish_bin_name_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c bin-name -n "__fish_bin_name_using_subcommand test" -s d
+complete -c bin-name -n "__fish_bin_name_using_subcommand test" -s c
+complete -c bin-name -n "__fish_bin_name_using_subcommand test" -s h -l help -d 'Print help'
+complete -c bin-name -n "__fish_bin_name_using_subcommand help; and not __fish_seen_subcommand_from test help" -f -a "test" -d 'Subcommand with a second line'
+complete -c bin-name -n "__fish_bin_name_using_subcommand help; and not __fish_seen_subcommand_from test help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/clap_complete/tests/snapshots/feature_sample.fish
+++ b/clap_complete/tests/snapshots/feature_sample.fish
@@ -1,10 +1,36 @@
-complete -c my-app -n "__fish_use_subcommand" -s c -s C -l config -l conf -d 'some config file'
-complete -c my-app -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_use_subcommand" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_use_subcommand" -a "test" -d 'tests things'
-complete -c my-app -n "__fish_use_subcommand" -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
-complete -c my-app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test help" -f -a "test" -d 'tests things'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_my_app_global_optspecs
+	string join \n c/config h/help V/version
+end
+
+function __fish_my_app_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_my_app_using_subcommand
+	set -l cmd (__fish_my_app_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'
+complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_needs_command" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_needs_command" -a "test" -d 'tests things'
+complete -c my-app -n "__fish_my_app_needs_command" -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand test" -l case -d 'the case to test' -r
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test help" -f -a "test" -d 'tests things'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_exhaustive_global_optspecs
-	string join \n global generate h/help V/version
+	string join \n global generate= h/help V/version
 end
 
 function __fish_exhaustive_needs_command

--- a/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
@@ -1,135 +1,161 @@
-complete -c exhaustive -n "__fish_use_subcommand" -l generate -d 'generate' -r -f -a "{bash\t'',elvish\t'',fish\t'',powershell\t'',zsh\t''}"
-complete -c exhaustive -n "__fish_use_subcommand" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_use_subcommand" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "action"
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "quote"
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "value"
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "pacman"
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "last"
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "alias"
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "hint"
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "complete" -d 'Register shell completions for this program'
-complete -c exhaustive -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -l set -d 'value' -r
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -l choice -d 'enum' -r -f -a "{first\t'',second\t''}"
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -l set-true -d 'bool'
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -l count -d 'number'
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from action" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l choice -r -f -a "{bash\t'bash (shell)',fish\t'fish shell',zsh\t'zsh shell'}"
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l single-quotes -d 'Can be \'always\', \'auto\', or \'never\''
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l double-quotes -d 'Can be "always", "auto", or "never"'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l backticks -d 'For more information see `echo test`'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l backslash -d 'Avoid \'\\n\''
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l brackets -d 'List packages [filter]'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l expansions -d 'Execute the shell command with $SHELL'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-backticks" -d 'For more information see `echo test`'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-brackets" -d 'List packages [filter]'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "escape-help" -d '\\tab	"\' New Line'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-single-quotes" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-single-quotes" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-single-quotes" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-double-quotes" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-double-quotes" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-double-quotes" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-backticks" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-backticks" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-backticks" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-backslash" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-backslash" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-backslash" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-brackets" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-brackets" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-brackets" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-expansions" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-expansions" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote cmd-expansions" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote escape-help" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote escape-help" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote escape-help" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-backticks" -d 'For more information see `echo test`'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-brackets" -d 'List packages [filter]'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "escape-help" -d '\\tab	"\' New Line'
-complete -c exhaustive -n "__fish_seen_subcommand_from quote help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c exhaustive -n "__fish_seen_subcommand_from value" -l delim -r
-complete -c exhaustive -n "__fish_seen_subcommand_from value" -l tuple -r
-complete -c exhaustive -n "__fish_seen_subcommand_from value" -l require-eq -r
-complete -c exhaustive -n "__fish_seen_subcommand_from value" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from value" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from value" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman; and not __fish_seen_subcommand_from one two help" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman; and not __fish_seen_subcommand_from one two help" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman; and not __fish_seen_subcommand_from one two help" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman; and not __fish_seen_subcommand_from one two help" -f -a "one"
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman; and not __fish_seen_subcommand_from one two help" -f -a "two"
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman; and not __fish_seen_subcommand_from one two help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman one" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman one" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman one" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman two" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman two" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman two" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman help; and not __fish_seen_subcommand_from one two help" -f -a "one"
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman help; and not __fish_seen_subcommand_from one two help" -f -a "two"
-complete -c exhaustive -n "__fish_seen_subcommand_from pacman help; and not __fish_seen_subcommand_from one two help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c exhaustive -n "__fish_seen_subcommand_from last" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from last" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from last" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from alias" -s o -s O -l option -l opt -d 'cmd option' -r
-complete -c exhaustive -n "__fish_seen_subcommand_from alias" -s f -s F -l flag -l flg -d 'cmd flag'
-complete -c exhaustive -n "__fish_seen_subcommand_from alias" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from alias" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from alias" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l choice -r -f -a "{bash\t'',fish\t'',zsh\t''}"
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l unknown -r
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l other -r -f
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s p -l path -r -F
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s f -l file -r -F
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s d -l dir -r -f -a "(__fish_complete_directories)"
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s e -l exe -r -F
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l cmd-name -r -f -a "(__fish_complete_command)"
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s c -l cmd -r -f -a "(__fish_complete_command)"
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s u -l user -r -f -a "(__fish_complete_users)"
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s H -l host -r -f -a "(__fish_print_hostnames)"
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l url -r -f
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l email -r -f
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s h -l help -d 'Print help'
-complete -c exhaustive -n "__fish_seen_subcommand_from hint" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l shell -d 'Specify shell to complete for' -r -f -a "{bash\t'',fish\t''}"
-complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l register -d 'Path to write completion-registration to' -r -F
-complete -c exhaustive -n "__fish_seen_subcommand_from complete" -l global -d 'everywhere'
-complete -c exhaustive -n "__fish_seen_subcommand_from complete" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c exhaustive -n "__fish_seen_subcommand_from complete" -s V -l version -d 'Print version'
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "action"
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "quote"
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "value"
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "pacman"
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "last"
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "alias"
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "hint"
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "complete" -d 'Register shell completions for this program'
-complete -c exhaustive -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c exhaustive -n "__fish_seen_subcommand_from help quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
-complete -c exhaustive -n "__fish_seen_subcommand_from help quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
-complete -c exhaustive -n "__fish_seen_subcommand_from help quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help" -f -a "cmd-backticks" -d 'For more information see `echo test`'
-complete -c exhaustive -n "__fish_seen_subcommand_from help quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
-complete -c exhaustive -n "__fish_seen_subcommand_from help quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help" -f -a "cmd-brackets" -d 'List packages [filter]'
-complete -c exhaustive -n "__fish_seen_subcommand_from help quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
-complete -c exhaustive -n "__fish_seen_subcommand_from help quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help" -f -a "escape-help" -d '\\tab	"\' New Line'
-complete -c exhaustive -n "__fish_seen_subcommand_from help pacman; and not __fish_seen_subcommand_from one two" -f -a "one"
-complete -c exhaustive -n "__fish_seen_subcommand_from help pacman; and not __fish_seen_subcommand_from one two" -f -a "two"
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_exhaustive_global_optspecs
+	string join \n global generate h/help V/version
+end
+
+function __fish_exhaustive_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_exhaustive_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_exhaustive_using_subcommand
+	set -l cmd (__fish_exhaustive_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -l generate -d 'generate' -r -f -a "{bash\t'',elvish\t'',fish\t'',powershell\t'',zsh\t''}"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "action"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "quote"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "value"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "pacman"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "last"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "alias"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "hint"
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "complete" -d 'Register shell completions for this program'
+complete -c exhaustive -n "__fish_exhaustive_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand action" -l set -d 'value' -r
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand action" -l choice -d 'enum' -r -f -a "{first\t'',second\t''}"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand action" -l set-true -d 'bool'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand action" -l count -d 'number'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand action" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand action" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand action" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l choice -r -f -a "{bash\t'bash (shell)',fish\t'fish shell',zsh\t'zsh shell'}"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l single-quotes -d 'Can be \'always\', \'auto\', or \'never\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l double-quotes -d 'Can be "always", "auto", or "never"'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l backticks -d 'For more information see `echo test`'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l backslash -d 'Avoid \'\\n\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l brackets -d 'List packages [filter]'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l expansions -d 'Execute the shell command with $SHELL'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-backticks" -d 'For more information see `echo test`'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-brackets" -d 'List packages [filter]'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "escape-help" -d '\\tab	"\' New Line'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions escape-help help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-single-quotes" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-single-quotes" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-single-quotes" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-double-quotes" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-double-quotes" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-double-quotes" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-backticks" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-backticks" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-backticks" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-backslash" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-backslash" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-backslash" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-brackets" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-brackets" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-brackets" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-expansions" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-expansions" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from cmd-expansions" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from escape-help" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from escape-help" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from escape-help" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "cmd-backticks" -d 'For more information see `echo test`'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "cmd-brackets" -d 'List packages [filter]'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "escape-help" -d '\\tab	"\' New Line'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand quote; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand value" -l delim -r
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand value" -l tuple -r
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand value" -l require-eq -r
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand value" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand value" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand value" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and not __fish_seen_subcommand_from one two help" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and not __fish_seen_subcommand_from one two help" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and not __fish_seen_subcommand_from one two help" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and not __fish_seen_subcommand_from one two help" -f -a "one"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and not __fish_seen_subcommand_from one two help" -f -a "two"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and not __fish_seen_subcommand_from one two help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from one" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from one" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from one" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from two" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from two" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from two" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from help" -f -a "one"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from help" -f -a "two"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand pacman; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand last" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand last" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand last" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand alias" -s o -s O -l option -l opt -d 'cmd option' -r
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand alias" -s f -s F -l flag -l flg -d 'cmd flag'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand alias" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand alias" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand alias" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -l choice -r -f -a "{bash\t'',fish\t'',zsh\t''}"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -l unknown -r
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -l other -r -f
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s p -l path -r -F
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s f -l file -r -F
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s d -l dir -r -f -a "(__fish_complete_directories)"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s e -l exe -r -F
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -l cmd-name -r -f -a "(__fish_complete_command)"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s c -l cmd -r -f -a "(__fish_complete_command)"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s u -l user -r -f -a "(__fish_complete_users)"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s H -l host -r -f -a "(__fish_print_hostnames)"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -l url -r -f
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -l email -r -f
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s h -l help -d 'Print help'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand hint" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand complete" -l shell -d 'Specify shell to complete for' -r -f -a "{bash\t'',fish\t''}"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand complete" -l register -d 'Path to write completion-registration to' -r -F
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand complete" -l global -d 'everywhere'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand complete" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand complete" -s V -l version -d 'Print version'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "action"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "quote"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "value"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "pacman"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "last"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "alias"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "hint"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "complete" -d 'Register shell completions for this program'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and not __fish_seen_subcommand_from action quote value pacman last alias hint complete help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from quote" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from quote" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from quote" -f -a "cmd-backticks" -d 'For more information see `echo test`'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from quote" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from quote" -f -a "cmd-brackets" -d 'List packages [filter]'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from quote" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from quote" -f -a "escape-help" -d '\\tab	"\' New Line'
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from pacman" -f -a "one"
+complete -c exhaustive -n "__fish_exhaustive_using_subcommand help; and __fish_seen_subcommand_from pacman" -f -a "two"

--- a/clap_complete/tests/snapshots/quoting.fish
+++ b/clap_complete/tests/snapshots/quoting.fish
@@ -1,28 +1,54 @@
-complete -c my-app -n "__fish_use_subcommand" -l single-quotes -d 'Can be \'always\', \'auto\', or \'never\''
-complete -c my-app -n "__fish_use_subcommand" -l double-quotes -d 'Can be "always", "auto", or "never"'
-complete -c my-app -n "__fish_use_subcommand" -l backticks -d 'For more information see `echo test`'
-complete -c my-app -n "__fish_use_subcommand" -l backslash -d 'Avoid \'\\n\''
-complete -c my-app -n "__fish_use_subcommand" -l brackets -d 'List packages [filter]'
-complete -c my-app -n "__fish_use_subcommand" -l expansions -d 'Execute the shell command with $SHELL'
-complete -c my-app -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_use_subcommand" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_use_subcommand" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
-complete -c my-app -n "__fish_use_subcommand" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
-complete -c my-app -n "__fish_use_subcommand" -f -a "cmd-backticks" -d 'For more information see `echo test`'
-complete -c my-app -n "__fish_use_subcommand" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
-complete -c my-app -n "__fish_use_subcommand" -f -a "cmd-brackets" -d 'List packages [filter]'
-complete -c my-app -n "__fish_use_subcommand" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
-complete -c my-app -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from cmd-single-quotes" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from cmd-double-quotes" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from cmd-backticks" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from cmd-backslash" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from cmd-brackets" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from cmd-expansions" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-backticks" -d 'For more information see `echo test`'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-brackets" -d 'List packages [filter]'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_my_app_global_optspecs
+	string join \n single-quotes double-quotes backticks backslash brackets expansions h/help V/version
+end
+
+function __fish_my_app_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_my_app_using_subcommand
+	set -l cmd (__fish_my_app_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c my-app -n "__fish_my_app_needs_command" -l single-quotes -d 'Can be \'always\', \'auto\', or \'never\''
+complete -c my-app -n "__fish_my_app_needs_command" -l double-quotes -d 'Can be "always", "auto", or "never"'
+complete -c my-app -n "__fish_my_app_needs_command" -l backticks -d 'For more information see `echo test`'
+complete -c my-app -n "__fish_my_app_needs_command" -l backslash -d 'Avoid \'\\n\''
+complete -c my-app -n "__fish_my_app_needs_command" -l brackets -d 'List packages [filter]'
+complete -c my-app -n "__fish_my_app_needs_command" -l expansions -d 'Execute the shell command with $SHELL'
+complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_needs_command" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "cmd-backticks" -d 'For more information see `echo test`'
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "cmd-brackets" -d 'List packages [filter]'
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand cmd-single-quotes" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand cmd-double-quotes" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand cmd-backticks" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand cmd-backslash" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand cmd-brackets" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand cmd-expansions" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-single-quotes" -d 'Can be \'always\', \'auto\', or \'never\''
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-double-quotes" -d 'Can be "always", "auto", or "never"'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-backticks" -d 'For more information see `echo test`'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-backslash" -d 'Avoid \'\\n\''
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-brackets" -d 'List packages [filter]'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "cmd-expansions" -d 'Execute the shell command with $SHELL'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/clap_complete/tests/snapshots/special_commands.fish
+++ b/clap_complete/tests/snapshots/special_commands.fish
@@ -1,23 +1,49 @@
-complete -c my-app -n "__fish_use_subcommand" -s c -s C -l config -l conf -d 'some config file'
-complete -c my-app -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_use_subcommand" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_use_subcommand" -a "test" -d 'tests things'
-complete -c my-app -n "__fish_use_subcommand" -a "some_cmd" -d 'tests other things'
-complete -c my-app -n "__fish_use_subcommand" -a "some-cmd-with-hyphens"
-complete -c my-app -n "__fish_use_subcommand" -a "some-hidden-cmd"
-complete -c my-app -n "__fish_use_subcommand" -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
-complete -c my-app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd" -l config -d 'the other case to test' -r
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some-cmd-with-hyphens" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from some-cmd-with-hyphens" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some-hidden-cmd" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from some-hidden-cmd" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "test" -d 'tests things'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "some_cmd" -d 'tests other things'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "some-cmd-with-hyphens"
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "some-hidden-cmd"
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_my_app_global_optspecs
+	string join \n c/config h/help V/version
+end
+
+function __fish_my_app_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_my_app_using_subcommand
+	set -l cmd (__fish_my_app_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'
+complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_needs_command" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_needs_command" -a "test" -d 'tests things'
+complete -c my-app -n "__fish_my_app_needs_command" -a "some_cmd" -d 'tests other things'
+complete -c my-app -n "__fish_my_app_needs_command" -a "some-cmd-with-hyphens"
+complete -c my-app -n "__fish_my_app_needs_command" -a "some-hidden-cmd"
+complete -c my-app -n "__fish_my_app_needs_command" -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand test" -l case -d 'the case to test' -r
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd" -l config -d 'the other case to test' -r
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some-cmd-with-hyphens" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand some-cmd-with-hyphens" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some-hidden-cmd" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand some-hidden-cmd" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "test" -d 'tests things'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "some_cmd" -d 'tests other things'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "some-cmd-with-hyphens"
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "some-hidden-cmd"
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd some-cmd-with-hyphens some-hidden-cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/clap_complete/tests/snapshots/sub_subcommands.fish
+++ b/clap_complete/tests/snapshots/sub_subcommands.fish
@@ -1,32 +1,58 @@
-complete -c my-app -n "__fish_use_subcommand" -s c -s C -l config -l conf -d 'some config file'
-complete -c my-app -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_use_subcommand" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_use_subcommand" -a "test" -d 'tests things'
-complete -c my-app -n "__fish_use_subcommand" -a "some_cmd" -d 'top level subcommand'
-complete -c my-app -n "__fish_use_subcommand" -a "some_cmd_alias" -d 'top level subcommand'
-complete -c my-app -n "__fish_use_subcommand" -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from test" -l case -d 'the case to test' -r
-complete -c my-app -n "__fish_seen_subcommand_from test" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from test" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -f -a "sub_cmd" -d 'sub-subcommand'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.\t'help,with,comma',Second to trigger display of options\t''}"
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd sub_cmd" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd sub_cmd" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd help; and not __fish_seen_subcommand_from sub_cmd help" -f -a "sub_cmd" -d 'sub-subcommand'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd help; and not __fish_seen_subcommand_from sub_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -f -a "sub_cmd" -d 'sub-subcommand'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.\t'help,with,comma',Second to trigger display of options\t''}"
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias sub_cmd" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias sub_cmd" -s V -l version -d 'Print version'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias help; and not __fish_seen_subcommand_from sub_cmd help" -f -a "sub_cmd" -d 'sub-subcommand'
-complete -c my-app -n "__fish_seen_subcommand_from some_cmd_alias help; and not __fish_seen_subcommand_from sub_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd help" -f -a "test" -d 'tests things'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd help" -f -a "some_cmd" -d 'top level subcommand'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from test some_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from help some_cmd; and not __fish_seen_subcommand_from sub_cmd" -f -a "sub_cmd" -d 'sub-subcommand'
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_my_app_global_optspecs
+	string join \n c/config h/help V/version
+end
+
+function __fish_my_app_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_my_app_using_subcommand
+	set -l cmd (__fish_my_app_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'
+complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_needs_command" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_needs_command" -a "test" -d 'tests things'
+complete -c my-app -n "__fish_my_app_needs_command" -a "some_cmd" -d 'top level subcommand'
+complete -c my-app -n "__fish_my_app_needs_command" -a "some_cmd_alias" -d 'top level subcommand'
+complete -c my-app -n "__fish_my_app_needs_command" -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand test" -l case -d 'the case to test' -r
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand test" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -f -a "sub_cmd" -d 'sub-subcommand'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and not __fish_seen_subcommand_from sub_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.\t'help,with,comma',Second to trigger display of options\t''}"
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -f -a "sub_cmd" -d 'sub-subcommand'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and not __fish_seen_subcommand_from sub_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and __fish_seen_subcommand_from sub_cmd" -l config -d 'the other case to test' -r -f -a "{Lest quotes\, aren\'t escaped.\t'help,with,comma',Second to trigger display of options\t''}"
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and __fish_seen_subcommand_from sub_cmd" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and __fish_seen_subcommand_from sub_cmd" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and __fish_seen_subcommand_from help" -f -a "sub_cmd" -d 'sub-subcommand'
+complete -c my-app -n "__fish_my_app_using_subcommand some_cmd_alias; and __fish_seen_subcommand_from help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd help" -f -a "test" -d 'tests things'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd help" -f -a "some_cmd" -d 'top level subcommand'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from test some_cmd help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and __fish_seen_subcommand_from some_cmd" -f -a "sub_cmd" -d 'sub-subcommand'

--- a/clap_complete/tests/snapshots/subcommand_last.fish
+++ b/clap_complete/tests/snapshots/subcommand_last.fish
@@ -1,9 +1,35 @@
-complete -c my-app -n "__fish_use_subcommand" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_use_subcommand" -a "foo"
-complete -c my-app -n "__fish_use_subcommand" -a "bar"
-complete -c my-app -n "__fish_use_subcommand" -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c my-app -n "__fish_seen_subcommand_from foo" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from bar" -s h -l help -d 'Print help'
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from foo bar help" -f -a "foo"
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from foo bar help" -f -a "bar"
-complete -c my-app -n "__fish_seen_subcommand_from help; and not __fish_seen_subcommand_from foo bar help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_my_app_global_optspecs
+	string join \n h/help
+end
+
+function __fish_my_app_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_my_app_using_subcommand
+	set -l cmd (__fish_my_app_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_needs_command" -a "foo"
+complete -c my-app -n "__fish_my_app_needs_command" -a "bar"
+complete -c my-app -n "__fish_my_app_needs_command" -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c my-app -n "__fish_my_app_using_subcommand foo" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand bar" -s h -l help -d 'Print help'
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from foo bar help" -f -a "foo"
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from foo bar help" -f -a "bar"
+complete -c my-app -n "__fish_my_app_using_subcommand help; and not __fish_seen_subcommand_from foo bar help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'


### PR DESCRIPTION
[As guided][1] by fish's maintainer, to handle nested subcommands, we try to generate 3 new functions for completion scripts:

* `__fish_{name}_global_optspecs` will gather global [option specifications][3],
* `__fish_{name}_needs_command`, with `rustup \t`,  used to check for `rustup`
* `__fish_{name}_using_subcommand show`, with `rustup show \t`,  check if current cmd is `show`

This pattern is popular within [fish-shell ](https://github.com/fish-shell/fish-shell)repository, for some commands:
* [npm](https://github.com/fish-shell/fish-shell/blob/e67ffc1a3b91df44e9aa1602852242a3c6cc9b1d/share/completions/npm.fish#L85-L86)
* [git](https://github.com/fish-shell/fish-shell/blob/e67ffc1a3b91df44e9aa1602852242a3c6cc9b1d/share/completions/git.fish#L2161-L2164)
* [meson](https://github.com/fish-shell/fish-shell/blob/e67ffc1a3b91df44e9aa1602852242a3c6cc9b1d/share/completions/meson.fish#L97-L99)

This is complicated, as stated by fish's maintainers. Let's hope [the new fish proposal][2] will improve things.

**This PR contains a HACK:**  Assuming subcommands are only nested less than 3 levels as more than that is unwieldy and takes more effort to support. For example, `rustup toolchain help install` is the longest valid command line of `rustup` that uses nested subcommands, and it cannot receive any flags to it.


[1]: https://github.com/fish-shell/fish-shell/issues/8773#issuecomment-1063899293
[2]: https://github.com/fish-shell/fish-shell/issues/7107
[3]: https://fishshell.com/docs/current/cmds/argparse.html#example-option-specs