### PR TITLE
fix(assert): Prevent arguments from requiring self

### DIFF
--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -139,12 +139,12 @@ pub(crate) fn assert_app(cmd: &Command) {
         }
 
         // requires, r_if, r_unless
-        for req in &arg.requires {
+        for (_predicate, req_id) in &arg.requires {
             assert!(
-                cmd.id_exists(&req.1),
+                cmd.id_exists(req_id),
                 "Command {}: Argument or group '{}' specified in 'requires*' for '{}' does not exist",
                 cmd.get_name(),
-                req.1,
+                req_id,
                 arg.get_id(),
             );
         }

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -141,6 +141,12 @@ pub(crate) fn assert_app(cmd: &Command) {
         // requires, r_if, r_unless
         for (_predicate, req_id) in &arg.requires {
             assert!(
+                &arg.id != req_id,
+                "Argument {} cannot require itself",
+                arg.get_id()
+            );
+
+            assert!(
                 cmd.id_exists(req_id),
                 "Command {}: Argument or group '{}' specified in 'requires*' for '{}' does not exist",
                 cmd.get_name(),

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -1480,10 +1480,9 @@ For more information, try '--help'.
 }
 
 #[test]
-/// This test demonstrates existing broken behavior, ideally it should panic
+#[should_panic = "Argument flag cannot require itself"]
 fn requires_self() {
-    let result = Command::new("flag_required")
+    let _result = Command::new("flag_required")
         .arg(arg!(-f --flag "some flag").requires("flag"))
         .try_get_matches_from(vec![""]);
-    assert!(result.is_ok());
 }

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -1478,3 +1478,12 @@ For more information, try '--help'.
 ";
     utils::assert_output(cmd, "test --require-first --second", EXPECTED, true);
 }
+
+#[test]
+/// This test demonstrates existing broken behavior, ideally it should panic
+fn requires_self() {
+    let result = Command::new("flag_required")
+        .arg(arg!(-f --flag "some flag").requires("flag"))
+        .try_get_matches_from(vec![""]);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
It's non-sensical for an argument to require itself, so it must be a mistake, and should be prevented.

This is arguably a breaking change, but of the spacebar heating kind.

Let me know if I should add any tests for this.