### PR TITLE
Support `allow_hyphen_values` in native completions

### DIFF
--- a/clap_complete/src/engine/complete.rs
+++ b/clap_complete/src/engine/complete.rs
@@ -59,6 +59,13 @@ pub fn complete(
         } else if arg.is_escape() {
             is_escaped = true;
         } else if let Some((flag, value)) = arg.to_long() {
+            if let ParseState::Opt((opt, count)) = current_state {
+                if opt.is_allow_hyphen_values_set() {
+                    next_state = parse_opt(opt, count);
+                    continue;
+                }
+            }
+
             if let Ok(flag) = flag {
                 let opt = current_cmd.get_arguments().find(|a| {
                     let longs = a.get_long_and_visible_aliases();
@@ -69,18 +76,32 @@ pub fn complete(
                     });
                     is_find.unwrap_or(false)
                 });
-                if opt.map(|o| o.get_action().takes_values()).unwrap_or(false) {
-                    if value.is_none() {
-                        next_state = ParseState::Opt((opt.unwrap(), 1));
+
+                if let Some(opt) = opt {
+                    if opt.get_action().takes_values() && value.is_none() {
+                        next_state = ParseState::Opt((opt, 1));
                     };
+                } else if pos_allows_hyphen(current_cmd, pos_index) {
+                    (next_state, pos_index) =
+                        parse_positional(current_cmd, pos_index, is_escaped, current_state);
                 }
             }
         } else if let Some(short) = arg.to_short() {
+            if let ParseState::Opt((opt, count)) = current_state {
+                if opt.is_allow_hyphen_values_set() {
+                    next_state = parse_opt(opt, count);
+                    continue;
+                }
+            }
+
             let (_, takes_value_opt, mut short) = parse_shortflags(current_cmd, short);
             if let Some(opt) = takes_value_opt {
                 if short.next_value_os().is_none() {
                     next_state = ParseState::Opt((opt, 1));
                 }
+            } else if pos_allows_hyphen(current_cmd, pos_index) {
+                (next_state, pos_index) =
+                    parse_positional(current_cmd, pos_index, is_escaped, current_state);
             }
         } else {
             match current_state {
@@ -88,14 +109,7 @@ pub fn complete(
                     (next_state, pos_index) =
                         parse_positional(current_cmd, pos_index, is_escaped, current_state);
                 }
-
-                ParseState::Opt((opt, count)) => {
-                    let range = opt.get_num_args().expect("built");
-                    let max = range.max_values();
-                    if count < max {
-                        next_state = ParseState::Opt((opt, count + 1));
-                    }
-                }
+                ParseState::Opt((opt, count)) => next_state = parse_opt(opt, count),
             }
         }
     }
@@ -545,4 +559,22 @@ fn parse_positional<'a>(
             because ParseState::Opt should not be seen as a positional argument and passed to this function."
         ),
     }
+}
+
+/// Parse optional flag argument. Return new state
+fn parse_opt(opt: &clap::Arg, count: usize) -> ParseState<'_> {
+    let range = opt.get_num_args().expect("built");
+    let max = range.max_values();
+    if count < max {
+        ParseState::Opt((opt, count + 1))
+    } else {
+        ParseState::ValueDone
+    }
+}
+
+fn pos_allows_hyphen(cmd: &clap::Command, pos_index: usize) -> bool {
+    cmd.get_positionals()
+        .find(|a| a.get_index() == Some(pos_index))
+        .map(|p| p.is_allow_hyphen_values_set())
+        .unwrap_or(false)
 }

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -1018,10 +1018,13 @@ fn suggest_allow_hyhpen() {
 
     assert_data_eq!(
         complete!(cmd, "--format --json --j[TAB]"),
-        snapbox::str![""]
+        snapbox::str!["--json"]
     );
 
-    assert_data_eq!(complete!(cmd, "-F --json --j[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "-F --json --j[TAB]"),
+        snapbox::str!["--json"]
+    );
 }
 
 #[test]
@@ -1062,7 +1065,7 @@ fn suggest_positional_long_allow_hyhpen() {
 --help	Print help
 -F
 -h	Print help
---pos_a"
+pos_b"
         ]
     );
     assert_data_eq!(
@@ -1072,17 +1075,17 @@ fn suggest_positional_long_allow_hyhpen() {
 --help	Print help
 -F
 -h	Print help
---pos_a"
+pos_b"
         ]
     );
 
     assert_data_eq!(
         complete!(cmd, "--format --json --pos_a p[TAB]"),
-        snapbox::str![""]
+        snapbox::str!["pos_b"]
     );
     assert_data_eq!(
         complete!(cmd, "-F --json --pos_a p[TAB]"),
-        snapbox::str![""]
+        snapbox::str!["pos_b"]
     );
 }
 
@@ -1115,7 +1118,7 @@ fn suggest_positional_short_allow_hyhpen() {
 --help	Print help
 -F
 -h	Print help
--a"
+pos_b"
         ]
     );
     assert_data_eq!(
@@ -1125,15 +1128,18 @@ fn suggest_positional_short_allow_hyhpen() {
 --help	Print help
 -F
 -h	Print help
--a"
+pos_b"
         ]
     );
 
     assert_data_eq!(
         complete!(cmd, "--format --json -a p[TAB]"),
-        snapbox::str![""]
+        snapbox::str!["pos_b"]
     );
