### PR TITLE
feat: allow set some heading

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -89,6 +89,7 @@ pub struct Arg {
     pub(crate) index: Option<usize>,
     pub(crate) help_heading: Option<Option<Str>>,
     pub(crate) ext: Extensions,
+    pub(crate) aliases_heading: Option<Str>,
 }
 
 /// # Basic API
@@ -463,6 +464,40 @@ impl Arg {
             debug_assert!(n != '-', "short alias name cannot be `-`");
             self.short_aliases.push((n, true));
         }
+        self
+    }
+
+    /// Set arg aliases heading
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, Arg, ArgAction};
+    /// let m = Command::new("myprog")
+    ///             .arg(Arg::new("test")
+    ///                 .long("test")
+    ///                 .action(ArgAction::SetTrue)
+    ///                 .visible_alias("b")
+    ///                 .aliases_heading("another heading")
+    ///             )
+    ///         .print_help();
+    ///```
+    ///
+    /// will produce
+    ///
+    /// ```text
+    /// myprog
+    ///
+    /// Usage: myprog [OPTIONS]
+    ///
+    /// Options:
+    ///      --test  [b: --b]
+    ///  -h, --help  Print help
+    /// ```
+    #[must_use]
+    pub fn aliases_heading(mut self, heading: impl IntoResettable<Str>) -> Self {
+        self.aliases_heading = heading.into_resettable().into_option();
         self
     }
 
@@ -4157,6 +4192,12 @@ impl Arg {
                     .collect(),
             )
         }
+    }
+
+    /// Get aliases heading
+    #[inline]
+    pub fn get_aliases_heading(&self) -> Option<&str> {
+        self.aliases_heading.as_deref()
     }
 
     /// Get *all* short aliases for this argument, if any, both visible and hidden.

--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -90,6 +90,7 @@ pub struct Arg {
     pub(crate) help_heading: Option<Option<Str>>,
     pub(crate) ext: Extensions,
     pub(crate) aliases_heading: Option<Str>,
+    pub(crate) default_heading: Option<Str>,
 }
 
 /// # Basic API
@@ -1888,6 +1889,38 @@ impl Arg {
             self.default_vals.clear();
             self
         }
+    }
+
+    /// # Examples
+    ///
+    /// First we use the default value without providing any value at runtime.
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, Arg, parser::ValueSource};
+    /// Command::new("prog")
+    ///     .arg(Arg::new("opt")
+    ///         .long("myopt")
+    ///         .default_value("myval")
+    ///         .default_heading("another default"))
+    ///     .print_help()
+    ///     .unwrap()
+    ///```
+    ///
+    /// get result:
+    ///
+    /// ```text
+    /// Usage: prog [OPTIONS]
+    ///
+    /// Options:
+    ///  --myopt <opt>  [default: myval]
+    ///  -h, --help         Print help
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn default_heading(mut self, heading: impl IntoResettable<Str>) -> Self {
+        self.default_heading = heading.into_resettable().into_option();
+        self
     }
 
     #[inline]
