### PR TITLE
feat(complete): Only complete flags in PowerShell when word starts with `-`

### DIFF
--- a/clap_complete/src/aot/shells/powershell.rs
+++ b/clap_complete/src/aot/shells/powershell.rs
@@ -53,6 +53,10 @@ Register-ArgumentCompleter -Native -CommandName '{bin_name}' -ScriptBlock {{
     $completions = @(switch ($command) {{{subcommands_cases}
     }})
 
+    if ($wordToComplete -notlike "-*") {{
+        $completions = $completions.Where{{ $_.CompletionText -notlike "-*" }}
+    }}
+
     $completions.Where{{ $_.CompletionText -like "$wordToComplete*" }} |
         Sort-Object -Property ListItemText
 }}

--- a/clap_complete/tests/snapshots/aliases.ps1
+++ b/clap_complete/tests/snapshots/aliases.ps1
@@ -37,6 +37,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/basic.ps1
+++ b/clap_complete/tests/snapshots/basic.ps1
@@ -49,6 +49,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/custom_bin_name.ps1
+++ b/clap_complete/tests/snapshots/custom_bin_name.ps1
@@ -49,6 +49,10 @@ Register-ArgumentCompleter -Native -CommandName 'bin-name' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/external_subcommands.ps1
+++ b/clap_complete/tests/snapshots/external_subcommands.ps1
@@ -45,6 +45,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/feature_sample.ps1
+++ b/clap_complete/tests/snapshots/feature_sample.ps1
@@ -54,6 +54,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/home/static/exhaustive/powershell/powershell/Microsoft.PowerShell_profile.ps1
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/powershell/powershell/Microsoft.PowerShell_profile.ps1
@@ -356,6 +356,10 @@ Register-ArgumentCompleter -Native -CommandName 'exhaustive' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/quoting.ps1
+++ b/clap_complete/tests/snapshots/quoting.ps1
@@ -103,6 +103,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/special_commands.ps1
+++ b/clap_complete/tests/snapshots/special_commands.ps1
@@ -91,6 +91,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/sub_subcommands.ps1
+++ b/clap_complete/tests/snapshots/sub_subcommands.ps1
@@ -120,6 +120,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/subcommand_last.ps1
+++ b/clap_complete/tests/snapshots/subcommand_last.ps1
@@ -55,6 +55,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.ps1
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.ps1
@@ -27,6 +27,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/value_hint.ps1
+++ b/clap_complete/tests/snapshots/value_hint.ps1
@@ -47,6 +47,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }

--- a/clap_complete/tests/snapshots/value_terminator.ps1
+++ b/clap_complete/tests/snapshots/value_terminator.ps1
@@ -27,6 +27,10 @@ Register-ArgumentCompleter -Native -CommandName 'my-app' -ScriptBlock {
         }
     })
 
+    if ($wordToComplete -notlike "-*") {
+        $completions = $completions.Where{ $_.CompletionText -notlike "-*" }
+    }
+
     $completions.Where{ $_.CompletionText -like "$wordToComplete*" } |
         Sort-Object -Property ListItemText
 }


### PR DESCRIPTION
In PowerShell, built-in completion system only completes parameter (flag) names when you type a `-` (dash), otherwise it assumes that you're entering a positional parameter value (or a subcommand). The completion script generated by `clap_complete` does not replicate this behavior, which feels out-of-place compared to the built-in completers.

This PR fixes the behavior to match built-in PowerShell completions.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
