### PR TITLE
Command groups #1553

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -108,7 +108,7 @@ pub struct Command {
     subcommand_heading: Option<Str>,
     external_value_parser: Option<super::ValueParser>,
     long_help_exists: bool,
-     deferred: Option<fn(Command) -> Command>,
+    deferred: Option<fn(Command) -> Command>,
     #[cfg(feature = "unstable-ext")]
     ext: Extensions,
     app_ext: Extensions,

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -108,7 +108,7 @@ pub struct Command {
     subcommand_heading: Option<Str>,
     external_value_parser: Option<super::ValueParser>,
     long_help_exists: bool,
-    deferred: Option<fn(Command) -> Command>,
+     deferred: Option<fn(Command) -> Command>,
     #[cfg(feature = "unstable-ext")]
     ext: Extensions,
     app_ext: Extensions,
@@ -343,6 +343,25 @@ impl Command {
         self
     }
 
+    /// Allows one to mutate an [`CommandGroup`] after it's been added to a [`Command`].
+    ///
+    /// # Panics
+    ///
+    /// If the argument is undefined
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, CommandGroup, arg, ArgGroup};
+    ///
+    /// Command::new("foo")
+    ///     .command_group(CommandGroup::new("bar")
+    ///          .help_heading("Bar commands")
+    ///          .command("bar")
+    ///     .mut_command_group("bar", |g| g.clear());
+    /// ```
+
     #[must_use]
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn mut_command_group<F>(mut self, cmd_id: impl AsRef<str>, f: F) -> Self
@@ -446,6 +465,32 @@ impl Command {
         self
     }
 
+    /// Adds an [`CommandGroup`] to the application.
+    ///
+    /// [`CommandGroup`]s are a family of related subcommands.
+    /// By placing them in a logical group, you can display help more clearly.
+    ///
+    /// # Examples
+    ///
+    /// The following example demonstrates using an [`CommandGroup`] to group related commands
+    /// when usage help is displayed.
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, CommandGroup};
+    /// Command::new("add-pizza-ingredient")
+    ///     .subcommand(Command::new("pepperoni"))
+    ///     .subcommand(Command::new("ham"))
+    ///     .subcommand(Command::new("peppers"))
+    ///     .subcommand(Command::new("onion"))
+    ///     .command_group(CommandGroup::new("meats")
+    ///         .help_heading("Meaty ingredients")
+    ///         .commands(["pepperoni", "ham"]))
+    ///     .command_group(CommandGroup::new("veggies")
+    ///         .help_heading("Vegetables")
+    ///         .commands(["peppers", "onion"]))
+    /// # ;
+    /// ```
     #[inline]
     #[must_use]
     pub fn command_group(mut self, group: impl Into<CommandGroup>) -> Self {
@@ -485,7 +530,34 @@ impl Command {
         self
     }
 
-
+    /// Adds an [`CommandGroup`] to the application.
+    ///
+    /// [`CommandGroup`]s are a family of related subcommands.
+    /// By placing them in a logical group, you can display help more clearly.
+    ///
+    /// # Examples
+    ///
+    /// The following example demonstrates using an [`CommandGroup`] to group related commands
+    /// when usage help is displayed.
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, CommandGroup};
+    /// Command::new("add-pizza-ingredient")
+    ///     .subcommand(Command::new("pepperoni"))
+    ///     .subcommand(Command::new("ham"))
+    ///     .subcommand(Command::new("peppers"))
+    ///     .subcommand(Command::new("onion"))
+    ///     .command_groups([
+    ///         CommandGroup::new("meats")
+    ///             .help_heading("Meaty ingredients")
+    ///             .commands(["pepperoni", "ham"]),
+    ///         CommandGroup::new("veggies")
+    ///             .help_heading("Vegetables")
+    ///             .commands(["peppers", "onion"])
+    ///     ])
+    /// # ;
+    /// ```
     #[must_use]
     pub fn command_groups(mut self, groups: impl IntoIterator<Item = impl Into<CommandGroup>>) -> Self {
         for g in groups {

--- a/clap_builder/src/builder/command_group.rs
+++ b/clap_builder/src/builder/command_group.rs
@@ -1,0 +1,278 @@
+// Internal
+use crate::builder::IntoResettable;
+use crate::builder::Str;
+use crate::util::Id;
+
+/// Family of related [commands].
+///
+/// By placing commands in a logical group, you can make help and documentation easier to
+/// understand and navigate.
+///
+/// # Examples
+///
+/// The following example demonstrates using a `CommandGroup` separate subcommands into two groups.
+///
+/// ```rust
+/// # use clap_builder as clap;
+/// # use clap::{Command, command, CommandGroup, error::ErrorKind};
+/// let result = Command::new("git")
+///     .subcommands([
+///         Command::new("git-apply"),
+///         Command::new("git-mktree"),
+///         Command::new("git-cat-file"),
+///         Command::new("git-cherry"),
+///     ])
+///     .command_group(CommandGroup::new("manipulation")
+///			.help_heading("Manipulation commands")
+///         .commands(["git-apply", "git-mktree"]))
+///     .command_group(CommandGroup::new("interrogation")
+///			.help_heading("Interrogation commands")
+///         .commands(["git-cat-file", "git-cherry"]))
+///
+///     .try_get_matches_from(vec!["git", "git-apply"]);
+/// assert!(result.is_ok());
+/// ```
+///
+/// This next example demonstrates having only some commands belonging to a group
+/// In the documentation, groups of commands will be displayed last,
+/// while commands not belonging to any group will be displayed first.
+/// ```rust
+/// # use clap_builder as clap;
+/// # use clap::{Command, arg, ArgGroup, Id};
+/// let result = Command::new("cmd")
+///     .subcommands([
+///         Command::new("add"),
+///         Command::new("remove"),
+///         Command::new("show"),
+///     ])
+///     .command_group(CommandGroup::new("manipulation")
+///			.help_heading("Manipulation commands")
+///         .commands(["add", "remove"]))
+///     .try_get_matches_from(vec!["cmd", "add"]);
+/// assert!(result.is_ok());
+/// ```
+///
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct CommandGroup {
+    pub(crate) id: Id,
+    pub(crate) commands: Vec<Str>,
+    pub(crate) heading: Option<Str>,
+}
+
+/// # Builder
+impl CommandGroup {
+    /// Create a `CommandGroup` using a unique name.
+    ///
+    /// The name will be used to get values from the group and to refer to the group
+    /// by subcommands.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, ArgGroup};
+    /// CommandGroup::new("config")
+    /// # ;
+    /// ```
+    pub fn new(id: impl Into<Id>) -> Self {
+        CommandGroup::default().id(id)
+    }
+
+    /// Sets the group name.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, ArgGroup};
+    /// CommandGroup::default().id("config")
+    /// # ;
+    /// ```
+    #[must_use]
+    pub fn id(mut self, id: impl Into<Id>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    /// Adds an [command] to this group by name
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, CommandGroup};
+    /// let m = Command::new("myprog")
+ 	///		.subcommands([
+	///			Command::new("add"),
+	///			Command::new("remove"),
+	///			Command::new("show"),
+	///		])
+	///     .command_group(CommandGroup::new("manipulation")
+	///			.help_heading("Manipulation commands")
+	///         .command("add"))
+    ///     .get_matches_from(vec!["myprog", "add"]);
+    /// ```
+    /// [argument]: crate::Str
+    #[must_use]
+    pub fn command(mut self, cmd_name: impl IntoResettable<Str>) -> Self {
+        if let Some(cmd_name) = cmd_name.into_resettable().into_option() {
+            self.commands.push(cmd_name);
+        } else {
+            self.commands.clear();
+        }
+        self
+    }
+
+    /// Adds multiple [commands] to this group by name
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, Arg, ArgGroup, ArgAction};
+    /// let m = Command::new("myprog")
+    ///     .arg(Arg::new("flag")
+    ///         .short('f')
+    ///         .action(ArgAction::SetTrue))
+    ///     .arg(Arg::new("color")
+    ///         .short('c')
+    ///         .action(ArgAction::SetTrue))
+    ///     .group(ArgGroup::new("req_flags")
+    ///         .args(["flag", "color"]))
+    ///     .get_matches_from(vec!["myprog", "-f"]);
+    /// // maybe we don't know which of the two flags was used...
+    /// assert!(m.contains_id("req_flags"));
+    /// // but we can also check individually if needed
+    /// assert!(m.contains_id("flag"));
+    /// ```
+    /// [commands]: crate::Arg
+    #[must_use]
+    pub fn commands(mut self, ns: impl IntoIterator<Item = impl Into<Str>>) -> Self {
+        for n in ns {
+            self = self.command(n);
+        }
+        self
+    }
+
+
+    #[must_use]
+    pub fn help_heading(mut self, heading: impl IntoResettable<Str>) -> Self {
+        self.heading = heading.into_resettable().into_option();
+        self
+    }
+
+
+    /// Getters for all args. It will return a vector of `Id`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{ArgGroup};
+    /// let args: Vec<&str> = vec!["a1".into(), "a4".into()];
+    /// let grp = ArgGroup::new("program").args(&args);
+    ///
+    /// for (pos, arg) in grp.get_args().enumerate() {
+    ///     assert_eq!(*arg, args[pos]);
+    /// }
+    /// ```
+    pub fn get_commands(&self) -> impl Iterator<Item = &Str> {
+        self.commands.iter()
+    }
+}
+
+/// # Reflection
+impl CommandGroup {
+    /// Get the name of the group
+    #[inline]
+    pub fn get_id(&self) -> &Id {
+        &self.id
+    }
+
+}
+
+impl From<&'_ CommandGroup> for CommandGroup {
+    fn from(g: &CommandGroup) -> Self {
+        g.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn groups() {
+        let g = ArgGroup::new("test")
+            .arg("a1")
+            .arg("a4")
+            .args(["a2", "a3"])
+            .required(true)
+            .conflicts_with("c1")
+            .conflicts_with_all(["c2", "c3"])
+            .conflicts_with("c4")
+            .requires("r1")
+            .requires_all(["r2", "r3"])
+            .requires("r4");
+
+        let args: Vec<Id> = vec!["a1".into(), "a4".into(), "a2".into(), "a3".into()];
+        let reqs: Vec<Id> = vec!["r1".into(), "r2".into(), "r3".into(), "r4".into()];
+        let confs: Vec<Id> = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];
+
+        assert_eq!(g.args, args);
+        assert_eq!(g.requires, reqs);
+        assert_eq!(g.conflicts, confs);
+    }
+
+    #[test]
+    fn test_from() {
+        let g = ArgGroup::new("test")
+            .arg("a1")
+            .arg("a4")
+            .args(["a2", "a3"])
+            .required(true)
+            .conflicts_with("c1")
+            .conflicts_with_all(["c2", "c3"])
+            .conflicts_with("c4")
+            .requires("r1")
+            .requires_all(["r2", "r3"])
+            .requires("r4");
+
+        let args: Vec<Id> = vec!["a1".into(), "a4".into(), "a2".into(), "a3".into()];
+        let reqs: Vec<Id> = vec!["r1".into(), "r2".into(), "r3".into(), "r4".into()];
+        let confs: Vec<Id> = vec!["c1".into(), "c2".into(), "c3".into(), "c4".into()];
+
+        let g2 = ArgGroup::from(&g);
+        assert_eq!(g2.args, args);
+        assert_eq!(g2.requires, reqs);
+        assert_eq!(g2.conflicts, confs);
+    }
+
+    // This test will *fail to compile* if ArgGroup is not Send + Sync
+    #[test]
+    fn arg_group_send_sync() {
+        fn foo<T: Send + Sync>(_: T) {}
+        foo(ArgGroup::new("test"));
+    }
+
+    #[test]
+    fn arg_group_expose_is_multiple_helper() {
+        let args: Vec<Id> = vec!["a1".into(), "a4".into()];
+
+        let mut grp_multiple = ArgGroup::new("test_multiple").args(&args).multiple(true);
+        assert!(grp_multiple.is_multiple());
+
+        let mut grp_not_multiple = ArgGroup::new("test_multiple").args(&args).multiple(false);
+        assert!(!grp_not_multiple.is_multiple());
+    }
+
+    #[test]
+    fn arg_group_expose_get_args_helper() {
+        let args: Vec<Id> = vec!["a1".into(), "a4".into()];
+        let grp = ArgGroup::new("program").args(&args);
+
+        for (pos, arg) in grp.get_args().enumerate() {
+            assert_eq!(*arg, args[pos]);
+        }
+    }
+}

