### PR TITLE
feat(clap-complete/unstable-dynamic): add '~' to HOME dir completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,7 @@ dependencies = [
  "clap_lex 0.7.4",
  "completest",
  "completest-pty",
+ "home",
  "is_executable",
  "shlex",
  "snapbox",

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -40,6 +40,7 @@ is_executable = { version = "1.0.1", optional = true }
 shlex = { version = "1.3.0", optional = true }
 completest = { version = "0.4.2", optional = true }
 completest-pty = { version = "0.5.5", optional = true }
+home = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 snapbox = { version = "0.6.0", features = ["diff", "dir", "examples"] }
@@ -55,7 +56,7 @@ required-features = ["unstable-dynamic"]
 [features]
 default = []
 unstable-doc = ["unstable-dynamic"] # for docs.rs
-unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:is_executable", "clap/unstable-ext"]
+unstable-dynamic = ["dep:clap_lex", "dep:shlex", "dep:is_executable", "dep:home", "clap/unstable-ext"]
 unstable-shell-tests = ["dep:completest", "dep:completest-pty"]
 debug = ["clap/debug"]
 


### PR DESCRIPTION
if input starts with '~' will complete to `/home/USER`

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
