### PR TITLE
Support dynamic value of argument completion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ string = ["clap_builder/string"]  # Allow runtime generated strings
 
 # In-work features
 unstable-v5 = ["clap_builder/unstable-v5", "clap_derive?/unstable-v5", "deprecated"]
-unstable-ext = []
+unstable-ext = ["clap_builder/unstable-ext"]
 unstable-styles = ["clap_builder/unstable-styles"]  # deprecated
 
 [lib]

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -57,7 +57,7 @@ required-features = ["unstable-dynamic"]
 [features]
 default = []
 unstable-doc = ["unstable-dynamic"] # for docs.rs
-unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:unicode-xid", "clap/derive", "dep:is_executable", "dep:pathdiff"]
+unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:unicode-xid", "clap/derive", "dep:is_executable", "dep:pathdiff", "clap/unstable-ext"]
 debug = ["clap/debug"]
 
 [lints]

--- a/clap_complete/tests/testsuite/dynamic.rs
+++ b/clap_complete/tests/testsuite/dynamic.rs
@@ -591,6 +591,13 @@ val3
 }
 
 #[test]
+fn suggest_custom_arg_value() {
+    let mut cmd = Command::new("dynamic").arg(clap::Arg::new("custom").long("custom"));
+
+    assert_data_eq!(complete!(cmd, "--custom [TAB]"), snapbox::str![""],);
+}
+
+#[test]
 fn suggest_multi_positional() {
     let mut cmd = Command::new("dynamic")
         .arg(


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Related issue https://github.com/clap-rs/clap/issues/1232

### Work in this PR
- Add `CustomCompleter` trait and `ArgValueCompleter` struct to provide users a way to add custom value of argument completion.
- Add test case to show the feat.

### What may be left
> Open question: does the completion function accept just the arg and current value or does it have access to `ArgMatches` for completing based on other data like in https://github.com/clap-rs/clap/issues/1910
- [ ]  Is there any way to access `ArgMatches` before the builder of the `Command`. We add custom value hint in builder now. If we really need this feat, we may need to do more things.
