### PR TITLE
docs: Highlight notes/warnings in a block

### DIFF
--- a/clap_builder/src/builder/action.rs
+++ b/clap_builder/src/builder/action.rs
@@ -32,9 +32,13 @@ use crate::util::AnyValueId;
 pub enum ArgAction {
     /// When encountered, store the associated value(s) in [`ArgMatches`][crate::ArgMatches]
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** If the argument has previously been seen, it will result in a
     /// [`ArgumentConflict`][crate::error::ErrorKind::ArgumentConflict] unless
     /// [`Command::args_override_self(true)`][crate::Command::args_override_self] is set.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -87,9 +91,13 @@ pub enum ArgAction {
     /// No value is allowed. To optionally accept a value, see
     /// [`Arg::default_missing_value`][super::Arg::default_missing_value]
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** If the argument has previously been seen, it will result in a
     /// [`ArgumentConflict`][crate::error::ErrorKind::ArgumentConflict] unless
     /// [`Command::args_override_self(true)`][crate::Command::args_override_self] is set.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -162,9 +170,13 @@ pub enum ArgAction {
     /// No value is allowed. To optionally accept a value, see
     /// [`Arg::default_missing_value`][super::Arg::default_missing_value]
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** If the argument has previously been seen, it will result in a
     /// [`ArgumentConflict`][crate::error::ErrorKind::ArgumentConflict] unless
     /// [`Command::args_override_self(true)`][crate::Command::args_override_self] is set.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///

--- a/clap_builder/src/builder/app_settings.rs
+++ b/clap_builder/src/builder/app_settings.rs
@@ -35,8 +35,12 @@ impl std::ops::BitOr for AppFlags {
 
 /// Application level settings, which affect how [`Command`] operates
 ///
+/// <div class="warning">
+///
 /// **NOTE:** When these settings are used, they apply only to current command, and are *not*
 /// propagated down or up through child or parent subcommands
+///
+/// </div>
 ///
 /// [`Command`]: crate::Command
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -98,9 +98,13 @@ impl Arg {
     /// The name is used to check whether or not the argument was used at
     /// runtime, get values, set relationships with other args, etc..
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** In the case of arguments that take values (i.e. [`Arg::action(ArgAction::Set)`])
     /// and positional arguments (i.e. those without a preceding `-` or `--`) the name will also
     /// be displayed when the user prints the usage/help information of the program.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -188,7 +192,11 @@ impl Arg {
     /// own arguments, in which case `clap` simply will not assign those to the auto-generated
     /// `version` or `help` arguments.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Any leading `-` characters will be stripped
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -456,18 +464,34 @@ impl Arg {
 
     /// Specifies the index of a positional argument **starting at** 1.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The index refers to position according to **other positional argument**. It does
     /// not define position in the argument list as a whole.
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** You can optionally leave off the `index` method, and the index will be
     /// assigned in order of evaluation. Utilizing the `index` method allows for setting
     /// indexes out of order
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This is only meant to be used for positional arguments and shouldn't to be used
     /// with [`Arg::short`] or [`Arg::long`].
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When utilized with [`Arg::num_args(1..)`], only the **last** positional argument
     /// may be defined as having a variable number of arguments (i.e. with the highest index)
+    ///
+    /// </div>
     ///
     /// # Panics
     ///
@@ -516,13 +540,25 @@ impl Arg {
     /// This is a "var arg" and everything that follows should be captured by it, as if the user had
     /// used a `--`.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** To start the trailing "var arg" on unknown flags (and not just a positional
     /// value), set [`allow_hyphen_values`][Arg::allow_hyphen_values].  Either way, users still
     /// have the option to explicitly escape ambiguous arguments with `--`.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** [`Arg::value_delimiter`] still applies if set.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Setting this requires [`Arg::num_args(..)`].
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -554,21 +590,41 @@ impl Arg {
     /// allows one to access this arg early using the `--` syntax. Accessing an arg early, even with
     /// the `--` syntax is otherwise not possible.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This will change the usage string to look like `$ prog [OPTIONS] [-- <ARG>]` if
     /// `ARG` is marked as `.last(true)`.
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** This setting will imply [`crate::Command::dont_collapse_args_in_usage`] because failing
     /// to set this can make the usage string very confusing.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE**: This setting only applies to positional arguments, and has no effect on OPTIONS
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** Setting this requires [taking values][Arg::num_args]
     ///
-    /// **CAUTION:** Using this setting *and* having child subcommands is not
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
+    /// **WARNING:** Using this setting *and* having child subcommands is not
     /// recommended with the exception of *also* using
     /// [`crate::Command::args_conflicts_with_subcommands`]
     /// (or [`crate::Command::subcommand_negates_reqs`] if the argument marked `Last` is also
     /// marked [`Arg::required`])
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -704,7 +760,11 @@ impl Arg {
     ///
     /// i.e. when using this argument, the following argument *must* be present.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** [Conflicting] rules and [override] rules take precedence over being required
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -812,10 +872,14 @@ impl Arg {
 
     /// Specifies that an argument can be matched to all child [`Subcommand`]s.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Global arguments *only* propagate down, **not** up (to parent commands), however
     /// their values once a user uses them will be propagated back up to parents. In effect, this
     /// means one should *define* all global arguments at the top level, however it doesn't matter
     /// where the user *uses* the global argument.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -994,6 +1058,8 @@ impl Arg {
     /// - Using an equals and no space such as `-o=value` or `--option=value`
     /// - Use a short and no space such as `-ovalue`
     ///
+    /// <div class="warning">
+    ///
     /// **WARNING:**
     ///
     /// Setting a variable number of values (e.g. `1..=10`) for an argument without
@@ -1011,6 +1077,8 @@ impl Arg {
     /// - Use a delimiter between values with [`Arg::value_delimiter`]
     /// - Require a flag occurrence per value with [`ArgAction::Append`]
     /// - Require positional arguments to appear after `--` with [`Arg::last`]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1155,7 +1223,11 @@ impl Arg {
     /// using, such as `FILE`, `INTERFACE`, etc. Although not required, it's somewhat convention to
     /// use all capital letters for the value name.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** implicitly sets [`Arg::action(ArgAction::Set)`]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1218,10 +1290,18 @@ impl Arg {
     /// using, such as `FILE`, `INTERFACE`, etc. Although not required, it's somewhat convention to
     /// use all capital letters for the value name.
     ///
-    /// **Pro Tip:** It may help to use [`Arg::next_line_help(true)`] if there are long, or
+    /// <div class="warning">
+    ///
+    /// **TIP:** It may help to use [`Arg::next_line_help(true)`] if there are long, or
     /// multiple value names in order to not throw off the help text alignment of all options.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** implicitly sets [`Arg::action(ArgAction::Set)`] and [`Arg::num_args(1..)`].
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1273,7 +1353,11 @@ impl Arg {
     ///
     /// See [`ValueHint`] for more information.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** implicitly sets [`Arg::action(ArgAction::Set)`].
+    ///
+    /// </div>
     ///
     /// For example, to take a username as argument:
     ///
@@ -1322,9 +1406,17 @@ impl Arg {
     /// [`Arg::required_if_eq_all`] is case-insensitive.
     ///
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Setting this requires [taking values][Arg::num_args]
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** To do unicode case folding, enable the `unicode` feature flag.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1381,17 +1473,29 @@ impl Arg {
     ///
     /// See also [`trailing_var_arg`][Arg::trailing_var_arg].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Setting this requires [taking values][Arg::num_args]
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **WARNING:** Prior arguments with `allow_hyphen_values(true)` get precedence over known
     /// flags but known flags get precedence over the next possible positional argument with
     /// `allow_hyphen_values(true)`.  When combined with [`Arg::num_args(..)`],
     /// [`Arg::value_terminator`] is one way to ensure processing stops.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **WARNING**: Take caution when using this setting combined with another argument using
     /// [`Arg::num_args`], as this becomes ambiguous `$ prog --arg -- -- val`. All
     /// three `--, --, val` will be values when the user may have thought the second `--` would
     /// constitute the normal, "Only positional args follow" idiom.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1443,7 +1547,11 @@ impl Arg {
     /// This is similar to [`Arg::allow_hyphen_values`] except that it only allows numbers,
     /// all other undefined leading hyphens will fail to parse.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Setting this requires [taking values][Arg::num_args]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1472,7 +1580,11 @@ impl Arg {
     ///
     /// i.e. an equals between the option and associated value.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Setting this requires [taking values][Arg::num_args]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1573,10 +1685,18 @@ impl Arg {
     /// argument until it reaches another valid argument, or one of the other more specific settings
     /// for multiple values is used (such as [`num_args`]).
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This setting only applies to [options] and [positional arguments]
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** When the terminator is passed in on the command line, it is **not** stored as one
     /// of the values
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1636,7 +1756,12 @@ impl Arg {
     /// may not be exactly what you are expecting and using [`Arg::trailing_var_arg`]
     /// may be more appropriate.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Implicitly sets [`Arg::action(ArgAction::Set)`] [`Arg::num_args(1..)`],
+    ///
+    /// </div>
+    ///
     /// [`Arg::allow_hyphen_values(true)`], and [`Arg::last(true)`] when set to `true`.
     ///
     /// [`Arg::action(ArgAction::Set)`]: Arg::action()
@@ -1654,9 +1779,17 @@ impl Arg {
 
     /// Value for the argument when not present.
     ///
+    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** If the user *does not* use this argument at runtime [`ArgMatches::contains_id`] will
     /// still return `true`. If you wish to determine whether the argument was used at runtime or
     /// not, consider [`ArgMatches::value_source`][crate::ArgMatches::value_source].
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** This setting is perfectly compatible with [`Arg::default_value_if`] but slightly
     /// different. `Arg::default_value` *only* takes effect when the user has not provided this arg
@@ -1666,7 +1799,7 @@ impl Arg {
     /// at runtime, nor were the conditions met for `Arg::default_value_if`, the `Arg::default_value`
     /// will be applied.
     ///
-    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1760,12 +1893,16 @@ impl Arg {
     /// argument is a common example. By supplying a default, such as `default_missing_value("always")`,
     /// the user can quickly just add `--color` to the command line to produce the desired color output.
     ///
+    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** using this configuration option requires the use of the
     /// [`.num_args(0..N)`][Arg::num_args] and the
     /// [`.require_equals(true)`][Arg::require_equals] configuration option. These are required in
     /// order to unambiguously determine what, if any, value was supplied for the argument.
     ///
-    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2080,7 +2217,11 @@ impl Arg {
     ///
     /// If [`Arg::long_help`] is not specified, this message will be displayed for `--help`.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Only `Arg::help` is used in completion script generation in order to be concise
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2132,7 +2273,11 @@ impl Arg {
     ///
     /// If [`Arg::help`] is not specified, this message will be displayed for `-h`.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Only [`Arg::help`] is used in completion script generation in order to be concise
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2201,8 +2346,12 @@ impl Arg {
     ///
     /// To change, see [`Command::next_display_order`][crate::Command::next_display_order].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This setting is ignored for [positional arguments] which are always displayed in
     /// [index] order.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2271,8 +2420,12 @@ impl Arg {
     /// This can be helpful for arguments with very long or complex help messages.
     /// This can also be helpful for arguments with very long flag names, or many/long value names.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** To apply this setting to all arguments and subcommands, consider using
     /// [`crate::Command::next_line_help`]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2323,7 +2476,11 @@ impl Arg {
 
     /// Do not display the argument in help message.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This does **not** hide the argument from usage strings on error
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2370,10 +2527,14 @@ impl Arg {
     /// This is useful for args with many values, or ones which are explained elsewhere in the
     /// help text.
     ///
-    /// **NOTE:** Setting this requires [taking values][Arg::num_args]
-    ///
     /// To set this for all arguments, see
     /// [`Command::hide_possible_values`][crate::Command::hide_possible_values].
+    ///
+    /// <div class="warning">
+    ///
+    /// **NOTE:** Setting this requires [taking values][Arg::num_args]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2403,7 +2564,11 @@ impl Arg {
     ///
     /// This is useful when default behavior of an arg is explained elsewhere in the help text.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Setting this requires [taking values][Arg::num_args]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2494,10 +2659,18 @@ impl Arg {
 
     /// Hides an argument from short help (`-h`).
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This does **not** hide the argument from usage strings on error
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** Setting this option will cause next-line-help output style to be used
     /// when long help (`--help`) is called.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2578,10 +2751,18 @@ impl Arg {
 
     /// Hides an argument from long help (`--help`).
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This does **not** hide the argument from usage strings on error
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** Setting this option will cause next-line-help output style to be used
     /// when long help (`--help`) is called.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2749,6 +2930,10 @@ impl Arg {
     ///
     /// If `default` is set to `None`, `default_value` will be removed.
     ///
+    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This setting is perfectly compatible with [`Arg::default_value`] but slightly
     /// different. `Arg::default_value` *only* takes effect when the user has not provided this arg
     /// at runtime. This setting however only takes effect when the user has not provided a value at
@@ -2756,7 +2941,7 @@ impl Arg {
     /// and `Arg::default_value_if`, and the user **did not** provide this arg at runtime, nor were
     /// the conditions met for `Arg::default_value_if`, the `Arg::default_value` will be applied.
     ///
-    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2894,10 +3079,14 @@ impl Arg {
     ///
     /// The method takes a slice of tuples in the `(arg, predicate, default)` format.
     ///
+    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE**: The conditions are stored in order and evaluated in the same order. I.e. the first
     /// if multiple conditions are true, the first one found will be applied and the ultimate value.
     ///
-    /// Like with command-line values, this will be split by [`Arg::value_delimiter`].
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3014,8 +3203,12 @@ impl Arg {
 
     /// Set this arg as [required] as long as the specified argument is not present at runtime.
     ///
-    /// **Pro Tip:** Using `Arg::required_unless_present` implies [`Arg::required`] and is therefore not
+    /// <div class="warning">
+    ///
+    /// **TIP:** Using `Arg::required_unless_present` implies [`Arg::required`] and is therefore not
     /// mandatory to also set.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3084,8 +3277,12 @@ impl Arg {
     /// * supplies the `self` arg.
     /// * supplies *all* of the `names` arguments.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** If you wish for this argument to only be required unless *any of* these args are
     /// present see [`Arg::required_unless_present_any`]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3163,8 +3360,12 @@ impl Arg {
     /// * supplies the `self` arg.
     /// * supplies *one or more* of the `unless` arguments.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** If you wish for this argument to be required unless *all of* these args are
     /// present see [`Arg::required_unless_present_all`]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3653,18 +3854,38 @@ impl Arg {
 
     /// This argument is mutually exclusive with the specified argument.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Conflicting rules take precedence over being required by default. Conflict rules
     /// only need to be set for one of the two arguments, they do not need to be set for each.
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** Defining a conflict is two-way, but does *not* need to defined for both arguments
     /// (i.e. if A conflicts with B, defining `A.conflicts_with(B)` is sufficient. You do not
     /// need to also do `B.conflicts_with(A)`)
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** [`Arg::conflicts_with_all(names)`] allows specifying an argument which conflicts with more than one argument.
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** All arguments implicitly conflict with themselves.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3713,14 +3934,26 @@ impl Arg {
     ///
     /// See [`Arg::conflicts_with`].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Conflicting rules take precedence over being required by default. Conflict rules
     /// only need to be set for one of the two arguments, they do not need to be set for each.
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** Defining a conflict is two-way, but does *not* need to defined for both arguments
     /// (i.e. if A conflicts with B, defining `A.conflicts_with(B)` is sufficient. You do not need
     /// need to also do `B.conflicts_with(A)`)
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** [`Arg::exclusive(true)`] allows specifying an argument which conflicts with every other argument.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3767,10 +4000,18 @@ impl Arg {
     /// will override each other in POSIX style (whichever argument was specified at runtime
     /// **last** "wins")
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
     /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Overriding an argument implies they [conflict][Arg::conflicts_with`].
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3807,10 +4048,18 @@ impl Arg {
     /// i.e. this argument and the following argument will override each other in POSIX style
     /// (whichever argument was specified at runtime **last** "wins")
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When an argument is overridden it is essentially as if it never was used, any
     /// conflicts, requirements, etc. are evaluated **after** all "overrides" have been removed
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Overriding an argument implies they [conflict][Arg::conflicts_with_all`].
+    ///
+    /// </div>
     ///
     /// # Examples
     ///

--- a/clap_builder/src/builder/arg_group.rs
+++ b/clap_builder/src/builder/arg_group.rs
@@ -289,13 +289,21 @@ impl ArgGroup {
     /// This is unless conflicting with another argument.  A required group will be displayed in
     /// the usage string of the application in the format `<arg|arg2|arg3>`.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This setting only applies to the current [`Command`] / [`Subcommand`]s, and not
     /// globally.
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** By default, [`ArgGroup::multiple`] is set to `false` which when combined with
     /// `ArgGroup::required(true)` states, "One and *only one* arg must be used from this group.
     /// Use of more than one arg is an error." Vice setting `ArgGroup::multiple(true)` which
     /// states, '*At least* one arg from this group must be used. Using multiple is OK."
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -335,7 +343,11 @@ impl ArgGroup {
     /// [argument requirement rules], you can name other arguments or groups that must be present
     /// when any one of the arguments from this group is used.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The name provided may be an argument or group name
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -380,7 +392,11 @@ impl ArgGroup {
     /// [argument requirement rules], you can name other arguments or groups that must be present
     /// when one of the arguments from this group is used.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The names provided may be an argument or group name
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -426,7 +442,11 @@ impl ArgGroup {
     /// other arguments or groups that must *not* be present when one of the arguments from this
     /// group are used.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The name provided may be an argument, or group name
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -468,7 +488,11 @@ impl ArgGroup {
     /// Exclusion rules function just like [argument exclusion rules], you can name other arguments
     /// or groups that must *not* be present when one of the arguments from this group are used.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The names provided may be an argument, or group name
+    ///
+    /// </div>
     ///
     /// # Examples
     ///

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -640,10 +640,14 @@ impl Command {
 
     /// Parse [`env::args_os`], returning a [`clap::Result`] on failure.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This method WILL NOT exit when `--help` or `--version` (or short versions) are
     /// used. It will return a [`clap::Error`], where the [`kind`] is a
     /// [`ErrorKind::DisplayHelp`] or [`ErrorKind::DisplayVersion`] respectively. You must call
     /// [`Error::exit`] or perform a [`std::process::exit`].
+    ///
+    /// </div>
     ///
     /// # Panics
     ///
@@ -675,8 +679,12 @@ impl Command {
 
     /// Parse the specified arguments, [exiting][Error::exit] on failure.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The first argument will be parsed as the binary name unless
     /// [`Command::no_binary_name`] is used.
+    ///
+    /// </div>
     ///
     /// # Panics
     ///
@@ -709,13 +717,21 @@ impl Command {
 
     /// Parse the specified arguments, returning a [`clap::Result`] on failure.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This method WILL NOT exit when `--help` or `--version` (or short versions) are
     /// used. It will return a [`clap::Error`], where the [`kind`] is a [`ErrorKind::DisplayHelp`]
     /// or [`ErrorKind::DisplayVersion`] respectively. You must call [`Error::exit`] or
     /// perform a [`std::process::exit`] yourself.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The first argument will be parsed as the binary name unless
     /// [`Command::no_binary_name`] is used.
+    ///
+    /// </div>
     ///
     /// # Panics
     ///
@@ -755,13 +771,21 @@ impl Command {
     ///
     /// Like [`Command::try_get_matches_from`] but doesn't consume the `Command`.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This method WILL NOT exit when `--help` or `--version` (or short versions) are
     /// used. It will return a [`clap::Error`], where the [`kind`] is a [`ErrorKind::DisplayHelp`]
     /// or [`ErrorKind::DisplayVersion`] respectively. You must call [`Error::exit`] or
     /// perform a [`std::process::exit`] yourself.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The first argument will be parsed as the binary name unless
     /// [`Command::no_binary_name`] is used.
+    ///
+    /// </div>
     ///
     /// # Panics
     ///
@@ -1087,7 +1111,11 @@ impl Command {
 
     /// Try not to fail on parse errors, like missing option values.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1125,7 +1153,11 @@ impl Command {
     /// This is the equivalent to saying the `foo` arg using [`Arg::overrides_with("foo")`] for all
     /// defined arguments.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// [`Arg::overrides_with("foo")`]: crate::Arg::overrides_with()
     #[inline]
@@ -1140,11 +1172,19 @@ impl Command {
     /// Disables the automatic delimiting of values after `--` or when [`Arg::trailing_var_arg`]
     /// was used.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The same thing can be done manually by setting the final positional argument to
     /// [`Arg::value_delimiter(None)`]. Using this setting is safer, because it's easier to locate
     /// when making changes.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1170,9 +1210,17 @@ impl Command {
     ///
     /// To customize how the output is styled, see [`Command::styles`].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Default behaviour is [`ColorChoice::Auto`].
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1201,9 +1249,17 @@ impl Command {
 
     /// Sets the [`Styles`] for terminal output
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Default behaviour is [`Styles::default`].
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1237,9 +1293,17 @@ impl Command {
     /// **`unstable-v5` feature**: Defaults to unbound, being subject to
     /// [`Command::max_term_width`].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This setting applies globally and *not* on a per-command basis.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This requires the `wrap_help` feature
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1267,9 +1331,17 @@ impl Command {
     ///
     /// **`unstable-v5` feature**: Defaults to 100.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This setting applies globally and *not* on a per-command basis.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This requires the `wrap_help` feature
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1345,7 +1417,11 @@ impl Command {
     ///
     /// Defaults to `false`; subcommands have independent version strings from their parents.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1373,7 +1449,11 @@ impl Command {
 
     /// Places the help string for all arguments and subcommands on the line after them.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1395,7 +1475,11 @@ impl Command {
 
     /// Disables `-h` and `--help` flag.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1450,7 +1534,11 @@ impl Command {
 
     /// Disables the `help` [`subcommand`].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1481,7 +1569,11 @@ impl Command {
 
     /// Disables colorized help messages.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1503,10 +1595,18 @@ impl Command {
 
     /// Panic if help descriptions are omitted.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When deriving [`Parser`][crate::Parser], you could instead check this at
     /// compile-time with `#![deny(missing_docs)]`
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1563,7 +1663,11 @@ impl Command {
     /// To set this per argument, see
     /// [`Arg::hide_possible_values`][crate::Arg::hide_possible_values].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     #[inline]
     pub fn hide_possible_values(self, yes: bool) -> Self {
         if yes {
@@ -1578,11 +1682,19 @@ impl Command {
     /// For example, to match an argument named `--test`, one could use `--t`, `--te`, `--tes`, and
     /// `--test`.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match
     /// `--te` to `--test` there could not also be another argument or alias `--temp` because both
     /// start with `--te`
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// [aliases]: crate::Command::aliases()
     #[inline]
@@ -1599,16 +1711,28 @@ impl Command {
     /// For example, to match a subcommand named `test`, one could use `t`, `te`, `tes`, and
     /// `test`.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The match *must not* be ambiguous at all in order to succeed. i.e. to match `te`
     /// to `test` there could not also be a subcommand or alias `temp` because both start with `te`
     ///
-    /// **CAUTION:** This setting can interfere with [positional/free arguments], take care when
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
+    /// **WARNING:** This setting can interfere with [positional/free arguments], take care when
     /// designing CLIs which allow inferred subcommands and have potential positional/free
     /// arguments whose values could start with the same characters as subcommands. If this is the
     /// case, it's recommended to use settings such as [`Command::args_conflicts_with_subcommands`] in
     /// conjunction with this setting.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This choice is propagated to all child subcommands.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1664,12 +1788,20 @@ impl Command {
     /// This should only be used when absolutely necessary, such as when the binary name for your
     /// application is misleading, or perhaps *not* how the user should invoke your program.
     ///
-    /// **Pro-tip:** When building things such as third party `cargo`
+    /// <div class="warning">
+    ///
+    /// **TIP:** When building things such as third party `cargo`
     /// subcommands, this setting **should** be used!
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** This *does not* change or set the name of the binary file on
     /// disk. It only changes what clap thinks the name is for the purposes of
     /// error or help messages.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1705,12 +1837,20 @@ impl Command {
 
     /// Sets the author(s) for the help message.
     ///
-    /// **Pro-tip:** Use `clap`s convenience macro [`crate_authors!`] to
+    /// <div class="warning">
+    ///
+    /// **TIP:** Use `clap`s convenience macro [`crate_authors!`] to
     /// automatically set your application's author(s) to the same thing as your
     /// crate at compile time.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** A custom [`help_template`][Command::help_template] is needed for author to show
     /// up.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1730,9 +1870,6 @@ impl Command {
     /// Sets the program's description for the short help (`-h`).
     ///
     /// If [`Command::long_about`] is not specified, this message will be displayed for `--help`.
-    ///
-    /// **NOTE:** Only `Command::about` (short format) is used in completion
-    /// script generation in order to be concise.
     ///
     /// See also [`crate_description!`](crate::crate_description!).
     ///
@@ -1756,8 +1893,12 @@ impl Command {
     /// If not set, [`Command::about`] will be used for long help in addition to short help
     /// (`-h`).
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Only [`Command::about`] (short format) is used in completion
     /// script generation in order to be concise.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1872,9 +2013,13 @@ impl Command {
     ///
     /// If [`Command::long_version`] is not specified, this message will be displayed for `--version`.
     ///
-    /// **Pro-tip:** Use `clap`s convenience macro [`crate_version!`] to
+    /// <div class="warning">
+    ///
+    /// **TIP:** Use `clap`s convenience macro [`crate_version!`] to
     /// automatically set your application's version to the same thing as your
     /// crate at compile time.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1895,9 +2040,13 @@ impl Command {
     ///
     /// If [`Command::version`] is not specified, this message will be displayed for `-V`.
     ///
-    /// **Pro-tip:** Use `clap`s convenience macro [`crate_version!`] to
+    /// <div class="warning">
+    ///
+    /// **TIP:** Use `clap`s convenience macro [`crate_version!`] to
     /// automatically set your application's version to the same thing as your
     /// crate at compile time.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1921,9 +2070,15 @@ impl Command {
 
     /// Overrides the `clap` generated usage string for help and error messages.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Using this setting disables `clap`s "context-aware" usage
     /// strings. After this setting is set, this will be *the only* usage string
     /// displayed to the user!
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** Multiple usage lines may be present in the usage argument, but
     /// some rules need to be followed to ensure the usage lines are formatted
@@ -1932,6 +2087,8 @@ impl Command {
     /// - Do not indent the first usage line.
     /// - Indent all subsequent usage lines with seven spaces.
     /// - The last line must not end with a newline.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -1968,10 +2125,14 @@ impl Command {
     ///
     /// This should only be used when the auto-generated message does not suffice.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This **only** replaces the help message for the current
     /// command, meaning if you are using subcommands, those help messages will
     /// still be auto-generated unless you specify a [`Command::override_help`] for
     /// them as well.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2003,9 +2164,6 @@ impl Command {
     }
 
     /// Sets the help template to be used, overriding the default format.
-    ///
-    /// **NOTE:** The template system is by design very simple. Therefore, the
-    /// tags have to be written in the lowercase and without spacing.
     ///
     /// Tags are given inside curly brackets.
     ///
@@ -2149,7 +2307,11 @@ impl Command {
 
     /// Exit gracefully if no arguments are present (e.g. `$ myprog`).
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** [`subcommands`] count as arguments
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2369,7 +2531,11 @@ impl Command {
     ///
     /// Allows the subcommand to be used as if it were an [`Arg::long`].
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Any leading `-` characters will be stripped.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2410,13 +2576,21 @@ impl Command {
     /// alias. This is more efficient and easier than creating multiple hidden subcommands as one
     /// only needs to check for the existence of this command, and not all aliased variants.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Aliases defined with this method are *hidden* from the help
     /// message. If you're looking for aliases that will be displayed in the help
     /// message, see [`Command::visible_alias`].
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When using aliases and checking for the existence of a
     /// particular subcommand within an [`ArgMatches`] struct, one only needs to
     /// search for the original name and not all aliases.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2501,13 +2675,21 @@ impl Command {
     /// given aliases. This is more efficient, and easier than creating multiple hidden subcommands
     /// as one only needs to check for the existence of this command and not all aliased variants.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Aliases defined with this method are *hidden* from the help
     /// message. If looking for aliases that will be displayed in the help
     /// message, see [`Command::visible_aliases`].
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When using aliases and checking for the existence of a
     /// particular subcommand within an [`ArgMatches`] struct, one only needs to
     /// search for the original name and not all aliases.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2595,14 +2777,22 @@ impl Command {
     /// than creating hidden subcommands as one only needs to check for
     /// the existence of this command and not all aliased variants.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The alias defined with this method is *visible* from the help
     /// message and displayed as if it were just another regular subcommand. If
     /// looking for an alias that will not be displayed in the help message, see
     /// [`Command::alias`].
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When using aliases and checking for the existence of a
     /// particular subcommand within an [`ArgMatches`] struct, one only needs to
     /// search for the original name and not all aliases.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2694,14 +2884,22 @@ impl Command {
     /// than creating multiple hidden subcommands as one only needs to check for
     /// the existence of this command and not all aliased variants.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The alias defined with this method is *visible* from the help
     /// message and displayed as if it were just another regular subcommand. If
     /// looking for an alias that will not be displayed in the help message, see
     /// [`Command::alias`].
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** When using aliases, and checking for the existence of a
     /// particular subcommand within an [`ArgMatches`] struct, one only needs to
     /// search for the original name and not all aliases.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2881,13 +3079,21 @@ impl Command {
     ///
     /// Arguments will be stored in the `""` argument in the [`ArgMatches`]
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Use this setting with caution,
     /// as a truly unexpected argument (i.e. one that is *NOT* an external subcommand)
     /// will **not** cause an error and instead be treated as a potential subcommand.
     /// One should check for such cases manually and inform the user appropriately.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** A built-in subcommand will be parsed as an external subcommand when escaped with
     /// `--`.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -2930,7 +3136,11 @@ impl Command {
     /// The default parser is for `OsString`.  This can be used to switch it to `String` or another
     /// type.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Setting this requires [`Command::allow_external_subcommands`]
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3090,7 +3300,11 @@ impl Command {
     /// using this setting would allow you to set those arguments to [`Arg::required(true)`]
     /// and yet receive no error so long as the user uses a valid subcommand instead.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This defaults to false (using subcommand does *not* negate requirements)
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3171,14 +3385,26 @@ impl Command {
     /// [`allow_external_subcommands`][Command::allow_external_subcommands] if you want to specifically
     /// get the unrecognized binary name.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** Multicall can't be used with [`no_binary_name`] since they interpret
     /// the command name in incompatible ways.
     ///
+    /// </div>
+    ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The multicall command cannot have arguments.
+    ///
+    /// </div>
+    ///
+    /// <div class="warning">
     ///
     /// **NOTE:** Applets are slightly semantically different from subcommands,
     /// so it's recommended to use [`Command::subcommand_help_heading`] and
     /// [`Command::subcommand_value_name`] to change the descriptive text as above.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///
@@ -3744,15 +3970,15 @@ impl Command {
         }
     }
 
-    // Get a unique list of all arguments of all commands and continuous subcommands the given argument conflicts with.
-    //
-    // This behavior follows the propagation rules of global arguments.
-    // It is useful for finding conflicts for arguments declared as global.
-    //
-    // ### Panics
-    //
-    // If the given arg contains a conflict with an argument that is unknown to
-    // this `Command`.
+    /// Get a unique list of all arguments of all commands and continuous subcommands the given argument conflicts with.
+    ///
+    /// This behavior follows the propagation rules of global arguments.
+    /// It is useful for finding conflicts for arguments declared as global.
+    ///
+    /// ### Panics
+    ///
+    /// If the given arg contains a conflict with an argument that is unknown to
+    /// this `Command`.
     fn get_global_arg_conflicts_with(&self, arg: &Arg) -> Vec<&Arg> // FIXME: This could probably have been an iterator
     {
         arg.blacklist
@@ -3774,19 +4000,24 @@ impl Command {
             .collect()
     }
 
-    // Get a list of subcommands which contain the provided Argument
-    //
-    // This command will only include subcommands in its list for which the subcommands
-    // parent also contains the Argument.
-    //
-    // This search follows the propagation rules of global arguments.
-    // It is useful to finding subcommands, that have inherited a global argument.
-    //
-    // **NOTE:** In this case only Sucommand_1 will be included
-    //   Subcommand_1 (contains Arg)
-    //     Subcommand_1.1 (doesn't contain Arg)
-    //       Subcommand_1.1.1 (contains Arg)
-    //
+    /// Get a list of subcommands which contain the provided Argument
+    ///
+    /// This command will only include subcommands in its list for which the subcommands
+    /// parent also contains the Argument.
+    ///
+    /// This search follows the propagation rules of global arguments.
+    /// It is useful to finding subcommands, that have inherited a global argument.
+    ///
+    /// <div class="warning">
+    ///
+    /// **NOTE:** In this case only `Sucommand_1` will be included
+    /// ```text
+    ///   Subcommand_1 (contains Arg)
+    ///     Subcommand_1.1 (doesn't contain Arg)
+    ///       Subcommand_1.1.1 (contains Arg)
+    /// ```
+    ///
+    /// </div>
     fn get_subcommands_containing(&self, arg: &Arg) -> Vec<&Self> {
         let mut vec = Vec::new();
         for idx in 0..self.subcommands.len() {

--- a/clap_builder/src/builder/os_str.rs
+++ b/clap_builder/src/builder/os_str.rs
@@ -2,8 +2,12 @@ use crate::builder::Str;
 
 /// A UTF-8-encoded fixed string
 ///
+/// <div class="warning">
+///
 /// **NOTE:** To support dynamic values (i.e. `OsString`), enable the `string`
 /// feature
+///
+/// </div>
 #[derive(Default, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct OsStr {
     name: Inner,

--- a/clap_builder/src/builder/possible_value.rs
+++ b/clap_builder/src/builder/possible_value.rs
@@ -9,9 +9,13 @@ use crate::util::eq_ignore_case;
 ///
 /// See also [`PossibleValuesParser`][crate::builder::PossibleValuesParser]
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Most likely you can use strings, rather than `PossibleValue` as it is only required
 /// to [hide] single values from help messages and shell completions or to attach [help] to
 /// possible values.
+///
+/// </div>
 ///
 /// # Examples
 ///
@@ -45,8 +49,12 @@ impl PossibleValue {
     ///
     /// The name will be used to decide whether this value was provided by the user to an argument.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** In case it is not [hidden] it will also be shown in help messages for arguments
     /// that use it as a [possible value] and have not hidden them through [`Arg::hide_possible_values(true)`].
+    ///
+    /// </div>
     ///
     /// # Examples
     ///

--- a/clap_builder/src/builder/str.rs
+++ b/clap_builder/src/builder/str.rs
@@ -1,7 +1,11 @@
 /// A UTF-8-encoded fixed string
 ///
+/// <div class="warning">
+///
 /// **NOTE:** To support dynamic values (i.e. `String`), enable the `string`
 /// feature
+///
+/// </div>
 #[derive(Default, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Str {
     name: Inner,

--- a/clap_builder/src/builder/value_parser.rs
+++ b/clap_builder/src/builder/value_parser.rs
@@ -1267,9 +1267,13 @@ where
 
 /// Parse number that fall within a range of values
 ///
+/// <div class="warning">
+///
 /// **NOTE:** To capture negative values, you will also need to set
 /// [`Arg::allow_negative_numbers`][crate::Arg::allow_negative_numbers] or
 /// [`Arg::allow_hyphen_values`][crate::Arg::allow_hyphen_values].
+///
+/// </div>
 ///
 /// # Example
 ///

--- a/clap_builder/src/derive.rs
+++ b/clap_builder/src/derive.rs
@@ -20,7 +20,11 @@ use std::ffi::OsString;
 ///
 /// See also [`Subcommand`] and [`Args`].
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Deriving requires the `derive` feature flag
+///
+/// </div>
 pub trait Parser: FromArgMatches + CommandFactory + Sized {
     /// Parse from `std::env::args_os()`, [exit][Error::exit] on error.
     fn parse() -> Self {
@@ -214,7 +218,11 @@ pub trait FromArgMatches: Sized {
 ///   `Args`.
 /// - `Variant(ChildArgs)`: No attribute is used with enum variants that impl `Args`.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Deriving requires the `derive` feature flag
+///
+/// </div>
 pub trait Args: FromArgMatches + Sized {
     /// Report the [`ArgGroup::id`][crate::ArgGroup::id] for this set of arguments
     fn group_id() -> Option<crate::Id> {
@@ -245,7 +253,11 @@ pub trait Args: FromArgMatches + Sized {
 /// - `#[command(flatten)] Variant(SubCmd)`: Attribute can only be used with enum variants that impl
 ///   `Subcommand`.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Deriving requires the `derive` feature flag
+///
+/// </div>
 pub trait Subcommand: FromArgMatches + Sized {
     /// Append to [`Command`] so it can instantiate `Self` via
     /// [`FromArgMatches::from_arg_matches_mut`]
@@ -272,7 +284,11 @@ pub trait Subcommand: FromArgMatches + Sized {
 /// - Call [`EnumValueParser`][crate::builder::EnumValueParser]
 /// - Allowing using the `#[arg(default_value_t)]` attribute without implementing `Display`.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Deriving requires the `derive` feature flag
+///
+/// </div>
 pub trait ValueEnum: Sized + Clone {
     /// All possible argument values, in display order.
     fn value_variants<'a>() -> &'a [Self];

--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -26,8 +26,12 @@ pub trait ErrorFormatter: Sized {
 ///
 /// No context is included.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Consider removing the `error-context` default feature if using this to remove all
 /// overhead for [`RichFormatter`].
+///
+/// </div>
 #[non_exhaustive]
 pub struct KindFormatter;
 

--- a/clap_builder/src/macros.rs
+++ b/clap_builder/src/macros.rs
@@ -79,11 +79,15 @@ macro_rules! crate_description {
 
 /// Allows you to pull the name from your Cargo.toml at compile time.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** This macro extracts the name from an environment variable `CARGO_PKG_NAME`.
 /// When the crate name is set to something different from the package name,
 /// use environment variables `CARGO_CRATE_NAME` or `CARGO_BIN_NAME`.
 /// See [the Cargo Book](https://doc.rust-lang.org/cargo/reference/environment-variables.html)
 /// for more information.
+///
+/// </div>
 ///
 /// # Examples
 ///
@@ -104,12 +108,16 @@ macro_rules! crate_name {
 
 /// Allows you to build the `Command` instance from your Cargo.toml at compile time.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Changing the values in your `Cargo.toml` does not trigger a re-build automatically,
 /// and therefore won't change the generated output until you recompile.
 ///
 /// In some cases you can "trick" the compiler into triggering a rebuild when your
 /// `Cargo.toml` is changed by including this in your `src/main.rs` file
 /// `include_str!("../Cargo.toml");`
+///
+/// </div>
 ///
 /// # Examples
 ///
@@ -430,8 +438,12 @@ macro_rules! arg_impl {
 ///
 /// Allows creation of basic settings for the [`Arg`].
 ///
+/// <div class="warning">
+///
 /// **NOTE**: Not all settings may be set using the usage string method. Some properties are
 /// only available via the builder pattern.
+///
+/// </div>
 ///
 /// # Syntax
 ///
@@ -467,8 +479,12 @@ macro_rules! arg_impl {
 /// A long flag is a `--` followed by either a bare-word or a string, like `--foo` or
 /// `--"foo"`.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Dashes in the long name (e.g. `--foo-bar`) is not supported and quoting is required
 /// (e.g. `--"foo-bar"`).
+///
+/// </div>
 ///
 /// See [`Arg::long`][crate::Arg::long].
 ///

--- a/clap_builder/src/parser/matches/arg_matches.rs
+++ b/clap_builder/src/parser/matches/arg_matches.rs
@@ -83,8 +83,12 @@ impl ArgMatches {
     ///
     /// Returns `None` if the option wasn't present.
     ///
+    /// <div class="warning">
+    ///
     /// *NOTE:* This will always return `Some(value)` if [`default_value`] has been set.
     /// [`ArgMatches::value_source`] can be used to check if a value is present at runtime.
+    ///
+    /// </div>
     ///
     /// # Panic
     ///
@@ -374,8 +378,12 @@ impl ArgMatches {
     ///
     /// Returns `None` if the option wasn't present.
     ///
+    /// <div class="warning">
+    ///
     /// *NOTE:* This will always return `Some(value)` if [`default_value`] has been set.
     /// [`ArgMatches::value_source`] can be used to check if a value is present at runtime.
+    ///
+    /// </div>
     ///
     /// # Panic
     ///
@@ -485,8 +493,12 @@ impl ArgMatches {
 
     /// Check if values are present for the argument or group id
     ///
+    /// <div class="warning">
+    ///
     /// *NOTE:* This will always return `true` if [`default_value`] has been set.
     /// [`ArgMatches::value_source`] can be used to check if a value is present at runtime.
+    ///
+    /// </div>
     ///
     /// # Panics
     ///
@@ -612,8 +624,12 @@ impl ArgMatches {
     ///
     /// The examples should clear this up.
     ///
+    /// <div class="warning">
+    ///
     /// *NOTE:* If an argument is allowed multiple times, this method will only give the *first*
     /// index.  See [`ArgMatches::indices_of`].
+    ///
+    /// </div>
     ///
     /// # Panics
     ///
@@ -760,8 +776,12 @@ impl ArgMatches {
     /// refer to the *values* `-o val` would therefore not represent two distinct indices, only the
     /// index for `val` would be recorded. This is by design.
     ///
+    /// <div class="warning">
+    ///
     /// *NOTE:* For more information about how clap indices compared to argv indices, see
     /// [`ArgMatches::index_of`]
+    ///
+    /// </div>
     ///
     /// # Panics
     ///

--- a/clap_builder/src/util/color.rs
+++ b/clap_builder/src/util/color.rs
@@ -6,7 +6,11 @@ use crate::derive::ValueEnum;
 pub enum ColorChoice {
     /// Enables colored output only when the output is going to a terminal or TTY.
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** This is the default behavior of `clap`.
+    ///
+    /// </div>
     ///
     /// # Examples
     ///

--- a/clap_complete/src/aot/generator/mod.rs
+++ b/clap_complete/src/aot/generator/mod.rs
@@ -68,8 +68,12 @@ pub trait Generator {
 
 /// Generate a completions file for a specified shell at compile-time.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** to generate the file at compile time you must use a `build.rs` "Build Script" or a
 /// [`cargo-xtask`](https://github.com/matklad/cargo-xtask)
+///
+/// </div>
 ///
 /// # Examples
 ///
@@ -160,8 +164,12 @@ pub trait Generator {
 /// Assuming we compiled with debug mode, it would be somewhere similar to
 /// `<project>/target/debug/build/myapp-<hash>/out/myapp.bash`.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** Please look at the individual [shells][crate::shells]
 /// to see the name of the files generated.
+///
+/// </div>
 ///
 /// Using [`ValueEnum::value_variants()`][clap::ValueEnum::value_variants] you can easily loop over
 /// all the supported shell variants to generate all the completions at once too.

--- a/clap_complete/src/aot/generator/utils.rs
+++ b/clap_complete/src/aot/generator/utils.rs
@@ -18,7 +18,11 @@ pub fn all_subcommands(cmd: &Command) -> Vec<(String, String)> {
 
 /// Finds the subcommand [`clap::Command`] from the given [`clap::Command`] with the given path.
 ///
+/// <div class="warning">
+///
 /// **NOTE:** `path` should not contain the root `bin_name`.
+///
+/// </div>
 pub fn find_subcommand_with_path<'cmd>(p: &'cmd Command, path: Vec<&str>) -> &'cmd Command {
     let mut cmd = p;
 

--- a/clap_complete/src/env/mod.rs
+++ b/clap_complete/src/env/mod.rs
@@ -24,12 +24,16 @@
 //!
 //! To source your completions:
 //!
+//! <div class="warning">
+//!
 //! **WARNING:** We recommend re-sourcing your completions on upgrade.
 //! These completions work by generating shell code that calls into `your_program` while completing.
 //! That interface is unstable and a mismatch between the shell code and `your_program` may result
 //! in either invalid completions or no completions being generated.
 //! For this reason, we recommend generating the shell code anew on shell startup so that it is
 //! "self-correcting" on shell launch, rather than writing the generated completions to a file.
+//!
+//! </div>
 //!
 //! Bash
 //! ```bash
@@ -355,9 +359,13 @@ pub trait EnvCompleter {
     /// - `bin`: see [`CompleteEnv::bin`]
     /// - `completer`: see [`CompleteEnv::completer`]
     ///
+    /// <div class="warning">
+    ///
     /// **WARNING:** There are no stability guarantees between the call to
     /// [`EnvCompleter::write_complete`] that this generates and actually calling [`EnvCompleter::write_complete`].
     /// Caching the results of this call may result in invalid or no completions to be generated.
+    ///
+    /// </div>
     fn write_registration(
         &self,
         var: &str,

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -133,7 +133,11 @@ pub struct RawArgs {
 impl RawArgs {
     //// Create an argument list to parse
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** The argument returned will be the current binary.
+    ///
+    /// </div>
     ///
     /// # Example
     ///
@@ -362,14 +366,22 @@ impl<'s> ParsedArg<'s> {
 
     /// Treat as a value
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** May return a flag or an escape.
+    ///
+    /// </div>
     pub fn to_value_os(&self) -> &OsStr {
         self.inner
     }
 
     /// Treat as a value
     ///
+    /// <div class="warning">
+    ///
     /// **NOTE:** May return a flag or an escape.
+    ///
+    /// </div>
     pub fn to_value(&self) -> Result<&str, &OsStr> {
         self.inner.to_str().ok_or(self.inner)
     }

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -75,5 +75,9 @@ For more information, try '--help'.
 
 ```
 
+<div class="warning">
+
 **NOTE:** Keep in mind that subcommands, flags, and long flags are *case sensitive*: `-Q` and `-q` are different flags/subcommands. For example, you can have both `-Q` subcommand and `-q` flag, and they will be properly disambiguated.
 Let's make a quick program to illustrate.
+
+</div>

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -126,9 +126,13 @@
 //! magic attributes documentation for details.  This allows users to access the
 //! raw behavior of an attribute via `<attr>(<value>)` syntax.
 //!
+//! <div class="warning">
+//!
 //! **NOTE:** Some attributes are inferred from [Arg Types](#arg-types) and [Doc
 //! Comments](#doc-comments).  Explicit attributes take precedence over inferred
 //! attributes.
+//!
+//! </div>
 //!
 //! ### Command Attributes
 //!
@@ -349,6 +353,8 @@
 //! }
 //! ```
 //!
+//! <div class="warning">
+//!
 //! **NOTE:** Attributes have priority over doc comments!
 //!
 //! **Top level doc comments always generate `Command::about/long_about` calls!**
@@ -356,6 +362,8 @@
 //! use the `about` / `long_about` attributes to override the calls generated from
 //! the doc comment.  To clear `long_about`, you can use
 //! `#[command(long_about = None)]`.
+//!
+//! </div>
 //!
 //! ### Pre-processing
 //!


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
