### PR TITLE
Fix docs for BoolishValueParser

### DIFF
--- a/clap_builder/src/builder/value_parser.rs
+++ b/clap_builder/src/builder/value_parser.rs
@@ -1828,7 +1828,7 @@ impl Default for FalseyValueParser {
     }
 }
 
-/// Parse bool-like string values, everything else is `true`
+/// Parse bool-like string values, everything else is an error
 ///
 /// See also:
 /// - [`ValueParser::bool`] for different human readable bool representations


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

The actual behavior is an error for non-bool-like values.