### PR TITLE
Teach dynamic fish completions to expand variables

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -219,7 +219,18 @@ impl EnvCompleter for Fish {
 
         writeln!(
             buf,
-            r#"complete --keep-order --exclusive --command {bin} --arguments "({var}=fish "'{completer}'" -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))""#
+            r#"
+                complete --keep-order --exclusive --command {bin} --arguments \
+                    "({var}=fish "'{completer}'" -- (
+                        set --local tokenize;
+                        if commandline --tokens-expanded >/dev/null 2>&1;
+                            set tokenize --tokens-expanded;
+                        else;
+                            set tokenize --tokenize;
+                        end;
+                        commandline --current-process $tokenize --cut-at-cursor
+                    ) (commandline --current-token))"
+            "#
         )
     }
     fn write_complete(


### PR DESCRIPTION
In fish, the command line

	cargo b --manifest-path $PWD/clap_complete/Cargo.toml --example

wrongly gets example-name completions from $PWD/Cargo.toml instead of
$PWD/clap_complete/Cargo.toml.

This is because fish's "commandline --tokenize" option produces tokens
like "$PWD/clap_complete/Cargo.toml", which clap cannot see through.

Starting in the upcoming fish version 4, there is a new option,
"--tokens-expanded"[^1] to output the expanded arguments, matching
what the program would see during execution.

If an expansion of a token like {1,2,3}{1,2,3} would produce too
many results, the unexpanded token is forwarded, thus falling back to
existing behavior. Similarly, command substitutions ("$()") present
on the command line are forwarded as-is, because they are not deemed
safe to expand given that the user hasn't agreed to running them.

Use this option if available, to fix the above example.

I have not checked if any existing clap user tries to expand variables
on their own. If this is a real possibility, we could let users
opt into the new behavior.

While at it, break up this overlong line.  Add redundant semicolons,
in case a preexisting completion accidentally joins these lines with
spaces[^2], like

	if set -l completions (COMPLETE=fish myapp 2>/dev/null)
		echo "$completions" | source
	end

I have not updated clap_complete/tests/snapshots/register_dynamic.fish
(not sure how?) or tested this but I'm happy to do so.

[^1]: https://github.com/fish-shell/fish-shell/pull/10212
[^2]: https://github.com/fish-shell/fish-shell/pull/11046#discussion_r1917875912
