### PR TITLE
fix(help): Display value terminator and delimiter in help

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4647,6 +4647,7 @@ impl Arg {
             val_names = vec![val_name; min];
         }
 
+        let delimiter = self.get_value_delimiter().unwrap_or(' ');
         debug_assert!(self.is_takes_value_set());
         for (n, val_name) in val_names.iter().enumerate() {
             let arg_name = if self.is_positional() && (num_vals.min_values() == 0 || !required) {
@@ -4656,7 +4657,7 @@ impl Arg {
             };
 
             if n != 0 {
-                rendered.push(' ');
+                rendered.push(delimiter);
             }
             rendered.push_str(&arg_name);
         }
@@ -4668,6 +4669,11 @@ impl Arg {
         }
         if extra_values {
             rendered.push_str("...");
+        }
+
+        if let Some(terminator) = self.get_value_terminator() {
+            rendered.push(' ');
+            rendered.push_str(terminator);
         }
 
         rendered

--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -2645,7 +2645,7 @@ impl Arg {
     /// ```
     ///
     /// If we were to run the above program with `$ CONNECT=super_secret connect --help` the
-    /// `[default: CONNECT=super_secret]` portion of the help text would be omitted.
+    /// `[env: CONNECT=super_secret]` portion of the help text would be omitted.
     #[cfg(feature = "env")]
     #[inline]
     #[must_use]

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -766,6 +766,13 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 a.default_vals
             );
 
+            // We might need up to 4 bytes to encode an utf-8 character
+            let mut buffer = [0u8; 4];
+            let delimiter = a
+                .get_value_delimiter()
+                .unwrap_or(' ')
+                .encode_utf8(&mut buffer);
+
             let pvs = a
                 .default_vals
                 .iter()
@@ -778,9 +785,19 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                     }
                 })
                 .collect::<Vec<_>>()
-                .join(" ");
+                .join(delimiter);
 
             spec_vals.push(format!("[default: {pvs}]"));
+        }
+
+        if let Some(delimiter) = a.get_value_delimiter() {
+            debug!("HelpTemplate::spec_vals: Found delimiter...{delimiter:?}");
+            spec_vals.push(format!("[value delimiter: {delimiter:?}]"));
+        }
+
+        if let Some(terminator) = a.get_value_terminator() {
+            debug!("HelpTemplate::spec_vals: Found terminator...{terminator:?}");
+            spec_vals.push(format!("[value terminator: {terminator:?}]"));
         }
 
         let als = a

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2053,10 +2053,10 @@ fn issue_1052_require_delim_help() {
     let expected = str![[r#"
 tests stuff
 
-Usage: test --fake <some> <val>
+Usage: test --fake <some>:<val>
 
 Options:
-  -f, --fake <some> <val>  some help
+  -f, --fake <some>:<val>  some help [value delimiter: ':']
   -h, --help               Print help
   -V, --version            Print version
 
@@ -2082,11 +2082,11 @@ fn display_value_terminator() {
     let expected = str![[r#"
 Likes seeing the value terminator
 
-Usage: test --cmd <cmd>...
+Usage: test --cmd <cmd>... ;
 
 Options:
-      --cmd <cmd>...  command to run
-  -h, --help          Print help
+      --cmd <cmd>... ;  command to run [value terminator: ";"]
+  -h, --help            Print help
 
 "#]];
     utils::assert_output(cmd, "test --help", expected, false);
@@ -2118,10 +2118,10 @@ fn custom_headers_headers() {
     let expected = str![[r#"
 does stuff
 
-Usage: test [OPTIONS] --fake <some> <val>
+Usage: test [OPTIONS] --fake <some>:<val>
 
 Options:
-  -f, --fake <some> <val>  some help
+  -f, --fake <some>:<val>  some help [value delimiter: ':']
   -h, --help               Print help
   -V, --version            Print version
 
@@ -2189,10 +2189,10 @@ fn multiple_custom_help_headers() {
     let expected = str![[r#"
 does stuff
 
-Usage: test [OPTIONS] --fake <some> <val> --birthday-song <song> --birthday-song-volume <volume>
+Usage: test [OPTIONS] --fake <some>:<val> --birthday-song <song> --birthday-song-volume <volume>
 
 Options:
-  -f, --fake <some> <val>  some help
+  -f, --fake <some>:<val>  some help [value delimiter: ':']
       --style <style>      Choose musical style to play the song
   -s, --speed <SPEED>      How fast? [possible values: fast, slow]
   -h, --help               Print help

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2065,6 +2065,34 @@ Options:
 }
 
 #[test]
+fn display_value_terminator() {
+    let cmd = Command::new("test")
+        .author("Jaffa")
+        .about("Likes seeing the value terminator")
+        .arg(
+            Arg::new("cmd")
+                .long("cmd")
+                .action(ArgAction::Append)
+                .help("command to run")
+                .required(true)
+                .num_args(1..)
+                .value_terminator(";"),
+        );
+
+    let expected = str![[r#"
+Likes seeing the value terminator
+
+Usage: test --cmd <cmd>...
+
+Options:
+      --cmd <cmd>...  command to run
+  -h, --help          Print help
+
+"#]];
+    utils::assert_output(cmd, "test --help", expected, false);
+}
+
+#[test]
 fn custom_headers_headers() {
     let cmd = Command::new("blorp")
         .author("Will M.")


### PR DESCRIPTION
Display value terminator and delimiter in the command usage and help.

I added explicitly `[value delimiter: ':']` and `[value terminator: ";"]` to the help message.

Closes https://github.com/clap-rs/clap/issues/5392 and https://github.com/clap-rs/clap/issues/4812.

Related to https://github.com/clap-rs/clap/issues/1052
