### PR TITLE
test(complete): Illustrate current behavior in zsh

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -370,7 +370,7 @@ function _clap_dynamic_completer_NAME() {
         _CLAP_IFS="$_CLAP_IFS" \
         _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
         VAR="zsh" \
-        COMPLETER -- ${words} 2>/dev/null \
+        COMPLETER -- "${words[@]}" 2>/dev/null \
     )}")
 
     if [[ -n $completions ]]; then

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
@@ -7,7 +7,7 @@ function _clap_dynamic_completer_exhaustive() {
         _CLAP_IFS="$_CLAP_IFS" \
         _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
         COMPLETE="zsh" \
-        exhaustive -- ${words} 2>/dev/null \
+        exhaustive -- "${words[@]}" 2>/dev/null \
     )}")
 
     if [[ -n $completions ]]; then

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -342,7 +342,19 @@ fn complete_dynamic_empty_space() {
 
     // Press left arrow twice to place cursor between the two spaces
     let input = "exhaustive quote  -\x1b[D\x1b[D\t\t";
-    let expected = snapbox::str!["% exhaustive quote - -"];
+    let expected = snapbox::str![[r#"
+% exhaustive quote  -
+--help                              -- Print help (see more with '--help')                                            
+cmd-backslash      --backslash      -- Avoid '/n'                                                                     
+cmd-backticks      --backticks      -- For more information see `echo test`                                           
+cmd-brackets       --brackets       -- List packages [filter]                                                         
+cmd-double-quotes  --double-quotes  -- Can be "always", "auto", or "never"                                            
+cmd-expansions     --expansions     -- Execute the shell command with $SHELL                                          
+cmd-single-quotes  --single-quotes  -- Can be 'always', 'auto', or 'never'                                            
+escape-help                         -- /tab/t"'                                                                       
+help                                -- Print this message or the help of the given subcommand(s)                      
+--choice
+"#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -328,3 +328,21 @@ fn complete_dynamic_empty_option_value() {
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }
+
+#[test]
+#[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
+fn complete_dynamic_empty_space() {
+    if !common::has_command(CMD) {
+        return;
+    }
+
+    let term = completest::Term::new();
+    let mut runtime = common::load_runtime::<RuntimeBuilder>("dynamic-env", "exhaustive");
+
+    // Press left arrow twice to place cursor between the two spaces
+    let input = "exhaustive quote  -\x1b[D\x1b[D\t\t";
+    let expected = snapbox::str!["% exhaustive quote - -"];
+    let actual = runtime.complete(input, &term).unwrap();
+    assert_data_eq!(actual, expected);
+}


### PR DESCRIPTION
Fixes #5979 for good.

I'm not familiar with zsh, and its completion engine is *completely* different from Bash's, but my experiments suggest it's really just a case of proper array expansion, which is more or less the same thing on both shells.
