### PR TITLE
fix(complete): Fix single quote escaping in PowerShell

### DIFF
--- a/clap_complete/src/aot/shells/powershell.rs
+++ b/clap_complete/src/aot/shells/powershell.rs
@@ -59,7 +59,7 @@ Register-ArgumentCompleter -Native -CommandName '{bin_name}' -ScriptBlock {{
 
 // Escape string inside single quotes
 fn escape_string(string: &str) -> String {
-    string.replace('\'', "''")
+    string.replace('\'', "''").replace('’', "'’")
 }
 
 fn escape_help<T: ToString>(help: Option<&StyledStr>, data: T) -> String {


### PR DESCRIPTION
fix #5820

PowerShell treats `’` as regular single quote, so it needs to be escaped with single quote as well.