### PR TITLE
feat(mangen): Add option to keep line breaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.31"
+version = "0.2.32-alpha.1"
 dependencies = [
  "automod",
  "clap 4.5.53",

--- a/clap_mangen/Cargo.toml
+++ b/clap_mangen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clap_mangen"
-version = "0.2.31"
+version = "0.2.32-alpha.1"
 description = "A manpage generator for clap"
 categories = ["command-line-interface"]
 keywords = [

--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -22,6 +22,7 @@ pub struct Man {
     date: String,
     source: String,
     manual: String,
+    keep_line_breaks: bool,
 }
 
 /// Build a [`Man`]
@@ -48,6 +49,7 @@ impl Man {
             date,
             source,
             manual,
+            keep_line_breaks: false,
         }
     }
 
@@ -94,6 +96,18 @@ impl Man {
     pub fn manual(mut self, manual: impl Into<String>) -> Self {
         self.manual = manual.into();
         self
+    }
+
+    /// Keep line breaks in arguments help
+    pub fn keep_line_breaks(mut self, keep: bool) -> Self {
+        self.keep_line_breaks = keep;
+        self
+    }
+
+    fn settings(&self) -> render::Parameters {
+        render::Parameters {
+            keep_line_breaks: self.keep_line_breaks,
+        }
     }
 }
 
@@ -265,7 +279,7 @@ impl Man {
 
         if !args.is_empty() {
             roff.control("SH", ["OPTIONS"]);
-            render::options(roff, &args);
+            render::options(roff, &args, &self.settings());
         }
 
         for heading in help_headings {
@@ -275,7 +289,7 @@ impl Man {
                 .partition(|&a| a.get_help_heading() == Some(heading));
 
             roff.control("SH", [heading.to_uppercase().as_str()]);
-            render::options(roff, &args);
+            render::options(roff, &args, &self.settings());
         }
     }
 

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -1,6 +1,11 @@
 use clap::{Arg, ArgAction};
 use roff::{bold, italic, roman, Inline, Roff};
 
+#[derive(Default)]
+pub(crate) struct Parameters {
+    pub keep_line_breaks: bool,
+}
+
 pub(crate) fn subcommand_heading(cmd: &clap::Command) -> &str {
     match cmd.get_subcommand_help_heading() {
         Some(title) => title,
@@ -92,7 +97,7 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     roff.text(line);
 }
 
-pub(crate) fn options(roff: &mut Roff, items: &[&Arg]) {
+pub(crate) fn options(roff: &mut Roff, items: &[&Arg], params: &Parameters) {
     let mut sorted_items = items.to_vec();
     sorted_items.sort_by_key(|opt| option_sort_key(opt));
 
@@ -140,7 +145,17 @@ pub(crate) fn options(roff: &mut Roff, items: &[&Arg]) {
         let mut arg_help_written = false;
         if let Some(help) = option_help(opt) {
             arg_help_written = true;
-            body.push(roman(help.to_string()));
+            let help = help.to_string();
+            if params.keep_line_breaks {
+                for (i, line) in help.lines().enumerate() {
+                    if i != 0 {
+                        body.push(Inline::LineBreak);
+                    }
+                    body.push(roman(line));
+                }
+            } else {
+                body.push(roman(help));
+            }
         }
 
         roff.control("TP", []);


### PR DESCRIPTION
### Feature: Add `keep_line_breaks` option to `clap_mangen::Man`

This pull request introduces the `keep_line_breaks` option to the `clap_mangen::Man` builder.

### Description & Motivation

The default behavior of `clap_mangen` is to strip line breaks within argument help text before rendering the man page. This can lead to a loss of intended formatting, particularly when arguments use multiline text, such as:

* **Bullet Lists:** Lists provided in the help text are merged into a single, potentially confusing, paragraph.
* **Structured Paragraphs:** Intended line breaks for clarity are discarded, making long help strings difficult to read in the generated man page.

This new `keep_line_breaks` option addresses this by instructing `clap_mangen` to **preserve the line breaks** within the help text of arguments. This makes the man page output consistent with the formatting seen in the application's standard **long help** output, thereby enabling authors to correctly format elements like **bullet lists** and maintain overall readability.

### Usage Example

The option can be enabled on the builder as follows:

```rust
let man = clap_mangen::Man::new(app)
    .keep_line_breaks(true) // New option
    .render();
```