### PR TITLE
feat: mark `StyledStr::push_str` functions public

### DIFF
--- a/clap_builder/src/builder/styled_str.rs
+++ b/clap_builder/src/builder/styled_str.rs
@@ -41,7 +41,8 @@ impl StyledStr {
         self.0.push_str(&msg);
     }
 
-    pub(crate) fn push_str(&mut self, msg: &str) {
+    /// Appends a given string slice onto the end of this `StyledStr`.
+    pub fn push_str(&mut self, msg: &str) {
         self.0.push_str(msg);
     }
 


### PR DESCRIPTION
Mark `StyledStr::push_str` as public, so that `ErrorFormatter` trait available outside of clap crate.

https://github.com/clap-rs/clap/issues/380#issuecomment-3217975004