### PR TITLE
Cleanup docs.rs related issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ include.workspace = true
 
 [package.metadata.docs.rs]
 features = ["unstable-doc"]
-rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.playground]
 features = ["unstable-doc"]

--- a/clap_builder/Cargo.toml
+++ b/clap_builder/Cargo.toml
@@ -18,7 +18,7 @@ include.workspace = true
 
 [package.metadata.docs.rs]
 features = ["unstable-doc"]
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--generate-link-to-definition"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [package.metadata.playground]

--- a/clap_complete/Cargo.toml
+++ b/clap_complete/Cargo.toml
@@ -17,7 +17,7 @@ include.workspace = true
 
 [package.metadata.docs.rs]
 features = ["unstable-doc"]
-rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
+rustdoc-args = ["--generate-link-to-definition"]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 
 [package.metadata.release]

--- a/src/_tutorial.rs
+++ b/src/_tutorial.rs
@@ -161,8 +161,8 @@
 //! ### Enumerated values
 //!
 //! If you have arguments of specific values you want to test for, you can use the
-//! [`PossibleValuesParser`][crate::builder::PossibleValuesParser] or [`Arg::value_parser(["val1",
-//! ...])`][crate::Arg::value_parser] for short.
+//! [`PossibleValuesParser`] or [`Arg::value_parser(["val1", ...])`][crate::Arg::value_parser]
+//! for short.
 //!
 //! This allows you to specify the valid values for that argument. If the user does not use one of
 //! those specific values, they will receive a graceful exit with error message informing them


### PR DESCRIPTION
This PR fixes an intra-doc link warning and remove unneeded `--cfg=docsrs` set in `Cargo.toml` files.

Also: the `--generate-link-to-definition` currently doesn't work and I think it's because docs.rs related values are not read in workspace `Cargo.toml` files. I think it should be declared in all sub-`Cargo.toml` files.