### PR TITLE
fix(complete)!: Dont assume powershell on Windows

### DIFF
--- a/clap_complete/src/dynamic/shells/mod.rs
+++ b/clap_complete/src/dynamic/shells/mod.rs
@@ -67,8 +67,6 @@ impl Shell {
     pub fn from_env() -> Option<Shell> {
         if let Some(env_shell) = std::env::var_os("SHELL") {
             Shell::from_shell_path(env_shell)
-        } else if cfg!(windows) {
-            Some(Shell::Powershell)
         } else {
             None
         }


### PR DESCRIPTION
We have issues open for other Windows shells, so this seems like a bad idea.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
