### PR TITLE
fix(parser): Dont report missing flags as present 

### DIFF
--- a/clap_builder/src/parser/matches/arg_matches.rs
+++ b/clap_builder/src/parser/matches/arg_matches.rs
@@ -575,7 +575,9 @@ impl ArgMatches {
     ///     .unwrap();
     /// assert!(! m.args_present());
     pub fn args_present(&self) -> bool {
-        !self.args.is_empty()
+        self.args
+            .values()
+            .any(|v| v.source().map(|s| s.is_explicit()).unwrap_or(false))
     }
 
     /// Report where argument value came from

--- a/clap_builder/src/parser/matches/arg_matches.rs
+++ b/clap_builder/src/parser/matches/arg_matches.rs
@@ -554,7 +554,10 @@ impl ArgMatches {
         }
     }
 
-    /// Check if any args were present on the command line
+    /// Check if any [`Arg`][crate::Arg]s were present on the command line
+    ///
+    /// See [`ArgMatches::subcommand_name()`] or [`ArgMatches::subcommand()`] to check if a
+    /// subcommand was present on the command line.
     ///
     /// # Examples
     ///

--- a/clap_builder/src/util/flat_map.rs
+++ b/clap_builder/src/util/flat_map.rs
@@ -118,6 +118,10 @@ impl<K: PartialEq + Eq, V> FlatMap<K, V> {
         self.keys.iter()
     }
 
+    pub(crate) fn values(&self) -> std::slice::Iter<'_, V> {
+        self.values.iter()
+    }
+
     pub(crate) fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             keys: self.keys.iter(),

--- a/tests/builder/arg_matches.rs
+++ b/tests/builder/arg_matches.rs
@@ -1,5 +1,4 @@
 use clap::{arg, value_parser, Command};
-#[cfg(debug_assertions)]
 use clap::{Arg, ArgAction};
 
 #[test]
@@ -82,4 +81,37 @@ fn arg_matches_subcommand_matches_wrong_sub() {
 
     assert!(m.subcommand_matches("speed").is_some());
     m.subcommand_matches("seed");
+}
+
+#[test]
+fn args_present_positional() {
+    let c = Command::new("test").arg(Arg::new("positional"));
+
+    let m = c.clone().try_get_matches_from(["test"]).unwrap();
+    assert!(!m.args_present());
+
+    let m = c.clone().try_get_matches_from(["test", "value"]).unwrap();
+    assert!(m.args_present());
+}
+
+#[test]
+fn args_present_flag() {
+    let c = Command::new("test").arg(Arg::new("flag").long("flag").action(ArgAction::SetTrue));
+
+    let m = c.clone().try_get_matches_from(["test"]).unwrap();
+    assert!(m.args_present());
+
+    let m = c.clone().try_get_matches_from(["test", "--flag"]).unwrap();
+    assert!(m.args_present());
+}
+
+#[test]
+fn args_present_subcommand() {
+    let c = Command::new("test").subcommand(Command::new("sub"));
+
+    let m = c.clone().try_get_matches_from(["test"]).unwrap();
+    assert!(!m.args_present());
+
+    let m = c.clone().try_get_matches_from(["test", "sub"]).unwrap();
+    assert!(!m.args_present());
 }

--- a/tests/builder/arg_matches.rs
+++ b/tests/builder/arg_matches.rs
@@ -99,7 +99,7 @@ fn args_present_flag() {
     let c = Command::new("test").arg(Arg::new("flag").long("flag").action(ArgAction::SetTrue));
 
     let m = c.clone().try_get_matches_from(["test"]).unwrap();
-    assert!(m.args_present());
+    assert!(!m.args_present());
 
     let m = c.clone().try_get_matches_from(["test", "--flag"]).unwrap();
     assert!(m.args_present());


### PR DESCRIPTION
When we switched flags to `ArgAction::SetTrue`,
we overlooked updating `args_present`.
Because of the default value for `ArgAction::SetTrue`,
`args_present` will always report true when a flag is defined.

I went with the trivial implementation for now.  We could proactively
track this but was unsure about correctness vs overhead and so I thought
I'd have those using it pay for it.

Looking over uses on github, this will fix a couple bugs but should
otherwise be unnoticeable.

Fixes #5860