### PR TITLE
Fix typo in dynamic completion doc comment

### DIFF
--- a/clap_complete/src/dynamic/candidate.rs
+++ b/clap_complete/src/dynamic/candidate.rs
@@ -32,7 +32,7 @@ impl CompletionCandidate {
 
     /// Set the visibility of the completion candidate
     ///
-    /// Only shown when no there is no visible candidate for completing the current argument.
+    /// Only shown when there is no visible candidate for completing the current argument.
     pub fn hide(mut self, hidden: bool) -> Self {
         self.hidden = hidden;
         self


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
