### PR TITLE
fix(complete): Hide dot files on dynamic completer

### DIFF
--- a/clap_complete/src/engine/custom.rs
+++ b/clap_complete/src/engine/custom.rs
@@ -333,9 +333,10 @@ pub(crate) fn complete_path(
         }
 
         if entry.metadata().map(|m| m.is_dir()).unwrap_or(false) {
-            let mut suggestion = prefix.join(raw_file_name);
+            let mut suggestion = prefix.join(&raw_file_name);
             suggestion.push(""); // Ensure trailing `/`
-            let candidate = CompletionCandidate::new(suggestion.as_os_str().to_owned());
+            let candidate = CompletionCandidate::new(suggestion.as_os_str().to_owned())
+                .hide(is_hidden(&raw_file_name));
 
             if is_wanted(&entry.path()) {
                 completions.push(candidate);
@@ -344,8 +345,9 @@ pub(crate) fn complete_path(
             }
         } else {
             if is_wanted(&entry.path()) {
-                let suggestion = prefix.join(raw_file_name);
-                let candidate = CompletionCandidate::new(suggestion.as_os_str().to_owned());
+                let suggestion = prefix.join(&raw_file_name);
+                let candidate = CompletionCandidate::new(suggestion.as_os_str().to_owned())
+                    .hide(is_hidden(&raw_file_name));
                 completions.push(candidate);
             }
         }
@@ -355,6 +357,10 @@ pub(crate) fn complete_path(
     completions.extend(potential);
 
     completions
+}
+
+fn is_hidden(file_name: &OsStr) -> bool {
+    file_name.starts_with(".")
 }
 
 fn split_file_name(path: &std::path::Path) -> (&std::path::Path, &OsStr) {

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -506,13 +506,21 @@ fn suggest_value_hint_file_path() {
     let testdir_path = testdir.path().unwrap();
 
     fs::write(testdir_path.join("a_file"), "").unwrap();
+    fs::write(testdir_path.join(".a_file"), "").unwrap();
     fs::write(testdir_path.join("b_file"), "").unwrap();
+    fs::write(testdir_path.join(".b_file"), "").unwrap();
     fs::create_dir_all(testdir_path.join("c_dir")).unwrap();
+    fs::create_dir_all(testdir_path.join(".c_dir")).unwrap();
     fs::create_dir_all(testdir_path.join("d_dir")).unwrap();
+    fs::create_dir_all(testdir_path.join(".d_dir")).unwrap();
 
     assert_data_eq!(
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
+.a_file
+.b_file
+.c_dir/
+.d_dir/
 a_file
 b_file
 c_dir/
@@ -524,16 +532,38 @@ d_dir/
         complete!(cmd, "--input a[TAB]", current_dir = Some(testdir_path)),
         snapbox::str!["a_file"],
     );
+    assert_data_eq!(
+        complete!(cmd, "--input .[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![[r#"
+./.a_file
+./.b_file
+./.c_dir/
+./.d_dir/
+./a_file
+./b_file
+./c_dir/
+./d_dir/
+"#]],
+    );
+    assert_data_eq!(
+        complete!(cmd, "--input .a[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![".a_file"],
+    );
 }
 
 #[test]
 fn suggest_value_path_file() {
     let testdir = snapbox::dir::DirRoot::mutable_temp().unwrap();
     let testdir_path = testdir.path().unwrap();
+
     fs::write(testdir_path.join("a_file"), "").unwrap();
+    fs::write(testdir_path.join(".a_file"), "").unwrap();
     fs::write(testdir_path.join("b_file"), "").unwrap();
+    fs::write(testdir_path.join(".b_file"), "").unwrap();
     fs::create_dir_all(testdir_path.join("c_dir")).unwrap();
+    fs::create_dir_all(testdir_path.join(".c_dir")).unwrap();
     fs::create_dir_all(testdir_path.join("d_dir")).unwrap();
+    fs::create_dir_all(testdir_path.join(".d_dir")).unwrap();
 
     let mut cmd = Command::new("dynamic")
         .arg(
@@ -551,8 +581,12 @@ fn suggest_value_path_file() {
     assert_data_eq!(
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
+.a_file
+.b_file
 a_file
 b_file
+.c_dir/
+.d_dir/
 c_dir/
 d_dir/
 -	stdio
@@ -563,16 +597,38 @@ d_dir/
         complete!(cmd, "--input a[TAB]", current_dir = Some(testdir_path)),
         snapbox::str!["a_file"],
     );
+    assert_data_eq!(
+        complete!(cmd, "--input .[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![[r#"
+./.a_file
+./.b_file
+./a_file
+./b_file
+./.c_dir/
+./.d_dir/
+./c_dir/
+./d_dir/
+"#]],
+    );
+    assert_data_eq!(
+        complete!(cmd, "--input .a[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![".a_file"],
+    );
 }
 
 #[test]
 fn suggest_value_path_dir() {
     let testdir = snapbox::dir::DirRoot::mutable_temp().unwrap();
     let testdir_path = testdir.path().unwrap();
+
     fs::write(testdir_path.join("a_file"), "").unwrap();
+    fs::write(testdir_path.join(".a_file"), "").unwrap();
     fs::write(testdir_path.join("b_file"), "").unwrap();
+    fs::write(testdir_path.join(".b_file"), "").unwrap();
     fs::create_dir_all(testdir_path.join("c_dir")).unwrap();
+    fs::create_dir_all(testdir_path.join(".c_dir")).unwrap();
     fs::create_dir_all(testdir_path.join("d_dir")).unwrap();
+    fs::create_dir_all(testdir_path.join(".d_dir")).unwrap();
 
     let mut cmd = Command::new("dynamic")
         .arg(
@@ -589,6 +645,8 @@ fn suggest_value_path_dir() {
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
 .
+.c_dir/
+.d_dir/
 c_dir/
 d_dir/
 "#]],
@@ -597,6 +655,19 @@ d_dir/
     assert_data_eq!(
         complete!(cmd, "--input c[TAB]", current_dir = Some(testdir_path)),
         snapbox::str!["c_dir/"],
+    );
+    assert_data_eq!(
+        complete!(cmd, "--input .[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![[r#"
+./.c_dir/
+./.d_dir/
+./c_dir/
+./d_dir/
+"#]],
+    );
+    assert_data_eq!(
+        complete!(cmd, "--input .c[TAB]", current_dir = Some(testdir_path)),
+        snapbox::str![".c_dir/"],
     );
 }
 

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -517,10 +517,6 @@ fn suggest_value_hint_file_path() {
     assert_data_eq!(
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
-.a_file
-.b_file
-.c_dir/
-.d_dir/
 a_file
 b_file
 c_dir/
@@ -535,10 +531,6 @@ d_dir/
     assert_data_eq!(
         complete!(cmd, "--input .[TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
-./.a_file
-./.b_file
-./.c_dir/
-./.d_dir/
 ./a_file
 ./b_file
 ./c_dir/
@@ -581,12 +573,8 @@ fn suggest_value_path_file() {
     assert_data_eq!(
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
-.a_file
-.b_file
 a_file
 b_file
-.c_dir/
-.d_dir/
 c_dir/
 d_dir/
 -	stdio
@@ -600,12 +588,8 @@ d_dir/
     assert_data_eq!(
         complete!(cmd, "--input .[TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
-./.a_file
-./.b_file
 ./a_file
 ./b_file
-./.c_dir/
-./.d_dir/
 ./c_dir/
 ./d_dir/
 "#]],
@@ -645,8 +629,6 @@ fn suggest_value_path_dir() {
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
 .
-.c_dir/
-.d_dir/
 c_dir/
 d_dir/
 "#]],
@@ -659,8 +641,6 @@ d_dir/
     assert_data_eq!(
         complete!(cmd, "--input .[TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
-./.c_dir/
-./.d_dir/
 ./c_dir/
 ./d_dir/
 "#]],


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
