### PR TITLE
fix(clap_complete): improve powershell registration script

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -286,8 +286,15 @@ Register-ArgumentCompleter -Native -CommandName {bin} -ScriptBlock {{
 
     $prev = $env:{var};
     $env:{var} = "powershell";
+
+    $args = $commandAst.Extent.Text
+    $args = $args.Substring(0, [math]::Min($cursorPosition, $args.Length));
+    if ($wordToComplete -eq "") {{
+        $args += " ''";
+    }}
+
     $results = Invoke-Expression @"
-& {completer} -- $commandAst
+& {completer} -- $args
 "@;
     if ($null -eq $prev) {{
         Remove-Item Env:\{var};


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

This PR modifies the PowerShell registration script for dynamic completions to handle the situation where the cursor is not on an partial argument. Previously, `clap_complete` would not generate any completion when hitting TAB for the first argument, and would generate a duplicate of the previous argument when present.

```console
> dynamic [TAB]
# tries to complete with a path
dynamic ./

> dynamic --format [TAB]
# duplicates the previous argument
dynamic --format --format
```

The proposed solution is to trim the argument list at the cursor position (matching the behavior of the Fish implementation), and to add an empty argument if the word to complete is empty.

With these changes, both the use-cases shown above work as expected:

```console
> dynamic [TAB]
dynamic --

> dynamic --[TAB]
--input   --format  --help

> dynamic --format [TAB]
json  yaml  toml
```

Fixes https://github.com/clap-rs/clap/issues/6010