### PR TITLE
fix(complete): follow symlinks when completing paths

### DIFF
--- a/clap_complete/src/engine/custom.rs
+++ b/clap_complete/src/engine/custom.rs
@@ -332,7 +332,7 @@ pub(crate) fn complete_path(
             continue;
         }
 
-        if entry.metadata().map(|m| m.is_dir()).unwrap_or(false) {
+        if entry.path().is_dir() {
             let mut suggestion = prefix.join(&raw_file_name);
             suggestion.push(""); // Ensure trailing `/`
             let candidate = CompletionCandidate::new(suggestion.as_os_str().to_owned())

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -690,11 +690,13 @@ fn suggest_value_hint_file_path_symlink_to_dir() {
     fs::write(testdir_path.join("real_dir/file.txt"), "").unwrap();
     symlink("real_dir", testdir_path.join("link_dir")).unwrap();
 
-    // BUG: Symlink to directory not shown - entry.metadata() returns symlink metadata,
-    // so is_dir() is false and it fails the is_file() filter
+    // Symlink to directory should appear with trailing slash
     assert_data_eq!(
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
-        snapbox::str!["real_dir/"],
+        snapbox::str![[r#"
+link_dir/
+real_dir/
+"#]],
     );
 
     // Should be able to complete through the symlink
@@ -752,12 +754,12 @@ fn suggest_value_hint_dir_path_symlink() {
     symlink("real_dir", testdir_path.join("link_dir")).unwrap();
     symlink("real_file.txt", testdir_path.join("link_file.txt")).unwrap();
 
-    // Symlink to directory currently lacks trailing slash (entry.metadata() returns symlink metadata)
+    // Symlink to directory should have trailing slash
     assert_data_eq!(
         complete!(cmd, "--input [TAB]", current_dir = Some(testdir_path)),
         snapbox::str![[r#"
 .
-link_dir
+link_dir/
 real_dir/
 "#]],
     );


### PR DESCRIPTION
## Summary

On Unix, https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.metadata is equivalent to symlink_metadata(), which returns metadata about the symlink itself rather than its target. This causes is_dir() to return false for symlinks pointing to directories, so they never appear in completions.

Solution is to use Path::is_dir() which follows symlinks to correctly identify symlinks to directories. Symlink paths are preserved in completions (user sees /home/, not the resolved target).

Fixes https://github.com/clap-rs/clap/issues/6201

Test plan

5 new Unix-specific tests covering:
- Symlink to directory (trailing /, traversal works)
- Symlink to file (no trailing /)
- DirPath hint filtering with symlinks
- Broken symlink with FilePath (gracefully excluded)
- Broken symlink with AnyPath (included)