### PR TITLE
fix(derive): Improve flattening-skipped-group assert 

### DIFF
--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -255,3 +255,22 @@ fn docstrings_ordering_with_multiple_clap_partial() {
 
     assert!(short_help.contains("This is the docstring for Flattened"));
 }
+
+#[test]
+#[should_panic = "#[arg(flatten)]`ed field type implements `Args::group_id"]
+fn flatten_skipped_group() {
+    #[derive(clap::Parser, Debug)]
+    struct Cli {
+        #[clap(flatten)]
+        args: Option<Args>,
+    }
+
+    #[derive(clap::Args, Debug)]
+    #[group(skip)]
+    struct Args {
+        #[clap(short)]
+        param: bool,
+    }
+
+    Cli::try_parse_from(["test"]).unwrap();
+}

--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -257,7 +257,7 @@ fn docstrings_ordering_with_multiple_clap_partial() {
 }
 
 #[test]
-#[should_panic = "#[arg(flatten)]`ed field type implements `Args::group_id"]
+#[should_panic = "cannot `#[flatten]` an `Option<Args>` with `#[group(skip)]"]
 fn flatten_skipped_group() {
     #[derive(clap::Parser, Debug)]
     struct Cli {


### PR DESCRIPTION
- Improves the error message
- Happens on initialization, rather than parse, making it so it will
  always show up and not just when certain parts of the CLI are
  exercised

Fixes #5609