### PR TITLE
Fix typos in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,7 +489,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Compatibility
 
 - Removed the languishing `unstable-replace` feature (open to discussion at [#2836](https://github.com/clap-rs/clap/issues/2836))
-- Removed the stablized `unstable-grouped` feature
+- Removed the stabilized `unstable-grouped` feature
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1639,7 +1639,7 @@ Note: All items deprecated in 3.0.0 are now hidden in the documentation. (#3458)
 
 ### Features
 
-- For very limited cases, like `cargo`, expose `ArgMatches::is_valid_arg` to avoid panicing on undefined arguments
+- For very limited cases, like `cargo`, expose `ArgMatches::is_valid_arg` to avoid panicking on undefined arguments
 
 ## [3.0.3] - 2022-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1878,7 +1878,7 @@ On top of the clap 2 changes
 - Provide extra context in long help messages (`--help`) with `before_long_help` and `after_long_help` ([clap-rs/clap#1903](https://github.com/clap-rs/clap/issues/1903))
 - Detect missing help descriptions via debug asserts by enabling `AppSettings::HelpExpected`
 - Aliases for short flags ([clap-rs/clap#1896](https://github.com/clap-rs/clap/issues/1896))
-- Validate UTF-8 values, rather than panicing during `ArgMatches::value_of` thanks to `AppSettings::AllowInvalidUtf8ForExternalSubcommands` and `ArgSettings::AllowInvalidUtf8`
+- Validate UTF-8 values, rather than panicking during `ArgMatches::value_of` thanks to `AppSettings::AllowInvalidUtf8ForExternalSubcommands` and `ArgSettings::AllowInvalidUtf8`
   - Debug builds will assert when the `ArgMatches` calls do not match the UTF-8 setting.
   - See [clap-rs/clap#751](https://github.com/clap-rs/clap/issues/751)
 - `clap::PossibleValue` to allow


### PR DESCRIPTION


## 📝 Title
Fix typos in `CHANGELOG.md`

---

## 🔍 Description
This pull request fixes multiple typos in `CHANGELOG.md` to improve documentation quality. The changes are as follows:
1. Corrected "stablized" to "stabilized".
2. Corrected "panicing" to "panicking".
3. Corrected "panicing" to "panicking" in another instance.

These fixes enhance the clarity and professionalism of the changelog.

---

## 📂 Related Files
The changes were made in the following file:
- `CHANGELOG.md`

---

## ✅ Checklist
- [x] Changes are purely textual and do not affect functionality.
- [x] Documentation is improved by fixing typos.
- [x] All changes adhere to the contributing guidelines.

---

## 📌 Related Issues
This PR does not resolve any specific open issues but contributes to overall documentation improvement.

---

## 📎 Additional Notes
- These changes focus solely on fixing typos. There are no structural or content changes beyond the corrections.
- The corrected sections are related to feature descriptions and compatibility notes, ensuring the changelog is accurate and professional.
