### PR TITLE
fix(nu): Set argument type based on `ValueHint`

### DIFF
--- a/clap_complete_nushell/src/lib.rs
+++ b/clap_complete_nushell/src/lib.rs
@@ -23,6 +23,7 @@
 #![warn(clippy::print_stdout)]
 
 use clap::builder::StyledStr;
+use clap::ValueHint;
 use clap::{builder::PossibleValue, Arg, ArgAction, Command};
 use clap_complete::Generator;
 
@@ -65,7 +66,23 @@ fn append_value_completion_and_help(
         .unwrap_or(false);
 
     if takes_values {
-        s.push_str(": string");
+        let nu_type = match arg.get_value_hint() {
+            ValueHint::Unknown => "string",
+            ValueHint::Other => "string",
+            ValueHint::AnyPath => "path",
+            ValueHint::FilePath => "path",
+            ValueHint::DirPath => "path",
+            ValueHint::ExecutablePath => "path",
+            ValueHint::CommandName => "string",
+            ValueHint::CommandString => "string",
+            ValueHint::CommandWithArguments => "string",
+            ValueHint::Username => "string",
+            ValueHint::Hostname => "string",
+            ValueHint::Url => "string",
+            ValueHint::EmailAddress => "string",
+            _ => "string",
+        };
+        s.push_str(format!(": {nu_type}").as_str());
 
         if !possible_values.is_empty() {
             s.push_str(format!(r#"@"nu-complete {} {}""#, name, arg.get_id()).as_str());

--- a/clap_complete_nushell/tests/snapshots/feature_sample.nu
+++ b/clap_complete_nushell/tests/snapshots/feature_sample.nu
@@ -6,7 +6,7 @@ module completions {
 
   # Tests completions
   export extern my-app [
-    file?: string             # some input file
+    file?: path               # some input file
     --config(-c)              # some config file with another line
     --conf                    # some config file with another line
     -C                        # some config file with another line

--- a/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
+++ b/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
@@ -178,10 +178,10 @@ module completions {
     --choice: string@"nu-complete test hint choice"
     --unknown: string
     --other: string
-    --path(-p): string
-    --file(-f): string
-    --dir(-d): string
-    --exe(-e): string
+    --path(-p): path
+    --file(-f): path
+    --dir(-d): path
+    --exe(-e): path
     --cmd-name: string
     --cmd(-c): string
     command_with_args?: string

--- a/clap_complete_nushell/tests/snapshots/special_commands.nu
+++ b/clap_complete_nushell/tests/snapshots/special_commands.nu
@@ -6,7 +6,7 @@ module completions {
 
   # Tests completions
   export extern my-app [
-    file?: string             # some input file
+    file?: path               # some input file
     --config(-c)              # some config file with another line
     --conf                    # some config file with another line
     -C                        # some config file with another line

--- a/clap_complete_nushell/tests/snapshots/sub_subcommands.nu
+++ b/clap_complete_nushell/tests/snapshots/sub_subcommands.nu
@@ -6,7 +6,7 @@ module completions {
 
   # Tests completions
   export extern my-app [
-    file?: string             # some input file
+    file?: path               # some input file
     --config(-c)              # some config file with another line
     --conf                    # some config file with another line
     -C                        # some config file with another line

--- a/clap_complete_nushell/tests/snapshots/value_hint.nu
+++ b/clap_complete_nushell/tests/snapshots/value_hint.nu
@@ -8,10 +8,10 @@ module completions {
     --choice: string@"nu-complete my-app choice"
     --unknown: string
     --other: string
-    --path(-p): string
-    --file(-f): string
-    --dir(-d): string
-    --exe(-e): string
+    --path(-p): path
+    --file(-f): path
+    --dir(-d): path
+    --exe(-e): path
     --cmd-name: string
     --cmd(-c): string
     command_with_args?: string


### PR DESCRIPTION
fixes #5605 

- Modified `append_value_completion_and_help` to set argument type to `path` for `ValueHint::AnyPath`, `ValueHint::FilePath`, and `ValueHint::DirPath`, and to `string` for other `ValueHint`s.
- Updated test snapshots to reflect the changes in argument types.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