--- a/clap_builder/src/builder/mod.rs
+++ b/clap_builder/src/builder/mod.rs
@@ -7,6 +7,7 @@ mod arg_group;
 mod arg_predicate;
 mod arg_settings;
 mod command;
+mod command_group;
 mod ext;
 mod os_str;
 mod possible_value;
@@ -33,6 +34,7 @@ pub use arg::ArgExt;
 pub use arg_group::ArgGroup;
 pub use arg_predicate::ArgPredicate;
 pub use command::Command;
+pub use command_group::CommandGroup;
 #[cfg(feature = "unstable-ext")]
 pub use command::CommandExt;
 pub use os_str::OsStr;

--- a/clap_builder/src/lib.rs
+++ b/clap_builder/src/lib.rs
@@ -16,6 +16,7 @@ compile_error!("`std` feature is currently required to build `clap`");
 
 pub use crate::builder::ArgAction;
 pub use crate::builder::Command;
+pub use crate::builder::CommandGroup;
 pub use crate::builder::ValueHint;
 pub use crate::builder::{Arg, ArgGroup};
 pub use crate::parser::ArgMatches;

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -963,41 +963,28 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 let _ = write!(styled, ", {literal}--{long}{literal:#}",);
             }
             longest = longest.max(styled.display_width());
