### PR TITLE
feat(mangen): allow custom_sections again

### DIFF
--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -298,6 +298,23 @@ impl Man {
         roff.control("SH", ["AUTHORS"]);
         roff.text([author]);
     }
+
+    /// Render a custom section into the writer.
+    pub fn render_custom_section(
+        &self,
+        w: &mut dyn Write,
+        section: &str,
+        text: &str,
+    ) -> Result<(), std::io::Error> {
+        let mut roff = Roff::default();
+        self._render_custom_section(&mut roff, section, text);
+        roff.to_writer(w)
+    }
+
+    fn _render_custom_section(&self, roff: &mut Roff, section: &str, text: &str) {
+        roff.control("SH", [section]);
+        roff.text([roman(text)]);
+    }
 }
 
 // Does the application have a version?


### PR DESCRIPTION
The added `render_custom_section` function allows to add arbitrary sections, which can come in handy for stuff like "EXAMPLES" or "AUTHORS".

There is some talk about this in https://github.com/clap-rs/clap/issues/3354 with specific sections, however I found it convenient to have a generic function for this.
