### PR TITLE
fix(parser): Don't include groups in argument suggestions 

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -1586,7 +1586,7 @@ impl Parser<'_> {
             .filter(|arg_id| {
                 matcher.check_explicit(arg_id, &crate::builder::ArgPredicate::IsPresent)
             })
-            .filter(|n| self.cmd.find(n).map(|a| !a.is_hide_set()).unwrap_or(true))
+            .filter(|n| self.cmd.find(n).map(|a| !a.is_hide_set()).unwrap_or(false))
             .cloned()
             .collect();
 

--- a/tests/derive/doc_comments_help.rs
+++ b/tests/derive/doc_comments_help.rs
@@ -15,6 +15,7 @@
 use crate::utils;
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use snapbox::str;
 
 #[test]
 fn doc_comments() {
@@ -276,7 +277,7 @@ fn respect_subcommand_doc_comment() {
         Twp,
     }
 
-    const OUTPUT: &str = "\
+    let output = str![[r#"
 Usage: cmd <COMMAND>
 
 Commands:
@@ -285,8 +286,9 @@ Commands:
 
 Options:
   -h, --help  Print help
-";
-    utils::assert_output::<Cmd>("cmd --help", OUTPUT, false);
+
+"#]];
+    utils::assert_output::<Cmd>("cmd --help", output, false);
 }
 
 #[test]

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -297,7 +297,7 @@ error: unexpected argument '--hell' found
 
   tip: a similar argument exists: '--hello'
 
-Usage: test <NAME|--hello <HELLO>|--count01 <COUNT01>|--count02 <COUNT02>|--count03 <COUNT03>|--count04 <COUNT04>|--count05 <COUNT05>|--count06 <COUNT06>|--count07 <COUNT07>|--count08 <COUNT08>|--count09 <COUNT09>|--count10 <COUNT10>|--count11 <COUNT11>|--count12 <COUNT12>|--count13 <COUNT13>|--count14 <COUNT14>|--count15 <COUNT15>|--count16 <COUNT16>|--count17 <COUNT17>|--count18 <COUNT18>>
+Usage: test --hello <HELLO> <NAME>
 
 For more information, try '--help'.
 

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -242,3 +242,65 @@ For more information, try '--help'.
 "#]];
     assert_output::<Opt>("test", output, true);
 }
