### PR TITLE
feat: Explicitly list items to re-export from derive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 pub use clap_builder::*;
 #[cfg(feature = "derive")]
 #[doc(hidden)]
-pub use clap_derive::{self, *};
+pub use clap_derive::{self, Args, Parser, Subcommand, ValueEnum};
 
 #[cfg(feature = "unstable-doc")]
 pub mod _cookbook;


### PR DESCRIPTION
This allows rustc to give a nice note about activating feature when it has not been activated.

Before:
```
error[E0433]: failed to resolve: could not find `Parser` in `clap`
 --> ssh/src/main.rs:1:16
  |
1 | #[derive(clap::Parser, Debug)]
  |                ^^^^^^ could not find `Parser` in `clap`
```

After:
```
error[E0433]: failed to resolve: could not find `Parser` in `clap`
  --> ssh/src/main.rs:1:16
   |
1  | #[derive(clap::Parser, Debug)]
   |                ^^^^^^ could not find `Parser` in `clap`
   |
note: found an item that was configured out
  --> /home/nora/.cargo/git/checkouts/clap-cf0796c5889852a8/ec804fa/src/lib.rs:93:35
   |
93 | pub use clap_derive::{self, Args, Parser, Subcommand, ValueEnum};
   |                                   ^^^^^^
note: the item is gated behind the `derive` feature
  --> /home/nora/.cargo/git/checkouts/clap-cf0796c5889852a8/ec804fa/src/lib.rs:89:7
   |
89 | #[cfg(feature = "derive")]
   |       ^^^^^^^^^^^^^^^^^^
```
