### PR TITLE
Add missing `--generate-link-to-definition` docs.rs options

### DIFF
--- a/clap_complete_nushell/Cargo.toml
+++ b/clap_complete_nushell/Cargo.toml
@@ -17,6 +17,7 @@ include.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -18,6 +18,7 @@ include.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.release]
 shared-version = true

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -17,6 +17,7 @@ include.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--generate-link-to-definition"]
 
 [package.metadata.release]
 pre-release-replacements = [


### PR DESCRIPTION
Follow-up of https://github.com/clap-rs/clap/pull/6045.

Hopefully it should make the option work on docs.rs once next version of `clap` is published.