### PR TITLE
feat(complete): Provide a way to disable env completions

### DIFF
--- a/clap_complete/src/env/mod.rs
+++ b/clap_complete/src/env/mod.rs
@@ -61,6 +61,8 @@
 //! ```zsh
 //! echo "source <(COMPLETE=zsh your_program)" >> ~/.zshrc
 //! ```
+//!
+//! To disable completions, you can set `COMPLETE=` or `COMPLETE=0`
 
 mod shells;
 
@@ -218,6 +220,9 @@ impl<'s, F: Fn() -> clap::Command> CompleteEnv<'s, F> {
         let Some(name) = std::env::var_os(self.var) else {
             return Ok(false);
         };
+        if name.is_empty() || name == "0" {
+            return Ok(false);
+        }
 
         // Ensure any child processes called for custom completers don't activate their own
         // completion logic.


### PR DESCRIPTION
You can remove the env variable but sometimes you want to override it.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
