### PR TITLE
feat(help): Merge lists of short and long aliases

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -786,6 +786,21 @@ impl HelpTemplate<'_, '_> {
         }
 
         let als = a
+            .short_aliases
+            .iter()
+            .filter(|&als| als.1) // visible
+            .map(|als| format!("-{}", als.0)) // name
+            .collect::<Vec<_>>()
+            .join(", ");
+        if !als.is_empty() {
+            debug!(
+                "HelpTemplate::spec_vals: Found short aliases...{:?}",
+                a.short_aliases
+            );
+            spec_vals.push(format!("[short aliases: {als}]"));
+        }
+
+        let als = a
             .aliases
             .iter()
             .filter(|&als| als.1) // visible
@@ -795,21 +810,6 @@ impl HelpTemplate<'_, '_> {
         if !als.is_empty() {
             debug!("HelpTemplate::spec_vals: Found aliases...{:?}", a.aliases);
             spec_vals.push(format!("[aliases: {als}]"));
-        }
-
-        let als = a
-            .short_aliases
-            .iter()
-            .filter(|&als| als.1) // visible
-            .map(|&als| format!("-{}", als.0)) // name
-            .collect::<Vec<_>>()
-            .join(", ");
-        if !als.is_empty() {
-            debug!(
-                "HelpTemplate::spec_vals: Found short aliases...{:?}",
-                a.short_aliases
-            );
-            spec_vals.push(format!("[short aliases: {als}]"));
         }
 
         if !a.is_hide_possible_values_set() && !self.use_long_pv(a) {

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -785,31 +785,29 @@ impl HelpTemplate<'_, '_> {
             spec_vals.push(format!("[default: {pvs}]"));
         }
 
-        let als = a
+        let mut als = Vec::new();
+
+        let short_als = a
             .short_aliases
             .iter()
             .filter(|&als| als.1) // visible
-            .map(|als| format!("-{}", als.0)) // name
-            .collect::<Vec<_>>()
-            .join(", ");
-        if !als.is_empty() {
-            debug!(
-                "HelpTemplate::spec_vals: Found short aliases...{:?}",
-                a.short_aliases
-            );
-            spec_vals.push(format!("[short aliases: {als}]"));
-        }
+            .map(|als| format!("-{}", als.0)); // name
+        debug!(
+            "HelpTemplate::spec_vals: Found short aliases...{:?}",
+            a.short_aliases
+        );
+        als.extend(short_als);
 
-        let als = a
+        let long_als = a
             .aliases
             .iter()
             .filter(|&als| als.1) // visible
-            .map(|als| format!("--{}", als.0)) // name
-            .collect::<Vec<_>>()
-            .join(", ");
+            .map(|als| format!("--{}", als.0)); // name
+        debug!("HelpTemplate::spec_vals: Found aliases...{:?}", a.aliases);
+        als.extend(long_als);
+
         if !als.is_empty() {
-            debug!("HelpTemplate::spec_vals: Found aliases...{:?}", a.aliases);
-            spec_vals.push(format!("[aliases: {als}]"));
+            spec_vals.push(format!("[aliases: {}]", als.join(", ")));
         }
 
         if !a.is_hide_possible_values_set() && !self.use_long_pv(a) {

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -194,7 +194,7 @@ Usage: ct test [OPTIONS]
 
 Options:
   -o, --opt <opt>  [short aliases: -v]
-  -f, --flag       [aliases: --flag1] [short aliases: -a, -b, -🦆]
+  -f, --flag       [short aliases: -a, -b, -🦆] [aliases: --flag1]
   -h, --help       Print help
   -V, --version    Print version
 ";

--- a/tests/builder/arg_aliases_short.rs
+++ b/tests/builder/arg_aliases_short.rs
@@ -193,8 +193,8 @@ Some help
 Usage: ct test [OPTIONS]
 
 Options:
-  -o, --opt <opt>  [short aliases: -v]
-  -f, --flag       [short aliases: -a, -b, -🦆] [aliases: --flag1]
+  -o, --opt <opt>  [aliases: -v]
+  -f, --flag       [aliases: -a, -b, -🦆, --flag1]
   -h, --help       Print help
   -V, --version    Print version
 ";


### PR DESCRIPTION
Short aliases are displayed before long aliases, consistent with the order of the short and long argument variants at the start of each line.

Based on [this suggestion][1] from @epage.

[1]: https://github.com/clap-rs/clap/pull/5996#discussion_r2083363726