### PR TITLE
docs(complete): Simplify sourcing fish completions

### DIFF
--- a/clap_complete/src/env/mod.rs
+++ b/clap_complete/src/env/mod.rs
@@ -47,7 +47,7 @@
 //!
 //! Fish
 //! ```fish
-//! echo "source (COMPLETE=fish your_program | psub)" >> ~/.config/fish/config.fish
+//! echo "COMPLETE=fish your_program | source" >> ~/.config/fish/config.fish
 //! ```
 //!
 //! Powershell


### PR DESCRIPTION
Unlike most other shells, fish [supports sourcing directly from the standard input](https://github.com/fish-shell/fish-shell/blob/898cc3242b15efc9be514538ff97048ed40c2d77/doc_src/cmds/source.rst), which is simpler and more idiomatic.

This is for instance how jj now recommend sourcing their dynamic completions since https://github.com/jj-vcs/jj/pull/4847.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
