### PR TITLE
fix(help): Don't show hidden arguments in groups

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -4827,6 +4827,7 @@ impl Command {
             .unroll_args_in_group(g)
             .iter()
             .filter_map(|x| self.find(x))
+            .filter(|x| !x.is_hide_set())
             .map(|x| {
                 if x.is_positional() {
                     // Print val_name for positional arguments. e.g. <file_name>


### PR DESCRIPTION
This should be pretty obvious, hidden arguments are shown in groups, but should be hidden
