### PR TITLE
feat: Defer subcommands created by derive macros

### DIFF
--- a/examples/cargo-example-derive.md
+++ b/examples/cargo-example-derive.md
@@ -9,7 +9,7 @@ $ cargo-example-derive --help
 Usage: cargo <COMMAND>
 
 Commands:
-  example-derive  A simple to use, efficient, and full-featured Command Line Argument Parser
+  example-derive  
   help            Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -140,29 +140,6 @@ fn app_help_heading_flattened() {
     assert_eq!(should_be_in_section_b.get_help_heading(), Some("HEADING B"));
 
     let sub_a_two = cmd.find_subcommand("sub-a-two").unwrap();
-
-    let should_be_in_sub_a = sub_a_two
-        .get_arguments()
-        .find(|a| a.get_id() == "should_be_in_sub_a")
-        .unwrap();
-    assert_eq!(should_be_in_sub_a.get_help_heading(), Some("SUB A"));
-
-    let sub_b_one = cmd.find_subcommand("sub-b-one").unwrap();
-
-    let should_be_in_sub_b = sub_b_one
-        .get_arguments()
-        .find(|a| a.get_id() == "should_be_in_sub_b")
-        .unwrap();
-    assert_eq!(should_be_in_sub_b.get_help_heading(), Some("SUB B"));
-
-    let sub_c = cmd.find_subcommand("sub-c").unwrap();
-    let sub_c_one = sub_c.find_subcommand("sub-c-one").unwrap();
-
-    let should_be_in_sub_c = sub_c_one
-        .get_arguments()
-        .find(|a| a.get_id() == "should_be_in_sub_c")
-        .unwrap();
-    assert_eq!(should_be_in_sub_c.get_help_heading(), Some("SUB C"));
 }
 
 #[test]


### PR DESCRIPTION
Partially addresses #4959.

I have faced the problem of slow start up time in my CLI (https://github.com/near/near-cli-rs/issues/408#issuecomment-2525584077) and solved it by introducing the defer by default. I have just discovered the issue which suggests to implement deferring in stages, but unfortunately I don't have the capacity now to finish the issue as it is outlined with the deprecation process in mind. I still wanted to share in case someone also hits the issue and could use a patched version for now.

Two tests do not pass as is, so it indicates the breaking change. I changed the failing tests to show that the rest of the test suite passes. The failing tests are due to the nature of deferring the augmentation, so they are expected and in my attempts to resolve them I could not find an elegant solution that would not introduce even more breaking changes on the API level. The proposed plan in the #4959 is the only transition path forward.