### PR TITLE
feat(clap_complete): Support hiding long flags and their long aliases

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -3952,6 +3952,21 @@ impl Arg {
         Some(longs)
     }
 
+    /// Get hidden aliases for this argument, if any
+    #[inline]
+    pub fn get_aliases(&self) -> Option<Vec<&str>> {
+        if self.aliases.is_empty() {
+            None
+        } else {
+            Some(
+                self.aliases
+                    .iter()
+                    .filter_map(|(s, v)| if !*v { Some(s.as_str()) } else { None })
+                    .collect(),
+            )
+        }
+    }
+
     /// Get the names of possible values for this argument. Only useful for user
     /// facing applications, such as building help messages or man files
     pub fn get_possible_values(&self) -> Vec<PossibleValue> {

--- a/clap_complete/src/dynamic/shells/bash.rs
+++ b/clap_complete/src/dynamic/shells/bash.rs
@@ -73,11 +73,11 @@ complete -o nospace -o bashdefault -F _clap_complete_NAME BIN
         let ifs: Option<String> = std::env::var("IFS").ok().and_then(|i| i.parse().ok());
         let completions = crate::dynamic::complete(cmd, args, index, current_dir)?;
 
-        for (i, (completion, _)) in completions.iter().enumerate() {
+        for (i, candidate) in completions.iter().enumerate() {
             if i != 0 {
                 write!(buf, "{}", ifs.as_deref().unwrap_or("\n"))?;
             }
-            write!(buf, "{}", completion.to_string_lossy())?;
+            write!(buf, "{}", candidate.get_content().to_string_lossy())?;
         }
         Ok(())
     }

--- a/clap_complete/src/dynamic/shells/elvish.rs
+++ b/clap_complete/src/dynamic/shells/elvish.rs
@@ -47,11 +47,11 @@ set edit:completion:arg-completer[BIN] = { |@words|
         let ifs: Option<String> = std::env::var("_CLAP_IFS").ok().and_then(|i| i.parse().ok());
         let completions = crate::dynamic::complete(cmd, args, index, current_dir)?;
 
-        for (i, (completion, _)) in completions.iter().enumerate() {
+        for (i, candidate) in completions.iter().enumerate() {
             if i != 0 {
                 write!(buf, "{}", ifs.as_deref().unwrap_or("\n"))?;
             }
-            write!(buf, "{}", completion.to_string_lossy())?;
+            write!(buf, "{}", candidate.get_content().to_string_lossy())?;
         }
         Ok(())
     }

--- a/clap_complete/src/dynamic/shells/fish.rs
+++ b/clap_complete/src/dynamic/shells/fish.rs
@@ -30,9 +30,9 @@ impl crate::dynamic::Completer for Fish {
         let index = args.len() - 1;
         let completions = crate::dynamic::complete(cmd, args, index, current_dir)?;
 
-        for (completion, help) in completions {
-            write!(buf, "{}", completion.to_string_lossy())?;
-            if let Some(help) = help {
+        for candidate in completions {
+            write!(buf, "{}", candidate.get_content().to_string_lossy())?;
+            if let Some(help) = candidate.get_help() {
                 write!(
                     buf,
                     "\t{}",

--- a/clap_complete/src/dynamic/shells/zsh.rs
+++ b/clap_complete/src/dynamic/shells/zsh.rs
@@ -54,11 +54,11 @@ compdef _clap_dynamic_completer BIN"#
         }
         let completions = crate::dynamic::complete(cmd, args, index, current_dir)?;
 
-        for (i, (completion, _)) in completions.iter().enumerate() {
+        for (i, candidate) in completions.iter().enumerate() {
             if i != 0 {
                 write!(buf, "{}", ifs.as_deref().unwrap_or("\n"))?;
             }
-            write!(buf, "{}", completion.to_string_lossy())?;
+            write!(buf, "{}", candidate.get_content().to_string_lossy())?;
         }
         Ok(())
     }

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -45,10 +45,7 @@ fn suggest_hidden_long_flags() {
 
     assert_data_eq!(
         complete!(cmd, "--hello-world"),
-        snapbox::str![
-            "--hello-world-visible
---hello-world-hidden"
-        ]
+        snapbox::str!["--hello-world-visible"]
     );
 
     assert_data_eq!(
@@ -108,9 +105,7 @@ fn suggest_hidden_long_flag_aliases() {
         complete!(cmd, "--test"),
         snapbox::str![
             "--test_visible
---test_visible-alias_visible
---test_hidden
---test_hidden-alias_visible"
+--test_visible-alias_visible"
         ]
     );
 
@@ -118,13 +113,20 @@ fn suggest_hidden_long_flag_aliases() {
         complete!(cmd, "--test_h"),
         snapbox::str![
             "--test_hidden
---test_hidden-alias_visible"
+--test_hidden-alias_visible
+--test_hidden-alias_hidden"
         ]
     );
 
-    assert_data_eq!(complete!(cmd, "--test_visible-alias_h"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "--test_visible-alias_h"),
+        snapbox::str!["--test_visible-alias_hidden"]
+    );
 
-    assert_data_eq!(complete!(cmd, "--test_hidden-alias_h"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "--test_hidden-alias_h"),
+        snapbox::str!["--test_hidden-alias_hidden"]
+    );
 }
 
 #[test]

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -171,9 +171,9 @@ fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>
     clap_complete::dynamic::complete(cmd, args, arg_index, current_dir)
         .unwrap()
         .into_iter()
-        .map(|(compl, help)| {
-            let compl = compl.to_str().unwrap();
-            if let Some(help) = help {
+        .map(|candidate| {
+            let compl = candidate.get_content().to_str().unwrap();
+            if let Some(help) = candidate.get_help() {
                 format!("{compl}\t{help}")
             } else {
                 compl.to_owned()

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -23,11 +23,38 @@ fn suggest_subcommand_subset() {
         .subcommand(Command::new("hello-moon"))
         .subcommand(Command::new("goodbye-world"));
 
-    assert_data_eq!(complete!(cmd, "he"), snapbox::str![[r#"
+    assert_data_eq!(
+        complete!(cmd, "he"),
+        snapbox::str![[r#"
 hello-moon
 hello-world
 help	Print this message or the help of the given subcommand(s)
-"#]],);
+"#]],
+    );
+}
+
+#[test]
+fn suggest_hidden_long_flags() {
+    let mut cmd = Command::new("exhaustive")
+        .arg(clap::Arg::new("hello-world-visible").long("hello-world-visible"))
+        .arg(
+            clap::Arg::new("hello-world-hidden")
+                .long("hello-world-hidden")
+                .hide(true),
+        );
+
+    assert_data_eq!(
+        complete!(cmd, "--hello-world"),
+        snapbox::str![
+            "--hello-world-visible
+--hello-world-hidden"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--hello-world-h"),
+        snapbox::str!["--hello-world-hidden"]
+    )
 }
 
 #[test]
@@ -61,6 +88,46 @@ hello-world-foo"
 }
 
 #[test]
+fn suggest_hidden_long_flag_aliases() {
+    let mut cmd = Command::new("exhaustive")
+        .arg(
+            clap::Arg::new("test_visible")
+                .long("test_visible")
+                .visible_alias("test_visible-alias_visible")
+                .alias("test_visible-alias_hidden"),
+        )
+        .arg(
+            clap::Arg::new("test_hidden")
+                .long("test_hidden")
+                .visible_alias("test_hidden-alias_visible")
+                .alias("test_hidden-alias_hidden")
+                .hide(true),
+        );
+
+    assert_data_eq!(
+        complete!(cmd, "--test"),
+        snapbox::str![
+            "--test_visible
+--test_visible-alias_visible
+--test_hidden
+--test_hidden-alias_visible"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--test_h"),
+        snapbox::str![
+            "--test_hidden
+--test_hidden-alias_visible"
+        ]
+    );
+
+    assert_data_eq!(complete!(cmd, "--test_visible-alias_h"), snapbox::str![""]);
+
+    assert_data_eq!(complete!(cmd, "--test_hidden-alias_h"), snapbox::str![""]);
+}
+
+#[test]
 fn suggest_long_flag_subset() {
     let mut cmd = Command::new("exhaustive")
         .arg(
@@ -79,11 +146,14 @@ fn suggest_long_flag_subset() {
                 .action(clap::ArgAction::Count),
         );
 
-    assert_data_eq!(complete!(cmd, "--he"), snapbox::str![[r#"
+    assert_data_eq!(
+        complete!(cmd, "--he"),
+        snapbox::str![[r#"
 --hello-world
 --hello-moon
 --help	Print help
-"#]],);
+"#]],
+    );
 }
 
 #[test]
@@ -95,10 +165,13 @@ fn suggest_possible_value_subset() {
         "goodbye-world".into(),
     ]));
 
-    assert_data_eq!(complete!(cmd, "hello"), snapbox::str![[r#"
+    assert_data_eq!(
+        complete!(cmd, "hello"),
+        snapbox::str![[r#"
 hello-world	Say hello to the world
 hello-moon
-"#]],);
+"#]],
+    );
 }
 
 #[test]
@@ -120,12 +193,15 @@ fn suggest_additional_short_flags() {
                 .action(clap::ArgAction::Count),
         );
 
-    assert_data_eq!(complete!(cmd, "-a"), snapbox::str![[r#"
+    assert_data_eq!(
+        complete!(cmd, "-a"),
+        snapbox::str![[r#"
 -aa
 -ab
 -ac
 -ah	Print help
-"#]],);
+"#]],
+    );
 }
 
 #[test]
@@ -138,13 +214,16 @@ fn suggest_subcommand_positional() {
         ]),
     ));
 
-    assert_data_eq!(complete!(cmd, "hello-world [TAB]"), snapbox::str![[r#"
+    assert_data_eq!(
+        complete!(cmd, "hello-world [TAB]"),
+        snapbox::str![[r#"
 --help	Print help (see more with '--help')
 -h	Print help (see more with '--help')
 hello-world	Say hello to the world
 hello-moon
 goodbye-world
-"#]],);
+"#]],
+    );
 }
 
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Based on PR: https://github.com/clap-rs/clap/pull/5549
Related issue: https://github.com/clap-rs/clap/issues/3951

#### Works in this PR
-  refactor: Add `CompletionCandidate`  to replace `(OsString, Option<StyledStr>)`. There will be a new field named `visible` for  `CompletionCandidate`. If we don't need this struct, there will be a type `(OsString, Option<StyledStr>, bool)`.
-  Support hiding long flags and their long aliases. The specific behavior is reflected in the differences between the test commit and the feat commit.
