### PR TITLE
test(derive): Rely on snapshot testing

### DIFF
--- a/tests/derive/app_name.rs
+++ b/tests/derive/app_name.rs
@@ -1,5 +1,8 @@
 use clap::CommandFactory;
 use clap::Parser;
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
 
 use crate::utils::get_help;
 use crate::utils::get_long_help;
@@ -12,7 +15,13 @@ fn app_name_in_short_help_from_struct() {
 
     let help = get_help::<MyApp>();
 
-    assert!(help.contains("my-cmd"));
+    assert_data_eq!(help, str![[r#"
+Usage: my-cmd
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -23,7 +32,13 @@ fn app_name_in_long_help_from_struct() {
 
     let help = get_help::<MyApp>();
 
-    assert!(help.contains("my-cmd"));
+    assert_data_eq!(help, str![[r#"
+Usage: my-cmd
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -34,7 +49,13 @@ fn app_name_in_short_help_from_enum() {
 
     let help = get_help::<MyApp>();
 
-    assert!(help.contains("my-cmd"));
+    assert_data_eq!(help, str![[r#"
+Usage: my-cmd
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -45,7 +66,14 @@ fn app_name_in_long_help_from_enum() {
 
     let help = get_long_help::<MyApp>();
 
-    assert!(help.contains("my-cmd"));
+    assert_data_eq!(help, str![[r#"
+Usage: my-cmd
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -56,7 +84,10 @@ fn app_name_in_short_version_from_struct() {
 
     let version = MyApp::command().render_version();
 
-    assert!(version.contains("my-cmd"));
+    assert_data_eq!(version, str![[r#"
+my-cmd 
+
+"#]].raw());
 }
 
 #[test]
@@ -67,7 +98,10 @@ fn app_name_in_long_version_from_struct() {
 
     let version = MyApp::command().render_long_version();
 
-    assert!(version.contains("my-cmd"));
+    assert_data_eq!(version, str![[r#"
+my-cmd 
+
+"#]].raw());
 }
 
 #[test]
@@ -78,7 +112,10 @@ fn app_name_in_short_version_from_enum() {
 
     let version = MyApp::command().render_version();
 
-    assert!(version.contains("my-cmd"));
+    assert_data_eq!(version, str![[r#"
+my-cmd 
+
+"#]].raw());
 }
 
 #[test]
@@ -89,5 +126,8 @@ fn app_name_in_long_version_from_enum() {
 
     let version = MyApp::command().render_long_version();
 
-    assert!(version.contains("my-cmd"));
+    assert_data_eq!(version, str![[r#"
+my-cmd 
+
+"#]].raw());
 }

--- a/tests/derive/arguments.rs
+++ b/tests/derive/arguments.rs
@@ -12,9 +12,12 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Parser;
-
 use crate::utils::get_help;
+
+use clap::Parser;
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
 
 #[test]
 fn required_argument() {
@@ -54,7 +57,17 @@ fn auto_value_name() {
 
     let help = get_help::<Opt>();
 
-    assert!(help.contains("MY_SPECIAL_ARG"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <MY_SPECIAL_ARG>
+
+Arguments:
+  <MY_SPECIAL_ARG>  
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
+
     // Ensure the implicit `num_vals` is just 1
     assert_eq!(
         Opt { my_special_arg: 10 },
@@ -72,8 +85,17 @@ fn explicit_value_name() {
 
     let help = get_help::<Opt>();
 
-    assert!(help.contains("BROWNIE_POINTS"));
-    assert!(!help.contains("MY_SPECIAL_ARG"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <BROWNIE_POINTS>
+
+Arguments:
+  <BROWNIE_POINTS>  
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
+
     // Ensure the implicit `num_vals` is just 1
     assert_eq!(
         Opt { my_special_arg: 10 },

--- a/tests/derive/author_version_about.rs
+++ b/tests/derive/author_version_about.rs
@@ -12,9 +12,12 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use crate::utils;
-
 use clap::Parser;
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
+
+use crate::utils;
 
 #[test]
 fn no_author_version_about() {
@@ -35,9 +38,20 @@ fn use_env() {
     struct Opt {}
 
     let output = utils::get_long_help::<Opt>();
-    assert!(output.starts_with("clap"));
-    assert!(output
-        .contains("A simple to use, efficient, and full-featured Command Line Argument Parser"));
+    assert_data_eq!(output, str![[r#"
+clap 4.5.43
+A simple to use, efficient, and full-featured Command Line Argument Parser
+
+Usage: clap
+
+Options:
+  -h, --help
+          Print help
+
+  -V, --version
+          Print version
+
+"#]].raw());
 }
 
 #[test]
@@ -50,5 +64,17 @@ fn explicit_version_not_str_lit() {
     pub(crate) struct Opt {}
 
     let output = utils::get_long_help::<Opt>();
-    assert!(output.contains("custom version"));
+    assert_data_eq!(output, str![[r#"
+clap custom version
+
+Usage: clap
+
+Options:
+  -h, --help
+          Print help
+
+  -V, --version
+          Print version
+
+"#]].raw());
 }

--- a/tests/derive/custom_string_parsers.rs
+++ b/tests/derive/custom_string_parsers.rs
@@ -12,10 +12,13 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use clap::Parser;
-
 use std::num::ParseIntError;
 use std::path::PathBuf;
+
+use clap::Parser;
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
 
 #[derive(Parser, PartialEq, Debug)]
 struct PathOpt {
@@ -82,11 +85,12 @@ fn test_parse_hex() {
     );
 
     let err = HexOpt::try_parse_from(["test", "-n", "gg"]).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid digit found in string"),
-        "{}",
-        err
-    );
+    assert_data_eq!(err.to_string(), str![[r#"
+error: invalid value 'gg' for '-n <NUMBER>': invalid digit found in string
+
+For more information, try '--help'.
+
+"#]].raw());
 }
 
 #[derive(Debug)]

--- a/tests/derive/default_value.rs
+++ b/tests/derive/default_value.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser};
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
 
 use crate::utils;
 
@@ -15,7 +18,18 @@ fn default_value() {
     assert_eq!(Opt { arg: 1 }, Opt::try_parse_from(["test", "1"]).unwrap());
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("[default: 3]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap [ARG]
+
+Arguments:
+  [ARG]
+          [default: 3]
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -29,7 +43,18 @@ fn default_value_t() {
     assert_eq!(Opt { arg: 1 }, Opt::try_parse_from(["test", "1"]).unwrap());
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("[default: 3]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap [ARG]
+
+Arguments:
+  [ARG]
+          [default: 3]
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -43,7 +68,18 @@ fn auto_default_value_t() {
     assert_eq!(Opt { arg: 1 }, Opt::try_parse_from(["test", "1"]).unwrap());
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("[default: 0]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap [ARG]
+
+Arguments:
+  [ARG]
+          [default: 0]
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -103,7 +139,33 @@ fn default_values_t() {
     );
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("[default: 1 2 3]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap [OPTIONS] [ARG1]...
+
+Arguments:
+  [ARG1]...
+          [default: 1 2 3]
+
+Options:
+      --arg2 <ARG2>
+          [default: 4 5 6]
+
+      --arg3 <ARG3>
+          [default: 7 8 9]
+
+      --arg4 <ARG4>
+          [default: 10 11 12]
+
+      --arg5 <ARG5>
+          [default: hello world]
+
+      --arg6 <ARG6>
+          [default: foo bar]
+
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -127,7 +189,18 @@ fn default_value_os_t() {
     );
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("[default: abc.def]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap [ARG]
+
+Arguments:
+  [ARG]
+          [default: abc.def]
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -161,7 +234,21 @@ fn default_values_os_t() {
     );
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("[default: abc.def 123.foo]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap [OPTIONS] [ARG1]...
+
+Arguments:
+  [ARG1]...
+          [default: abc.def 123.foo]
+
+Options:
+      --arg2 <ARG2>
+          [default: bar.baz]
+
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]

--- a/tests/derive/explicit_name_no_renaming.rs
+++ b/tests/derive/explicit_name_no_renaming.rs
@@ -1,6 +1,9 @@
-use crate::utils;
-
 use clap::Parser;
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
+
+use crate::utils;
 
 #[test]
 fn explicit_short_long_no_rename() {
@@ -32,5 +35,16 @@ fn explicit_name_no_rename() {
     }
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("<.options>"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <.options>
+
+Arguments:
+  <.options>
+          
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }

--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -12,9 +12,12 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use crate::utils;
-
 use clap::{Args, Parser, Subcommand};
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
+
+use crate::utils;
 
 #[test]
 fn flatten() {
@@ -211,8 +214,16 @@ fn flatten_with_doc_comment() {
     );
 
     let help = utils::get_help::<Opt>();
-    assert!(help.contains("This is an arg."));
-    assert!(!help.contains("The very important"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <ARG>
+
+Arguments:
+  <ARG>  This is an arg. Arg means "argument". Command line argument
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -233,7 +244,16 @@ fn docstrings_ordering_with_multiple_command() {
 
     let short_help = utils::get_help::<Command>();
 
-    assert!(short_help.contains("This is the docstring for Command"));
+    assert_data_eq!(short_help, str![[r#"
+This is the docstring for Command
+
+Usage: clap [OPTIONS]
+
+Options:
+      --foo   
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -253,7 +273,16 @@ fn docstrings_ordering_with_multiple_clap_partial() {
 
     let short_help = utils::get_help::<Command>();
 
-    assert!(short_help.contains("This is the docstring for Flattened"));
+    assert_data_eq!(short_help, str![[r#"
+This is the docstring for Flattened
+
+Usage: clap [OPTIONS]
+
+Options:
+      --foo   
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]

--- a/tests/derive/issues.rs
+++ b/tests/derive/issues.rs
@@ -1,8 +1,11 @@
 // https://github.com/TeXitoi/structopt/issues/{NUMBER}
 
-use crate::utils;
-
 use clap::{ArgGroup, Args, Parser, Subcommand};
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
+
+use crate::utils;
 
 #[test]
 fn issue_151_groups_within_subcommands() {
@@ -72,7 +75,23 @@ fn issue_324() {
     }
 
     let help = utils::get_long_help::<Opt>();
-    assert!(help.contains("MY_VERSION"));
+    assert_data_eq!(help, str![[r#"
+clap MY_VERSION
+
+Usage: clap <COMMAND>
+
+Commands:
+  start  
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help
+
+  -V, --version
+          Print version
+
+"#]].raw());
 }
 
 #[test]
@@ -98,7 +117,19 @@ fn issue_418() {
     }
 
     let help = utils::get_long_help::<Opts>();
-    assert!(help.contains("Reticulate the splines [aliases: ret]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <COMMAND>
+
+Commands:
+  reticulate  Reticulate the splines [aliases: ret]
+  frobnicate  Frobnicate the rest [aliases: frob]
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]

--- a/tests/derive/non_literal_attributes.rs
+++ b/tests/derive/non_literal_attributes.rs
@@ -12,9 +12,13 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
+use std::num::ParseIntError;
+
 use clap::error::ErrorKind;
 use clap::Parser;
-use std::num::ParseIntError;
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
 
 pub(crate) const DISPLAY_ORDER: usize = 2;
 
@@ -150,11 +154,12 @@ fn test_parse_hex_function_path() {
     );
 
     let err = HexOpt::try_parse_from(["test", "-n", "gg"]).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid digit found in string"),
-        "{}",
-        err
-    );
+    assert_data_eq!(err.to_string(), str![[r#"
+error: invalid value 'gg' for '-n <NUMBER>': invalid digit found in string
+
+For more information, try '--help'.
+
+"#]].raw());
 }
 
 #[test]

--- a/tests/derive/options.rs
+++ b/tests/derive/options.rs
@@ -14,9 +14,12 @@
 
 #![allow(clippy::option_option)]
 
-use crate::utils;
-
 use clap::{Parser, Subcommand};
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
+
+use crate::utils;
 
 #[test]
 fn required_option() {
@@ -282,8 +285,14 @@ fn option_option_type_help() {
         arg: Option<Option<i32>>,
     }
     let help = utils::get_help::<Opt>();
-    assert!(help.contains("--arg [<val>]"));
-    assert!(!help.contains("--arg [<val>...]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap [OPTIONS]
+
+Options:
+      --arg [<val>]  
+  -h, --help         Print help
+
+"#]].raw());
 }
 
 #[test]

--- a/tests/derive/rename_all_env.rs
+++ b/tests/derive/rename_all_env.rs
@@ -1,8 +1,11 @@
 #![cfg(feature = "env")]
 
-use crate::utils;
-
 use clap::Parser;
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
+
+use crate::utils;
 
 #[test]
 fn it_works() {
@@ -14,7 +17,16 @@ fn it_works() {
     }
 
     let help = utils::get_help::<BehaviorModel>();
-    assert!(help.contains("[env: be-nice=]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <BE_NICE>
+
+Arguments:
+  <BE_NICE>  [env: be-nice=]
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -26,7 +38,16 @@ fn default_is_screaming() {
     }
 
     let help = utils::get_help::<BehaviorModel>();
-    assert!(help.contains("[env: BE_NICE=]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <BE_NICE>
+
+Arguments:
+  <BE_NICE>  [env: BE_NICE=]
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
 }
 
 #[test]
@@ -42,6 +63,15 @@ fn overridable() {
     }
 
     let help = utils::get_help::<BehaviorModel>();
-    assert!(help.contains("[env: be-nice=]"));
-    assert!(help.contains("[env: BeAggressive=]"));
+    assert_data_eq!(help, str![[r#"
+Usage: clap <BE_NICE> <BE_AGGRESSIVE>
+
+Arguments:
+  <BE_NICE>        [env: be-nice=]
+  <BE_AGGRESSIVE>  [env: BeAggressive=]
+
+Options:
+  -h, --help  Print help
+
+"#]].raw());
 }

--- a/tests/derive/subcommands.rs
+++ b/tests/derive/subcommands.rs
@@ -12,9 +12,12 @@
 // commit#ea76fa1b1b273e65e3b0b1046643715b49bec51f which is licensed under the
 // MIT/Apache 2.0 license.
 
-use crate::utils;
-
 use clap::{Args, Parser, Subcommand};
+use snapbox::assert_data_eq;
+use snapbox::prelude::*;
+use snapbox::str;
+
+use crate::utils;
 
 #[derive(Parser, PartialEq, Eq, Debug)]
 enum Opt {
@@ -159,9 +162,20 @@ fn test_tuple_commands() {
 
     let output = utils::get_long_help::<Opt4>();
 
-    assert!(output.contains("download history from remote"));
-    assert!(output.contains("Add a file"));
-    assert!(!output.contains("Not shown"));
+    assert_data_eq!(output, str![[r#"
+Usage: clap <COMMAND>
+
+Commands:
+  add    Add a file
+  init   
+  fetch  download history from remote
+  help   Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help
+
+"#]].raw());
 }
 
 #[test]


### PR DESCRIPTION
`contains` assertions can be fairly brittle, easy to miss when wrong, and hard to update.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
