### PR TITLE
docs(builder): Explain dont_delimit_trailing_values

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -1657,6 +1657,8 @@ impl Arg {
     /// i.e. allow values (`val1,val2,val3`) to be parsed as three values (`val1`, `val2`,
     /// and `val3`) instead of one value (`val1,val2,val3`).
     ///
+    /// See also [`Command::dont_delimit_trailing_values`][crate::Command::dont_delimit_trailing_values].
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1251,7 +1251,7 @@ impl Command {
         }
     }
 
-    /// Disables the automatic delimiting of values after `--` or when [`Arg::trailing_var_arg`]
+    /// Disables the automatic [delimiting of values][Arg::value_delimiter] after `--` or when [`Arg::trailing_var_arg`]
     /// was used.
     ///
     /// <div class="warning">


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
