### PR TITLE
feat(derive): Support RFC 3681 default field values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ checksum = "ebb4bd301db2e2ca1f5be131c24eb8ebf2d9559bc3744419e93baf8ddea7e670"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -228,7 +228,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ dependencies = [
  "proc-macro2",
  "pulldown-cmark",
  "quote",
- "syn",
+ "syn 2.0.113",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ checksum = "1b4464d46ce68bfc7cb76389248c7c254def7baca8bece0693b02b83842c4c88"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1429,7 +1429,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1652,7 +1652,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2313,7 +2313,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2447,7 +2447,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -2934,7 +2934,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3150,7 +3150,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3186,6 +3186,16 @@ name = "syn"
 version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.113"
+source = "git+https://github.com/DJMcNab/syn.git?branch=with-default-fields#218d003ea6f37910d3d997f2183026c974063eec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3313,7 +3323,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3524,7 +3534,7 @@ checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -3888,7 +3898,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "wasm-bindgen-shared",
 ]
 
@@ -3910,7 +3920,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4226,7 +4236,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.99",
 ]
 
 [[package]]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -30,7 +30,7 @@ proc-macro = true
 bench = false
 
 [dependencies]
-syn = { version = "2.0.8", features = ["full"] }
+syn = { git = "https://github.com/DJMcNab/syn.git", branch = "with-default-fields", features = ["full"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.69"
 heck = "0.5.0"

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -17,8 +17,8 @@ use std::env;
 use heck::{ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{self, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
-use syn::DeriveInput;
-use syn::{self, ext::IdentExt, spanned::Spanned, Attribute, Field, Ident, LitStr, Type, Variant};
+use syn::{self, ext::IdentExt, spanned::Spanned, Attribute, Ident, LitStr, Type, Variant};
+use syn::{DeriveInput, DeriveInputWithDefault, FieldWithDefault, VariantWithDefault};
 
 use crate::attr::{AttrKind, AttrValue, ClapAttr, MagicAttrName};
 use crate::utils::{extract_doc_comment, format_doc_comment, inner_type, is_simple_ty, Sp, Ty};
@@ -53,7 +53,10 @@ pub(crate) struct Item {
 }
 
 impl Item {
-    pub(crate) fn from_args_struct(input: &DeriveInput, name: Name) -> Result<Self, syn::Error> {
+    pub(crate) fn from_args_struct(
+        input: &DeriveInputWithDefault,
+        name: Name,
+    ) -> Result<Self, syn::Error> {
         let ident = input.ident.clone();
         let span = input.ident.span();
         let attrs = &input.attrs;
@@ -71,7 +74,7 @@ impl Item {
     }
 
     pub(crate) fn from_subcommand_enum(
-        input: &DeriveInput,
+        input: &DeriveInputWithDefault,
         name: Name,
     ) -> Result<Self, syn::Error> {
         let ident = input.ident.clone();
@@ -117,7 +120,7 @@ impl Item {
     }
 
     pub(crate) fn from_subcommand_variant(
-        variant: &Variant,
+        variant: &VariantWithDefault,
         struct_casing: Sp<CasingStyle>,
         env_casing: Sp<CasingStyle>,
     ) -> Result<Self, syn::Error> {
@@ -125,12 +128,12 @@ impl Item {
         let ident = variant.ident.clone();
         let span = variant.span();
         let ty = match variant.fields {
-            syn::Fields::Unnamed(syn::FieldsUnnamed { ref unnamed, .. }) if unnamed.len() == 1 => {
-                Ty::from_syn_ty(&unnamed[0].ty)
-            }
-            syn::Fields::Named(_) | syn::Fields::Unnamed(..) | syn::Fields::Unit => {
-                Sp::new(Ty::Other, span)
-            }
+            syn::FieldsWithDefault::Unnamed(syn::FieldsUnnamedWithDefault {
+                ref unnamed, ..
+            }) if unnamed.len() == 1 => Ty::from_syn_ty(&unnamed[0].ty),
+            syn::FieldsWithDefault::Named(_)
+            | syn::FieldsWithDefault::Unnamed(..)
+            | syn::FieldsWithDefault::Unit => Sp::new(Ty::Other, span),
         };
         let kind = Sp::new(Kind::Command(ty), span);
         let mut res = Self::new(
@@ -197,7 +200,7 @@ impl Item {
     }
 
     pub(crate) fn from_args_field(
-        field: &Field,
+        field: &FieldWithDefault,
         struct_casing: Sp<CasingStyle>,
         env_casing: Sp<CasingStyle>,
     ) -> Result<Self, syn::Error> {

--- a/clap_derive/src/lib.rs
+++ b/clap_derive/src/lib.rs
@@ -21,8 +21,10 @@
 #![warn(clippy::print_stdout)]
 
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, DeriveInput};
-use syn::{Data, DataStruct, Fields};
+use syn::{
+    parse_macro_input, DataStructWithDefault, DataWithDefault, DeriveInput, DeriveInputWithDefault,
+    FieldsWithDefault,
+};
 
 #[macro_use]
 mod macros;
@@ -53,19 +55,19 @@ pub fn value_enum(input: TokenStream) -> TokenStream {
 /// context struct.
 #[proc_macro_derive(Parser, attributes(clap, structopt, command, arg, group))]
 pub fn parser(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = parse_macro_input!(input);
+    let input: DeriveInputWithDefault = parse_macro_input!(input);
     derives::derive_parser(&input)
         .unwrap_or_else(|err| {
             let specific_dummy = match input.data {
-                Data::Struct(DataStruct {
-                    fields: Fields::Named(ref _fields),
+                DataWithDefault::Struct(DataStructWithDefault {
+                    fields: FieldsWithDefault::Named(ref _fields),
                     ..
                 }) => Some(dummies::args(&input.ident)),
-                Data::Struct(DataStruct {
-                    fields: Fields::Unit,
+                DataWithDefault::Struct(DataStructWithDefault {
+                    fields: FieldsWithDefault::Unit,
                     ..
                 }) => Some(dummies::args(&input.ident)),
-                Data::Enum(_) => Some(dummies::subcommand(&input.ident)),
+                DataWithDefault::Enum(_) => Some(dummies::subcommand(&input.ident)),
                 _ => None,
             };
             let dummy = specific_dummy
@@ -85,7 +87,7 @@ pub fn parser(input: TokenStream) -> TokenStream {
 /// Generates the `Subcommand` impl.
 #[proc_macro_derive(Subcommand, attributes(clap, command, arg, group))]
 pub fn subcommand(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = parse_macro_input!(input);
+    let input: DeriveInputWithDefault = parse_macro_input!(input);
     derives::derive_subcommand(&input)
         .unwrap_or_else(|err| {
             let dummy = dummies::subcommand(&input.ident);
@@ -97,7 +99,7 @@ pub fn subcommand(input: TokenStream) -> TokenStream {
 /// Generates the `Args` impl.
 #[proc_macro_derive(Args, attributes(clap, command, arg, group))]
 pub fn args(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = parse_macro_input!(input);
+    let input: DeriveInputWithDefault = parse_macro_input!(input);
     derives::derive_args(&input)
         .unwrap_or_else(|err| {
             let dummy = dummies::args(&input.ident);

--- a/tests/derive/arguments.rs
+++ b/tests/derive/arguments.rs
@@ -49,6 +49,20 @@ fn argument_with_default() {
 }
 
 #[test]
+fn argument_with_field_default() {
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        arg: i32 = 42,
+    }
+    assert_eq!(
+        Opt { arg: 24 },
+        Opt::try_parse_from(["test", "24"]).unwrap()
+    );
+    assert_eq!(Opt { arg: 42 }, Opt::try_parse_from(["test"]).unwrap());
+    assert!(Opt::try_parse_from(["test", "42", "24"]).is_err());
+}
+
+#[test]
 fn auto_value_name() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {

--- a/tests/derive/main.rs
+++ b/tests/derive/main.rs
@@ -1,3 +1,4 @@
+#![feature(default_field_values)]
 #![cfg(feature = "derive")]
 #![cfg(feature = "help")]
 #![cfg(feature = "usage")]


### PR DESCRIPTION
This is a proof of concept to demonstrate what supporting the language-level field defaults defined by [RFC 3681](https://github.com/rust-lang/rust/issues/132162) might look like.

The behavior implemented is that the language-level field default gets ignored if the existing `default_value` attribute is present. I haven't decided if that's optimal or not.

It uses the `syn` version from this PR: https://github.com/dtolnay/syn/pull/1955