### PR TITLE
test: Make shell integration tests non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,6 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - uses: Swatinem/rust-cache@v2
-    - name: Install shells
-      if: runner.os == 'Linux'
-      run: sudo apt-get install -y elvish fish zsh
     - name: Build
       run: make build-${{matrix.features}}
     - name: Test
@@ -84,6 +81,35 @@ jobs:
       run: make test-minimal ARGS='--manifest-path Cargo.toml'
     - name: Test dynamic completions
       run: cargo test -p clap_complete -F unstable-dynamic
+  shell-integration:
+    name: Shell Integration
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Install shells
+      if: runner.os == 'Linux'
+      run: sudo apt-get install -y elvish fish zsh
+    - name: clap_complete
+      run: cargo test -p clap_complete -F unstable-dynamic -F unstable-shell-tests
+  shell-integration-nu:
+    name: Nushell Integration
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v2
+    - name: clap_complete_nu
+      run: cargo test -p clap_complete_nushell -F unstable-shell-tests
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -38,13 +38,13 @@ clap = { path = "../", version = "4.5.18", default-features = false, features = 
 clap_lex = { path = "../clap_lex", version = "0.7.0", optional = true }
 is_executable = { version = "1.0.1", optional = true }
 shlex = { version = "1.3.0", optional = true }
+completest = { version = "0.4.2", optional = true }
+completest-pty = { version = "0.5.5", optional = true }
 
 [dev-dependencies]
 snapbox = { version = "0.6.0", features = ["diff", "dir", "examples"] }
 # Cutting out `filesystem` feature
 trycmd = { version = "0.15.1", default-features = false, features = ["color-auto", "diff", "examples"] }
-completest = "0.4.2"
-completest-pty = "0.5.5"
 clap = { path = "../", version = "4.5.18", default-features = false, features = ["std", "derive", "help"] }
 automod = "1.0.14"
 
@@ -56,6 +56,7 @@ required-features = ["unstable-dynamic"]
 default = []
 unstable-doc = ["unstable-dynamic"] # for docs.rs
 unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:is_executable", "clap/unstable-ext"]
+unstable-shell-tests = ["dep:completest", "dep:completest-pty"]
 debug = ["clap/debug"]
 
 [lints]

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -1,10 +1,13 @@
+#[allow(unused_imports)]
 use snapbox::assert_data_eq;
 
 use crate::common;
 
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 const CMD: &str = "bash";
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 type RuntimeBuilder = completest_pty::BashRuntimeBuilder;
 
 #[test]
@@ -142,12 +145,14 @@ fn subcommand_last() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_completion() {
     common::register_example::<RuntimeBuilder>("static", "exhaustive");
 }
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete() {
     if !common::has_command(CMD) {
         return;
@@ -236,12 +241,14 @@ fn complete() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_dynamic_env() {
     common::register_example::<RuntimeBuilder>("dynamic-env", "exhaustive");
 }
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_toplevel() {
     if !common::has_command(CMD) {
         return;
@@ -262,6 +269,7 @@ quote       pacman      alias       help        --generate  --version
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_help() {
     if !common::has_command(CMD) {
         return;
@@ -283,6 +291,7 @@ cmd-backticks      cmd-expansions     --single-quotes    --backticks        --ex
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_option_value() {
     if !common::has_command(CMD) {
         return;
@@ -304,6 +313,7 @@ fn complete_dynamic_env_option_value() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_value() {
     if !common::has_command(CMD) {
         return;

--- a/clap_complete/tests/testsuite/common.rs
+++ b/clap_complete/tests/testsuite/common.rs
@@ -299,6 +299,7 @@ pub(crate) fn assert_matches(
         .eq(buf, expected);
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 pub(crate) fn register_example<R: completest::RuntimeBuilder>(context: &str, name: &str) {
     use completest::Runtime as _;
 
@@ -352,6 +353,7 @@ pub(crate) fn register_example<R: completest::RuntimeBuilder>(context: &str, nam
     scratch.close().unwrap();
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 pub(crate) fn load_runtime<R: completest::RuntimeBuilder>(
     context: &str,
     name: &str,
@@ -394,12 +396,14 @@ where
     })
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 #[derive(Debug)]
 struct ScratchRuntime {
     _scratch: snapbox::dir::DirRoot,
     runtime: Box<dyn completest::Runtime>,
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 impl completest::Runtime for ScratchRuntime {
     fn home(&self) -> &std::path::Path {
         self.runtime.home()
@@ -419,6 +423,7 @@ impl completest::Runtime for ScratchRuntime {
     }
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 pub(crate) fn has_command(command: &str) -> bool {
     let output = match std::process::Command::new(command)
         .arg("--version")
@@ -428,9 +433,7 @@ pub(crate) fn has_command(command: &str) -> bool {
         Err(e) => {
             // CI is expected to support all of the commands
             if is_ci() && cfg!(target_os = "linux") {
-                panic!(
-                    "expected command `{command}` to be somewhere in PATH: {e}"
-                );
+                panic!("expected command `{command}` to be somewhere in PATH: {e}");
             }
             return false;
         }
@@ -463,6 +466,7 @@ pub(crate) fn has_command(command: &str) -> bool {
 }
 
 /// Whether or not this running in a Continuous Integration environment.
+#[cfg(feature = "unstable-shell-tests")]
 fn is_ci() -> bool {
     // Consider using `tracked_env` instead of option_env! when it is stabilized.
     // `tracked_env` will handle changes, but not require rebuilding the macro

--- a/clap_complete/tests/testsuite/elvish.rs
+++ b/clap_complete/tests/testsuite/elvish.rs
@@ -1,9 +1,12 @@
 use crate::common;
+#[allow(unused_imports)]
 use snapbox::assert_data_eq;
 
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 const CMD: &str = "elvish";
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 type RuntimeBuilder = completest_pty::ElvishRuntimeBuilder;
 
 #[test]
@@ -141,12 +144,14 @@ fn subcommand_last() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_completion() {
     common::register_example::<RuntimeBuilder>("static", "exhaustive");
 }
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_static_toplevel() {
     if !common::has_command(CMD) {
         return;
@@ -180,12 +185,14 @@ value          value
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_dynamic_env() {
     common::register_example::<RuntimeBuilder>("dynamic-env", "exhaustive");
 }
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_toplevel() {
     if !common::has_command(CMD) {
         return;
@@ -207,6 +214,7 @@ fn complete_dynamic_env_toplevel() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_help() {
     if !common::has_command(CMD) {
         return;
@@ -229,6 +237,7 @@ fn complete_dynamic_env_quoted_help() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_option_value() {
     if !common::has_command(CMD) {
         return;
@@ -258,6 +267,7 @@ fn complete_dynamic_env_option_value() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_value() {
     if !common::has_command(CMD) {
         return;

--- a/clap_complete/tests/testsuite/fish.rs
+++ b/clap_complete/tests/testsuite/fish.rs
@@ -1,9 +1,12 @@
 use crate::common;
+#[allow(unused_imports)]
 use snapbox::assert_data_eq;
 
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 const CMD: &str = "fish";
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 type RuntimeBuilder = completest_pty::FishRuntimeBuilder;
 
 #[test]
@@ -141,12 +144,14 @@ fn subcommand_last() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_completion() {
     common::register_example::<RuntimeBuilder>("static", "exhaustive");
 }
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete() {
     if !common::has_command(CMD) {
         return;
@@ -175,12 +180,14 @@ another shell  (something with a space)  bash  (bash (shell))  fish  (fish shell
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_dynamic_env() {
     common::register_example::<RuntimeBuilder>("dynamic-env", "exhaustive");
 }
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_toplevel() {
     if !common::has_command(CMD) {
         return;
@@ -202,6 +209,7 @@ value   alias   --global                                             (everywhere
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_help() {
     if !common::has_command(CMD) {
         return;
@@ -238,6 +246,7 @@ help  (Print this message or the help of the given subcommand(s))
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_option_value() {
     if !common::has_command(CMD) {
         return;
@@ -262,6 +271,7 @@ fn complete_dynamic_env_option_value() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_value() {
     if !common::has_command(CMD) {
         return;

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -1,10 +1,13 @@
+#[allow(unused_imports)]
 use snapbox::assert_data_eq;
 
 use crate::common;
 
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 const CMD: &str = "zsh";
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 type RuntimeBuilder = completest_pty::ZshRuntimeBuilder;
 
 #[test]
@@ -142,12 +145,14 @@ fn subcommand_last() {
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_completion() {
     common::register_example::<RuntimeBuilder>("static", "exhaustive");
 }
 
 #[test]
 #[cfg(unix)]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete() {
     if !common::has_command(CMD) {
         return;
@@ -168,12 +173,14 @@ pacman  action  alias  value  quote  hint  last  --
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn register_dynamic_env() {
     common::register_example::<RuntimeBuilder>("dynamic-env", "exhaustive");
 }
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_toplevel() {
     if !common::has_command(CMD) {
         return;
@@ -194,6 +201,7 @@ fn complete_dynamic_env_toplevel() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_help() {
     if !common::has_command(CMD) {
         return;
@@ -215,6 +223,7 @@ fn complete_dynamic_env_quoted_help() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_option_value() {
     if !common::has_command(CMD) {
         return;
@@ -239,6 +248,7 @@ fn complete_dynamic_env_option_value() {
 
 #[test]
 #[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
 fn complete_dynamic_env_quoted_value() {
     if !common::has_command(CMD) {
         return;

--- a/clap_complete_nushell/Cargo.toml
+++ b/clap_complete_nushell/Cargo.toml
@@ -33,12 +33,16 @@ bench = false
 [dependencies]
 clap = { path = "../", version = "4.0.0", default-features = false, features = ["std"] }
 clap_complete = { path = "../clap_complete", version = "4.0.0" }
+completest = { version = "0.4.0", optional = true }
+completest-nu = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 snapbox = { version = "0.6.0", features = ["diff", "examples", "dir"] }
 clap = { path = "../", version = "4.0.0", default-features = false, features = ["std", "help"] }
-completest = "0.4.0"
-completest-nu = "0.4.0"
+
+[features]
+default = []
+unstable-shell-tests = ["dep:completest", "dep:completest-nu"]
 
 [lints]
 workspace = true

--- a/clap_complete_nushell/tests/common.rs
+++ b/clap_complete_nushell/tests/common.rs
@@ -259,6 +259,7 @@ pub(crate) fn assert_matches(
         .eq(buf, expected);
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 pub(crate) fn register_example<R: completest::RuntimeBuilder>(context: &str, name: &str) {
     use completest::Runtime as _;
 
@@ -307,6 +308,7 @@ pub(crate) fn register_example<R: completest::RuntimeBuilder>(context: &str, nam
     scratch.close().unwrap();
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 pub(crate) fn load_runtime<R: completest::RuntimeBuilder>(
     context: &str,
     name: &str,
@@ -342,11 +344,13 @@ where
 }
 
 #[derive(Debug)]
+#[cfg(feature = "unstable-shell-tests")]
 struct ScratchRuntime {
     _scratch: snapbox::dir::DirRoot,
     runtime: Box<dyn completest::Runtime>,
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 impl completest::Runtime for ScratchRuntime {
     fn home(&self) -> &std::path::Path {
         self.runtime.home()
@@ -366,6 +370,7 @@ impl completest::Runtime for ScratchRuntime {
     }
 }
 
+#[cfg(feature = "unstable-shell-tests")]
 pub(crate) fn has_command(command: &str) -> bool {
     let output = match std::process::Command::new(command)
         .arg("--version")
@@ -408,6 +413,7 @@ pub(crate) fn has_command(command: &str) -> bool {
 }
 
 /// Whether or not this running in a Continuous Integration environment.
+#[cfg(feature = "unstable-shell-tests")]
 fn is_ci() -> bool {
     // Consider using `tracked_env` instead of option_env! when it is stabilized.
     // `tracked_env` will handle changes, but not require rebuilding the macro

--- a/clap_complete_nushell/tests/completion.rs
+++ b/clap_complete_nushell/tests/completion.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "unstable-shell-tests")]
+
 mod common;
 
 use snapbox::assert_data_eq;


### PR DESCRIPTION
We're running into the problem of tests being dependent on the version of the command.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
