### PR TITLE
docs: fix command formatting

### DIFF
--- a/clap_complete/src/lib.rs
+++ b/clap_complete/src/lib.rs
@@ -22,16 +22,13 @@
 //!
 //! fn build_cli() -> Command {
 //!     Command::new("example")
-//!          .arg(Arg::new("file")
-//!              .help("some input file")
-//!                 .value_hint(ValueHint::AnyPath),
-//!         )
-//!        .arg(
-//!            Arg::new("generator")
-//!                .long("generate")
-//!                .action(ArgAction::Set)
-//!                .value_parser(value_parser!(Shell)),
-//!        )
+//!         .arg(Arg::new("file")
+//!             .help("some input file")
+//!             .value_hint(ValueHint::AnyPath))
+//!         .arg(Arg::new("generator")
+//!             .long("generate")
+//!             .action(ArgAction::Set)
+//!             .value_parser(value_parser!(Shell)))
 //! }
 //!
 //! fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {


### PR DESCRIPTION
The document formatting is inconsistent, so I aligned it with the style used in [generate_to](https://docs.rs/clap_complete/latest/clap_complete/aot/fn.generate_to.html)