### PR TITLE
feat(mangen): Separate options based on `help_heading`

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -88,9 +88,7 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     roff.text(line);
 }
 
-pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command) {
-    let items: Vec<_> = cmd.get_arguments().filter(|i| !i.is_hide_set()).collect();
-
+pub(crate) fn options(roff: &mut Roff, items: &[&Arg]) {
     for opt in items.iter().filter(|a| !a.is_positional()) {
         let mut header = match (opt.get_short(), opt.get_long()) {
             (Some(short), Some(long)) => {

--- a/clap_mangen/tests/snapshots/help_headings.bash.roff
+++ b/clap_mangen/tests/snapshots/help_headings.bash.roff
@@ -1,0 +1,23 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-r\fR|\fB\-\-recursive\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIcolor\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-r\fR, \fB\-\-recursive\fR
+
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+[\fIcolor\fR]
+
+.br
+[\fIpossible values: \fRalways, never, auto]

--- a/clap_mangen/tests/snapshots/help_headings.bash.roff
+++ b/clap_mangen/tests/snapshots/help_headings.bash.roff
@@ -11,11 +11,13 @@ my\-app
 \fB\-r\fR, \fB\-\-recursive\fR
 
 .TP
-\fB\-f\fR, \fB\-\-force\fR
-
-.TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
+.SH "CONFLICT OPTIONS"
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+
+.SH "GLOBAL OPTIONS"
 .TP
 [\fIcolor\fR]
 

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -323,3 +323,34 @@ pub(crate) fn value_name_without_arg(name: &'static str) -> clap::Command {
             .action(clap::ArgAction::SetTrue),
     )
 }
+
+pub(crate) fn help_headings(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("recursive")
+                .long("recursive")
+                .short('r')
+                .action(clap::ArgAction::SetTrue),
+        )
+        .next_help_heading("Conflict Options")
+        .arg(
+            clap::Arg::new("force")
+                .long("force")
+                .short('f')
+                .action(clap::ArgAction::SetTrue),
+        )
+        .next_help_heading("Hidden Options")
+        .arg(
+            clap::Arg::new("debug")
+                .long("debug")
+                .short('d')
+                .hide(true)
+                .action(clap::ArgAction::SetTrue),
+        )
+        .next_help_heading("Global Options")
+        .arg(
+            clap::Arg::new("color")
+                .global(true)
+                .value_parser(["always", "never", "auto"]),
+        )
+}

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -97,6 +97,13 @@ fn sub_subcommands_help() {
 }
 
 #[test]
+fn help_headings() {
+    let name = "my-app";
+    let cmd = common::help_headings(name);
+    common::assert_matches(snapbox::file!["../snapshots/help_headings.bash.roff"], cmd);
+}
+
+#[test]
 fn value_name_without_arg() {
     let name = "my-app";
     let cmd = common::value_name_without_arg(name);


### PR DESCRIPTION
An implementation for #3363

Could also make this a flag on `Man`.