### PR TITLE
feat(builder): Make `clap::Error` be `Clone`

### DIFF
--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -17,7 +17,7 @@ use crate::output::TAB;
 use crate::ArgAction;
 
 /// Defines how to format an error for displaying to the user
-pub trait ErrorFormatter: Sized {
+pub trait ErrorFormatter: Sized + Clone {
     /// Stylize the error for the terminal
     fn format_error(error: &crate::error::Error<Self>) -> StyledStr;
 }
@@ -33,6 +33,7 @@ pub trait ErrorFormatter: Sized {
 ///
 /// </div>
 #[non_exhaustive]
+#[derive(Clone)]
 pub struct KindFormatter;
 
 impl ErrorFormatter for KindFormatter {
@@ -59,6 +60,7 @@ impl ErrorFormatter for KindFormatter {
 /// This follows the [rustc diagnostic style guide](https://rustc-dev-guide.rust-lang.org/diagnostics.html#suggestion-style-guide).
 #[non_exhaustive]
 #[cfg(feature = "error-context")]
+#[derive(Clone)]
 pub struct RichFormatter;
 
 #[cfg(feature = "error-context")]


### PR DESCRIPTION
#5935

As he mentioned in https://github.com/clap-rs/clap/issues/5935#issuecomment-2707958021, @yuja just refactored the `jj` code so that it no longer requires this, quite easily in retrospect (https://github.com/jj-vcs/jj/pull/5929).

Still, I will list a few reasons to do this, since I still think it's worth doing. All of them amount to a "nice to have", not anything crucial. So, if this idea does not sit well with you, no pressure. 

---------------

Some reasons to make `clap::Error` be `Clone`:

- As you (@epage) suggested, `clap::Error`s could be cached
- `Clone` types are convenient for new Rust users who might not be experienced in solving ownership problems
- Since `clap::Error`s can be edited, one might want to edit them in a fallible way. It should be possible to save a backup copy in case the edit fails.
- More generally, all else being equal, it's nice to not require people to refactor their programs. In this case, one could argue that the refactor would improve their programs, but the improvement of avoiding a clone in the error path would be quite minor and might not be worth their time.
- There's little to no cost to doing so 