### PR TITLE
Bugfix for default value UI when there's no help description

### DIFF
--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -657,12 +657,15 @@ impl HelpTemplate<'_, '_> {
         help.indent("", &trailing_indent);
         self.writer.push_styled(&help);
 
+        let mut has_possible_values = false;
         if let Some(arg) = arg {
             if !arg.is_hide_possible_values_set() && self.use_long_pv(arg) {
                 const DASH_SPACE: usize = "- ".len();
                 let possible_vals = arg.get_possible_values();
                 if !possible_vals.is_empty() {
                     debug!("HelpTemplate::help: Found possible vals...{possible_vals:?}");
+                    has_possible_values = true;
+
                     let longest = possible_vals
                         .iter()
                         .filter(|f| !f.is_hide_set())
@@ -709,7 +712,7 @@ impl HelpTemplate<'_, '_> {
 
         if !spec_vals.is_empty() && next_line_specs {
             let mut help = StyledStr::new();
-            if !help_is_empty {
+            if !help_is_empty || has_possible_values {
                 let sep = "\n\n";
                 help.push_str(sep);
             }

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -3131,7 +3131,9 @@ Options:
   -c, --config <MODE>
           Possible values:
           - fast
-          - slow: slower than fast[default: fast]
+          - slow: slower than fast
+          
+          [default: fast]
 
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
- [x] Demonstrate test showing current behaviour
   The first commit of this PR shows the current behaviour i.e. if there is no description to an argument, then the default value appears on the same line as the last possible value in case there are multiple values for the `--help` flag.
- [x] Update the test to show new behaviour
- [x] Add fix: default value should show up on a separate line even if there's no help description in case there are multiple possible values. related to #6204


