### PR TITLE
fix(complete): Fix PowerShell dynamic completion

### DIFF
--- a/clap_complete/src/env/mod.rs
+++ b/clap_complete/src/env/mod.rs
@@ -52,7 +52,9 @@
 //!
 //! Powershell
 //! ```powershell
-//! echo "COMPLETE=powershell your_program | Invoke-Expression" >> $PROFILE
+//! $env:COMPLETE = "powershell"
+//! echo "your_program | Out-String | Invoke-Expression" >> $PROFILE
+//! Remove-Item Env:\COMPLETE
 //! ```
 //!
 //! Zsh


### PR DESCRIPTION
PowerShell does not support inline syntax for assigning environment variables, so we must instead set the value before running the completer and restore it after it exits.

The completer will often, if not always, be surrounded by double quotes on Windows. To avoid syntax errors, define the argument to Invoke-Expression as a here-string so the quotes don't create a syntax error.

Updates the instructions for adding the argument completer to the profile. Piping a native command to Invoke-Expression invokes each line separately. Adding `Out-String` to the pipeline ensures that Invoke-Expression receives the whole script as a single value from the pipeline.

Fixes: #5847
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
