### PR TITLE
ValueEnum fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,9 +3070,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ default = [
   "usage",
   "error-context",
   "suggestions",
+"unstable-derive-ui-tests"
 ]
 debug = ["clap_builder/debug", "clap_derive?/debug"] # Enables debug messages
 unstable-doc = ["clap_builder/unstable-doc", "derive"] # for docs.rs

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -29,7 +29,7 @@ proc-macro = true
 bench = false
 
 [dependencies]
-syn = { version = "2.0.8", features = ["full"] }
+syn = { version = "2.0.73", features = ["full"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.69"
 heck = "0.5.0"

--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -102,6 +102,7 @@ impl Parse for ClapAttr {
             "long_help" => Some(MagicAttrName::LongHelp),
             "author" => Some(MagicAttrName::Author),
             "version" => Some(MagicAttrName::Version),
+            "fallback" => Some(MagicAttrName::Fallback),
             _ => None,
         };
 
@@ -168,6 +169,7 @@ pub(crate) enum MagicAttrName {
     DefaultValuesOsT,
     NextDisplayOrder,
     NextHelpHeading,
+    Fallback,
 }
 
 #[derive(Clone)]

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -49,6 +49,8 @@ pub(crate) struct Item {
     skip_group: bool,
     group_id: Name,
     group_methods: Vec<Method>,
+    /// Used as fallback value `ValueEnum`.
+    is_fallback: bool,
     kind: Sp<Kind>,
 }
 
@@ -279,6 +281,7 @@ impl Item {
             group_id,
             group_methods: vec![],
             kind,
+            is_fallback: false,
         }
     }
 
@@ -835,6 +838,12 @@ impl Item {
                     self.skip_group = true;
                 }
 
+                Some(MagicAttrName::Fallback) => {
+                    assert_attr_kind(attr, &[AttrKind::Value])?;
+
+                    self.is_fallback = true;
+                }
+
                 None
                 // Magic only for the default, otherwise just forward to the builder
                 | Some(MagicAttrName::Short)
@@ -1076,6 +1085,10 @@ impl Item {
 
     pub(crate) fn skip_group(&self) -> bool {
         self.skip_group
+    }
+
+    pub(crate) fn is_fallback(&self) -> bool {
+        self.is_fallback
     }
 }
 

--- a/tests/derive/value_enum.rs
+++ b/tests/derive/value_enum.rs
@@ -626,3 +626,152 @@ fn vec_type_default_value() {
         Opt::try_parse_from(["", "-a", "foo,baz"]).unwrap()
     );
 }
+
+#[test]
+fn unit_fallback() {
+    #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
+    enum ArgChoice {
+        Foo,
+        #[clap(fallback)]
+        Fallback,
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(value_enum)]
+        arg: ArgChoice,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Foo
+        },
+        Opt::try_parse_from(["", "foo"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Fallback
+        },
+        Opt::try_parse_from(["", "not-foo"]).unwrap()
+    );
+}
+
+#[test]
+fn empty_tuple_fallback() {
+    #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
+    enum ArgChoice {
+        Foo,
+        #[clap(fallback)]
+        Fallback(),
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(value_enum)]
+        arg: ArgChoice,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Foo
+        },
+        Opt::try_parse_from(["", "foo"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Fallback()
+        },
+        Opt::try_parse_from(["", "not-foo"]).unwrap()
+    );
+}
+
+#[test]
+fn empty_struct_fallback() {
+    #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
+    enum ArgChoice {
+        Foo,
+        #[clap(fallback)]
+        Fallback {},
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(value_enum)]
+        arg: ArgChoice,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Foo
+        },
+        Opt::try_parse_from(["", "foo"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Fallback {}
+        },
+        Opt::try_parse_from(["", "not-foo"]).unwrap()
+    );
+}
+
+#[test]
+fn non_empty_struct_fallback() {
+    #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
+    enum ArgChoice {
+        Foo,
+        #[clap(fallback)]
+        Fallback {
+            value: String,
+        },
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(value_enum)]
+        arg: ArgChoice,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Foo
+        },
+        Opt::try_parse_from(["", "foo"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Fallback {
+                value: String::from("not-foo")
+            }
+        },
+        Opt::try_parse_from(["", "not-foo"]).unwrap()
+    );
+}
+
+#[test]
+fn non_empty_tuple_fallback() {
+    #[derive(clap::ValueEnum, PartialEq, Debug, Clone)]
+    enum ArgChoice {
+        Foo,
+        #[clap(fallback)]
+        Fallback(String),
+    }
+
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(value_enum)]
+        arg: ArgChoice,
+    }
+
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Foo
+        },
+        Opt::try_parse_from(["", "foo"]).unwrap()
+    );
+    assert_eq!(
+        Opt {
+            arg: ArgChoice::Fallback(String::from("not-foo"))
+        },
+        Opt::try_parse_from(["", "not-foo"]).unwrap()
+    );
+}

