### PR TITLE
feat: called the third_party_subcommands function

### DIFF
--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -1082,7 +1082,8 @@ fn suggest_external_subcommand() {
     let mut cmd = Command::new("dynamic")
         .allow_external_subcommands(true)
         .add(SubcommandCandidates::new(|| {
-            vec![CompletionCandidate::new("external")]
+            let gctx = GlobalContext::default();
+            let _ = third_party_subcommands(&gctx);
         }))
         .arg(clap::Arg::new("positional").value_parser(["pos1", "pos2", "pos3"]));
 

--- a/clap_complete/tests/testsuite/main.rs
+++ b/clap_complete/tests/testsuite/main.rs
@@ -1,1 +1,3 @@
+pub mod engine;
+
 automod::dir!("tests/testsuite");


### PR DESCRIPTION
Hey there,

I want to let you know that I called the [third_party_subcommands](https://github.com/rust-lang/cargo/blob/91d8140d66e86127348c1230c9b913effca3d1c9/src/bin/cargo/main.rs#L222) function in the test but I have some points about the issue.

1. The `third_party_subcommands` function is not present in the clap repo. How would the clap repo know that it is calling from the cargo repo? There could be a few possibilities:
    - The API is already defined here that will communicate with a cargo repo.
    - There is a requirement for a mock function for the third-party subcommand for testing.
    - The test code here should be written in the cargo repo for the third-party function to be called there.
3.  Although I tested it and it gave me an OK sign but I am still unsure about how to make the third-party subcommand work. Because `cargo hack [TAB]` was not auto-completing the command.
4. The `engine.rs` file was not included in the module tree. So rust-analyzer was not able to offer IDE services. So I added a module `pub mod engine` and this error was removed but this time, `pub mod engine` gave me the following message:
> code is inactive due to #[cfg] directives: feature = "unstable-dynamic" is disabledrust-analyzer[inactive-code](https://rust-analyzer.github.io/manual.html#inactive-code)
5. If I define the `unstable-dynamic` in the cargo.toml file in the `clap_complete`, it also gives me an error by unidentifying this feature.

Let me know if there are other improvements required to make it work.

Thank you!

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
