### PR TITLE
Support multiple values in native completions

### DIFF
--- a/clap_complete/src/dynamic/completer.rs
+++ b/clap_complete/src/dynamic/completer.rs
@@ -1,3 +1,4 @@
+use core::num;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 
@@ -71,8 +72,7 @@ pub fn complete(
         }
 
         if is_escaped {
-            pos_index += 1;
-            state = ParseState::Pos(pos_index);
+            (state, pos_index) = parse_positional(current_cmd, pos_index, is_escaped, state);
         } else if arg.is_escape() {
             is_escaped = true;
             state = ParseState::ValueDone;
@@ -124,10 +124,11 @@ pub fn complete(
             }
         } else {
             match state {
-                ParseState::ValueDone | ParseState::Pos(_) => {
-                    pos_index += 1;
-                    state = ParseState::ValueDone;
+                ParseState::ValueDone | ParseState::Pos(..) => {
+                    (state, pos_index) =
+                        parse_positional(current_cmd, pos_index, is_escaped, state);
                 }
+
                 ParseState::Opt((ref opt, count)) => match opt.get_num_args() {
                     Some(range) => {
                         let max = range.max_values();
@@ -156,8 +157,8 @@ enum ParseState<'a> {
     /// Parsing a value done, there is no state to record.
     ValueDone,
 
-    /// Parsing a positional argument after `--`
-    Pos(usize),
+    /// Parsing a positional argument after `--`. Pos(pos_index, takes_num_args)
+    Pos((usize, usize)),
 
     /// Parsing a optional flag argument
     Opt((&'a clap::Arg, usize)),
@@ -300,7 +301,7 @@ fn complete_arg(
                 completions.extend(complete_subcommand(value, cmd));
             }
         }
-        ParseState::Pos(_) => {
+        ParseState::Pos(..) => {
             if let Some(positional) = cmd
                 .get_positionals()
                 .find(|p| p.get_index() == Some(pos_index))
@@ -601,6 +602,57 @@ fn parse_shortflags<'c, 's>(
     }
 
     (leading_flags, takes_value_opt, short)
+}
+
+/// Parse the positional arguments. Return the new state and the new positional index.
+fn parse_positional<'a>(
+    cmd: &clap::Command,
+    pos_index: usize,
+    is_escaped: bool,
+    state: ParseState<'a>,
+) -> (ParseState<'a>, usize) {
+    let pos_arg = cmd
+        .get_positionals()
+        .find(|p| p.get_index() == Some(pos_index));
+    let num_args = pos_arg
+        .and_then(|a| a.get_num_args().and_then(|r| Some(r.max_values())))
+        .unwrap_or(1);
+
+    let update_state_with_new_positional = |pos_index| -> (ParseState<'a>, usize) {
+        if num_args > 1 {
+            (ParseState::Pos((pos_index, 1)), pos_index)
+        } else {
+            if is_escaped {
+                (ParseState::Pos((pos_index, 1)), pos_index + 1)
+            } else {
+                (ParseState::ValueDone, pos_index + 1)
+            }
+        }
+    };
+    match state {
+        ParseState::ValueDone => {
+            update_state_with_new_positional(pos_index)
+        },
+        ParseState::Pos((prev_pos_index, num_arg)) => {
+            if prev_pos_index == pos_index {
+                if num_arg + 1 < num_args {
+                    (ParseState::Pos((pos_index, num_arg + 1)), pos_index)
+                } else {
+                    if is_escaped {
+                        (ParseState::Pos((pos_index, 1)), pos_index + 1)
+                    } else {
+                        (ParseState::ValueDone, pos_index + 1)
+                    }
+                }
+            } else {
+                update_state_with_new_positional(pos_index)
+            }
+        }
+        ParseState::Opt(..) => unreachable!(
+            "This branch won't be hit, 
+            because ParseState::Opt should not be seen as a positional argument and passed to this function."
+        ),
+    }
 }
 
 /// A completion candidate definition

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -469,12 +469,9 @@ val3"
     assert_data_eq!(
         complete!(cmd, "--certain-num val1 [TAB]"),
         snapbox::str![
-            "--certain-num
---uncertain-num
---help\tPrint help
--Y
--N
--h\tPrint help"
+            "val1
+val2
+val3"
         ]
     );
 
@@ -502,7 +499,10 @@ val3"
     assert_data_eq!(
         complete!(cmd, "--uncertain-num val1 [TAB]"),
         snapbox::str![
-            "--certain-num
+            "val1
+val2
+val3
+--certain-num
 --uncertain-num
 --help\tPrint help
 -Y
@@ -535,12 +535,9 @@ val3"
     assert_data_eq!(
         complete!(cmd, "-Y val1 [TAB]"),
         snapbox::str![
-            "--certain-num
---uncertain-num
---help\tPrint help
--Y
--N
--h\tPrint help"
+            "val1
+val2
+val3"
         ]
     );
 
@@ -568,7 +565,10 @@ val3"
     assert_data_eq!(
         complete!(cmd, "-N val1 [TAB]"),
         snapbox::str![
-            "--certain-num
+            "val1
+val2
+val3
+--certain-num
 --uncertain-num
 --help\tPrint help
 -Y

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -439,6 +439,157 @@ pos_c"
     );
 }
 
+#[test]
+fn suggest_argument_multi_values() {
+    let mut cmd = Command::new("dynamic")
+        .arg(
+            clap::Arg::new("certain-num")
+                .long("certain-num")
+                .short('Y')
+                .value_parser(["val1", "val2", "val3"])
+                .num_args(3),
+        )
+        .arg(
+            clap::Arg::new("uncertain-num")
+                .long("uncertain-num")
+                .short('N')
+                .value_parser(["val1", "val2", "val3"])
+                .num_args(1..=3),
+        );
+
+    assert_data_eq!(
+        complete!(cmd, "--certain-num [TAB]"),
+        snapbox::str![
+            "val1
+val2
+val3"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--certain-num val1 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--certain-num val1 val2 val3 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--uncertain-num [TAB]"),
+        snapbox::str![
+            "val1
+val2
+val3"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--uncertain-num val1 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--uncertain-num val1 val2 val3 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-Y [TAB]"),
+        snapbox::str![
+            "val1
+val2
+val3"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-Y val1 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-Y val1 val2 val3 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-N [TAB]"),
+        snapbox::str![
+            "val1
+val2
+val3"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-N val1 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-N val1 val2 val3 [TAB]"),
+        snapbox::str![
+            "--certain-num
+--uncertain-num
+--help\tPrint help
+-Y
+-N
+-h\tPrint help"
+        ]
+    );
+}
+
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {
     let input = args.as_ref();
     let mut args = vec![std::ffi::OsString::from(cmd.get_name())];

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -590,6 +590,96 @@ val3
     );
 }
 
+#[test]
+fn suggest_multi_positional() {
+    let mut cmd = Command::new("dynamic")
+        .arg(
+            clap::Arg::new("positional")
+                .value_parser(["pos_1, pos_2, pos_3"])
+                .index(1),
+        )
+        .arg(
+            clap::Arg::new("positional-2")
+                .value_parser(["pos_a", "pos_b", "pos_c"])
+                .index(2)
+                .num_args(3),
+        )
+        .arg(
+            clap::Arg::new("--format")
+                .long("format")
+                .short('F')
+                .value_parser(["json", "yaml", "toml"]),
+        );
+
+    assert_data_eq!(
+        complete!(cmd, "pos_1 pos_a [TAB]"),
+        snapbox::str![
+            "--format
+--help\tPrint help
+-F
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "pos_1 pos_a pos_b [TAB]"),
+        snapbox::str![
+            "--format
+--help\tPrint help
+-F
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format json pos_1 [TAB]"),
+        snapbox::str![
+            "--format
+--help\tPrint help
+-F
+-h\tPrint help
+pos_a
+pos_b
+pos_c"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format json pos_1 pos_a [TAB]"),
+        snapbox::str![
+            "--format
+--help\tPrint help
+-F
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format json pos_1 pos_a pos_b pos_c [TAB]"),
+        snapbox::str![
+            "--format
+--help\tPrint help
+-F
+-h\tPrint help"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format json -- pos_1 pos_a [TAB]"),
+        snapbox::str![""]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format json -- pos_1 pos_a pos_b [TAB]"),
+        snapbox::str![""]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format json -- pos_1 pos_a pos_b pos_c [TAB]"),
+        snapbox::str![""]
+    );
+}
+
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {
     let input = args.as_ref();
     let mut args = vec![std::ffi::OsString::from(cmd.get_name())];

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -614,20 +614,18 @@ fn suggest_multi_positional() {
     assert_data_eq!(
         complete!(cmd, "pos_1 pos_a [TAB]"),
         snapbox::str![
-            "--format
---help\tPrint help
--F
--h\tPrint help"
+            "pos_a
+pos_b
+pos_c"
         ]
     );
 
     assert_data_eq!(
         complete!(cmd, "pos_1 pos_a pos_b [TAB]"),
         snapbox::str![
-            "--format
---help\tPrint help
--F
--h\tPrint help"
+            "pos_a
+pos_b
+pos_c"
         ]
     );
 
@@ -647,10 +645,9 @@ pos_c"
     assert_data_eq!(
         complete!(cmd, "--format json pos_1 pos_a [TAB]"),
         snapbox::str![
-            "--format
---help\tPrint help
--F
--h\tPrint help"
+            "pos_a
+pos_b
+pos_c"
         ]
     );
 
@@ -666,12 +663,20 @@ pos_c"
 
     assert_data_eq!(
         complete!(cmd, "--format json -- pos_1 pos_a [TAB]"),
-        snapbox::str![""]
+        snapbox::str![
+            "pos_a
+pos_b
+pos_c"
+        ]
     );
 
     assert_data_eq!(
         complete!(cmd, "--format json -- pos_1 pos_a pos_b [TAB]"),
-        snapbox::str![""]
+        snapbox::str![
+            "pos_a
+pos_b
+pos_c"
+        ]
     );
 
     assert_data_eq!(


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
**Related issue** https://github.com/clap-rs/clap/issues/3921
### Work in this PR
- Support multi-values for both short flag and long flag
  What we can complete now?
  ```
  dynamic --flag bar1 [TAB]
  ```
  It will complete`bar1 bar2 bar3`.
  Also,
  ```
  dynamic -F bar1 [TAB]
  ```
  will complete`bar1 bar2 bar3`.
- Support multi-values for positional argument with `num_args(N)` which N is fixed.
  ```
  dynamic pos_a [TAB]
  ```
  will complete `pos_a pos_b pos_c`
  ```
  dynamic -- pos_a [TAB]
  ```
  will complete `pos_a pos_b pos_c`

### What may be is left
- Support multi-values for both short flag and long flag with format as follows
  ```
  dynamic --flag=bar1 [TAB]
  dynamic -F=bar1 [TAB]
  ```
- Support multi-values for positional argument with `last` or `trailing_var_arg`