### PR TITLE
Add Subcommand help headings

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -406,7 +406,9 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 .cmd
                 .get_subcommand_help_heading()
                 .unwrap_or(&default_help_heading);
-            let _ = write!(self.writer, "{header}{help_heading}:{header:#}\n",);
+            if self.cmd.needs_commands_header() {
+                let _ = write!(self.writer, "{header}{help_heading}:{header:#}\n",);
+            }
 
             self.write_subcommands(self.cmd);
         }
@@ -864,13 +866,14 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
             .filter(|subcommand| should_show_subcommand(subcommand))
         {
             ord_v.push((
+                subcommand.get_subcommand_help_heading(),
                 subcommand.get_display_order(),
                 subcommand.get_name(),
                 subcommand,
             ));
         }
-        ord_v.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
-        for (_, _, subcommand) in ord_v {
+        ord_v.sort_by(|a, b| (a.0, a.1, &a.2).cmp(&(b.0, b.1, &b.2)));
+        for (_, _, _, subcommand) in ord_v {
             if !*first {
                 self.writer.push_str("\n\n");
             }
@@ -930,19 +933,41 @@ impl<'cmd, 'writer> HelpTemplate<'cmd, 'writer> {
                 let _ = write!(styled, ", {literal}--{long}{literal:#}",);
             }
             longest = longest.max(styled.display_width());
-            ord_v.push((subcommand.get_display_order(), styled, subcommand));
+            ord_v.push((
+                subcommand.get_subcommand_help_heading(),
+                subcommand.get_display_order(),
+                styled,
+                subcommand,
+            ));
         }
-        ord_v.sort_by(|a, b| (a.0, &a.1).cmp(&(b.0, &b.1)));
+        ord_v.sort_by(|a, b| (a.0, a.1, &a.2).cmp(&(b.0, b.1, &b.2)));
 
         debug!("HelpTemplate::write_subcommands longest = {longest}");
 
         let next_line_help = self.will_subcommands_wrap(cmd.get_subcommands(), longest);
+        let mut current_help_heading = &None;
+        let mut help_heading_nl_needed = true;
 
-        for (i, (_, sc_str, sc)) in ord_v.into_iter().enumerate() {
+        for (i, (opt_help_heading, _, sc_str, sc)) in ord_v.iter().enumerate() {
             if 0 < i {
                 self.writer.push_str("\n");
             }
-            self.write_subcommand(sc_str, sc, next_line_help, longest);
+            if current_help_heading != opt_help_heading {
+                if let Some(help_heading) = opt_help_heading {
+                    let header = &self.styles.get_header();
+                    if help_heading_nl_needed {
+                        help_heading_nl_needed = false;
+                    } else {
+                        self.writer.push_str("\n");
+                    };
+                    let _ = write!(self.writer, "{header}{help_heading}:{header:#}\n",);
+                }
+                current_help_heading = &ord_v[i].0;
+            } else {
+                help_heading_nl_needed = false;
+            }
+
+            self.write_subcommand(sc_str.clone(), sc, next_line_help, longest);
         }
     }
 

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -1,5 +1,6 @@
 use clap::{arg, error::ErrorKind, Arg, ArgAction, Command};
 
+
 use super::utils;
 use snapbox::assert_data_eq;
 use snapbox::str;
@@ -629,4 +630,87 @@ fn duplicate_subcommand_alias() {
         .subcommand(Command::new("repeat"))
         .subcommand(Command::new("unique").alias("repeat"))
         .build();
+}
+
+#[test]
+fn subcommand_help_header() {
+    static VISIBLE_ALIAS_HELP: &str = "\
+Usage: clap-test [COMMAND]
+
+Commands:
+  help  Print this message or the help of the given subcommand(s)
+
+Test commands:
+  test  Some help
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test").version("2.6").subcommand(
+        Command::new("test")
+            .about("Some help")
+            .subcommand_help_heading("Test commands")
+    );
+    utils::assert_output(cmd, "clap-test --help", VISIBLE_ALIAS_HELP, false);
+}
+
+
+#[test]
+fn subcommand_help_header_hide_commands_header() {
+    static VISIBLE_ALIAS_HELP: &str = "\
+Usage: clap-test [COMMAND]
+
+Test commands:
+  test  Some help
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test")
+        .version("2.6")
+        .disable_help_subcommand(true)
+        .subcommand(
+            Command::new("test")
+                .about("Some help")
+                .subcommand_help_heading("Test commands")
+        );
+    utils::assert_output(cmd, "clap-test --help", VISIBLE_ALIAS_HELP, false);
+}
+
+
+#[test]
+fn subcommand_help_header_multiple_help_headers() {
+    static VISIBLE_ALIAS_HELP: &str = "\
+Usage: clap-test [COMMAND]
+
+Test commands 1:
+  test1  Some help
+
+Test commands 2:
+  test2  Some help
+
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
+";
+
+    let cmd = Command::new("clap-test")
+        .version("2.6")
+        .disable_help_subcommand(true)
+        .subcommand(
+            Command::new("test1")
+                .about("Some help")
+                .subcommand_help_heading("Test commands 1")
+        )
+        .subcommand(
+            Command::new("test2")
+                .about("Some help")
+                .subcommand_help_heading("Test commands 2")
+        );
+
+    utils::assert_output(cmd, "clap-test --help", VISIBLE_ALIAS_HELP, false);
 }


### PR DESCRIPTION
Group subcommands displayed in help (https://github.com/clap-rs/clap/issues/1553)
This is for help only, does not affect matching.

I've done the builder part, still figuring out derive support
(ah - it works automatically by setting subcommand_help_header=Some("foo"). I'd probably should just document it somewhere).

This is done the same way grouping args works: subcommand has optional subcommand_help_heading.
If provided, it will be used to group commands visually when displaying subcommand help.

so that we can go from

Commands:
cmd1 ...
cmd2 ...
help ...

to

Commands:
help ...

Utility commands:
cmd1 ...
cmd2 ....

Nothing changes if groups aren't used. See tests for examples.

Issues:
having subcommand_heading and subcommand_help_heading may be confusing, maybe naming should change.