### PR TITLE
fix: Path quoting with dynamic env completer

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -224,7 +224,7 @@ impl EnvCompleter for Fish {
 
         writeln!(
             buf,
-            r#"complete --keep-order --exclusive --command {bin} --arguments "({var}=fish "'{completer}'" -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))""#
+            r#"complete --keep-order --exclusive --command {bin} --arguments "({var}=fish {completer} -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))""#
         )
     }
     fn write_complete(
@@ -476,25 +476,19 @@ mod tests {
         let script = get_fish_registration("completer");
         assert_data_eq!(
             script.trim(),
-            snapbox::str![r#"complete [..] "([..] "'completer'"[..])""#]
+            snapbox::str![r#"complete [..] "([..] completer [..])""#]
         );
 
         let script = get_fish_registration("/path/completer");
         assert_data_eq!(
             script.trim(),
-            snapbox::str![r#"complete [..] "([..] "'/path/completer'"[..])""#]
+            snapbox::str![r#"complete [..] "([..] /path/completer [..])""#]
         );
 
-        // This case demonstrates the existing bug when handling paths with spaces as described in
-        // https://github.com/clap-rs/clap/issues/6196
-        // The problem shown here is:
-        // * The double quote started at `"(` is closed by the double quote before the path
-        // * Then we have an empty pair of single quotes
-        // * Then we have the _unquoted_ path with a space, which is problematic
         let script = get_fish_registration("/path with a space/completer");
         assert_data_eq!(
             script.trim(),
-            snapbox::str![r#"complete [..] "([..] "''/path with a space/completer''"[..])""#]
+            snapbox::str![r#"complete [..] "([..] '/path with a space/completer' [..])""#]
         );
     }
 }

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/fish/fish/completions/exhaustive.fish
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/fish/fish/completions/exhaustive.fish
@@ -1,1 +1,1 @@
-complete --keep-order --exclusive --command exhaustive --arguments "(COMPLETE=fish "'exhaustive'" -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+complete --keep-order --exclusive --command exhaustive --arguments "(COMPLETE=fish exhaustive -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"


### PR DESCRIPTION
Fixes: #6196 

This PR fixes the dynamic env completer's quoting of the command's path in the fish shell. It does this by avoiding the extra `"' .. '"` quotes around the `{completer}`, which aren't needed (and were causing previously opened quotes to be _closed_) because the `completer` came from `shlex::try_quote()`.

Note: There is still (and was before this PR) an issue where a `completer` path with an embedded null (`/like\0this`) will be problematic because `shlex::try_quote()` will return an error in this case, and the `.unwrap_or()` will continue on with an _unquoted_ string. I think the right fix is to change that `.unwrap_or()` to an `.expect()` and panic if this ever happens, because embedded nuls in strings like that aren't going to work on Unix anyway. But I can send a followup test PR to demonstrate the current behavior, and then consider a fix.


<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
