### PR TITLE
Update LICENSE-MIT

### DIFF
--- a/clap_lex/LICENSE-MIT
+++ b/clap_lex/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2022 Kevin B. Knapp and Clap Contributors
+Copyright (c) 2015-2025 Kevin B. Knapp and Clap Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the copyright year from 2022 to 2025 in the LICENSE file