### PR TITLE
Fix value_terminator has no effect when it is the first argument 

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -132,6 +132,10 @@ impl<'cmd> Parser<'cmd> {
                         self.cmd[opt].is_allow_hyphen_values_set())
                     {
                         // ParseResult::MaybeHyphenValue, do nothing
+                    } else if self.cmd.get_keymap().get(&pos_counter).is_some_and(|arg| {
+                        self.check_terminator(arg, arg_os.to_value_os()).is_some()
+                    }) {
+                        // Value terminator for this positional, let positional parsing handle it.
                     } else {
                         debug!("Parser::get_matches_with: setting TrailingVals=true");
                         trailing_values = true;

--- a/tests/builder/multiple_values.rs
+++ b/tests/builder/multiple_values.rs
@@ -1687,17 +1687,17 @@ fn escape_as_value_terminator_with_empty_list() {
     let m = res.unwrap();
     let cmd1: Vec<_> = m
         .get_many::<String>("cmd1")
-        .unwrap()
-        .map(|v| v.as_str())
-        .collect();
-    assert_eq!(&cmd1, &["ls", "-l"]);
+        .map(|v| v.map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    let expected_cmd1: Vec<&str> = Vec::new();
+    assert_eq!(cmd1, expected_cmd1);
 
     let cmd2: Vec<_> = m
         .get_many::<String>("cmd2")
-        .map(|v| v.map(|v| v.as_str()).collect())
-        .unwrap_or_default();
-    let expected_cmd2: Vec<&str> = Vec::new();
-    assert_eq!(cmd2, expected_cmd2);
+        .unwrap()
+        .map(|v| v.as_str())
+        .collect();
+    assert_eq!(&cmd2, &["ls", "-l"]);
 }
 
 #[test]


### PR DESCRIPTION
Problem:
When -- is used as the first argument, a positional value_terminator should consume it and leave following values for the next positional. Instead, parsing switched to trailing values, causing the first positional to capture everything.

Solution:
Adjust escape handling so the current positional’s value_terminator takes precedence over entering trailing-values mode when it matches --.

Tests:

Added value_terminator_as_first_argument to cover the first-argument -- case.

#5040 