--- a/tests/derive_ui/value_enum_fallback_two_fields.rs
+++ b/tests/derive_ui/value_enum_fallback_two_fields.rs
@@ -1,0 +1,10 @@
+use clap::ValueEnum;
+
+#[derive(ValueEnum, Clone, Debug)]
+enum Opt {
+    #[clap(fallback)]
+    First(String, String),
+}
+
+fn main() {}
+

--- a/tests/derive_ui/value_enum_fallback_two_fields.stderr
+++ b/tests/derive_ui/value_enum_fallback_two_fields.stderr
@@ -1,0 +1,6 @@
+error: `fallback` only supports Unit variants, or variants with a single field
+ --> tests/derive_ui/value_enum_fallback_two_fields.rs:5:5
+  |
+5 | /     #[clap(fallback)]
+6 | |     First(String, String),
+  | |_________________________^

--- a/tests/derive_ui/value_enum_two_fallback.rs
+++ b/tests/derive_ui/value_enum_two_fallback.rs
@@ -1,0 +1,11 @@
+use clap::ValueEnum;
+
+#[derive(ValueEnum, Clone, Debug)]
+enum Opt {
+    #[clap(fallback)]
+    First(String),
+    #[clap(fallback)]
+    Second(String),
+}
+
+fn main() {}

--- a/tests/derive_ui/value_enum_two_fallback.stderr
+++ b/tests/derive_ui/value_enum_two_fallback.stderr
@@ -1,0 +1,13 @@
+error: `#[derive(ValueEnum)]` only supports one `fallback`.
+ --> tests/derive_ui/value_enum_two_fallback.rs:5:5
+  |
+5 | /     #[clap(fallback)]
+6 | |     First(String),
+  | |_________________^
+
+error: second fallback defined here
+ --> tests/derive_ui/value_enum_two_fallback.rs:7:5
+  |
+7 | /     #[clap(fallback)]
+8 | |     Second(String),
+  | |__________________^

--- a/tests/derive_ui/value_parser_unsupported.stderr
+++ b/tests/derive_ui/value_parser_unsupported.stderr
@@ -37,6 +37,14 @@ note: the traits `From`, `FromStr`, `ValueEnum`,  and `ValueParserFactory` must 
   |
   | pub trait ValueEnum: Sized + Clone {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- --> $RUST/core/src/convert/mod.rs
- --> $RUST/core/src/str/traits.rs
+  |
+ ::: $RUST/core/src/convert/mod.rs
+  |
+  | pub trait From<T>: Sized {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+ ::: $RUST/core/src/str/traits.rs
+  |
+  | pub trait FromStr: Sized {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the macro `clap::value_parser` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

Would fix #5885 if `EnumValueParser` were actually using `ValueEnum::from_str` instead of apparently shipping it's own implementation here: <https://docs.rs/clap_builder/4.5.26/src/clap_builder/builder/value_parser.rs.html#1119-1135> not sure what the best remedy is... supporting fallback explicitly in the `ValueEnum` trait? or making `EnumValueParser` respect `ValueEnum::from_str`.
