### PR TITLE
feat(help): Prefix argument long and short aliases in output with `--` and `-`

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -789,7 +789,7 @@ impl HelpTemplate<'_, '_> {
             .aliases
             .iter()
             .filter(|&als| als.1) // visible
-            .map(|als| als.0.as_str()) // name
+            .map(|als| format!("--{}", als.0)) // name
             .collect::<Vec<_>>()
             .join(", ");
         if !als.is_empty() {

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -801,7 +801,7 @@ impl HelpTemplate<'_, '_> {
             .short_aliases
             .iter()
             .filter(|&als| als.1) // visible
-            .map(|&als| als.0.to_string()) // name
+            .map(|&als| format!("-{}", als.0)) // name
             .collect::<Vec<_>>()
             .join(", ");
         if !als.is_empty() {

--- a/tests/builder/arg_aliases.rs
+++ b/tests/builder/arg_aliases.rs
@@ -226,8 +226,8 @@ Some help
 Usage: ct test [OPTIONS]
 
 Options:
-  -o, --opt <opt>  [aliases: visible]
-  -f, --flag       [aliases: v_flg, flag2, flg3]
+  -o, --opt <opt>  [aliases: --visible]
+  -f, --flag       [aliases: --v_flg, --flag2, --flg3]
   -h, --help       Print help
   -V, --version    Print version
 ";

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -193,8 +193,8 @@ Some help
 Usage: ct test [OPTIONS]
 
 Options:
-  -o, --opt <opt>  [short aliases: v]
-  -f, --flag       [aliases: --flag1] [short aliases: a, b, 🦆]
+  -o, --opt <opt>  [short aliases: -v]
+  -f, --flag       [aliases: --flag1] [short aliases: -a, -b, -🦆]
   -h, --help       Print help
   -V, --version    Print version
 ";

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -194,7 +194,7 @@ Usage: ct test [OPTIONS]
 
 Options:
   -o, --opt <opt>  [short aliases: v]
-  -f, --flag       [aliases: flag1] [short aliases: a, b, 🦆]
+  -f, --flag       [aliases: --flag1] [short aliases: a, b, 🦆]
   -h, --help       Print help
   -V, --version    Print version
 ";


### PR DESCRIPTION
Fixes #5997.