### PR TITLE
fix(mangen): do not generate man pages for hidden subcommands

### DIFF
--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -130,7 +130,7 @@ pub fn generate_to(
     out_dir: impl AsRef<std::path::Path>,
 ) -> Result<(), std::io::Error> {
     fn generate(cmd: clap::Command, out_dir: &std::path::Path) -> Result<(), std::io::Error> {
-        for cmd in cmd.get_subcommands().cloned() {
+        for cmd in cmd.get_subcommands().filter(|s| !s.is_hide_set()).cloned() {
             generate(cmd, out_dir)?;
         }
         Man::new(cmd).generate_to(out_dir)?;


### PR DESCRIPTION
This aligns with the logic in `clap_mangen::render::subcommands`, where hidden subcommands are not shown in the subcommand list.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
