### PR TITLE
fix(complete): remove duplicate bash subcmd cases caused by aliases

### DIFF
--- a/clap_complete/src/aot/shells/bash.rs
+++ b/clap_complete/src/aot/shells/bash.rs
@@ -132,6 +132,7 @@ fn subcommand_details(cmd: &Command) -> String {
         .collect::<Vec<_>>();
 
     scs.sort();
+    scs.dedup();
 
     subcmd_dets.extend(scs.iter().map(|sc| {
         format!(

--- a/clap_complete/tests/snapshots/sub_subcommands.bash
+++ b/clap_complete/tests/snapshots/sub_subcommands.bash
@@ -152,20 +152,6 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some_cmd)
-            opts="-h -V --help --version sub_cmd help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
         my__app__some_cmd__help)
             opts="sub_cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then


### PR DESCRIPTION
Visible alias completions were causing duplicate case conditions when offering subcommand completions, due to the fact that they share the same function name as the command they are aliasing. This commit deduplicates them so as to not redefine the exact same case statement logic.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
