### PR TITLE
Revert "feat(help): Only print short when required"

### DIFF
--- a/examples/find.md
+++ b/examples/find.md
@@ -11,9 +11,9 @@ Options:
   -V, --version  Print version
 
 TESTS:
-  --empty        File is empty and is either a regular file or a directory
-  --name <name>  Base of file name (the path with the leading directories removed) matches shell
-                 pattern pattern
+      --empty        File is empty and is either a regular file or a directory
+      --name <name>  Base of file name (the path with the leading directories removed) matches shell
+                     pattern pattern
 
 OPERATORS:
   -o, --or   expr2 is not evaluate if exp1 is true

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -4037,7 +4037,7 @@ Options:
   -h, --help  Print help
 
 Mixed:
-  --long        Long only
+      --long    Long only
   <POSITIONAL>  Positional
 
 "#]];


### PR DESCRIPTION
Concern was raised over the alignment in #5963 and decided to defer this for now.  This wasn't part of the original issue and hadn't been discussed before.

If someone wants to move this forward again, I'd recommend starting with an issue to discuss the trade offs.

This reverts commit 78e41f66665f89ceea5975ab6320cfd4524122f2.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
