### PR TITLE
fix(complete): Trailing space after zsh directory completions

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -381,7 +381,25 @@ function _clap_dynamic_completer_NAME() {
     )}")
 
     if [[ -n $completions ]]; then
-        _describe 'values' completions
+        local -a dirs=()
+        local -a other=()
+        local completion
+        for completion in $completions; do
+            local value="${completion%%:*}"
+            if [[ "$value" == */ ]]; then
+                local dir_no_slash="${value%/}"
+                if [[ "$completion" == *:* ]]; then
+                    local desc="${completion#*:}"
+                    dirs+=("$dir_no_slash:$desc")
+                else
+                    dirs+=("$dir_no_slash")
+                fi
+            else
+                other+=("$completion")
+            fi
+        done
+        [[ -n $dirs ]] && _describe 'values' dirs -S '/' -r '/'
+        [[ -n $other ]] && _describe 'values' other
     fi
 }
 

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
@@ -11,7 +11,25 @@ function _clap_dynamic_completer_exhaustive() {
     )}")
 
     if [[ -n $completions ]]; then
-        _describe 'values' completions
+        local -a dirs=()
+        local -a other=()
+        local completion
+        for completion in $completions; do
+            local value="${completion%%:*}"
+            if [[ "$value" == */ ]]; then
+                local dir_no_slash="${value%/}"
+                if [[ "$completion" == *:* ]]; then
+                    local desc="${completion#*:}"
+                    dirs+=("$dir_no_slash:$desc")
+                else
+                    dirs+=("$dir_no_slash")
+                fi
+            else
+                other+=("$completion")
+            fi
+        done
+        [[ -n $dirs ]] && _describe 'values' dirs -S '/' -r '/'
+        [[ -n $other ]] && _describe 'values' other
     fi
 }
 

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -370,3 +370,32 @@ help                                -- Print this message or the help of the giv
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }
+
+#[test]
+#[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
+fn complete_dynamic_dir_no_trailing_space() {
+    if !common::has_command(CMD) {
+        return;
+    }
+
+    let term = completest::Term::new();
+    let mut runtime = common::load_runtime::<RuntimeBuilder>("dynamic-env", "exhaustive");
+
+    // First, complete to the directory name with slash.
+    // A trailing slash should not be added after the slash.
+    let input = "exhaustive hint --file tes\t\t";
+    let expected = snapbox::str!["% exhaustive hint --file tests/"];
+    let actual = runtime.complete(input, &term).unwrap();
+    assert_data_eq!(actual, expected);
+
+    // Verify hitting tab again shows the directory contents.
+    // This only works if there is no trailing space after the slash.
+    let input = "exhaustive hint --file tests/\t\t";
+    let expected = snapbox::str![[r#"
+% exhaustive hint --file tests/
+tests/examples.rs  tests/snapshots    tests/testsuite
+"#]];
+    let actual = runtime.complete(input, &term).unwrap();
+    assert_data_eq!(actual, expected);
+}


### PR DESCRIPTION
zsh dynamic completions would add a trailing space after all completions, including directories. This prevented natural path completion. Users had to delete the trailing space before continuing to type or tab-complete within the directory.

The fix is for the dynamic completion script to separate completions into directories and non-directories, and providing the directory completions to zsh with a different _describe invocation.

For directories:
1. Strip the trailing slash from the completion value
2. Let zsh add it back as a suffix using `_describe -S '/'`
3. Also provide `-r '/'` to make the slash auto-removable when typing '/'

This makes dynamic path completions reasonably emulate zsh-native file completions.

This matches the behavior already implemented for bash completions which uses 'compopt -o nospace' to achieve the same result.

Fixes: #6178
Ref: https://github.com/jj-vcs/jj/issues/5582

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