+
+#[test]
+#[cfg(feature = "error-context")]
+#[cfg(feature = "suggestions")]
+fn suggestion() {
+    #[derive(Parser, Debug)]
+    struct Args {
+        name: String,
+
+        #[arg(long)]
+        hello: Option<u8>,
+
+        #[arg(long)]
+        count01: Vec<u8>,
+        #[arg(long)]
+        count02: Vec<u8>,
+        #[arg(long)]
+        count03: Vec<u8>,
+        #[arg(long)]
+        count04: Vec<u8>,
+        #[arg(long)]
+        count05: Vec<u8>,
+        #[arg(long)]
+        count06: Vec<u8>,
+        #[arg(long)]
+        count07: Vec<u8>,
+        #[arg(long)]
+        count08: Vec<u8>,
+        #[arg(long)]
+        count09: Vec<u8>,
+        #[arg(long)]
+        count10: Vec<u8>,
+        #[arg(long)]
+        count11: Vec<u8>,
+        #[arg(long)]
+        count12: Vec<u8>,
+        #[arg(long)]
+        count13: Vec<u8>,
+        #[arg(long)]
+        count14: Vec<u8>,
+        #[arg(long)]
+        count15: Vec<u8>,
+        #[arg(long)]
+        count16: Vec<u8>,
+        #[arg(long)]
+        count17: Vec<u8>,
+        #[arg(long)]
+        count18: Vec<u8>,
+    }
+
+    let output = str![[r#"
+error: unexpected argument '--hell' found
+
+  tip: a similar argument exists: '--hello'
+
+Usage: test <NAME|--hello <HELLO>|--count01 <COUNT01>|--count02 <COUNT02>|--count03 <COUNT03>|--count04 <COUNT04>|--count05 <COUNT05>|--count06 <COUNT06>|--count07 <COUNT07>|--count08 <COUNT08>|--count09 <COUNT09>|--count10 <COUNT10>|--count11 <COUNT11>|--count12 <COUNT12>|--count13 <COUNT13>|--count14 <COUNT14>|--count15 <COUNT15>|--count16 <COUNT16>|--count17 <COUNT17>|--count18 <COUNT18>>
+
+For more information, try '--help'.
+
+"#]];
+    assert_output::<Args>("test --hell", output, true);
+}

--- a/tests/derive/groups.rs
+++ b/tests/derive/groups.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use snapbox::str;
 
 use crate::utils::assert_output;
 
@@ -44,15 +45,16 @@ fn implicit_struct_group() {
         git: Option<String>,
     }
 
-    const OUTPUT: &str = "\
+    let output = str![[r#"
 error: the following required arguments were not provided:
   <CRATES|--path <PATH>|--git <GIT>>
 
 Usage: prog --add <CRATES|--path <PATH>|--git <GIT>>
 
 For more information, try '--help'.
-";
-    assert_output::<Opt>("prog --add", OUTPUT, true);
+
+"#]];
+    assert_output::<Opt>("prog --add", output, true);
 
     use clap::Args;
     assert_eq!(Source::group_id(), Some(clap::Id::from("Source")));
@@ -229,13 +231,14 @@ fn required_group() {
         Opt::try_parse_from(["test", "--path=./"]).unwrap()
     );
 
-    const OUTPUT: &str = "\
+    let output = str![[r#"
 error: the following required arguments were not provided:
   <--path <PATH>|--git <GIT>>
 
 Usage: test <--path <PATH>|--git <GIT>>
 
 For more information, try '--help'.
-";
-    assert_output::<Opt>("test", OUTPUT, true);
+
+"#]];
+    assert_output::<Opt>("test", output, true);
 }

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -220,14 +220,16 @@ fn derive_generated_error_has_full_context() {
         result.unwrap()
     );
 
-    let expected = r#"error: The following required argument was not provided: req_str
+    let expected = str![[r#"
+error: The following required argument was not provided: req_str
 
 Usage: clap --req-str <REQ_STR>
        clap <COMMAND>
 
 For more information, try '--help'.
-"#;
-    assert_eq!(result.unwrap_err().to_string(), expected);
+
+"#]];
+    assert_data_eq!(result.unwrap_err().to_string(), expected);
 }
 
 #[test]
@@ -340,18 +342,6 @@ Options:
 
 #[test]
 fn derive_order_no_next_order() {
-    static HELP: &str = "\
-Usage: test [OPTIONS]
-
-Options:
-      --flag-a               first flag
-      --flag-b               second flag
-  -h, --help                 Print help
-      --option-a <OPTION_A>  first option
-      --option-b <OPTION_B>  second option
-  -V, --version              Print version
-";
-
     #[derive(Parser, Debug)]
     #[command(name = "test", version = "1.2")]
     #[command(next_display_order = None)]
@@ -386,7 +376,18 @@ Options:
     let mut cmd = Args::command();
 
     let help = cmd.render_help().to_string();
-    assert_data_eq!(HELP, help);
+    assert_data_eq!(help, str![[r#"
+Usage: test [OPTIONS]
+
+Options:
+      --flag-a               first flag
+      --flag-b               second flag
+  -h, --help                 Print help
+      --option-a <OPTION_A>  first option
+      --option-b <OPTION_B>  second option
+  -V, --version              Print version
+
+"#]]);
 }
 
 #[test]

--- a/tests/derive/utils.rs
+++ b/tests/derive/utils.rs
@@ -65,5 +65,5 @@ pub(crate) fn assert_output<P: clap::Parser + std::fmt::Debug>(
         stderr,
         err.use_stderr()
     );
-    assert_data_eq!(actual, expected);
+    assert_data_eq!(actual, expected.raw());
 }


### PR DESCRIPTION
If we are assuming the arguments are present, then there is no reason to
show alternatives from the group.

There may be other ways large groups show up.
For now, I'm taking the whack-a-mole approach of handling them on a
case-by-case basis.
When we get to one where the group is relevant to show,
we should handle a general case then.

Fixes #5958