### PR TITLE
Markdown parsing in doc comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
+name = "anstyle-lossy"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934ff8719effd2023a48cf63e69536c1c3ced9d3895068f6f5cc9a4ff845e59b"
+dependencies = [
+ "anstyle",
+]
+
+[[package]]
 name = "anstyle-parse"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-svg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3607949e9f6de49ea4bafe12f5e4fd73613ebf24795e48587302a8cc0e4bb35"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "anstyle-lossy",
+ "html-escape",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1154,6 +1176,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -2976,6 +3007,7 @@ checksum = "96dcfc4581e3355d70ac2ee14cfdf81dce3d85c85f1ed9e2c1d3013f53b3436b"
 dependencies = [
  "anstream",
  "anstyle",
+ "anstyle-svg",
  "content_inspector",
  "dunce",
  "escargot",
@@ -2983,6 +3015,7 @@ dependencies = [
  "libc",
  "normalize-line-endings",
  "os_pipe",
+ "serde_json",
  "similar",
  "snapbox-macros",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-lossy"
@@ -524,8 +524,10 @@ dependencies = [
 name = "clap_derive"
 version = "4.5.24"
 dependencies = [
+ "anstyle",
  "heck 0.5.0",
  "proc-macro2",
+ "pulldown-cmark",
  "quote",
  "syn",
 ]
@@ -1462,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2544,6 +2546,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e05aef7befb11a210468a2d77d978dde2c6381a0381e33beb575e91f57fe8cf"
 dependencies = [
  "nix 0.26.4",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.6.0",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ rustversion = "1.0.15"
 # Cutting out `filesystem` feature
 trycmd = { version = "0.15.3", default-features = false, features = ["color-auto", "diff", "examples"] }
 humantime = "2.1.0"
-snapbox = "0.6.16"
+snapbox = { version = "0.6.16", features = ["term-svg"] }
 shlex = "1.3.0"
 automod = "1.0.14"
 clap-cargo = { version = "0.14.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ unstable-v5 = ["clap_builder/unstable-v5", "clap_derive?/unstable-v5", "deprecat
 unstable-ext = ["clap_builder/unstable-ext"]
 unstable-styles = ["clap_builder/unstable-styles"]  # deprecated
 unstable-derive-ui-tests = []
+unstable-markdown = ["clap_derive/unstable-markdown"]
 
 [lib]
 bench = false

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ _FEATURES_minimal = --no-default-features --features "std"
 _FEATURES_default =
 _FEATURES_wasm = --no-default-features --features "std help usage error-context suggestions" --features "deprecated derive cargo env unicode string"
 _FEATURES_full = --features "deprecated derive cargo env unicode string wrap_help unstable-ext"
-_FEATURES_next = ${_FEATURES_full} --features unstable-v5
+_FEATURES_next = ${_FEATURES_full} --features "unstable-v5 unstable-markdown"
 _FEATURES_debug = ${_FEATURES_full} --features debug --features clap_complete/debug
 _FEATURES_release = ${_FEATURES_full} --release
 

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -33,6 +33,8 @@ syn = { version = "2.0.8", features = ["full"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.69"
 heck = "0.5.0"
+pulldown-cmark = { version = "0.12.2", default-features = false, optional = true}
+anstyle = {version ="1.0.10", optional = true}
 
 [features]
 default = []
@@ -40,6 +42,7 @@ debug = []
 unstable-v5 = ["deprecated"]
 deprecated = []
 raw-deprecated = ["deprecated"]
+unstable-markdown = ["dep:pulldown-cmark", "dep:anstyle"]
 
 [lints]
 workspace = true

--- a/clap_derive/src/utils/doc_comments.rs
+++ b/clap_derive/src/utils/doc_comments.rs
@@ -3,7 +3,8 @@
 //! #[derive(Parser)] works in terms of "paragraphs". Paragraph is a sequence of
 //! non-empty adjacent lines, delimited by sequences of blank (whitespace only) lines.
 
-use std::iter;
+#[cfg(feature = "unstable-markdown")]
+use markdown::parse_markdown;
 
 pub(crate) fn extract_doc_comment(attrs: &[syn::Attribute]) -> Vec<String> {
     // multiline comments (`/** ... */`) may have LFs (`\n`) in them,
@@ -54,36 +55,28 @@ pub(crate) fn format_doc_comment(
     preprocess: bool,
     force_long: bool,
 ) -> (Option<String>, Option<String>) {
-    if let Some(first_blank) = lines.iter().position(|s| is_blank(s)) {
-        let (short, long) = if preprocess {
-            let paragraphs = split_paragraphs(lines);
-            let short = paragraphs[0].clone();
-            let long = paragraphs.join("\n\n");
-            (remove_period(short), long)
-        } else {
-            let short = lines[..first_blank].join("\n");
-            let long = lines.join("\n");
-            (short, long)
-        };
+    if preprocess {
+        let (short, long) = parse_markdown(lines);
+        let long = long.or_else(|| force_long.then(|| short.clone()));
+
+        (Some(remove_period(short)), long)
+    } else if let Some(first_blank) = lines.iter().position(|s| is_blank(s)) {
+        let short = lines[..first_blank].join("\n");
+        let long = lines.join("\n");
 
         (Some(short), Some(long))
     } else {
-        let (short, long) = if preprocess {
-            let short = merge_lines(lines);
-            let long = force_long.then(|| short.clone());
-            let short = remove_period(short);
-            (short, long)
-        } else {
-            let short = lines.join("\n");
-            let long = force_long.then(|| short.clone());
-            (short, long)
-        };
+        let short = lines.join("\n");
+        let long = force_long.then(|| short.clone());
 
         (Some(short), long)
     }
 }
 
+#[cfg(not(feature = "unstable-markdown"))]
 fn split_paragraphs(lines: &[String]) -> Vec<String> {
+    use std::iter;
+
     let mut last_line = 0;
     iter::from_fn(|| {
         let slice = &lines[last_line..];
@@ -117,10 +110,297 @@ fn is_blank(s: &str) -> bool {
     s.trim().is_empty()
 }
 
+#[cfg(not(feature = "unstable-markdown"))]
 fn merge_lines(lines: impl IntoIterator<Item = impl AsRef<str>>) -> String {
     lines
         .into_iter()
         .map(|s| s.as_ref().trim().to_owned())
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+#[cfg(not(feature = "unstable-markdown"))]
+fn parse_markdown(lines: &[String]) -> (String, Option<String>) {
+    if lines.iter().any(|s| is_blank(s)) {
+        let paragraphs = split_paragraphs(lines);
+        let short = paragraphs[0].clone();
+        let long = paragraphs.join("\n\n");
+        (short, Some(long))
+    } else {
+        let short = merge_lines(lines);
+        (short, None)
+    }
+}
+
+#[cfg(feature = "unstable-markdown")]
+mod markdown {
+    use anstyle::{Reset, Style};
+    use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+    use std::fmt;
+    use std::fmt::Write;
+    use std::ops::AddAssign;
+
+    #[derive(Default)]
+    struct MarkdownWriter {
+        output: String,
+        /// Prefix inserted for each line.
+        prefix: String,
+        /// Should an empty line be inserted before the next anything.
+        hanging_paragraph: bool,
+        /// Are we in an empty line
+        dirty_line: bool,
+        styles: Vec<Style>,
+    }
+
+    impl MarkdownWriter {
+        fn newline(&mut self) {
+            self.reset();
+            self.output.push('\n');
+            self.dirty_line = false;
+        }
+        fn endline(&mut self) {
+            if self.dirty_line {
+                self.newline();
+            }
+        }
+        fn new_paragraph(&mut self) {
+            self.endline();
+            self.hanging_paragraph = true;
+        }
+
+        fn write_fmt(&mut self, arguments: fmt::Arguments<'_>) {
+            if self.hanging_paragraph {
+                self.hanging_paragraph = false;
+                self.newline();
+            }
+            if !self.dirty_line {
+                self.output.push_str(&self.prefix);
+                self.apply_styles();
+                self.dirty_line = true;
+            }
+            self.output.write_fmt(arguments).unwrap();
+        }
+
+        fn start_link(&mut self, dest_url: pulldown_cmark::CowStr<'_>) {
+            write!(self, "\x1B]8;;{dest_url}\x1B\\");
+        }
+        fn end_link(&mut self) {
+            write!(self, "\x1B]8;;\x1B\\");
+        }
+
+        fn start_style(&mut self, style: Style) {
+            self.styles.push(style);
+            write!(self, "{style}");
+        }
+        fn end_style(&mut self, style: Style) {
+            let last_style = self.styles.pop();
+            debug_assert_eq!(last_style.unwrap(), style);
+
+            write!(self, "{Reset}");
+            self.apply_styles();
+        }
+
+        fn reset(&mut self) {
+            write!(self, "{Reset}");
+        }
+
+        fn apply_styles(&mut self) {
+            // Reapplying all, because anstyle doesn't support merging styles
+            // (probably because the ambiguity around colors)
+            // TODO If we decide not to support any colors, we can replace this with
+            // anstyle::Effects and remove the need for applying them all individually.
+            for style in &self.styles {
+                write!(self.output, "{style}").unwrap();
+            }
+        }
+
+        fn remove_prefix(&mut self, quote_prefix: &str) {
+            debug_assert!(self.prefix.ends_with(quote_prefix));
+            let new_len = self.prefix.len() - quote_prefix.len();
+            self.prefix.truncate(new_len);
+        }
+
+        fn add_prefix(&mut self, quote_prefix: &str) {
+            if self.hanging_paragraph {
+                self.hanging_paragraph = false;
+                self.newline();
+            }
+            self.prefix += quote_prefix;
+        }
+    }
+
+    pub(super) fn parse_markdown(input: &[String]) -> (String, Option<String>) {
+        // Markdown Configuration
+        let parsing_options = Options::ENABLE_STRIKETHROUGH;
+        // Minimal Styling for now, because we cannot configure it
+        let style_heading = Style::new().bold().underline();
+        let style_emphasis = Style::new().italic();
+        let style_strong = Style::new().bold();
+        let style_strike_through = Style::new().strikethrough();
+        let style_link = Style::new().underline();
+        let style_code = Style::new().bold();
+        let list_symbol = '-';
+        let quote_prefix = "| ";
+        let indentation = "  ";
+
+        let input = input.join("\n");
+        let input = Parser::new_ext(&input, parsing_options);
+
+        let mut short = None;
+        let mut has_details = false;
+
+        let mut writer = MarkdownWriter::default();
+
+        let mut list_indices = Vec::new();
+
+        for event in input {
+            if short.is_some() {
+                has_details = true;
+            }
+            match event {
+                Event::Start(Tag::Paragraph) => { /* nothing to do */ }
+                Event::End(TagEnd::Paragraph) => {
+                    if short.is_none() {
+                        short = Some(writer.output.trim().to_owned());
+                    }
+                    writer.new_paragraph();
+                }
+
+                Event::Start(Tag::Heading { .. }) => writer.start_style(style_heading),
+                Event::End(TagEnd::Heading(..)) => {
+                    writer.end_style(style_heading);
+                    writer.new_paragraph();
+                }
+
+                Event::Start(Tag::Image { .. } | Tag::HtmlBlock) => { /* IGNORED */ }
+                Event::End(TagEnd::Image) => { /* IGNORED */ }
+                Event::End(TagEnd::HtmlBlock) => writer.new_paragraph(),
+
+                Event::Start(Tag::BlockQuote(_)) => writer.add_prefix(quote_prefix),
+                Event::End(TagEnd::BlockQuote(_)) => {
+                    writer.remove_prefix(quote_prefix);
+                    writer.new_paragraph();
+                }
+
+                Event::Start(Tag::CodeBlock(_)) => {
+                    writer.add_prefix(indentation);
+                    writer.start_style(style_code);
+                }
+                Event::End(TagEnd::CodeBlock) => {
+                    writer.remove_prefix(indentation);
+                    writer.end_style(style_code);
+                    writer.dirty_line = false;
+                    writer.hanging_paragraph = true;
+                }
+
+                Event::Start(Tag::List(list_start)) => {
+                    list_indices.push(list_start);
+                    writer.endline();
+                }
+                Event::End(TagEnd::List(_)) => {
+                    let list = list_indices.pop();
+                    debug_assert!(list.is_some());
+                    if list_indices.is_empty() {
+                        writer.new_paragraph();
+                    }
+                }
+                Event::Start(Tag::Item) => {
+                    if let Some(Some(index)) = list_indices.last_mut() {
+                        write!(writer, "{index}. ");
+                        index.add_assign(1);
+                    } else {
+                        write!(writer, "{list_symbol} ");
+                    }
+                    writer.add_prefix(indentation);
+                }
+                Event::End(TagEnd::Item) => {
+                    writer.remove_prefix(indentation);
+                    writer.endline();
+                }
+
+                Event::Start(Tag::Emphasis) => writer.start_style(style_emphasis),
+                Event::End(TagEnd::Emphasis) => writer.end_style(style_emphasis),
+                Event::Start(Tag::Strong) => writer.start_style(style_strong),
+                Event::End(TagEnd::Strong) => writer.end_style(style_strong),
+                Event::Start(Tag::Strikethrough) => writer.start_style(style_strike_through),
+                Event::End(TagEnd::Strikethrough) => writer.end_style(style_strike_through),
+
+                Event::Start(Tag::Link { dest_url, .. }) => {
+                    writer.start_link(dest_url);
+                    writer.start_style(style_link);
+                }
+                Event::End(TagEnd::Link) => {
+                    writer.end_link();
+                    writer.end_style(style_link);
+                }
+
+                Event::Text(segment) => {
+                    // split into lines to support code blocks
+                    let mut lines = segment.lines();
+                    // `.lines()`  always returns at least one
+                    write!(writer, "{}", lines.next().unwrap());
+                    for line in lines {
+                        writer.endline();
+                        write!(writer, "{line}");
+                    }
+                    if segment.ends_with('\n') {
+                        writer.endline();
+                    }
+                }
+
+                Event::Code(code) => {
+                    writer.start_style(style_code);
+                    write!(writer, "{code}");
+                    writer.end_style(style_code);
+                }
+
+                // There is not really anything useful to do with block level html.
+                Event::Html(html) => write!(writer, "{html}"),
+                // At some point we could support custom tags like `<red>`
+                Event::InlineHtml(html) => write!(writer, "{html}"),
+                Event::SoftBreak => write!(writer, " "),
+                Event::HardBreak => writer.endline(),
+
+                Event::Rule => {
+                    writer.new_paragraph();
+                    write!(writer, "---");
+                    writer.new_paragraph();
+                }
+
+                // Markdown features currently not supported
+                Event::Start(
+                    Tag::FootnoteDefinition(_)
+                    | Tag::DefinitionList
+                    | Tag::DefinitionListTitle
+                    | Tag::DefinitionListDefinition
+                    | Tag::Table(_)
+                    | Tag::TableHead
+                    | Tag::TableRow
+                    | Tag::TableCell
+                    | Tag::MetadataBlock(_),
+                )
+                | Event::End(
+                    TagEnd::FootnoteDefinition
+                    | TagEnd::DefinitionList
+                    | TagEnd::DefinitionListTitle
+                    | TagEnd::DefinitionListDefinition
+                    | TagEnd::Table
+                    | TagEnd::TableHead
+                    | TagEnd::TableRow
+                    | TagEnd::TableCell
+                    | TagEnd::MetadataBlock(_),
+                )
+                | Event::InlineMath(_)
+                | Event::DisplayMath(_)
+                | Event::FootnoteReference(_)
+                | Event::TaskListMarker(_) => {
+                    unimplemented!("feature not enabled {event:?}")
+                }
+            }
+        }
+        let short = short.unwrap_or_else(|| writer.output.trim_end().to_owned());
+        let long = writer.output.trim_end();
+        let long = has_details.then(|| long.to_owned());
+        (short, long)
+    }
 }

--- a/tests/derive/markdown.rs
+++ b/tests/derive/markdown.rs
@@ -1,0 +1,145 @@
+#![cfg(feature = "derive")]
+
+use clap::CommandFactory;
+use clap_derive::Parser;
+use snapbox::file;
+
+macro_rules! assert_help {
+    ($Command:ty, $filename:literal) => {{
+        let help = <$Command>::command().render_long_help().ansi().to_string();
+        snapbox::assert_data_eq!(help, file![$filename]);
+    }};
+}
+
+#[test]
+fn headers() {
+    /// # This is a header
+    /// ## second level
+    /// ### `additional` *styling **on ~top~ of** it*
+    /// regular paragraph
+    #[derive(Parser)]
+    struct Command;
+
+    assert_help!(Command, "snapshots/headers.term.svg");
+}
+
+#[test]
+fn inline_styles() {
+    /// *emphasis* **bold** ~strike through~ `code`
+    ///
+    /// *all **of ~them `combined` in~ one** line*
+    #[derive(Parser)]
+    struct Command;
+
+    assert_help!(Command, "snapshots/inline_styles.term.svg");
+}
+
+#[test]
+fn links() {
+    /// <https://example.com/literal>
+    ///
+    /// [with name](https://example.com/with%20name)
+    ///
+    /// ![image](https://example.com/image)
+    ///
+    /// [referencing][reference]
+    ///
+    /// [reference]: https://example.com/reference
+    #[derive(Parser)]
+    struct Command;
+
+    assert_help!(Command, "snapshots/links.term.svg");
+}
+
+#[test]
+fn html() {
+    /// <html>
+    ///     <is>
+    ///         <used>
+    ///     </verbatim>
+    /// </html>
+    ///
+    /// <inline>html</as-well>
+    #[derive(Parser)]
+    struct Command;
+
+    assert_help!(Command, "snapshots/html.term.svg");
+}
+
+#[test]
+fn blocks() {
+    /// ```rust
+    /// This is a *fenced* code block.
+    ///
+    /// There is not much going on in terms of **styling**.
+    /// ```
+    ///
+    /// ---
+    ///
+    ///     Code blocks can also be initiated through
+    ///     Indentation.
+    ///
+    /// > This is a block quote.
+    /// > **Regular ~styling *should* work~ here.**
+    /// >
+    /// > # even headings
+    /// > and regular paragraphs.
+    /// >
+    /// > - lists
+    /// >   - are
+    /// >
+    /// > 1. also
+    /// >    1. supported
+    /// >
+    /// > > nesting them
+    /// > > > also works (not)
+    ///
+    #[derive(Parser)]
+    struct Command;
+
+    assert_help!(Command, "snapshots/blocks.term.svg");
+}
+
+#[test]
+fn lists() {
+    /// Lists:
+    ///
+    /// - unordered
+    ///   - bullet
+    ///     - lists
+    /// - with multiple
+    ///   - levels
+    ///
+    /// 0. numeric lists
+    /// 1. only care
+    ///    1. about the initial number
+    /// 2. 5. and count from there
+    ///    7. anything goes
+    /// 3. though they need an empty line
+    #[derive(Parser)]
+    struct Command;
+
+    assert_help!(Command, "snapshots/lists.term.svg");
+}
+
+#[test]
+fn paragraphs() {
+    /// Paragraphs are separated by empty lines.
+    /// All lines will be joined onto one.
+    ///
+    /// The first paragraph is used as short help by clap.\
+    /// backslashes can be used to insert hard line breaks.
+    ///
+    /// | these | can   |\
+    /// | ----- | ----- |\
+    /// | be    | used  |\
+    /// | for   | tables|
+    ///
+    /// Because tables are not yet supported.
+    ///
+    #[doc = "You can also use trailing spaces for hard breaks,  \nbut this is not really recommended."]
+    #[derive(Parser)]
+    struct Command;
+
+    assert_help!(Command, "snapshots/paragraphs.term.svg");
+}

--- a/tests/derive/markdown.rs
+++ b/tests/derive/markdown.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "derive")]
+#![cfg(feature = "unstable-markdown")]
 
 use clap::CommandFactory;
 use clap_derive::Parser;

--- a/tests/derive/snapshots/blocks.term.svg
+++ b/tests/derive/snapshots/blocks.term.svg
@@ -1,0 +1,57 @@
+<svg width="995px" height="326px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>```rust This is a *fenced* code block.</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>There is not much going on in terms of **styling**. ```</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan>---</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+    <tspan x="10px" y="136px"><tspan>Code blocks can also be initiated through Indentation.</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+    <tspan x="10px" y="172px"><tspan>&gt; This is a block quote. &gt; **Regular ~styling *should* work~ here.** &gt; &gt; # even headings &gt; and regular paragraphs. &gt;</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>&gt; - lists &gt;   - are &gt; &gt; 1. also &gt;    1. supported &gt; &gt; &gt; nesting them &gt; &gt; &gt; also works (not)</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="244px">
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="316px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/derive/snapshots/blocks.term.svg
+++ b/tests/derive/snapshots/blocks.term.svg
@@ -1,4 +1,4 @@
-<svg width="995px" height="326px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="578px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -7,7 +7,9 @@
       line-height: 18px;
     }
     .bold { font-weight: bold; }
+    .italic { font-style: italic; }
     .underline { text-decoration-line: underline; }
+    .strikethrough { text-decoration-line: line-through; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -18,11 +20,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>```rust This is a *fenced* code block.</tspan>
+    <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="bold">This is a *fenced* code block.</tspan>
 </tspan>
-    <tspan x="10px" y="46px">
+    <tspan x="10px" y="46px"><tspan>  </tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>There is not much going on in terms of **styling**. ```</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="bold">There is not much going on in terms of **styling**.</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
@@ -30,27 +32,55 @@
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Code blocks can also be initiated through Indentation.</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="bold">Code blocks can also be initiated through</tspan>
 </tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="bold">Indentation.</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>&gt; This is a block quote. &gt; **Regular ~styling *should* work~ here.** &gt; &gt; # even headings &gt; and regular paragraphs. &gt;</tspan>
+    <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px"><tspan>&gt; - lists &gt;   - are &gt; &gt; 1. also &gt;    1. supported &gt; &gt; &gt; nesting them &gt; &gt; &gt; also works (not)</tspan>
+    <tspan x="10px" y="190px"><tspan>| This is a block quote. </tspan><tspan class="bold">Regular </tspan><tspan class="strikethrough bold">styling </tspan><tspan class="strikethrough bold italic">should</tspan><tspan class="strikethrough bold"> work</tspan><tspan class="bold"> here.</tspan>
 </tspan>
-    <tspan x="10px" y="208px">
+    <tspan x="10px" y="208px"><tspan>| </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+    <tspan x="10px" y="226px"><tspan>| </tspan><tspan class="underline bold">even headings</tspan>
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan>| </tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan class="underline bold">Options:</tspan>
+    <tspan x="10px" y="262px"><tspan>| and regular paragraphs.</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+    <tspan x="10px" y="280px"><tspan>| </tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>          Print help (see a summary with '-h')</tspan>
+    <tspan x="10px" y="298px"><tspan>| - lists</tspan>
 </tspan>
-    <tspan x="10px" y="316px">
+    <tspan x="10px" y="316px"><tspan>|   - are</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan>| </tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>| 1. also</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>|   1. supported</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan>| </tspan>
+</tspan>
+    <tspan x="10px" y="406px"><tspan>| | nesting them</tspan>
+</tspan>
+    <tspan x="10px" y="424px"><tspan>| | </tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>| | | also works (not)</tspan>
+</tspan>
+    <tspan x="10px" y="460px">
+</tspan>
+    <tspan x="10px" y="478px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="496px">
+</tspan>
+    <tspan x="10px" y="514px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="532px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="550px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
   </text>
 

--- a/tests/derive/snapshots/headers.term.svg
+++ b/tests/derive/snapshots/headers.term.svg
@@ -1,4 +1,4 @@
-<svg width="844px" height="164px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -7,7 +7,9 @@
       line-height: 18px;
     }
     .bold { font-weight: bold; }
+    .italic { font-style: italic; }
     .underline { text-decoration-line: underline; }
+    .strikethrough { text-decoration-line: line-through; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -18,21 +20,33 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan># This is a header ## second level ### `additional` *styling **on ~top~ of** it* regular paragraph</tspan>
+    <tspan x="10px" y="28px"><tspan class="underline bold">This is a header</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+    <tspan x="10px" y="64px"><tspan class="underline bold">second level</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="underline bold">Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="underline bold">additional</tspan><tspan class="underline bold"> </tspan><tspan class="underline bold italic">styling on </tspan><tspan class="underline strikethrough bold italic">top</tspan><tspan class="underline bold italic"> of</tspan><tspan class="underline bold italic"> it</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+    <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>          Print help</tspan>
+    <tspan x="10px" y="136px"><tspan>regular paragraph</tspan>
 </tspan>
     <tspan x="10px" y="154px">
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>          Print help</tspan>
+</tspan>
+    <tspan x="10px" y="262px">
 </tspan>
   </text>
 

--- a/tests/derive/snapshots/headers.term.svg
+++ b/tests/derive/snapshots/headers.term.svg
@@ -1,0 +1,39 @@
+<svg width="844px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan># This is a header ## second level ### `additional` *styling **on ~top~ of** it* regular paragraph</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>          Print help</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/derive/snapshots/html.term.svg
+++ b/tests/derive/snapshots/html.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,25 +18,35 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>&lt;html&gt; &lt;is&gt; &lt;used&gt; &lt;/verbatim&gt; &lt;/html&gt;</tspan>
+    <tspan x="10px" y="28px"><tspan>&lt;html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="46px">
+    <tspan x="10px" y="46px"><tspan>    &lt;is&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>&lt;inline&gt;html&lt;/as-well&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan>        &lt;used&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan>    &lt;/verbatim&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+    <tspan x="10px" y="100px"><tspan>&lt;/html&gt;</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="underline bold">Options:</tspan>
+    <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+    <tspan x="10px" y="154px"><tspan>&lt;inline&gt;html&lt;/as-well&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>          Print help (see a summary with '-h')</tspan>
+    <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px">
+    <tspan x="10px" y="190px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>          Print help</tspan>
+</tspan>
+    <tspan x="10px" y="280px">
 </tspan>
   </text>
 

--- a/tests/derive/snapshots/html.term.svg
+++ b/tests/derive/snapshots/html.term.svg
@@ -1,0 +1,43 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>&lt;html&gt; &lt;is&gt; &lt;used&gt; &lt;/verbatim&gt; &lt;/html&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>&lt;inline&gt;html&lt;/as-well&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/derive/snapshots/inline_styles.term.svg
+++ b/tests/derive/snapshots/inline_styles.term.svg
@@ -1,0 +1,43 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>*emphasis* **bold** ~strike through~ `code`</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>*all **of ~them `combined` in~ one** line*</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/derive/snapshots/inline_styles.term.svg
+++ b/tests/derive/snapshots/inline_styles.term.svg
@@ -7,7 +7,9 @@
       line-height: 18px;
     }
     .bold { font-weight: bold; }
+    .italic { font-style: italic; }
     .underline { text-decoration-line: underline; }
+    .strikethrough { text-decoration-line: line-through; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -18,11 +20,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>*emphasis* **bold** ~strike through~ `code`</tspan>
+    <tspan x="10px" y="28px"><tspan class="italic">emphasis</tspan><tspan> </tspan><tspan class="bold">bold</tspan><tspan> </tspan><tspan class="strikethrough">strike through</tspan><tspan> </tspan><tspan class="bold">code</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>*all **of ~them `combined` in~ one** line*</tspan>
+    <tspan x="10px" y="64px"><tspan class="italic">all </tspan><tspan class="bold italic">of </tspan><tspan class="strikethrough bold italic">them combined</tspan><tspan class="strikethrough bold italic"> in</tspan><tspan class="bold italic"> one</tspan><tspan class="italic"> line</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/derive/snapshots/links.term.svg
+++ b/tests/derive/snapshots/links.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="308px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -18,37 +18,33 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>&lt;https://example.com/literal&gt;</tspan>
+    <tspan x="10px" y="28px"><tspan class="underline">https://example.com/literal</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>[with name](https://example.com/with%20name)</tspan>
+    <tspan x="10px" y="64px"><tspan class="underline">with name</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>![image](https://example.com/image)</tspan>
+    <tspan x="10px" y="100px"><tspan>image</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>[referencing][reference]</tspan>
+    <tspan x="10px" y="136px"><tspan class="underline">referencing</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>[reference]: https://example.com/reference</tspan>
+    <tspan x="10px" y="172px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+    <tspan x="10px" y="208px"><tspan class="underline bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="226px">
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="underline bold">Options:</tspan>
+    <tspan x="10px" y="244px"><tspan>          Print help (see a summary with '-h')</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
-</tspan>
-    <tspan x="10px" y="280px"><tspan>          Print help (see a summary with '-h')</tspan>
-</tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="262px">
 </tspan>
   </text>
 

--- a/tests/derive/snapshots/links.term.svg
+++ b/tests/derive/snapshots/links.term.svg
@@ -1,0 +1,55 @@
+<svg width="740px" height="308px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>&lt;https://example.com/literal&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>[with name](https://example.com/with%20name)</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan>![image](https://example.com/image)</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+    <tspan x="10px" y="136px"><tspan>[referencing][reference]</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+    <tspan x="10px" y="172px"><tspan>[reference]: https://example.com/reference</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="226px">
+</tspan>
+    <tspan x="10px" y="244px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="298px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/derive/snapshots/lists.term.svg
+++ b/tests/derive/snapshots/lists.term.svg
@@ -1,4 +1,4 @@
-<svg width="995px" height="254px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="416px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -22,27 +22,45 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>- unordered - bullet - lists - with multiple - levels</tspan>
+    <tspan x="10px" y="64px"><tspan>- unordered</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan>  - bullet</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>0. numeric lists 1. only care 1. about the initial number 2. 5. and count from there 7. anything goes 3. though they</tspan>
+    <tspan x="10px" y="100px"><tspan>    - lists</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>need an empty line</tspan>
+    <tspan x="10px" y="118px"><tspan>- with multiple</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan>  - levels</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+    <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px">
+    <tspan x="10px" y="172px"><tspan>0. numeric lists</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="underline bold">Options:</tspan>
+    <tspan x="10px" y="190px"><tspan>1. only care</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+    <tspan x="10px" y="208px"><tspan>  1. about the initial number</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>          Print help (see a summary with '-h')</tspan>
+    <tspan x="10px" y="226px"><tspan>2. </tspan>
 </tspan>
-    <tspan x="10px" y="244px">
+    <tspan x="10px" y="244px"><tspan>  5. and count from there</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>  6. anything goes</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>3. though they need an empty line</tspan>
+</tspan>
+    <tspan x="10px" y="298px">
+</tspan>
+    <tspan x="10px" y="316px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="334px">
+</tspan>
+    <tspan x="10px" y="352px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
   </text>
 

--- a/tests/derive/snapshots/lists.term.svg
+++ b/tests/derive/snapshots/lists.term.svg
@@ -1,0 +1,49 @@
+<svg width="995px" height="254px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Lists:</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>- unordered - bullet - lists - with multiple - levels</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan>0. numeric lists 1. only care 1. about the initial number 2. 5. and count from there 7. anything goes 3. though they</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>need an empty line</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="244px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/derive/snapshots/paragraphs.term.svg
+++ b/tests/derive/snapshots/paragraphs.term.svg
@@ -1,0 +1,55 @@
+<svg width="886px" height="308px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .underline { text-decoration-line: underline; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Paragraphs are separated by empty lines. All lines will be joined onto one.</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan>The first paragraph is used as short help by clap./ backslashes can be used to insert hard line breaks.</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan>| these | can   |/ | ----- | ----- |/ | be    | used  |/ | for   | tables|</tspan>
+</tspan>
+    <tspan x="10px" y="118px">
+</tspan>
+    <tspan x="10px" y="136px"><tspan>Because tables are not yet supported.</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+    <tspan x="10px" y="172px"><tspan>You can also use trailing spaces for hard breaks, but this is not really recommended.</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="226px">
+</tspan>
+    <tspan x="10px" y="244px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="298px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/derive/snapshots/paragraphs.term.svg
+++ b/tests/derive/snapshots/paragraphs.term.svg
@@ -1,4 +1,4 @@
-<svg width="886px" height="308px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -22,33 +22,43 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>The first paragraph is used as short help by clap./ backslashes can be used to insert hard line breaks.</tspan>
+    <tspan x="10px" y="64px"><tspan>The first paragraph is used as short help by clap.</tspan>
 </tspan>
-    <tspan x="10px" y="82px">
+    <tspan x="10px" y="82px"><tspan>backslashes can be used to insert hard line breaks.</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan>| these | can   |/ | ----- | ----- |/ | be    | used  |/ | for   | tables|</tspan>
+    <tspan x="10px" y="100px">
 </tspan>
-    <tspan x="10px" y="118px">
+    <tspan x="10px" y="118px"><tspan>| these | can   |</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Because tables are not yet supported.</tspan>
+    <tspan x="10px" y="136px"><tspan>| ----- | ----- |</tspan>
 </tspan>
-    <tspan x="10px" y="154px">
+    <tspan x="10px" y="154px"><tspan>| be    | used  |</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>You can also use trailing spaces for hard breaks, but this is not really recommended.</tspan>
+    <tspan x="10px" y="172px"><tspan>| for   | tables|</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+    <tspan x="10px" y="208px"><tspan>Because tables are not yet supported.</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="underline bold">Options:</tspan>
+    <tspan x="10px" y="244px"><tspan>You can also use trailing spaces for hard breaks,</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+    <tspan x="10px" y="262px"><tspan>but this is not really recommended.</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>          Print help (see a summary with '-h')</tspan>
+    <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan class="underline bold">Usage:</tspan><tspan> </tspan><tspan class="bold">clap</tspan>
+</tspan>
+    <tspan x="10px" y="316px">
+</tspan>
+    <tspan x="10px" y="334px"><tspan class="underline bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="bold">-h</tspan><tspan>, </tspan><tspan class="bold">--help</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan>          Print help (see a summary with '-h')</tspan>
+</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
   </text>
 


### PR DESCRIPTION
fixes #2389

- [ ] add tests for markdown parsing


| markdown | output | comment |
| - | - | - |
|  paragraph | surrounded by empty line |
| `# heading` | bold + underline + surrounded by empty line | default style for heading |
| `![image]()` | alt text | anyone feeling sixel?!|
| `<html>` | verbatim |
| `> blockquote` | ![image](https://github.com/user-attachments/assets/3eec1b6e-fcc5-4293-9bb5-1fa1e869b270) | alternatively could use `>` |
| code block | ![image](https://github.com/user-attachments/assets/a3ce198c-a4e1-43d9-9a42-bd77dc2733c6)| same styling as `` `code` ``|
| (un)ordered lists | ![ordered list example](https://github.com/user-attachments/assets/880b93b9-b19c-445e-9605-280f41dff941) | |
| `*emphasis*` | italic |
| `**strong**` | bold |
| `~stikethrough~` | strikethrough |
| `[link](url)` | underlined alt text + OSC 8 |
| `` `inline code ` `` | bold | default style for literal |
| ` --- ` hrule | `---` surrounded by empty lines |
| ` \| tables \| ` | verbatim |
| `\\\n` and `  \n` hard break | ends line |

## Open Questions
- [ ] unicode support i.e. `•` for bullet lists, `Options::ENABLE_SMART_PUNCTUATION` for `pulldown_cmark`, unicode lines for blockquotes
- [ ] using the default clap styling for code makes it the same to bold.
- [ ] should we make images a link to the image source
- [ ] should we add custom html tags a la https://docs.rs/color-print/latest/color_print/ this would allow users to use colors without us actually supporting runtime style information.
- [ ]  should we use other enumeration for nested lists? e.g. `a.`, `b.` and `i.`, `ii.`? we could use https://docs.rs/nominals for that
- [ ] styling for code blocks and block quotes
