### PR TITLE
Default value on separate line in case of multiple possible values + empty default value fix.

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -799,7 +799,7 @@ impl HelpTemplate<'_, '_> {
                 .iter()
                 .map(|dv| dv.to_string_lossy())
                 .map(|dv| {
-                    if dv.contains(char::is_whitespace) {
+                    if dv.is_empty() || dv.contains(char::is_whitespace) {
                         Cow::from(format!("{dv:?}"))
                     } else {
                         dv


### PR DESCRIPTION
This PR fixes two things for defaults:
- Currently, when there are multiple possible values, the default is displayed at the end of the last possible value. The UI looks weird. I would want the default value to be shown on a separate line in this case.
- Empty string as default value: While checking if an existing issue/PR exists for the above, I came across #4976 - since it's a simple fix, I've included it in this PR. I don't mind separating it into a separate PR if needed.

Before:
```
  -s, --strategy <STRATEGY>
          Possible values:
          - close-game: Uses an algorithm that starts from the correct word and back tracks in a way that the game feels close
          - full:       Pick words that eliminate the least amount of possible words each turn[default: close-game]

      --empty-default <EMPTY_DEFAULT>
          [default: ]
```
After:
```
  -s, --strategy <STRATEGY>
          Possible values:
          - close-game: Uses an algorithm that starts from the correct word and back tracks in a way that the game feels close
          - full:       Pick words that eliminate the least amount of possible words each turn
          [default: close-game]

      --empty-default <EMPTY_DEFAULT>
          [default: ""]

```

Above results are for the struct:
```
#[derive(Parser)]
#[command(version, about, long_about = None)]
struct Cli {
    #[arg(value_enum)]
    #[arg(default_value_t = SolverMode::CloseGame)]
    #[arg(short, long)]
    strategy: SolverMode,
    #[clap(long, default_value_t)]
    empty_default: String,
}
```