### PR TITLE
docs: combine NOTE lines that were accidentally split

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -1762,11 +1762,10 @@ impl Arg {
     ///
     /// <div class="warning">
     ///
-    /// **NOTE:** Implicitly sets [`Arg::action(ArgAction::Set)`] [`Arg::num_args(1..)`],
+    /// **NOTE:** Implicitly sets [`Arg::action(ArgAction::Set)`], [`Arg::num_args(1..)`],
+    /// [`Arg::allow_hyphen_values(true)`], and [`Arg::last(true)`] when set to `true`.
     ///
     /// </div>
-    ///
-    /// [`Arg::allow_hyphen_values(true)`], and [`Arg::last(true)`] when set to `true`.
     ///
     /// [`Arg::action(ArgAction::Set)`]: Arg::action()
     /// [`Arg::num_args(1..)`]: Arg::num_args()


### PR DESCRIPTION
Commit 6f78e2a3ff01 split apart the lines of the note, which looks like a mistake.

The documentation looks a little jumbled as a result: https://docs.rs/clap/4.5.35/clap/struct.Arg.html#method.raw

I also added a comma between the first two items.
