### PR TITLE
fix(help): Correctly calculate padding for short-only args 

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -479,20 +479,18 @@ impl HelpTemplate<'_, '_> {
             // args alignment
             should_show_arg(self.use_long, arg)
         }) {
-            if longest_filter(arg) {
-                let width = display_width(&arg.to_string());
-                let actual_width = if arg.is_positional() {
-                    width
-                } else {
-                    width + SHORT_SIZE
-                };
-                longest = longest.max(actual_width);
-                debug!(
-                    "HelpTemplate::write_args: arg={:?} longest={}",
-                    arg.get_id(),
-                    longest
-                );
-            }
+            let width = display_width(&arg.to_string());
+            let actual_width = if arg.get_long().is_some() {
+                width + SHORT_SIZE
+            } else {
+                width
+            };
+            longest = longest.max(actual_width);
+            debug!(
+                "HelpTemplate::write_args: arg={:?} longest={}",
+                arg.get_id(),
+                longest
+            );
 
             let key = (sort_key)(arg);
             ord_v.insert(key, arg);
@@ -1142,10 +1140,6 @@ fn should_show_arg(use_long: bool, arg: &Arg) -> bool {
 
 fn should_show_subcommand(subcommand: &Command) -> bool {
     !subcommand.is_hide_set()
-}
-
-fn longest_filter(arg: &Arg) -> bool {
-    arg.is_takes_value_set() || arg.get_long().is_some() || arg.get_short().is_none()
 }
 
 #[cfg(test)]

--- a/examples/typed-derive/fn_parser.md
+++ b/examples/typed-derive/fn_parser.md
@@ -4,8 +4,8 @@ $ typed-derive fn-parser --help
 Usage: typed-derive fn-parser [OPTIONS]
 
 Options:
-  -D <KEY=VALUE>      Hand-written parser for tuples
-  -h, --help          Print help
+  -D <KEY=VALUE>  Hand-written parser for tuples
+  -h, --help      Print help
 
 ```
 

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -2433,14 +2433,13 @@ Options:
   -h, --help  Print help
 
 Baz:
-  -z <BAZ>      Short only
+  -z <BAZ>  Short only
 
 "#]];
     utils::assert_output(cmd, "demo -h", expected, false);
 }
 
 #[test]
-#[should_panic]
 fn short_with_count() {
     let cmd = Command::new("demo").arg(
         Arg::new("baz")

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -480,8 +480,8 @@ fn optional_value() {
 Usage: test [OPTIONS]
 
 Options:
-  -p [<NUM>]      
-  -h, --help      Print help
+  -p [<NUM>]  
+  -h, --help  Print help
 
 "#]]
     );

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -308,8 +308,8 @@ mod arg {
 Usage: test [OPTIONS]
 
 Options:
-  -p [<NUM>]      
-  -h, --help      Print help
+  -p [<NUM>]  
+  -h, --help  Print help
 
 "#]]
         );


### PR DESCRIPTION
This manifests in two ways
- If a value is taken, we double the padding
- If `ArgAction::Count` is used, we don't account for `...` and crash

Fixes https://github.com/clap-rs/clap/issues/6164