### PR TITLE
chore: Avoid using `gen` for rust 2024 preserved keyword

### DIFF
--- a/clap_complete/examples/completion-derive.rs
+++ b/clap_complete/examples/completion-derive.rs
@@ -66,8 +66,13 @@ struct ValueHintOpt {
     email: Option<String>,
 }
 
-fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
-    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+fn print_completions<G: Generator>(generator: G, cmd: &mut Command) {
+    generate(
+        generator,
+        cmd,
+        cmd.get_name().to_string(),
+        &mut io::stdout(),
+    );
 }
 
 fn main() {

--- a/clap_complete/examples/completion.rs
+++ b/clap_complete/examples/completion.rs
@@ -94,8 +94,13 @@ fn build_cli() -> Command {
         .subcommand(value_hint_command)
 }
 
-fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
-    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+fn print_completions<G: Generator>(generator: G, cmd: &mut Command) {
+    generate(
+        generator,
+        cmd,
+        cmd.get_name().to_string(),
+        &mut io::stdout(),
+    );
 }
 
 fn main() {

--- a/clap_complete/examples/exhaustive.rs
+++ b/clap_complete/examples/exhaustive.rs
@@ -19,8 +19,13 @@ fn main() {
     println!("{matches:?}");
 }
 
-fn print_completions<G: Generator>(gen: G, cmd: &mut clap::Command) {
-    generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout());
+fn print_completions<G: Generator>(generator: G, cmd: &mut clap::Command) {
+    generate(
+        generator,
+        cmd,
+        cmd.get_name().to_string(),
+        &mut std::io::stdout(),
+    );
 }
 
 const EMPTY: [&str; 0] = [];

--- a/clap_complete/src/aot/generator/mod.rs
+++ b/clap_complete/src/aot/generator/mod.rs
@@ -197,7 +197,7 @@ pub trait Generator {
 /// }
 /// ```
 pub fn generate_to<G, S, T>(
-    gen: G,
+    generator: G,
     cmd: &mut Command,
     bin_name: S,
     out_dir: T,
@@ -210,12 +210,12 @@ where
     cmd.set_bin_name(bin_name);
 
     let out_dir = PathBuf::from(out_dir.into());
-    let file_name = gen.file_name(cmd.get_bin_name().unwrap());
+    let file_name = generator.file_name(cmd.get_bin_name().unwrap());
 
     let path = out_dir.join(file_name);
     let mut file = File::create(&path)?;
 
-    _generate::<G>(gen, cmd, &mut file);
+    _generate::<G>(generator, cmd, &mut file);
     Ok(path)
 }
 
@@ -254,13 +254,13 @@ where
 /// ```console
 /// $ myapp generate-bash-completions > /usr/share/bash-completion/completions/myapp.bash
 /// ```
-pub fn generate<G, S>(gen: G, cmd: &mut Command, bin_name: S, buf: &mut dyn Write)
+pub fn generate<G, S>(generator: G, cmd: &mut Command, bin_name: S, buf: &mut dyn Write)
 where
     G: Generator,
     S: Into<String>,
 {
     cmd.set_bin_name(bin_name);
-    _generate::<G>(gen, cmd, buf);
+    _generate::<G>(generator, cmd, buf);
 }
 
 fn _generate<G: Generator>(gen: G, cmd: &mut Command, buf: &mut dyn Write) {

--- a/clap_complete/src/aot/generator/mod.rs
+++ b/clap_complete/src/aot/generator/mod.rs
@@ -263,7 +263,7 @@ where
     _generate::<G>(generator, cmd, buf);
 }
 
-fn _generate<G: Generator>(gen: G, cmd: &mut Command, buf: &mut dyn Write) {
+fn _generate<G: Generator>(generator: G, cmd: &mut Command, buf: &mut dyn Write) {
     cmd.build();
-    gen.generate(cmd, buf);
+    generator.generate(cmd, buf);
 }

--- a/clap_complete/src/aot/mod.rs
+++ b/clap_complete/src/aot/mod.rs
@@ -33,8 +33,8 @@
 //!        )
 //! }
 //!
-//! fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
-//!     generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+//! fn print_completions<G: Generator>(generator: G, cmd: &mut Command) {
+//!     generate(generator, cmd, cmd.get_name().to_string(), &mut io::stdout());
 //! }
 //!
 //! fn main() {

--- a/clap_complete/src/lib.rs
+++ b/clap_complete/src/lib.rs
@@ -31,8 +31,8 @@
 //!             .value_parser(value_parser!(Shell)))
 //! }
 //!
-//! fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
-//!     generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
+//! fn print_completions<G: Generator>(generator: G, cmd: &mut Command) {
+//!     generate(generator, cmd, cmd.get_name().to_string(), &mut io::stdout());
 //! }
 //!
 //! fn main() {

--- a/clap_complete/tests/testsuite/common.rs
+++ b/clap_complete/tests/testsuite/common.rs
@@ -286,12 +286,12 @@ pub(crate) fn subcommand_last(name: &'static str) -> clap::Command {
 
 pub(crate) fn assert_matches(
     expected: impl IntoData,
-    gen: impl clap_complete::Generator,
+    generator: impl clap_complete::Generator,
     mut cmd: clap::Command,
     name: &'static str,
 ) {
     let mut buf = vec![];
-    clap_complete::generate(gen, &mut cmd, name, &mut buf);
+    clap_complete::generate(generator, &mut cmd, name, &mut buf);
 
     snapbox::Assert::new()
         .action_env(snapbox::assert::DEFAULT_ACTION_ENV)

--- a/clap_complete_nushell/tests/common.rs
+++ b/clap_complete_nushell/tests/common.rs
@@ -246,12 +246,12 @@ pub(crate) fn value_hint_command(name: &'static str) -> Command {
 
 pub(crate) fn assert_matches(
     expected: impl IntoData,
-    gen: impl clap_complete::Generator,
+    generator: impl clap_complete::Generator,
     mut cmd: Command,
     name: &'static str,
 ) {
     let mut buf = vec![];
-    clap_complete::generate(gen, &mut cmd, name, &mut buf);
+    clap_complete::generate(generator, &mut cmd, name, &mut buf);
 
     snapbox::Assert::new()
         .action_env(snapbox::assert::DEFAULT_ACTION_ENV)


### PR DESCRIPTION
In the rust 2024 edition, [`gen` has been a reserved keyword](https://doc.rust-lang.org/edition-guide/rust-2024/gen-keyword.html), so we should avoid using it.