### PR TITLE
fix: minor fix for builder docs (help -> version)

### DIFF
--- a/clap_builder/src/builder/action.rs
+++ b/clap_builder/src/builder/action.rs
@@ -341,11 +341,11 @@ pub enum ArgAction {
     ///             .action(clap::ArgAction::Version)
     ///     );
     ///
-    /// // Existing help still exists
+    /// // Existing version still exists
     /// let err = cmd.clone().try_get_matches_from(["mycmd", "--version"]).unwrap_err();
     /// assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
     ///
-    /// // New help available
+    /// // New version available
     /// let err = cmd.try_get_matches_from(["mycmd", "--special-version"]).unwrap_err();
     /// assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
     /// ```


### PR DESCRIPTION
Fixed the doc comment in the builder.
The fixed part appears to be `version`, not `help`.   

I created a PR without an associated issue because this seems to be an obvious and simple mistake. 

edited: sorry for forgetting `committed`