-    assert_data_eq!(complete!(cmd, "-F --json -a p[TAB]"), snapbox::str![""]);
+    assert_data_eq!(
+        complete!(cmd, "-F --json -a p[TAB]"),
+        snapbox::str!["pos_b"]
+    );
 }
 
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -981,6 +981,161 @@ a_pos,c_pos"
     );
 }
 
+#[test]
+fn suggest_allow_hyhpen() {
+    let mut cmd = Command::new("exhaustive")
+        .arg(
+            clap::Arg::new("format")
+                .long("format")
+                .short('F')
+                .allow_hyphen_values(true)
+                .value_parser(["--json", "--toml", "--yaml"]),
+        )
+        .arg(clap::Arg::new("json").long("json"));
+
+    assert_data_eq!(complete!(cmd, "--format --j[TAB]"), snapbox::str!["--json"]);
+    assert_data_eq!(complete!(cmd, "-F --j[TAB]"), snapbox::str!["--json"]);
+    assert_data_eq!(complete!(cmd, "--format --t[TAB]"), snapbox::str!["--toml"]);
+    assert_data_eq!(complete!(cmd, "-F --t[TAB]"), snapbox::str!["--toml"]);
+
+    assert_data_eq!(
+        complete!(cmd, "--format --[TAB]"),
+        snapbox::str![
+            "--json
+--toml
+--yaml"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-F --[TAB]"),
+        snapbox::str![
+            "--json
+--toml
+--yaml"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format --json --j[TAB]"),
+        snapbox::str![""]
+    );
+
+    assert_data_eq!(complete!(cmd, "-F --json --j[TAB]"), snapbox::str![""]);
+}
+
+#[test]
+fn suggest_positional_long_allow_hyhpen() {
+    let mut cmd = Command::new("exhaustive")
+        .arg(
+            clap::Arg::new("format")
+                .long("format")
+                .short('F')
+                .allow_hyphen_values(true)
+                .value_parser(["--json", "--toml", "--yaml"]),
+        )
+        .arg(
+            clap::Arg::new("positional_a")
+                .value_parser(["--pos_a"])
+                .index(1)
+                .allow_hyphen_values(true),
+        )
+        .arg(
+            clap::Arg::new("positional_b")
+                .index(2)
+                .value_parser(["pos_b"]),
+        );
+
+    assert_data_eq!(
+        complete!(cmd, "--format --json --pos[TAB]"),
+        snapbox::str!["--pos_a"]
+    );
+    assert_data_eq!(
+        complete!(cmd, "-F --json --pos[TAB]"),
+        snapbox::str!["--pos_a"]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format --json --pos_a [TAB]"),
+        snapbox::str![
+            "--format
+--help	Print help
+-F
+-h	Print help
+--pos_a"
+        ]
+    );
+    assert_data_eq!(
+        complete!(cmd, "-F --json --pos_a [TAB]"),
+        snapbox::str![
+            "--format
+--help	Print help
+-F
+-h	Print help
+--pos_a"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format --json --pos_a p[TAB]"),
+        snapbox::str![""]
+    );
+    assert_data_eq!(
+        complete!(cmd, "-F --json --pos_a p[TAB]"),
+        snapbox::str![""]
+    );
+}
+
+#[test]
+fn suggest_positional_short_allow_hyhpen() {
+    let mut cmd = Command::new("exhaustive")
+        .arg(
+            clap::Arg::new("format")
+                .long("format")
+                .short('F')
+                .allow_hyphen_values(true)
+                .value_parser(["--json", "--toml", "--yaml"]),
+        )
+        .arg(
+            clap::Arg::new("positional_a")
+                .value_parser(["-a"])
+                .index(1)
+                .allow_hyphen_values(true),
+        )
+        .arg(
+            clap::Arg::new("positional_b")
+                .index(2)
+                .value_parser(["pos_b"]),
+        );
+
+    assert_data_eq!(
+        complete!(cmd, "--format --json -a [TAB]"),
+        snapbox::str![
+            "--format
+--help	Print help
+-F
+-h	Print help
+-a"
+        ]
+    );
+    assert_data_eq!(
+        complete!(cmd, "-F --json -a [TAB]"),
+        snapbox::str![
+            "--format
+--help	Print help
+-F
+-h	Print help
+-a"
+        ]
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--format --json -a p[TAB]"),
+        snapbox::str![""]
+    );
+    assert_data_eq!(complete!(cmd, "-F --json -a p[TAB]"), snapbox::str![""]);
+}
+
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {
     let input = args.as_ref();
     let mut args = vec![std::ffi::OsString::from(cmd.get_name())];

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -982,7 +982,7 @@ a_pos,c_pos"
 }
 
 #[test]
-fn suggest_allow_hyhpen() {
+fn suggest_allow_hyphen() {
     let mut cmd = Command::new("exhaustive")
         .arg(
             clap::Arg::new("format")
@@ -1028,7 +1028,7 @@ fn suggest_allow_hyhpen() {
 }
 
 #[test]
-fn suggest_positional_long_allow_hyhpen() {
+fn suggest_positional_long_allow_hyphen() {
     let mut cmd = Command::new("exhaustive")
         .arg(
             clap::Arg::new("format")
@@ -1090,7 +1090,7 @@ pos_b"
 }
 
 #[test]
-fn suggest_positional_short_allow_hyhpen() {
+fn suggest_positional_short_allow_hyphen() {
     let mut cmd = Command::new("exhaustive")
         .arg(
             clap::Arg::new("format")


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Resolves #5594