### PR TITLE
feat: add arg index to error context

### DIFF
--- a/clap_builder/src/error/context.rs
+++ b/clap_builder/src/error/context.rs
@@ -37,6 +37,8 @@ pub enum ContextKind {
     Usage,
     /// An opaque message to the user
     Custom,
+    /// Index of the argument
+    ArgIndex,
 }
 
 impl ContextKind {
@@ -60,6 +62,7 @@ impl ContextKind {
             Self::Suggested => Some("Suggested"),
             Self::Usage => None,
             Self::Custom => None,
+            Self::ArgIndex => Some("Argument Index"),
         }
     }
 }

--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -274,7 +274,8 @@ where
 /// Position within [`RawArgs`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ArgCursor {
-    cursor: usize,
+    /// Current position
+    pub cursor: usize,
 }
 
 impl ArgCursor {

--- a/tests/builder/possible_values.rs
+++ b/tests/builder/possible_values.rs
@@ -539,6 +539,7 @@ mod expensive {
             _cmd: &Command,
             _arg: Option<&Arg>,
             _value: &std::ffi::OsStr,
+            _index: isize,
         ) -> Result<Self::Value, clap_builder::Error> {
             unimplemented!()
         }


### PR DESCRIPTION
Adds arg index to the error context, LMK if this seems like a reasonable approach. We would like to utilize this information to create "at line/character XYZ" style errors using miette.

related issue
#4948 