### PR TITLE
feat(builder): Add `clap::Error::remove` and a test

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -203,6 +203,16 @@ impl<F: ErrorFormatter> Error<F> {
         self.inner.context.insert(kind, value)
     }
 
+    /// Remove a piece of context, return the old value if any
+    ///
+    /// The context is currently implemented in a vector, so `remove` takes
+    /// linear time.
+    #[inline(never)]
+    #[cfg(feature = "error-context")]
+    pub fn remove(&mut self, kind: ContextKind) -> Option<ContextValue> {
+        self.inner.context.remove(&kind)
+    }
+
     /// Should the message be written to `stdout` or not?
     #[inline]
     pub fn use_stderr(&self) -> bool {


### PR DESCRIPTION
#5935

The added test covers both `Error::insert` and `Error::remove`.

If we merge this after #5942, I could make the new test use the same `assert_error` as the other ones (though I'm not sure that would be better, up to you). I could also make `assert_error` take `&Error`, but that changes a lot of call sites.
