### PR TITLE
docs(complete): Fix instructions for sourcing PowerShell completions

### DIFF
--- a/clap_complete/src/env/mod.rs
+++ b/clap_complete/src/env/mod.rs
@@ -52,10 +52,13 @@
 //!
 //! **Powershell**
 //! ```powershell
-//! $env:COMPLETE = "powershell"
-//! echo "your_program | Out-String | Invoke-Expression" >> $PROFILE
-//! Remove-Item Env:\COMPLETE
+//! echo '$env:COMPLETE = "powershell"; your_program | Out-String | Invoke-Expression; Remove-Item Env:\COMPLETE' >> $PROFILE
 //! ```
+//! Note that to execute scripts in PowerShell on Windows, including [`$PROFILE`][$Profile],
+//! the [execution policy][ExecutionPolicies] needs to be set to `RemoteSigned` at minimum.
+//!
+//! [$Profile]: https://learn.microsoft.com/en-us/powershell/scripting/learn/shell/creating-profiles
+//! [ExecutionPolicies]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies
 //!
 //! **Zsh**
 //! ```zsh


### PR DESCRIPTION
The previous instructions were wrong in that they set the `COMPLETE` env var only while the `$PROFILE` script was written. This was akin to

    COMPLETE=bash echo "source <(your_program)" >> ~/.bashrc

whereas the corrected version sets `COMPLETE` as part of the `$PROFILE` script, mirroring the instructions for sourcing completion in the other shells.

Extending `$PROFILE` in this way also requires that scripts are allowed to be executed. This requires changing the execution policy from its default value `Restricted` on Windows. There's no such issue when using PowerShell on macOS or Linux.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