-            ord_v.push((subcommand.get_display_order(), styled, subcommand, true));
+            let no_group = self.cmd.get_command_groups().filter(|cg| cg.commands.contains(subcommand.get_name_str())).next().is_none();
+            ord_v.push((subcommand.get_display_order(), styled, subcommand, no_group));
         }
         ord_v.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
 
-        //self.cmd.visible_ungroupped_subcommands();
-
-        let has_groups = cmd.get_command_groups().next().is_some();
-        //find subcommands that do not belong to any group
-        if has_groups {
-            for cmd_group in cmd.get_command_groups() {
-                 for cmd_name in cmd_group.commands.iter() {
-                    match ord_v.iter_mut().filter(|(_, _, sc, _)| sc.get_name() == cmd_name).next() {
-                        None => {},
-                        Some((_, _, _, ref mut show)) => {
-                             *show = false;
-                        }
-                    }
-                }
-            }
-        }
-
         debug!("HelpTemplate::write_subcommands longest = {longest}");
 
+        //first show commands that do not belong to any group
+        //if groups are not used, that means all visible commands
         let next_line_help = self.will_subcommands_wrap(cmd.get_subcommands(), longest);
-        for (i, (_, sc_str, sc, show)) in ord_v.iter().enumerate() {
-            if *show {
-                if 0 < i {
-                    self.writer.push_str("\n");
-                }
+        for (i, (_, sc_str, sc, no_group)) in ord_v.iter().enumerate() {
+            if *no_group {
                 self.write_subcommand(sc_str.clone(), sc, next_line_help, longest);
+                //if 0 < i {
+                    self.writer.push_str("\n");
+                //}
+
             }
         }
-
-
-        if has_groups {
+        //if groups are defined, show group header followed by all commands in group
+        if cmd.get_command_groups().next().is_some() {
+            self.writer.push_str("\n");
             let header = &self.styles.get_header();
 
             for cmd_group in cmd.get_command_groups() {
@@ -1014,9 +1001,10 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 self.will_subcommands_wrap(it, longest)
                 };
                 for cmd_name in cmd_group.commands.iter() {
-                    match ord_v.iter_mut().filter(|(_, sc_str, sc, _)| sc.get_name() == cmd_name).next() {
+                    match ord_v.iter_mut().filter(|(_, _, sc, _)| sc.get_name() == cmd_name).next() {
                         None => {},
-                        Some((_, sc_str, sc, ref mut show)) => {
+                        Some((_, sc_str, sc, _)) => {
+
                             self.write_subcommand(sc_str.clone(), sc, next_line_help, longest);
                             //if i < 0 {
                                 self.writer.push_str("\n");
@@ -1025,6 +1013,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                         }
                     }
                 }
+                self.writer.push_str("\n");
             }
 
 

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -370,7 +370,7 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
     pub(crate) fn write_all_args(&mut self) {
         debug!("HelpTemplate::write_all_args");
         use std::fmt::Write as _;
-       let header = &self.styles.get_header();
+        let header = &self.styles.get_header();
 
         let pos = self
             .cmd
@@ -909,29 +909,26 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         }
     }
 
-
-	//// Check if this subcommand should display help header
-	/// which will be the case if either there are subcommands and no command groups
-	/// or there are subcommands and some of them do not belong to any group
+    /// Check if this subcommand should display help header
+    /// which will be the case if either there are subcommands and no command groups
+    /// or there are subcommands and some of them do not belong to any group
     #[cfg(any(feature = "usage", feature = "help"))]
     pub(crate) fn needs_subcmd_help_header(&self) -> bool {
-		self.visible_ungroupped_subcommands()
-			.next()
-			.is_some()
+       self.visible_ungroupped_subcommands()
+           .next()
+           .is_some()
     }
 
-
     pub(crate) fn visible_subcommands(&self) -> impl Iterator<Item = &Command> {
-	    self.cmd
+        self.cmd
             .get_subcommands()
             .filter(|subcommand| should_show_subcommand(subcommand))
-	}
-
+    }
 
     #[cfg(any(feature = "usage", feature = "help"))]
     pub(crate) fn visible_ungroupped_subcommands(&self) -> impl Iterator<Item = &Command> {
-		self.visible_subcommands()
-			.filter(|sc| self.cmd.get_command_groups().filter(|cg| cg.commands.contains(sc.get_name_str())).next().is_none())
+        self.visible_subcommands()
+            .filter(|sc| self.cmd.get_command_groups().filter(|cg| cg.commands.contains(sc.get_name_str())).next().is_none())
     }
 
     /// Writes help for subcommands of a Parser Object to the wrapped stream.

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -909,12 +909,6 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
         }
     }
 
-#[cfg(any(feature = "usage", feature = "help"))]
-    pub(crate) fn has_visible_subcommands(&self) -> bool {
-        self.visible_subcommands()
-            .next()
-            .is_some()
-    }
 
 	//// Check if this subcommand should display help header
 	/// which will be the case if either there are subcommands and no command groups

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -28,7 +28,7 @@ fn cli() -> Command {
                         .require_equals(true)
                         .default_value("auto")
                         .default_missing_value("always"),
-                ),
+                ).subcommand_help_heading(Some("DIFF")),
         )
         .subcommand(
             Command::new("push")

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -1,7 +1,7 @@
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use clap::{arg, Command};
+use clap::{arg, Command, CommandGroup};
 
 fn cli() -> Command {
     Command::new("git")
@@ -30,6 +30,12 @@ fn cli() -> Command {
                         .default_missing_value("always"),
                 ),
         )
+        .command_group(CommandGroup::new("clone")
+            .help_heading("clone/diff commands")
+            .commands(&["clone", "diff"]))
+        .command_group(CommandGroup::new("add")
+            .help_heading("adding commands")
+            .commands(&["add"]))
         .subcommand(
             Command::new("push")
                 .about("pushes things")

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -30,12 +30,6 @@ fn cli() -> Command {
                         .default_missing_value("always"),
                 ),
         )
-        .command_group(CommandGroup::new("clone")
-            .help_heading("clone/diff commands")
-            .commands(&["clone", "diff"]))
-        .command_group(CommandGroup::new("add")
-            .help_heading("adding commands")
-            .commands(&["add"]))
         .subcommand(
             Command::new("push")
                 .about("pushes things")

--- a/tests/builder/command_group.rs
+++ b/tests/builder/command_group.rs
@@ -94,7 +94,6 @@ fn command_group_help_output_group_with_heading() {
 Usage: clap-test [COMMAND]
 
 Test:
-
   test  Some help
   help  Print this message or the help of the given subcommand(s)
 
@@ -124,16 +123,13 @@ fn command_group_help_output_two_groups_with_headings() {
 Usage: clap-test [COMMAND]
 
 TestGroup1:
-
   test1  Some help
   test2  Some help
 
 TestGroup2:
-
   test3  Some help
   test4  Some help
   help   Print this message or the help of the given subcommand(s)
-
 
 Options:
   -h, --help     Print help

--- a/tests/builder/command_group.rs
+++ b/tests/builder/command_group.rs
@@ -1,0 +1,167 @@
+use clap::{arg, error::ErrorKind, Arg, ArgAction, Command, CommandGroup};
+
+use super::utils;
+use snapbox::assert_data_eq;
+use snapbox::str;
+
+#[test]
+fn command_group_help_output_one_ungrouped_command() {
+    let visible_help: &str = "\
+Usage: clap-test [COMMAND]
+
+Commands:
+  help  Print this message or the help of the given subcommand(s)
+
+  test  Some help
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test")
+        .version("2.6")
+        .subcommand(
+            Command::new("test")
+                .about("Some help")
+        )
+        .command_group(CommandGroup::new("Test commands")
+            .commands(&["test"]));
+
+
+    utils::assert_output(cmd, "clap-test --help", visible_help, false);
+}
+
+#[test]
+fn command_group_help_output_one_ungrouped_command_one_group() {
+    let visible_help: &str = "\
+Usage: clap-test [COMMAND]
+
+Commands:
+  help  Print this message or the help of the given subcommand(s)
+
+Test:
+  test  Some help
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test")
+        .version("2.6")
+        .subcommand(
+            Command::new("test")
+                .about("Some help")
+        )
+        .command_group(CommandGroup::new("Test commands")
+            .help_heading("Test")
+            .commands(&["test"]));
+
+
+    utils::assert_output(cmd, "clap-test --help", visible_help, false);
+}
+
+#[test]
+fn command_group_help_output_no_ungrouped_commands_no_heading() {
+    let visible_help: &str = "\
+Usage: clap-test [COMMAND]
+
+  test  Some help
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test")
+        .version("2.6")
+        .subcommand(
+            Command::new("test")
+                .about("Some help")
+        )
+        .command_group(CommandGroup::new("test_commands")
+            .commands(&["test", "help"]));
+
+
+    utils::assert_output(cmd, "clap-test --help", visible_help, false);
+}
+
+#[test]
+fn command_group_help_output_group_with_heading() {
+    let visible_help: &str = "\
+Usage: clap-test [COMMAND]
+
+Test:
+
+  test  Some help
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test")
+        .version("2.6")
+        .subcommand(
+            Command::new("test")
+                .about("Some help")
+        )
+        .command_group(CommandGroup::new("test_commands")
+            .help_heading("Test")
+            .commands(&["test", "help"]));
+
+
+    utils::assert_output(cmd, "clap-test --help", visible_help, false);
+}
+
+
+#[test]
+fn command_group_help_output_two_groups_with_headings() {
+    let visible_help: &str = "\
+Usage: clap-test [COMMAND]
+
+TestGroup1:
+
+  test1  Some help
+  test2  Some help
+
+TestGroup2:
+
+  test3  Some help
+  test4  Some help
+  help   Print this message or the help of the given subcommand(s)
+
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test")
+        .version("2.6")
+        .subcommand(
+            Command::new("test1").about("Some help")
+        )
+        .subcommand(
+            Command::new("test2").about("Some help")
+        )
+        .subcommand(
+            Command::new("test3").about("Some help")
+        )
+        .subcommand(
+            Command::new("test4").about("Some help")
+        )
+        .command_group(CommandGroup::new("test_commands1")
+            .help_heading("TestGroup1")
+            .commands(&["test1", "test2"]))
+        .command_group(CommandGroup::new("test_commands2")
+            .help_heading("TestGroup2")
+            .commands(&["test3", "test4", "help"]));
+
+
+    utils::assert_output(cmd, "clap-test --help", visible_help, false);
+}
+


### PR DESCRIPTION
Group subcommands displayed in help (#1553)
This is for help only, does not affect matching.

I've done the builder part, still figuring out derive support.

Main idea:

Added concept of CommandGroups. Command group has a name, optional help heading,
and a list of commands it groups. Order of groups and commands in group determines order of display in usage help.

so that we can go from

Commands:
    cmd1 ...
    cmd2 ...
    help ...

to

Commands:
    help ...

Utility commands:
    cmd1 ...
    cmd2 ....

Nothing changes if groups aren't used. Group with no heading leaves a space between groups,
see tests for examples.