### PR TITLE
chore(deps): Switch humantime to cyborgtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
  "clap-cargo",
  "clap_builder 4.5.31",
  "clap_derive",
- "humantime",
+ "cyborgtime",
  "rustversion",
  "shlex",
  "snapbox",
@@ -797,6 +797,12 @@ checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "cyborgtime"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
 
 [[package]]
 name = "deranged"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ trybuild = "1.0.91"
 rustversion = "1.0.15"
 # Cutting out `filesystem` feature
 trycmd = { version = "0.15.3", default-features = false, features = ["color-auto", "diff", "examples"] }
-humantime = "2.1.0"
+cyborgtime = "2.1.1"
 snapbox = { version = "0.6.16", features = ["term-svg"] }
 shlex = "1.3.0"
 automod = "1.0.14"

--- a/examples/typed-derive.rs
+++ b/examples/typed-derive.rs
@@ -19,7 +19,7 @@ struct Args {
 
     /// Allow human-readable durations
     #[arg(long)]
-    sleep: Option<humantime::Duration>,
+    sleep: Option<cyborgtime::Duration>,
 
     /// Hand-written parser for tuples
     #[arg(short = 'D', value_parser = parse_key_val::<String, i32>)]


### PR DESCRIPTION
[`humantime`](https://crates.io/crates/humantime) crate seems to be unmaintained and [`cyborgtime`](https://crates.io/crates/cyborgtime) is forked from that. According to crates.io's stats clap is the most downloaded user of `humantime`. 

Since `humantime` crate is only used in one example code this shouldn't cause any bigger change to project.

Ref. https://github.com/rustsec/advisory-db/pull/2249

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
