### PR TITLE
fix: clap_man doesn't render optional values with [=<VALUE>]

### DIFF
--- a/clap_mangen/tests/snapshots/multiple_optional_values.bash.roff
+++ b/clap_mangen/tests/snapshots/multiple_optional_values.bash.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-config\fR=\fIFILE1 FILE2\fR
+Optional config file
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/multiple_optional_values.bash.roff
+++ b/clap_mangen/tests/snapshots/multiple_optional_values.bash.roff
@@ -8,7 +8,7 @@ my\-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-\fB\-\-config\fR=\fIFILE1 FILE2\fR
+\fB\-\-config\fR [\fI<FILE1>\fR\fI \fR\fI<FILE2>\fR]
 Optional config file
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/clap_mangen/tests/snapshots/optional_value.bash.roff
+++ b/clap_mangen/tests/snapshots/optional_value.bash.roff
@@ -8,7 +8,7 @@ my\-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-\fB\-\-config\fR=\fIFILE\fR
+\fB\-\-config\fR [\fI<FILE>\fR]
 Optional config file
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/clap_mangen/tests/snapshots/optional_value.bash.roff
+++ b/clap_mangen/tests/snapshots/optional_value.bash.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-config\fR=\fIFILE\fR
+Optional config file
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/optional_with_required_equals_value.bash.roff
+++ b/clap_mangen/tests/snapshots/optional_with_required_equals_value.bash.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-config\fR=\fIFILE\fR
+Optional config file
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/optional_with_required_equals_value.bash.roff
+++ b/clap_mangen/tests/snapshots/optional_with_required_equals_value.bash.roff
@@ -8,7 +8,7 @@ my\-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-\fB\-\-config\fR=\fIFILE\fR
+\fB\-\-config\fR[=\fI<FILE>\fR]
 Optional config file
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/clap_mangen/tests/snapshots/value_with_required_equals.bash.roff
+++ b/clap_mangen/tests/snapshots/value_with_required_equals.bash.roff
@@ -8,7 +8,7 @@ my\-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-\fB\-\-config\fR=\fIFILE\fR
+\fB\-\-config\fR=\fI<FILE>\fR
 Optional config file
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/clap_mangen/tests/snapshots/value_with_required_equals.bash.roff
+++ b/clap_mangen/tests/snapshots/value_with_required_equals.bash.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-config\fR=\fIFILE\fR
+Optional config file
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/variadic_values.bash.roff
+++ b/clap_mangen/tests/snapshots/variadic_values.bash.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-config\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-config\fR=\fIFILE1 FILE2\fR
+Optional config file
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/variadic_values.bash.roff
+++ b/clap_mangen/tests/snapshots/variadic_values.bash.roff
@@ -8,7 +8,7 @@ my\-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-\fB\-\-config\fR=\fIFILE1 FILE2\fR
+\fB\-\-config\fR \fI<FILE1>\fR\fI \fR\fI<FILE2>...\fR
 Optional config file
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -354,3 +354,60 @@ pub(crate) fn help_headings(name: &'static str) -> clap::Command {
                 .value_parser(["always", "never", "auto"]),
         )
 }
+
+pub(crate) fn value_with_required_equals(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+    .arg(
+        clap::Arg::new("config")
+            .long("config")
+            .value_name("FILE")
+            .require_equals(true)
+            .help("Optional config file"),
+    )
+}
+
+pub(crate) fn optional_value_with_required_equals(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+    .arg(
+        clap::Arg::new("config")
+            .long("config")
+            .value_name("FILE")
+            .require_equals(true)
+            .num_args(0..=1)
+            .help("Optional config file"),
+    )
+}
+
+pub(crate) fn optional_value(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+    .arg(
+        clap::Arg::new("config")
+            .long("config")
+            .value_name("FILE")
+            .num_args(0..=1)
+            .help("Optional config file"),
+    )
+}
+
+pub(crate) fn multiple_optional_values(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+    .arg(
+        clap::Arg::new("config")
+            .long("config")
+            .value_names(["FILE1", "FILE2"])
+            .num_args(0..=2)
+            .help("Optional config file"),
+    )
+}
+
+pub(crate) fn variadic_values(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+    .arg(
+        clap::Arg::new("config")
+            .long("config")
+            .value_names(["FILE1", "FILE2"])
+            .require_equals(false)
+            .num_args(3)
+            .help("Optional config file"),
+    )
+}

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -112,3 +112,53 @@ fn value_name_without_arg() {
         cmd,
     );
 }
+
+#[test]
+fn value_with_required_equals() {
+    let name = "my-app";
+    let cmd = common::value_with_required_equals(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/value_with_required_equals.bash.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn optional_value_with_required_equals() {
+    let name = "my-app";
+    let cmd = common::optional_value_with_required_equals(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/optional_with_required_equals_value.bash.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn optional_value() {
+    let name = "my-app";
+    let cmd = common::optional_value(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/optional_value.bash.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn multiple_optional_values() {
+    let name = "my-app";
+    let cmd = common::multiple_optional_values(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/multiple_optional_values.bash.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn variadic_values() {
+    let name = "my-app";
+    let cmd = common::variadic_values(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/variadic_values.bash.roff"],
+        cmd,
+    );
+}


### PR DESCRIPTION
In #3358 we discovered clapmangen wouldn’t render optional `required_equals` values with `[=<VALUE>]`. After further experimentation it was also found out that it didn’t appropriately render optional values `[VALUE]` and variadic values `<Val>…`  as well. This commit adds a check to the options render section where it will add the correct formatting. e.g instead of

`--option=VALUE` it will render `—option \<VALUE\>`, `—option [VALUE]`
`--option[=VALUE]` or option `<VALUE>…` and so on

Bringing it more in line with what clap shows when running --help. 

Fixes #3358