### PR TITLE
docs: replace `concolor-clap` with `colorchoice-clap`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //! - [clio](https://crates.io/crates/clio) for reading/writing to files specified as arguments
 //! - [clap-verbosity-flag](https://crates.io/crates/clap-verbosity-flag)
 //! - [clap-cargo](https://crates.io/crates/clap-cargo)
-//! - [concolor-clap](https://crates.io/crates/concolor-clap)
+//! - [colorchoice-clap](https://crates.io/crates/colorchoice-clap)
 //!
 //! Testing
 //! - [`trycmd`](https://crates.io/crates/trycmd):  Bulk snapshot testing


### PR DESCRIPTION
Since [concolor is deprecated](https://github.com/rust-cli/concolor/issues/47), the docs should point to its replacement, 
 `colorchoice-clap`, instead

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
