### PR TITLE
feat(clap_complete): Support `-fbar` and `-f=bar` in native completions

### DIFF
--- a/clap_complete/src/dynamic/completer.rs
+++ b/clap_complete/src/dynamic/completer.rs
@@ -109,47 +109,17 @@ pub fn complete(
             } else {
                 state = ParseState::ValueDone;
             }
-        } else if let Some(mut short) = arg.to_short() {
-            let mut takes_value = false;
-            loop {
-                if let Some(Ok(opt)) = short.next_flag() {
-                    let opt = current_cmd.get_arguments().find(|a| {
-                        let shorts = a.get_short_and_visible_aliases();
-                        let is_find = shorts.map(|v| {
-                            let mut iter = v.into_iter();
-                            let c = iter.find(|c| *c == opt);
-                            c.is_some()
-                        });
-                        is_find.unwrap_or(false)
-                    });
-
-                    state = match opt.map(|o| o.get_action()) {
-                        Some(clap::ArgAction::Set) | Some(clap::ArgAction::Append) => {
-                            takes_value = true;
-                            if short.next_value_os().is_some() {
-                                ParseState::ValueDone
-                            } else {
-                                ParseState::Opt(opt.unwrap().clone())
-                            }
-                        }
-                        Some(clap::ArgAction::SetTrue) | Some(clap::ArgAction::SetFalse) => {
-                            ParseState::ValueDone
-                        }
-                        Some(clap::ArgAction::Count) => ParseState::ValueDone,
-                        Some(clap::ArgAction::Version) => ParseState::ValueDone,
-                        Some(clap::ArgAction::Help)
-                        | Some(clap::ArgAction::HelpShort)
-                        | Some(clap::ArgAction::HelpLong) => ParseState::ValueDone,
+        } else if let Some(short) = arg.to_short() {
+            let (_, takes_value_opt, mut short) = parse_shortflags(current_cmd, short);
+            match takes_value_opt {
+                Some(opt) => {
+                    state = match short.next_value_os() {
                         Some(_) => ParseState::ValueDone,
-                        None => ParseState::ValueDone,
+                        None => ParseState::Opt(opt.clone()),
                     };
-
-                    if takes_value {
-                        break;
-                    }
-                } else {
+                }
+                None => {
                     state = ParseState::ValueDone;
-                    break;
                 }
             }
         } else {
@@ -263,46 +233,10 @@ fn complete_arg(
                             .visible(true)
                         }),
                 );
-            } else if let Some(mut short) = arg.to_short() {
+            } else if let Some(short) = arg.to_short() {
                 if !short.is_negative_number() {
-                    let takes_value_opt;
-                    let mut leading_flags = OsString::new();
                     // Find the first takes_value option.
-                    loop {
-                        match short.next_flag() {
-                            Some(Ok(opt)) => {
-                                leading_flags.push(opt.to_string());
-                                let opt = cmd.get_arguments().find(|a| {
-                                    let shorts = a.get_short_and_visible_aliases();
-                                    let is_find = shorts.map(|v| {
-                                        let mut iter = v.into_iter();
-                                        let c = iter.find(|c| *c == opt);
-                                        c.is_some()
-                                    });
-                                    is_find.unwrap_or(false)
-                                });
-                                match opt.map(|o| o.get_action()) {
-                                    Some(clap::ArgAction::Set) | Some(clap::ArgAction::Append) => {
-                                        takes_value_opt = opt;
-                                        break;
-                                    }
-                                    Some(clap::ArgAction::SetTrue)
-                                    | Some(clap::ArgAction::SetFalse)
-                                    | Some(clap::ArgAction::Count)
-                                    | Some(clap::ArgAction::Version)
-                                    | Some(clap::ArgAction::Help)
-                                    | Some(clap::ArgAction::HelpShort)
-                                    | Some(clap::ArgAction::HelpLong) => (),
-                                    Some(_) => (),
-                                    None => (),
-                                }
-                            }
-                            Some(Err(_)) | None => {
-                                takes_value_opt = None;
-                                break;
-                            }
-                        }
-                    }
+                    let (leading_flags, takes_value_opt, mut short) = parse_shortflags(&cmd, short);
 
                     // Clone `short` to `peek_short` to peek whether the next flag is a `=`.
                     if let Some(opt) = takes_value_opt {
@@ -316,7 +250,7 @@ fn complete_arg(
 
                         let value = short.next_value_os().unwrap_or(OsStr::new(""));
                         completions.extend(
-                            complete_arg_value(value.to_str().ok_or(value), opt, current_dir)
+                            complete_arg_value(value.to_str().ok_or(value), &opt, current_dir)
                                 .into_iter()
                                 .map(|comp| {
                                     CompletionCandidate::new(format!(
@@ -599,6 +533,53 @@ fn subcommands(p: &clap::Command) -> Vec<CompletionCandidate> {
                 }))
         })
         .collect()
+}
+
+/// Parse the short flags and find the first takes_value option.
+fn parse_shortflags<'s>(
+    cmd: &clap::Command,
+    mut short: clap_lex::ShortFlags<'s>,
+) -> (OsString, Option<clap::Arg>, clap_lex::ShortFlags<'s>) {
+    let takes_value_opt;
+    let mut leading_flags = OsString::new();
+    // Find the first takes_value option.
+    loop {
+        match short.next_flag() {
+            Some(Ok(opt)) => {
+                leading_flags.push(opt.to_string());
+                let opt = cmd.get_arguments().find(|a| {
+                    let shorts = a.get_short_and_visible_aliases();
+                    let is_find = shorts.map(|v| {
+                        let mut iter = v.into_iter();
+                        let c = iter.find(|c| *c == opt);
+                        c.is_some()
+                    });
+                    is_find.unwrap_or(false)
+                });
+                match opt.map(|o| o.get_action()) {
+                    Some(clap::ArgAction::Set) | Some(clap::ArgAction::Append) => {
+                        takes_value_opt = opt;
+                        break;
+                    }
+                    Some(clap::ArgAction::SetTrue)
+                    | Some(clap::ArgAction::SetFalse)
+                    | Some(clap::ArgAction::Count)
+                    | Some(clap::ArgAction::Version)
+                    | Some(clap::ArgAction::Help)
+                    | Some(clap::ArgAction::HelpShort)
+                    | Some(clap::ArgAction::HelpLong) => (),
+                    Some(_) => (),
+                    None => (),
+                }
+            }
+            Some(Err(_)) | None => {
+                takes_value_opt = None;
+                break;
+            }
+        }
+    }
+
+    (leading_flags, takes_value_opt.cloned(), short)
 }
 
 /// A completion candidate definition

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -402,6 +402,56 @@ pos_b
 pos_c"
         ]
     );
+
+    assert_data_eq!(
+        complete!(cmd, "-ci[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![
+            "-cii
+-ciF
+-cic
+-cih	Print help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-ci=[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![
+            "-ci=i
+-ci=F
+-ci=c
+-ci=h	Print help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-ci=a[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![
+            "-ci=ai
+-ci=aF
+-ci=ac
+-ci=ah	Print help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-ciF[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![
+            "-ciFi
+-ciFF
+-ciFc
+-ciFh\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-ciF=[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![
+            "-ciF=i
+-ciF=F
+-ciF=c
+-ciF=h\tPrint help"
+        ]
+    )
 }
 
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -406,51 +406,36 @@ pos_c"
     assert_data_eq!(
         complete!(cmd, "-ci[TAB]", current_dir = Some(testdir_path)),
         snapbox::str![
-            "-cii
--ciF
--cic
--cih	Print help"
+            "-cia_file
+-cib_file
+-cic_dir/
+-cid_dir/"
         ]
     );
 
     assert_data_eq!(
         complete!(cmd, "-ci=[TAB]", current_dir = Some(testdir_path)),
         snapbox::str![
-            "-ci=i
--ci=F
--ci=c
--ci=h	Print help"
+            "-ci=a_file
+-ci=b_file
+-ci=c_dir/
+-ci=d_dir/"
         ]
     );
 
     assert_data_eq!(
         complete!(cmd, "-ci=a[TAB]", current_dir = Some(testdir_path)),
-        snapbox::str![
-            "-ci=ai
--ci=aF
--ci=ac
--ci=ah	Print help"
-        ]
+        snapbox::str!["-ci=a_file"]
     );
 
     assert_data_eq!(
         complete!(cmd, "-ciF[TAB]", current_dir = Some(testdir_path)),
-        snapbox::str![
-            "-ciFi
--ciFF
--ciFc
--ciFh\tPrint help"
-        ]
+        snapbox::str![""]
     );
 
     assert_data_eq!(
         complete!(cmd, "-ciF=[TAB]", current_dir = Some(testdir_path)),
-        snapbox::str![
-            "-ciF=i
--ciF=F
--ciF=c
--ciF=h\tPrint help"
-        ]
+        snapbox::str![""]
     )
 }
 


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
related issue: https://github.com/clap-rs/clap/issues/3920

This is a later PR based on https://github.com/clap-rs/clap/pull/5539

### What is left
Error parsing for `--flag=bar` in `bash`
**more details:**
https://github.com/clap-rs/clap/blob/43e73682835653ac48f32cc786514553d697c693/clap_complete/src/dynamic/shells/mod.rs#L36-L48
The `comp_words` will be ['command', '--flag', '=', 'value'] rather than ['command', '--flag=value'] because of `COMP_WORDBREAKS`.

