### PR TITLE
Respect the configured display order

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -24,6 +24,7 @@ use crate::error::ErrorKind;
 use crate::error::Result as ClapResult;
 use crate::mkeymap::MKeyMap;
 use crate::output::fmt::Stream;
+use crate::output::HelpTemplate;
 use crate::output::{fmt::Colorizer, write_help, Usage};
 use crate::parser::{ArgMatcher, ArgMatches, Parser};
 use crate::util::ChildGraph;
@@ -4002,6 +4003,16 @@ impl Command {
     #[inline]
     pub fn get_arguments(&self) -> impl Iterator<Item = &Arg> {
         self.args.args()
+    }
+
+    #[inline]
+    /// Iterate through the set of arguments sorted by display order.
+    pub fn get_arguments_sorted(&self) -> impl Iterator<Item = &Arg> {
+        let mut sorted = self.args.args().collect::<Vec<_>>();
+        sorted.sort_by(|a, b| {
+            HelpTemplate::option_sort_key(a).cmp(&HelpTemplate::option_sort_key(b))
+        });
+        sorted.into_iter()
     }
 
     /// Iterate through the *positionals* arguments.

--- a/clap_builder/src/mkeymap.rs
+++ b/clap_builder/src/mkeymap.rs
@@ -2,7 +2,6 @@ use std::iter::Iterator;
 use std::ops::Index;
 
 use crate::builder::OsStr;
-use crate::output::HelpTemplate;
 use crate::Arg;
 use crate::INTERNAL_ERROR_MSG;
 
@@ -94,10 +93,6 @@ impl MKeyMap {
     /// Push an argument in the map.
     pub(crate) fn push(&mut self, new_arg: Arg) {
         self.args.push(new_arg);
-
-        self.args.sort_by(|a, b| {
-            HelpTemplate::option_sort_key(a).cmp(&HelpTemplate::option_sort_key(b))
-        });
     }
 
     /// Find the arg have corresponding key in this map, we can search the key

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -82,17 +82,17 @@ fn sub_subcommands() {
     );
 }
 
-	#[test]
-	fn external_subcommands() {
-		let name = "my-app";
-		let cmd = common::external_subcommand(name);
-		common::assert_matches(
-			snapbox::file!["../snapshots/external_subcommands.bash"],
-			clap_complete::shells::Bash,
-			cmd,
-			name,
-		);
-	}
+#[test]
+fn external_subcommands() {
+    let name = "my-app";
+    let cmd = common::external_subcommand(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/external_subcommands.bash"],
+        clap_complete::shells::Bash,
+        cmd,
+        name,
+    );
+}
 
 #[test]
 fn custom_bin_name() {
@@ -175,7 +175,7 @@ fn complete() {
 
     let input = "exhaustive \t\t";
     let expected = snapbox::str![[r#"
-% 
+%
 -h              --empty-choice  empty           action          value           last            hint
 --generate      --help          global          quote           pacman          alias           help
 "#]];
@@ -214,8 +214,8 @@ fn complete() {
     // Trigger completion from empty space
     let input = "exhaustive quote --choice  b\x1b[D\x1b[D\t\t";
     let expected = snapbox::str![[r#"
-% 
-another  shell    bash     fish     zsh      
+%
+another  shell    bash     fish     zsh
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
@@ -223,8 +223,8 @@ another  shell    bash     fish     zsh
     // Trigger completion immediately after "--"
     let input = "exhaustive -- hint\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D\t\t";
     let expected = snapbox::str![[r#"
-% 
---generate      --empty-choice  --help          
+%
+--generate      --empty-choice  --help
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
@@ -312,9 +312,9 @@ fn complete_dynamic_env_toplevel() {
 
     let input = "exhaustive \t\t";
     let expected = snapbox::str![[r#"
-% 
+%
 empty           action          value           last            hint            --generate      --help
-global          quote           pacman          alias           help            --empty-choice  
+global          quote           pacman          alias           help            --empty-choice
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
@@ -333,10 +333,10 @@ fn complete_dynamic_env_quoted_help() {
 
     let input = "exhaustive quote \t\t";
     let expected = snapbox::str![[r#"
-% 
+%
 cmd-single-quotes  cmd-backslash      escape-help        --double-quotes    --brackets         --help
-cmd-double-quotes  cmd-brackets       help               --backticks        --expansions       
-cmd-backticks      cmd-expansions     --single-quotes    --backslash        --choice           
+cmd-double-quotes  cmd-brackets       help               --backticks        --expansions
+cmd-backticks      cmd-expansions     --single-quotes    --backslash        --choice
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
@@ -356,8 +356,8 @@ fn complete_dynamic_env_option_value() {
     let input = "exhaustive action --choice=\t\t";
     let expected = snapbox::str![
         r#"
-% 
-first   second  
+%
+first   second
 "#
     ];
     let actual = runtime.complete(input, &term).unwrap();
@@ -382,8 +382,8 @@ fn complete_dynamic_env_quoted_value() {
 
     let input = "exhaustive quote --choice \t\t";
     let expected = snapbox::str![[r#"
-% 
-another shell  bash           fish           zsh            
+%
+another shell  bash           fish           zsh
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
@@ -468,8 +468,8 @@ fn complete_dynamic_middle_of_word() {
     // Trigger completion from empty space
     let input = "exhaustive quote --choice  b\x1b[D\x1b[D\t\t";
     let expected = snapbox::str![[r#"
-% 
-another shell  bash           fish           zsh            
+%
+another shell  bash           fish           zsh
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
@@ -477,8 +477,8 @@ another shell  bash           fish           zsh
     // Trigger completion immediately after "--"
     let input = "exhaustive -- hint\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D\t\t";
     let expected = snapbox::str![[r#"
-% 
---generate      --empty-choice  --help          
+%
+--generate      --empty-choice  --help
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);

--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -257,11 +257,11 @@ impl Man {
                 acc
             });
 
-        let (args, mut args_with_heading) =
-            self.cmd
-                .get_arguments()
-                .filter(|a| !a.is_hide_set())
-                .partition::<Vec<_>, _>(|a| a.get_help_heading().is_none());
+        let (args, mut args_with_heading) = self
+            .cmd
+            .get_arguments_sorted()
+            .filter(|a| !a.is_hide_set())
+            .partition::<Vec<_>, _>(|a| a.get_help_heading().is_none());
 
         if !args.is_empty() {
             roff.control("SH", ["OPTIONS"]);
@@ -351,36 +351,3 @@ fn app_has_subcommands(cmd: &clap::Command) -> bool {
 #[doc = include_str!("../README.md")]
 #[cfg(doctest)]
 pub struct ReadmeDoctests;
-
-#[cfg(test)]
-mod tests {
-    use crate::Man;
-
-    #[test]
-    fn respect_order() {
-        let mut cmd = clap::Command::new("mybin")
-            .next_display_order(None) // mark all following args with display_order `None`
-            .arg(clap::arg!(-n --name <NAME>))
-            .arg(clap::arg!(-c --count <NUM>));
-
-        let help_message = cmd.render_help().to_string();
-        let name_position = help_message.find("--name").expect("Flag must be in output");
-        let count_position = help_message
-            .find("--count")
-            .expect("Flag must be in output");
-
-        // As we can see, clap sorts args with alphabetically for args with display_order `None`
-        assert!(count_position < name_position);
-
-        let man = Man::new(cmd);
-        let mut buffer: Vec<u8> = Default::default();
-        man.render(&mut buffer).unwrap();
-
-        let result = str::from_utf8(&buffer).unwrap();
-        let name_position = result.find("-\\-name").expect("Flag must be in output");
-        let count_position = result.find("-\\-count").expect("Flag must be in output");
-
-        // clap_mangen must also respect display_order
-        assert!(count_position < name_position);
-    }
-}

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -33,7 +33,7 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     let name = cmd.get_bin_name().unwrap_or_else(|| cmd.get_name());
     let mut line = vec![bold(name), roman(" ")];
 
-    for opt in cmd.get_arguments().filter(|i| !i.is_hide_set()) {
+    for opt in cmd.get_arguments_sorted().filter(|i| !i.is_hide_set()) {
         let (lhs, rhs) = option_markers(opt);
         match (opt.get_short(), opt.get_long()) {
             (Some(short), Some(long)) => {

--- a/clap_mangen/tests/snapshots/display_order.bash.roff
+++ b/clap_mangen/tests/snapshots/display_order.bash.roff
@@ -1,0 +1,27 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-0 \fR] [\fB\-a \fR] [\fB\-\-aa\fR] [\fB\-b \fR] [\fB\-c \fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-0\fR
+
+.TP
+\fB\-a\fR
+
+.TP
+\fB\-\-aa\fR
+
+.TP
+\fB\-b\fR
+
+.TP
+\fB\-c\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -356,8 +356,7 @@ pub(crate) fn help_headings(name: &'static str) -> clap::Command {
 }
 
 pub(crate) fn value_with_required_equals(name: &'static str) -> clap::Command {
-    clap::Command::new(name)
-    .arg(
+    clap::Command::new(name).arg(
         clap::Arg::new("config")
             .long("config")
             .value_name("FILE")
@@ -367,8 +366,7 @@ pub(crate) fn value_with_required_equals(name: &'static str) -> clap::Command {
 }
 
 pub(crate) fn optional_value_with_required_equals(name: &'static str) -> clap::Command {
-    clap::Command::new(name)
-    .arg(
+    clap::Command::new(name).arg(
         clap::Arg::new("config")
             .long("config")
             .value_name("FILE")
@@ -379,8 +377,7 @@ pub(crate) fn optional_value_with_required_equals(name: &'static str) -> clap::C
 }
 
 pub(crate) fn optional_value(name: &'static str) -> clap::Command {
-    clap::Command::new(name)
-    .arg(
+    clap::Command::new(name).arg(
         clap::Arg::new("config")
             .long("config")
             .value_name("FILE")
@@ -390,8 +387,7 @@ pub(crate) fn optional_value(name: &'static str) -> clap::Command {
 }
 
 pub(crate) fn multiple_optional_values(name: &'static str) -> clap::Command {
-    clap::Command::new(name)
-    .arg(
+    clap::Command::new(name).arg(
         clap::Arg::new("config")
             .long("config")
             .value_names(["FILE1", "FILE2"])
@@ -401,8 +397,7 @@ pub(crate) fn multiple_optional_values(name: &'static str) -> clap::Command {
 }
 
 pub(crate) fn variadic_values(name: &'static str) -> clap::Command {
-    clap::Command::new(name)
-    .arg(
+    clap::Command::new(name).arg(
         clap::Arg::new("config")
             .long("config")
             .value_names(["FILE1", "FILE2"])
@@ -410,4 +405,14 @@ pub(crate) fn variadic_values(name: &'static str) -> clap::Command {
             .num_args(3)
             .help("Optional config file"),
     )
+}
+
+pub(crate) fn display_order(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .next_display_order(None)
+        .arg(clap::Arg::new("c").short('c'))
+        .arg(clap::Arg::new("b").short('b'))
+        .arg(clap::Arg::new("a").short('a'))
+        .arg(clap::Arg::new("aa").long("aa"))
+        .arg(clap::Arg::new("0").short('0'))
 }

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -15,6 +15,13 @@ fn feature_sample() {
 }
 
 #[test]
+fn feature_sample_display_order() {
+    let name = "my-app";
+    let cmd = common::display_order(name);
+    common::assert_matches(snapbox::file!["../snapshots/display_order.bash.roff"], cmd);
+}
+
+#[test]
 fn special_commands() {
     let name = "my-app";
     let cmd = common::special_commands_command(name);
@@ -137,10 +144,7 @@ fn optional_value_with_required_equals() {
 fn optional_value() {
     let name = "my-app";
     let cmd = common::optional_value(name);
-    common::assert_matches(
-        snapbox::file!["../snapshots/optional_value.bash.roff"],
-        cmd,
-    );
+    common::assert_matches(snapbox::file!["../snapshots/optional_value.bash.roff"], cmd);
 }
 
 #[test]


### PR DESCRIPTION
This is an attempt to make mangen respect the display order for args. (not yet for subcommands) The implementation is minimalistic with as few changes as possible. It's probably not be quite what we want to merge, which is why I've marked it as draft.

The failing tests also show that currently the change reorders too much. I will probably have dig a bit deeper to understand why this happens, but maybe somebody knows.

Fixes https://github.com/clap-rs/clap/issues/3362