### PR TITLE
refactor(styles): make styles example use a const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -1432,7 +1432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/clap_builder/Cargo.toml
+++ b/clap_builder/Cargo.toml
@@ -63,7 +63,7 @@ clap_lex = { path = "../clap_lex", version = "0.7.0" }
 unicase = { version = "2.6.0", optional = true }
 strsim = { version = "0.11.0",  optional = true }
 anstream = { version = "0.6.7", optional = true }
-anstyle = "1.0.0"
+anstyle = "1.0.8"
 terminal_size = { version = "0.3.0", optional = true }
 backtrace = { version = "0.3.73", optional = true }
 unicode-width = { version = "0.1.9", optional = true }

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1199,13 +1199,13 @@ impl Command {
     /// ```no_run
     /// # use clap_builder as clap;
     /// # use clap::{Command, ColorChoice, builder::styling};
-    /// let styles = styling::Styles::styled()
-    ///     .header(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
-    ///     .usage(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
-    ///     .literal(styling::AnsiColor::Blue.on_default() | styling::Effects::BOLD)
+    /// const STYLES: styling::Styles = styling::Styles::styled()
+    ///     .header(styling::AnsiColor::Green.on_default().bold())
+    ///     .usage(styling::AnsiColor::Green.on_default().bold())
+    ///     .literal(styling::AnsiColor::Blue.on_default().bold())
     ///     .placeholder(styling::AnsiColor::Cyan.on_default());
     /// Command::new("myprog")
-    ///     .styles(styles)
+    ///     .styles(STYLES)
     ///     .get_matches();
     /// ```
     #[cfg(feature = "color")]

--- a/src/bin/stdio-fixture.rs
+++ b/src/bin/stdio-fixture.rs
@@ -15,12 +15,12 @@ fn main() {
     #[cfg(feature = "color")]
     {
         use clap::builder::styling;
-        let styles = styling::Styles::styled()
-            .header(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
-            .usage(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
-            .literal(styling::AnsiColor::Blue.on_default() | styling::Effects::BOLD)
+        const STYLES: styling::Styles = styling::Styles::styled()
+            .header(styling::AnsiColor::Green.on_default().bold())
+            .usage(styling::AnsiColor::Green.on_default().bold())
+            .literal(styling::AnsiColor::Blue.on_default().bold())
             .placeholder(styling::AnsiColor::Cyan.on_default());
-        cmd = cmd.styles(styles);
+        cmd = cmd.styles(STYLES);
     }
     cmd.get_matches();
 }


### PR DESCRIPTION
I was trying to set up colours for the derive macro, and copying this didn't immediately work, but using `.bold()` as per https://github.com/clap-rs/clap/issues/3234#issuecomment-2056568175 did work, so figured it would be worth updating the defaults so things are a bit easier for the next person.

---

#### Commits _(oldest to newest)_

6f215eee refactor(styles): make styles example use a const

This makes it easier to copy this example for use in the derive API,
like so:

```rust
const STYLES: Styles = Styles::styled()
    .header(AnsiColor::Green.on_default().bold())
    .usage(AnsiColor::Green.on_default().bold())
    .literal(AnsiColor::Blue.on_default().bold())
    .placeholder(AnsiColor::Cyan.on_default());

#[derive(Parser)]
#[clap(styles = STYLES)]
struct Cmd {
  ...
}
```

If you use the `|` method then it's not a constant function.

<br/>