### PR TITLE
clap_derive: Fix minor build issues outside of workspace

### DIFF
--- a/clap_derive/src/derives/mod.rs
+++ b/clap_derive/src/derives/mod.rs
@@ -17,7 +17,7 @@ mod parser;
 mod subcommand;
 mod value_enum;
 
+pub(crate) use self::args::derive_args;
 pub(crate) use self::parser::derive_parser;
-pub(crate) use args::derive_args;
-pub(crate) use subcommand::derive_subcommand;
-pub(crate) use value_enum::derive_value_enum;
+pub(crate) use self::subcommand::derive_subcommand;
+pub(crate) use self::value_enum::derive_value_enum;

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -1413,21 +1413,19 @@ pub(crate) enum Name {
 
 impl Name {
     pub(crate) fn translate(self, style: CasingStyle) -> TokenStream {
-        use CasingStyle::{Camel, Kebab, Lower, Pascal, ScreamingSnake, Snake, Upper, Verbatim};
-
         match self {
             Name::Assigned(tokens) => tokens,
             Name::Derived(ident) => {
                 let s = ident.unraw().to_string();
                 let s = match style {
-                    Pascal => s.to_upper_camel_case(),
-                    Kebab => s.to_kebab_case(),
-                    Camel => s.to_lower_camel_case(),
-                    ScreamingSnake => s.to_shouty_snake_case(),
-                    Snake => s.to_snake_case(),
-                    Lower => s.to_snake_case().replace('_', ""),
-                    Upper => s.to_shouty_snake_case().replace('_', ""),
-                    Verbatim => s,
+                    CasingStyle::Pascal => s.to_upper_camel_case(),
+                    CasingStyle::Kebab => s.to_kebab_case(),
+                    CasingStyle::Camel => s.to_lower_camel_case(),
+                    CasingStyle::ScreamingSnake => s.to_shouty_snake_case(),
+                    CasingStyle::Snake => s.to_snake_case(),
+                    CasingStyle::Lower => s.to_snake_case().replace('_', ""),
+                    CasingStyle::Upper => s.to_shouty_snake_case().replace('_', ""),
+                    CasingStyle::Verbatim => s,
                 };
                 quote_spanned!(ident.span()=> #s)
             }
@@ -1435,21 +1433,19 @@ impl Name {
     }
 
     pub(crate) fn translate_char(self, style: CasingStyle) -> TokenStream {
-        use CasingStyle::{Camel, Kebab, Lower, Pascal, ScreamingSnake, Snake, Upper, Verbatim};
-
         match self {
             Name::Assigned(tokens) => quote!( (#tokens).chars().next().unwrap() ),
             Name::Derived(ident) => {
                 let s = ident.unraw().to_string();
                 let s = match style {
-                    Pascal => s.to_upper_camel_case(),
-                    Kebab => s.to_kebab_case(),
-                    Camel => s.to_lower_camel_case(),
-                    ScreamingSnake => s.to_shouty_snake_case(),
-                    Snake => s.to_snake_case(),
-                    Lower => s.to_snake_case(),
-                    Upper => s.to_shouty_snake_case(),
-                    Verbatim => s,
+                    CasingStyle::Pascal => s.to_upper_camel_case(),
+                    CasingStyle::Kebab => s.to_kebab_case(),
+                    CasingStyle::Camel => s.to_lower_camel_case(),
+                    CasingStyle::ScreamingSnake => s.to_shouty_snake_case(),
+                    CasingStyle::Snake => s.to_snake_case(),
+                    CasingStyle::Lower => s.to_snake_case(),
+                    CasingStyle::Upper => s.to_shouty_snake_case(),
+                    CasingStyle::Verbatim => s,
                 };
 
                 let s = s.chars().next().unwrap();

--- a/clap_derive/src/utils/mod.rs
+++ b/clap_derive/src/utils/mod.rs
@@ -4,10 +4,6 @@ mod doc_comments;
 mod spanned;
 mod ty;
 
-pub(crate) use doc_comments::extract_doc_comment;
-pub(crate) use doc_comments::format_doc_comment;
-
-pub(crate) use self::{
-    spanned::Sp,
-    ty::{inner_type, is_simple_ty, sub_type, subty_if_name, Ty},
-};
+pub(crate) use self::doc_comments::{extract_doc_comment, format_doc_comment};
+pub(crate) use self::spanned::Sp;
+pub(crate) use self::ty::{inner_type, is_simple_ty, sub_type, subty_if_name, Ty};


### PR DESCRIPTION
I copied clap_derive into my project and included it like this:
```
[workspace.dependencies]
clap = { version = "4", default-features = false, features = ["std", "derive", "help", "usage", "error-context", "cargo"] }

[patch.crates-io]
clap_derive = { path = "./clap_derive" }
```
This PR solves some build problems.