### PR TITLE
document `clap::Error::insert` a bit better

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -195,6 +195,8 @@ impl<F: ErrorFormatter> Error<F> {
     }
 
     /// Insert a piece of context
+    ///
+    /// If this `ContextKind` is already present, its value is replaced and the old value is returned.
     #[inline(never)]
     #[cfg(feature = "error-context")]
     pub fn insert(&mut self, kind: ContextKind, value: ContextValue) -> Option<ContextValue> {


### PR DESCRIPTION
This is very minor, and could be considered obvious, but I didn't notice the return value immediately so why not mention it.