### PR TITLE
Support delimited values in native completions

### DIFF
--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -661,18 +661,35 @@ tab"
         snapbox::str!["--delimiter=comma"]
     );
 
-    assert_data_eq!(complete!(cmd, "--delimiter comma,[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "--delimiter comma,[TAB]"),
+        snapbox::str![
+            "comma,comma
+comma,space
+comma,tab"
+        ]
+    );
 
-    assert_data_eq!(complete!(cmd, "--delimiter=comma,[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "--delimiter=comma,[TAB]"),
+        snapbox::str![
+            "--delimiter=comma,comma
+--delimiter=comma,space
+--delimiter=comma,tab
+--delimiter=comma,a_pos
+--delimiter=comma,b_pos
+--delimiter=comma,c_pos"
+        ]
+    );
 
     assert_data_eq!(
         complete!(cmd, "--delimiter comma,s[TAB]"),
-        snapbox::str![""]
+        snapbox::str!["comma,space"]
     );
 
     assert_data_eq!(
         complete!(cmd, "--delimiter=comma,s[TAB]"),
-        snapbox::str![""]
+        snapbox::str!["--delimiter=comma,space"]
     );
 
     assert_data_eq!(
@@ -697,13 +714,36 @@ tab"
 
     assert_data_eq!(complete!(cmd, "-D=c[TAB]"), snapbox::str!["-D=comma"]);
 
-    assert_data_eq!(complete!(cmd, "-D comma,[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "-D comma,[TAB]"),
+        snapbox::str![
+            "comma,comma
+comma,space
+comma,tab"
+        ]
+    );
 
-    assert_data_eq!(complete!(cmd, "-D=comma,[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "-D=comma,[TAB]"),
+        snapbox::str![
+            "-D=comma,comma
+-D=comma,space
+-D=comma,tab
+-D=comma,a_pos
+-D=comma,b_pos
+-D=comma,c_pos"
+        ]
+    );
 
-    assert_data_eq!(complete!(cmd, "-D comma,s[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "-D comma,s[TAB]"),
+        snapbox::str!["comma,space"]
+    );
 
-    assert_data_eq!(complete!(cmd, "-D=comma,s[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "-D=comma,s[TAB]"),
+        snapbox::str!["-D=comma,space"]
+    );
 
     assert_data_eq!(
         complete!(cmd, "-- [TAB]"),
@@ -718,9 +758,19 @@ c_pos"
         ]
     );
 
-    assert_data_eq!(complete!(cmd, " -- a_pos,[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, " -- a_pos,[TAB]"),
+        snapbox::str![
+            "a_pos,a_pos
+a_pos,b_pos
+a_pos,c_pos"
+        ]
+    );
 
-    assert_data_eq!(complete!(cmd, "-- a_pos,b[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "-- a_pos,b[TAB]"),
+        snapbox::str!["a_pos,b_pos"]
+    );
 }
 
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -615,6 +615,114 @@ pos_c
     );
 }
 
+#[test]
+fn suggest_delimiter_values() {
+    let mut cmd = Command::new("delimiter")
+        .arg(
+            clap::Arg::new("delimiter")
+                .long("delimiter")
+                .short('D')
+                .value_parser([
+                    PossibleValue::new("comma"),
+                    PossibleValue::new("space"),
+                    PossibleValue::new("tab"),
+                ])
+                .value_delimiter(','),
+        )
+        .arg(
+            clap::Arg::new("pos")
+                .index(1)
+                .value_parser(["a_pos", "b_pos", "c_pos"])
+                .value_delimiter(','),
+        );
+
+    assert_data_eq!(
+        complete!(cmd, "--delimiter [TAB]"),
+        snapbox::str![
+            "comma
+space
+tab"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--delimiter=[TAB]"),
+        snapbox::str![
+            "--delimiter=comma
+--delimiter=space
+--delimiter=tab"
+        ]
+    );
+
+    assert_data_eq!(complete!(cmd, "--delimiter c[TAB]"), snapbox::str!["comma"]);
+
+    assert_data_eq!(
+        complete!(cmd, "--delimiter=c[TAB]"),
+        snapbox::str!["--delimiter=comma"]
+    );
+
+    assert_data_eq!(complete!(cmd, "--delimiter comma,[TAB]"), snapbox::str![""]);
+
+    assert_data_eq!(complete!(cmd, "--delimiter=comma,[TAB]"), snapbox::str![""]);
+
+    assert_data_eq!(
+        complete!(cmd, "--delimiter comma,s[TAB]"),
+        snapbox::str![""]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--delimiter=comma,s[TAB]"),
+        snapbox::str![""]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-D [TAB]"),
+        snapbox::str![
+            "comma
+space
+tab"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-D=[TAB]"),
+        snapbox::str![
+            "-D=comma
+-D=space
+-D=tab"
+        ]
+    );
+
+    assert_data_eq!(complete!(cmd, "-D c[TAB]"), snapbox::str!["comma"]);
+
+    assert_data_eq!(complete!(cmd, "-D=c[TAB]"), snapbox::str!["-D=comma"]);
+
+    assert_data_eq!(complete!(cmd, "-D comma,[TAB]"), snapbox::str![""]);
+
+    assert_data_eq!(complete!(cmd, "-D=comma,[TAB]"), snapbox::str![""]);
+
+    assert_data_eq!(complete!(cmd, "-D comma,s[TAB]"), snapbox::str![""]);
+
+    assert_data_eq!(complete!(cmd, "-D=comma,s[TAB]"), snapbox::str![""]);
+
+    assert_data_eq!(
+        complete!(cmd, "-- [TAB]"),
+        snapbox::str![
+            "--delimiter
+--help\tPrint help
+-D
+-h\tPrint help
+a_pos
+b_pos
+c_pos"
+        ]
+    );
+
+    assert_data_eq!(complete!(cmd, " -- a_pos,[TAB]"), snapbox::str![""]);
+
+    assert_data_eq!(complete!(cmd, "-- a_pos,b[TAB]"), snapbox::str![""]);
+}
+
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {
     let input = args.as_ref();
     let mut args = vec![std::ffi::OsString::from(cmd.get_name())];


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
**Related issue** https://github.com/clap-rs/clap/issues/3922

- [x] Support `--flag bar1,bar1,[TAB]`
- [x] Support `--flag=bar1,bar2,[TAB]`
- [x] Support `-F bar1,bar2,[TAB]`
- [x] Support `-F=bar1,bar2,[TAB]`
- [x] Support delimited values for positional argument in native completions. `-- a_pos,[TAB]`
