### PR TITLE
Slugify `github.repository` for Bencher

### DIFF
--- a/.github/workflows/bench-baseline.yml
+++ b/.github/workflows/bench-baseline.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Report
       run: |
         bencher run \
-        --project "${{ github.repository }}" \
+        --project $(echo "${{ github.repository }}" | sed 's/\//-/g') \
         --branch "${{ github.ref_name }}" \
         --testbed "${{ matrix.os }}" \
         --token '${{ secrets.BENCHER_API_TOKEN }}' \


### PR DESCRIPTION
This changeset slugifies the output of `${{ github.repository }}` to work with the Bencher CLI `--project` option.
Implementing this change should fix the error seen [in this CI run](https://github.com/clap-rs/clap/actions/runs/11901042045/job/33163189244#step:7:17).

Also see: https://github.com/epage/_rust/issues/25