### PR TITLE
fix(parser): Fill in defaults on ignored error 

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -54,7 +54,14 @@ impl<'cmd> Parser<'cmd> {
     ) -> ClapResult<()> {
         debug!("Parser::get_matches_with");
 
-        ok!(self.parse(matcher, raw_args, args_cursor));
+        ok!(self.parse(matcher, raw_args, args_cursor).map_err(|err| {
+            if self.cmd.is_ignore_errors_set() {
+                #[cfg(feature = "env")]
+                let _ = self.add_env(matcher);
+                let _ = self.add_defaults(matcher);
+            }
+            err
+        }));
         ok!(self.resolve_pending(matcher));
 
         #[cfg(feature = "env")]

--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -50,9 +50,29 @@ impl<'cmd> Parser<'cmd> {
         &mut self,
         matcher: &mut ArgMatcher,
         raw_args: &mut clap_lex::RawArgs,
-        mut args_cursor: clap_lex::ArgCursor,
+        args_cursor: clap_lex::ArgCursor,
     ) -> ClapResult<()> {
         debug!("Parser::get_matches_with");
+
+        ok!(self.parse(matcher, raw_args, args_cursor));
+        ok!(self.resolve_pending(matcher));
+
+        #[cfg(feature = "env")]
+        ok!(self.add_env(matcher));
+        ok!(self.add_defaults(matcher));
+
+        Validator::new(self.cmd).validate(matcher)
+    }
+
+    // The actual parsing function
+    #[allow(clippy::cognitive_complexity)]
+    pub(crate) fn parse(
+        &mut self,
+        matcher: &mut ArgMatcher,
+        raw_args: &mut clap_lex::RawArgs,
+        mut args_cursor: clap_lex::ArgCursor,
+    ) -> ClapResult<()> {
+        debug!("Parser::parse");
         // Verify all positional assertions pass
 
         let mut subcmd_name: Option<String> = None;
@@ -436,11 +456,7 @@ impl<'cmd> Parser<'cmd> {
                     matches: sc_m.into_inner(),
                 });
 
-                ok!(self.resolve_pending(matcher));
-                #[cfg(feature = "env")]
-                ok!(self.add_env(matcher));
-                ok!(self.add_defaults(matcher));
-                return Validator::new(self.cmd).validate(matcher);
+                return Ok(());
             } else {
                 // Start error processing
                 let _ = self.resolve_pending(matcher);
@@ -474,11 +490,7 @@ impl<'cmd> Parser<'cmd> {
             ok!(self.parse_subcommand(&sc_name, matcher, raw_args, args_cursor, keep_state));
         }
 
-        ok!(self.resolve_pending(matcher));
-        #[cfg(feature = "env")]
-        ok!(self.add_env(matcher));
-        ok!(self.add_defaults(matcher));
-        Validator::new(self.cmd).validate(matcher)
+        Ok(())
     }
 
     fn match_arg_error(

--- a/tests/builder/ignore_errors.rs
+++ b/tests/builder/ignore_errors.rs
@@ -5,7 +5,7 @@ use super::utils;
 #[test]
 fn single_short_arg_without_value() {
     let cmd = Command::new("cmd").ignore_errors(true).arg(arg!(
-        -c --config [FILE] "Sets a custom config file"
+        -c --config <FILE> "Sets a custom config file"
     ));
 
     let r = cmd.try_get_matches_from(vec!["cmd", "-c" /* missing: , "config file" */]);
@@ -18,7 +18,7 @@ fn single_short_arg_without_value() {
 #[test]
 fn single_long_arg_without_value() {
     let cmd = Command::new("cmd").ignore_errors(true).arg(arg!(
-        -c --config [FILE] "Sets a custom config file"
+        -c --config <FILE> "Sets a custom config file"
     ));
 
     let r = cmd.try_get_matches_from(vec!["cmd", "--config" /* missing: , "config file" */]);
@@ -33,10 +33,10 @@ fn multiple_args_and_final_arg_without_value() {
     let cmd = Command::new("cmd")
         .ignore_errors(true)
         .arg(arg!(
-            -c --config [FILE] "Sets a custom config file"
+            -c --config <FILE> "Sets a custom config file"
         ))
         .arg(arg!(
-            -x --stuff [FILE] "Sets a custom stuff file"
+            -x --stuff <FILE> "Sets a custom stuff file"
         ))
         .arg(arg!(f: -f "Flag").action(ArgAction::SetTrue));
 
@@ -59,10 +59,10 @@ fn multiple_args_and_intermittent_arg_without_value() {
     let cmd = Command::new("cmd")
         .ignore_errors(true)
         .arg(arg!(
-            -c --config[FILE] "Sets a custom config file"
+            -c --config <FILE> "Sets a custom config file"
         ))
         .arg(arg!(
-            -x --stuff[FILE] "Sets a custom stuff file"
+            -x --stuff <FILE> "Sets a custom stuff file"
         ))
         .arg(arg!(f: -f "Flag").action(ArgAction::SetTrue));
 

--- a/tests/builder/ignore_errors.rs
+++ b/tests/builder/ignore_errors.rs
@@ -113,7 +113,7 @@ fn unexpected_argument() {
         m.get_one::<String>("config").cloned(),
         Some("config file".to_owned())
     );
-    assert_eq!(m.get_one::<bool>("unset-flag").copied(), None);
+    assert_eq!(m.get_one::<bool>("unset-flag").copied(), Some(false));
 }
 
 #[test]

--- a/tests/builder/ignore_errors.rs
+++ b/tests/builder/ignore_errors.rs
@@ -96,6 +96,27 @@ fn multiple_args_and_intermittent_arg_without_value() {
 }
 
 #[test]
+fn unexpected_argument() {
+    let cmd = Command::new("cmd")
+        .ignore_errors(true)
+        .arg(arg!(
+            -c --config [FILE] "Sets a custom config file"
+        ))
+        .arg(arg!(--"unset-flag"));
+
+    let r = cmd.try_get_matches_from(vec!["cmd", "-c", "config file", "unexpected"]);
+
+    assert!(r.is_ok(), "unexpected error: {r:?}");
+    let m = r.unwrap();
+    assert!(m.contains_id("config"));
+    assert_eq!(
+        m.get_one::<String>("config").cloned(),
+        Some("config file".to_owned())
+    );
+    assert_eq!(m.get_one::<bool>("unset-flag").copied(), None);
+}
+
+#[test]
 fn subcommand() {
     let cmd = Command::new("test")
         .ignore_errors(true)


### PR DESCRIPTION
This came up in clap-rs#5812 and is especially problematic for derives.

Not really a fan of this solution but its the least invasive.
I also considered going wild with error recovery or moving towards a
solution for clap-rs#1546.