### PR TITLE
fix(lex): allow `E` in scientific notation

### DIFF
--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -505,9 +505,9 @@ fn is_number(arg: &str) -> bool {
             // optional exponent, and only if it's not the first character.
             b'.' if !seen_dot && position_of_e.is_none() && i > 0 => seen_dot = true,
 
-            // Allow an exponent `e` but only at most one after the first
+            // Allow an exponent `e`/`E` but only at most one after the first
             // character.
-            b'e' if position_of_e.is_none() && i > 0 => position_of_e = Some(i),
+            b'e' | b'E' if position_of_e.is_none() && i > 0 => position_of_e = Some(i),
 
             _ => return false,
         }

--- a/clap_lex/tests/testsuite/parsed.rs
+++ b/clap_lex/tests/testsuite/parsed.rs
@@ -120,7 +120,7 @@ fn to_short() {
 
 #[test]
 fn is_negative_number() {
-    for number in ["-10.0", "-1", "-100", "-3.5", "-1e10", "-1.3e10"] {
+    for number in ["-10.0", "-1", "-100", "-3.5", "-1e10", "-1.3e10", "-1E10"] {
         let raw = clap_lex::RawArgs::new(["bin", number]);
         let mut cursor = raw.cursor();
         assert_eq!(raw.next_os(&mut cursor), Some(OsStr::new("bin")));
@@ -142,7 +142,9 @@ fn is_positive_number() {
 
 #[test]
 fn is_not_number() {
-    for number in ["--10.0", "-..", "-2..", "-e", "-1e", "-1e10.2", "-.2"] {
+    for number in [
+        "--10.0", "-..", "-2..", "-e", "-1e", "-1e10.2", "-.2", "-E", "-1E", "-1E10.2",
+    ] {
         let raw = clap_lex::RawArgs::new(["bin", number]);
         let mut cursor = raw.cursor();
         assert_eq!(raw.next_os(&mut cursor), Some(OsStr::new("bin")));


### PR DESCRIPTION
This PR allows an `E` in scientific notation. Currently only `e` is allowed.
