### PR TITLE
fix(complete): Change ValueHint::Unknown to Other, from AnyPath

### DIFF
--- a/clap_complete/src/engine/complete.rs
+++ b/clap_complete/src/engine/complete.rs
@@ -329,10 +329,10 @@ fn complete_arg_value(
         }
     } else {
         match arg.get_value_hint() {
-            clap::ValueHint::Other => {
+            clap::ValueHint::Unknown | clap::ValueHint::Other => {
                 // Should not complete
             }
-            clap::ValueHint::Unknown | clap::ValueHint::AnyPath => {
+            clap::ValueHint::AnyPath => {
                 values.extend(complete_path(value_os, current_dir, &|_| true));
             }
             clap::ValueHint::FilePath => {


### PR DESCRIPTION
`AnyPath` is the documented behavior *but* thats to help when there isn't much other information.  With us choosing a `ValueHint` based on the value parser, we are less likely to get benefit from `AnyPath`.

Instead, this will greatly improve cases like Cargo where we offer path completions on many arguments where it doesn't make sense.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
