### PR TITLE
docs: Clarify the default state of an Arg/field

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -98,6 +98,10 @@ impl Arg {
     /// The name is used to check whether or not the argument was used at
     /// runtime, get values, set relationships with other args, etc..
     ///
+    /// By default, an `Arg` is
+    /// - Positional, see [`Arg::short`] or [`Arg::long`] turn it into an option
+    /// - Accept a single value, see [`Arg::action`] to override this
+    ///
     /// <div class="warning">
     ///
     /// **NOTE:** In the case of arguments that take values (i.e. [`Arg::action(ArgAction::Set)`])

--- a/src/_derive/_tutorial/chapter_2.rs
+++ b/src/_derive/_tutorial/chapter_2.rs
@@ -10,7 +10,7 @@
 //!
 //! ### Positionals
 //!
-//! You can have users specify values by their position on the command-line:
+//! By default, struct fields define positional arguments:
 //!
 //! ```rust
 #![doc = include_str!("../../../examples/tutorial_derive/03_03_positional.rs")]

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -220,6 +220,9 @@
 //! ### Arg Attributes
 //!
 //! These correspond to a [`Arg`][crate::Arg].
+//! The default state for a field without attributes is to be a positional argument with [behavior
+//! inferred from the field type](#arg-types).
+//! `#[arg(...)]` attributes allow overriding or extending those defaults.
 //!
 //! **Raw attributes:**  Any [`Arg` method][crate::Arg] can also be used as an attribute, see [Terminology](#terminology) for syntax.
 //! - e.g. `#[arg(num_args(..=3))]` would translate to `arg.num_args(..=3)`

--- a/src/_tutorial/chapter_2.rs
+++ b/src/_tutorial/chapter_2.rs
@@ -9,7 +9,7 @@
 //!
 //! ### Positionals
 //!
-//! You can have users specify values by their position on the command-line:
+//! By default, an [`Arg`] defines a positional argument:
 //!
 //! ```rust
 #![doc = include_str!("../../examples/tutorial_builder/03_03_positional.rs")]


### PR DESCRIPTION
Inspired by https://www.reddit.com/r/rust/comments/1i5np88/clap_documentation_is_too_confusing_for_me/m87mutm/

> I always use derive, and I mostly use the reference. From manual
> experimentation I’ve had to develop the mental model that short
> implicitly is what makes an argument non-positional, and if I want an
> argument to be positional then it will be by default unless I specify
> short. When I search for the word “positional” in the reference, there
> are no results. When I search for it in the tutorial, there is one
> result that says something I can do with an argument that i’ve made
> positional, but there’s no indication for how to make the argument
> positional in the first place. The reference documentation on short
> doesn’t mention anything about the fact that that’s what determines
> whether an argument is positional, even when I click through to the
> builder documentation on Arg::short.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
