### PR TITLE
fix(help): Don't add \n when a flat subcommand has no args

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -880,9 +880,17 @@ impl HelpTemplate<'_, '_> {
                 .or_else(|| subcommand.get_long_about())
                 .unwrap_or_default();
 
-            let _ = write!(self.writer, "{header}{heading}:{header:#}\n",);
+            let _ = write!(self.writer, "{header}{heading}:{header:#}",);
             if !about.is_empty() {
-                let _ = write!(self.writer, "{about}\n",);
+                let _ = write!(self.writer, "\n{about}",);
+            }
+
+            let args = subcommand
+                .get_arguments()
+                .filter(|arg| should_show_arg(self.use_long, arg) && !arg.is_global_set())
+                .collect::<Vec<_>>();
+            if !args.is_empty() {
+                self.writer.push_str("\n");
             }
 
             let mut sub_help = HelpTemplate {
@@ -894,10 +902,6 @@ impl HelpTemplate<'_, '_> {
                 term_w: self.term_w,
                 use_long: self.use_long,
             };
-            let args = subcommand
-                .get_arguments()
-                .filter(|arg| should_show_arg(self.use_long, arg) && !arg.is_global_set())
-                .collect::<Vec<_>>();
             sub_help.write_args(&args, heading, option_sort_key);
             if subcommand.is_flatten_help_set() {
                 sub_help.write_flat_subcommands(subcommand, first);

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -3869,7 +3869,6 @@ greatgrandchild3 command
 parent child1 grandchild1 help:
 Print this message or the help of the given subcommand(s)
 
-
 parent child1 grandchild2:
 grandchild2 command
       --grandchild2 <grandchild>  
@@ -3882,7 +3881,6 @@ grandchild3 command
 
 parent child1 help:
 Print this message or the help of the given subcommand(s)
-
 
 parent child2:
 child2 command


### PR DESCRIPTION
Check to see if a subcommand has arguments and only print the preceding newline if it does.

Fixes #5960.