### PR TITLE
feat(derive): derive `clap::Args` for enum types

### DIFF
--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -282,7 +282,7 @@ fn gen_augment(
                     Named(ref fields) => {
                         // Defer to `gen_augment` for adding cmd methods
                         let fields = collect_args_fields(item, fields)?;
-                        args::gen_augment(&fields, &subcommand_var, item, override_required)?
+                        args::gen_augment(&fields, &subcommand_var, item, &[], override_required)?
                     }
                     Unit => {
                         let arg_block = quote!( #subcommand_var );

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1724567349,
+        "narHash": "sha256-w2G1EJlGvgRSC1OAm2147mCzlt6ZOWIiqX/TSJUgrGE=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "71fe264f6e208831aa0e7e54ad557a283c375014",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724015816,
+        "narHash": "sha256-hVESnM7Eiz93+4DeiE0a1TwMeaeph1ytRJ5QtqxYRWg=",
+        "path": "/nix/store/d87mpjlsl8flcgazpjnhimq21y46a3g4-source",
+        "rev": "9aa35efbea27d320d0cdc5f922f0890812affb60",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1724480527,
+        "narHash": "sha256-C+roFDGk6Bn/C58NGpyt7cneLCetdRMUfFTkm3O4zWM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "74a6427861eb8d1e3b7c6090b2c2890ff4c53e0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  inputs.fenix = {
+    url = "github:nix-community/fenix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    { nixpkgs, fenix, ... }:
+    let
+      pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+    in
+    {
+      devShells.aarch64-darwin.default = pkgs.mkShell {
+        shellHook = ''
+          export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}";
+        '';
+        packages = [
+          pkgs.lldb
+          pkgs.libiconv
+          pkgs.darwin.apple_sdk.frameworks.Security
+          pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+          (fenix.packages.aarch64-darwin.combine [
+            fenix.packages.aarch64-darwin.stable.cargo
+            fenix.packages.aarch64-darwin.stable.rust
+            fenix.packages.aarch64-darwin.targets.wasm32-wasi.stable.rust-std
+            fenix.packages.aarch64-darwin.targets.wasm32-wasip1.stable.rust-std
+            fenix.packages.aarch64-darwin.targets.aarch64-apple-darwin.stable.rust-std
+          ])
+        ];
+      };
+
+      formatter.aarch64-darwin = pkgs.nixfmt-rfc-style;
+
+    };
+
+}

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -239,3 +239,57 @@ For more information, try '--help'.
 ";
     assert_output::<Opt>("test", OUTPUT, true);
 }
+
+#[test]
+fn enum_groups_1() {
+    #[derive(Parser, Debug, PartialEq, Eq)]
+    struct Opt {
+        #[command(flatten)]
+        source: Source,
+    }
+
+    #[derive(clap::Args, Clone, Debug, PartialEq, Eq)]
+    enum Source {
+        A {
+            #[arg(short)]
+            a: bool,
+            #[arg(long)]
+            aaa: bool,
+        },
+        B {
+            #[arg(short)]
+            b: bool,
+        },
+    }
+
+    assert_eq!(
+        Opt {
+            source: Source::A {
+                a: true,
+                aaa: false,
+            }
+        },
+        Opt::try_parse_from(["test", "-a"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            source: Source::A { a: true, aaa: true }
+        },
+        Opt::try_parse_from(["test", "-a", "--aaa"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            source: Source::B { b: true }
+        },
+        Opt::try_parse_from(["test", "-b"]).unwrap()
+    );
+
+    assert_eq!(
+        clap::error::ErrorKind::ArgumentConflict,
+        Opt::try_parse_from(["test", "-b", "-a"])
+            .unwrap_err()
+            .kind(),
+    );
+
+    // assert_eq!(       )
+}


### PR DESCRIPTION
Implement `derive(clap::Args)` support for enum types, where each variant is a mutually exclusive `ArgGroup`.
Relevant discussion and motivation for this PR is in #2621.

-----

Impl notes:

At the moment this is a rough initial implementation.

* It only supports `Named` / struct like enum variants such as this:

```rust
#[derive(clap::Args, Clone, Debug, PartialEq, Eq)]
enum Source {
    A {
        #[arg(short)]
        a: bool,
        #[arg(long)]
        aaa: bool,
    },
    B {
        #[arg(short)]
        b: bool,
    },
}
```

* it has issues with determining a default when neither branch matches explicitly
* it's not fully covered with tests
* parts of it are frankensteined together from the `subcommand` impl and deriving from structs

Regardless this is a dear feature to me so i'm looking for some guidance to polish this into completion.


