### PR TITLE
bash: improve current-word detection

### DIFF
--- a/clap_complete/src/aot/shells/bash.rs
+++ b/clap_complete/src/aot/shells/bash.rs
@@ -25,8 +25,12 @@ impl Generator for Bash {
             "_{name}() {{
     local i cur prev opts cmd
     COMPREPLY=()
-    cur=\"${{COMP_WORDS[COMP_CWORD]}}\"
-    prev=\"${{COMP_WORDS[COMP_CWORD-1]}}\"
+    if [[ \"${{BASH_VERSINFO[0]}}\" -ge 4 ]]; then
+        cur=\"$2\"
+    else
+        cur=\"${{COMP_WORDS[COMP_CWORD]}}\"
+    fi
+    prev=\"$3\"
     cmd=\"\"
     opts=\"\"
 

--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -37,13 +37,17 @@ _clap_complete_NAME() {
     else
         local _CLAP_COMPLETE_SPACE=true
     fi
+    local words=("${COMP_WORDS[@]}")
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        words[COMP_CWORD]="$2"
+    fi
     COMPREPLY=( $( \
         _CLAP_IFS="$IFS" \
         _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
         _CLAP_COMPLETE_COMP_TYPE="$_CLAP_COMPLETE_COMP_TYPE" \
         _CLAP_COMPLETE_SPACE="$_CLAP_COMPLETE_SPACE" \
         VAR="bash" \
-        "COMPLETER" -- "${COMP_WORDS[@]}" \
+        "COMPLETER" -- "${words[@]}" \
     ) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY

--- a/clap_complete/tests/snapshots/aliases.bash
+++ b/clap_complete/tests/snapshots/aliases.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/basic.bash
+++ b/clap_complete/tests/snapshots/basic.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/custom_bin_name.bash
+++ b/clap_complete/tests/snapshots/custom_bin_name.bash
@@ -1,8 +1,12 @@
 _bin-name() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/feature_sample.bash
+++ b/clap_complete/tests/snapshots/feature_sample.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
@@ -10,13 +10,17 @@ _clap_complete_exhaustive() {
     else
         local _CLAP_COMPLETE_SPACE=true
     fi
+    local words=("${COMP_WORDS[@]}")
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        words[COMP_CWORD]="$2"
+    fi
     COMPREPLY=( $( \
         _CLAP_IFS="$IFS" \
         _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
         _CLAP_COMPLETE_COMP_TYPE="$_CLAP_COMPLETE_COMP_TYPE" \
         _CLAP_COMPLETE_SPACE="$_CLAP_COMPLETE_SPACE" \
         COMPLETE="bash" \
-        "exhaustive" -- "${COMP_WORDS[@]}" \
+        "exhaustive" -- "${words[@]}" \
     ) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -3,8 +3,12 @@ PS1='% '
 _exhaustive() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/quoting.bash
+++ b/clap_complete/tests/snapshots/quoting.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/special_commands.bash
+++ b/clap_complete/tests/snapshots/special_commands.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/sub_subcommands.bash
+++ b/clap_complete/tests/snapshots/sub_subcommands.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/subcommand_last.bash
+++ b/clap_complete/tests/snapshots/subcommand_last.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/snapshots/value_terminator.bash
+++ b/clap_complete/tests/snapshots/value_terminator.bash
@@ -1,8 +1,12 @@
 _my-app() {
     local i cur prev opts cmd
     COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
     cmd=""
     opts=""
 

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -195,14 +195,16 @@ fn complete() {
     // Type in "bx", press left arrow, then trigger completion
     let input = "exhaustive quote --choice bx\x1b[D\t";
     let expected =
-        snapbox::str!["exhaustive quote --choice bx^[[D        % exhaustive quote --choice bx"];
+        snapbox::str!["exhaustive quote --choice bx^[[D        % exhaustive quote --choice bashx"];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
     // Trigger completion from empty space
-    let input = "exhaustive quote --choice  b\x1b[D\x1b[D\t";
-    let expected =
-        snapbox::str!["exhaustive quote --choice  b^[[D^[[D    % exhaustive quote --choice bash b"];
+    let input = "exhaustive quote --choice  b\x1b[D\x1b[D\t\t";
+    let expected = snapbox::str![[r#"
+% 
+another  shell    bash     fish     zsh      
+"#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
@@ -331,7 +333,12 @@ fn complete_dynamic_env_option_value() {
     let mut runtime = common::load_runtime::<RuntimeBuilder>("dynamic-env", "exhaustive");
 
     let input = "exhaustive action --choice=\t\t";
-    let expected = snapbox::str!["% "];
+    let expected = snapbox::str![
+        r#"
+% 
+first   second  
+"#
+    ];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
@@ -413,7 +420,8 @@ fn complete_dynamic_quoted_word() {
     let mut runtime = common::load_runtime::<RuntimeBuilder>("dynamic-env", "exhaustive");
 
     let input = "exhaustive quote --choice 'b\t";
-    let expected = snapbox::str!["exhaustive quote --choice 'b    % exhaustive quote --choice 'b"];
+    let expected =
+        snapbox::str!["exhaustive quote --choice 'b    % exhaustive quote --choice 'bash' "];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }
@@ -432,14 +440,16 @@ fn complete_dynamic_middle_of_word() {
     // Type in "bx", press left arrow, then trigger completion
     let input = "exhaustive quote --choice bx\x1b[D\t";
     let expected =
-        snapbox::str!["exhaustive quote --choice bx^[[D        % exhaustive quote --choice bx"];
+        snapbox::str!["exhaustive quote --choice bx^[[D        % exhaustive quote --choice bashx"];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
     // Trigger completion from empty space
-    let input = "exhaustive quote --choice  b\x1b[D\x1b[D\t";
-    let expected =
-        snapbox::str!["exhaustive quote --choice  b^[[D^[[D    % exhaustive quote --choice bash b"];
+    let input = "exhaustive quote --choice  b\x1b[D\x1b[D\t\t";
+    let expected = snapbox::str![[r#"
+% 
+another shell  bash           fish           zsh            
+"#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }


### PR DESCRIPTION
Fixes #5979, along with a few other issues:

- Dynamic completion didn't work properly when the argument is quoted (e.g. `exhaustive 'hi`) — static completion works because `compgen` apparently ignores leading quotes in the input word
- Both static and dynamic completion gave wrong results when the cursor was not at the end of the word (e.g. `exhaustive --h⇥XYZ` should result in `cargo --helpXYZ`, where `⇥` represents the position the cursor should be when pressing Tab)

The fix for static completion is fairly straightforward: rather than `cur="${COMP_WORDS[COMP_CWORD]}"`, we use `cur="$2"`. `$2` omits leading quotes (which are inserted back by Bash automatically) and only returns the word up until the cursor point. The latter point is what also addresses #5979.

I couldn't find any downsides to this in Bash 4+ — back in 3.x days `$COMP_WORDS` would ignore `$COMP_WORDBREAKS`, so this was a way to e.g. capture `--foo=`, but sadly Bash's behavior keeps changing in subtle ways. I included a conditional to keep old behavior for <4, as it seems the least bad option.

The change for dynamic completion, though, is quite the hack — to keep the same contract and minimize impact, I still pass `$COMP_WORDS` as arguments to the binary, but replace `$COMP_WORDS[$COMP_CWORD]` with `$2`. For the common case (cursor at the last position) everything I said for static completion still applies, but otherwise it does destroy some information — for example, if the user types `exhaustive hint ⇥ --dir /foo`, the binary will receive the arguments `["exhaustive", "hint", "", "/foo"]`, completely missing `--dir`. No issue for completers that don't inspect the argument list, but if `--dir /foo` was for example relevant for context, it wouldn't be parsed. This can be worked around by injecting `${COMP_LINE:$COMP_POINT}` until the rest of the word as a new item in the array, but I found it caused a few other corner cases, so I'm not sure it's worth the trouble.

Completely by accident, this also partially, arguably improves `--foo=` Bash ≥4 — the binary now receives `["--foo", ""]` and has one shot at providing a completion. If any character is entered, however, `--foo=b` turns into `["--foo", "=", "b"]`, and stops working again. I'm afraid the way to *properly* solve this along with the previously mentioned loss of data is to parse `$COMP_LINE`, as was previously discussed on #5512.