@@ -4198,6 +4231,12 @@ impl Arg {
     #[inline]
     pub fn get_aliases_heading(&self) -> Option<&str> {
         self.aliases_heading.as_deref()
+    }
+
+    /// Get default heading
+    #[inline]
+    pub fn get_default_heading(&self) -> Option<&str> {
+        self.default_heading.as_deref()
     }
 
     /// Get *all* short aliases for this argument, if any, both visible and hidden.

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -104,6 +104,7 @@ pub struct Command {
     current_disp_ord: Option<usize>,
     subcommand_value_name: Option<Str>,
     subcommand_heading: Option<Str>,
+    aliases_heading: Option<Str>,
     external_value_parser: Option<super::ValueParser>,
     long_help_exists: bool,
     deferred: Option<fn(Command) -> Command>,
@@ -2275,6 +2276,46 @@ impl Command {
         self
     }
 
+    /// Sets the aliases heading used for subcommands when printing usage and help.
+    ///
+    /// By default, this is "COMMAND".
+    ///
+    /// See also [`Command::subcommand_help_heading`]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, Arg};
+    /// Command::new("myprog")
+    ///     .subcommand(Command::new("sub1"))
+    ///     .subcommand_aliases_heading("another aliases")
+    ///     .print_help()
+    /// # ;
+    /// ```
+    ///
+    /// will produce
+    ///
+    /// ```text
+    /// myprog
+    ///
+    /// Usage: myprog [COMMAND]
+    ///
+    /// Commands:
+    ///     help    Print this message or the help of the given subcommand(s)
+    ///     sub1    [another aliases: sub2]
+    ///
+    /// Options:
+    ///     -h, --help       Print help
+    ///     -V, --version    Print version
+    /// ```
+    #[must_use]
+    #[cfg(feature = "help")]
+    pub fn subcommand_aliases_heading(mut self, s: impl IntoResettable<Str>) -> Self {
+        self.aliases_heading = s.into_resettable().into_option();
+        self
+    }
+
     #[inline]
     #[must_use]
     pub(crate) fn setting(mut self, setting: AppSettings) -> Self {
@@ -3873,6 +3914,12 @@ impl Command {
         }
     }
 
+    /// Return aliases heading
+    #[inline]
+    pub fn get_subcommand_aliases_heading(&self) -> Option<&str> {
+        self.aliases_heading.as_deref()
+    }
+
     /// Return the current `Styles` for the `Command`
     #[inline]
     pub fn get_styles(&self) -> &Styles {
@@ -5187,6 +5234,7 @@ impl Default for Command {
             #[cfg(feature = "unstable-ext")]
             ext: Default::default(),
             app_ext: Default::default(),
+            aliases_heading: Default::default(),
         }
     }
 }

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -832,7 +832,8 @@ impl HelpTemplate<'_, '_> {
 
         if !als.is_empty() {
             let als = als.join(&val_sep);
-            spec_vals.push(format!("{ctx}[aliases: {ctx:#}{als}{ctx}]{ctx:#}"));
+            let help_heading = a.get_aliases_heading().unwrap_or("aliases");
+            spec_vals.push(format!("{ctx}[{help_heading}: {ctx:#}{als}{ctx}]{ctx:#}"));
         }
 
         if !a.is_hide_possible_values_set() && !self.use_long_pv(a) {
@@ -1041,7 +1042,10 @@ impl HelpTemplate<'_, '_> {
                 "HelpTemplate::spec_vals: Found long flag aliases...{:?}",
                 a.get_all_long_flag_aliases().collect::<Vec<_>>()
             );
-            spec_vals.push(format!("{ctx}[aliases: {ctx:#}{all_als}{ctx}]{ctx:#}"));
+            let help_heading = a.get_subcommand_aliases_heading().unwrap_or("aliases");
+            spec_vals.push(format!(
+                "{ctx}[{help_heading}: {ctx:#}{all_als}{ctx}]{ctx:#}",
+            ));
         }
 
         spec_vals.join(" ")

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -805,7 +805,8 @@ impl HelpTemplate<'_, '_> {
                 .join(" ");
 
             spec_vals.push(format!(
-                "{ctx}[default: {ctx:#}{ctx_val}{dvs}{ctx_val:#}{ctx}]{ctx:#}"
+                "{ctx}[{}: {ctx:#}{ctx_val}{dvs}{ctx_val:#}{ctx}]{ctx:#}",
+                a.get_default_heading().unwrap_or("default")
             ));
         }
 


### PR DESCRIPTION
Like:

```rust
fn main() {
    use clap::Command;
    Command::new("myprog")
        .arg(
            Arg::new("test")
                .long("test")
                .action(ArgAction::SetTrue)
                .visible_alias("b")
                .aliases_heading("又叫")
        )
        .print_help()
        .unwrap();
}
```

Will output:

```
Usage: myprog [OPTIONS]

Options:
      --test  [又叫: --b]
      -h, --help  Print help
```