### PR TITLE
docs: Cross-link color control to Command::styles

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1157,6 +1157,8 @@ impl Command {
 
     /// Sets when to color output.
     ///
+    /// To customize how the output is styled, see [`Command::styles`].
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
     ///
     /// **NOTE:** Default behaviour is [`ColorChoice::Auto`].

--- a/src/_features.rs
+++ b/src/_features.rs
@@ -5,7 +5,8 @@
 //! #### Default Features
 //!
 //! * `std`: _Not Currently Used._ Placeholder for supporting `no_std` environments in a backwards compatible manner.
-//! * `color`: Turns on colored error messages.
+//! * `color`: Turns on terminal styling of help and error messages.  See
+//!   [`Command::styles`][crate::Command::styles] to customize this.
 //! * `help`: Auto-generate help output
 //! * `usage`: Auto-generate usage
 //! * `error-context`: Include contextual information for errors (which arg failed, etc)


### PR DESCRIPTION
Inspired by #5590

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
