### PR TITLE
fix(help): quote empty string defaults in help output

### DIFF
--- a/clap_builder/src/builder/possible_value.rs
+++ b/clap_builder/src/builder/possible_value.rs
@@ -186,7 +186,7 @@ impl PossibleValue {
     #[cfg(feature = "help")]
     pub(crate) fn get_visible_quoted_name(&self) -> Option<std::borrow::Cow<'_, str>> {
         if !self.hide {
-            Some(if self.name.contains(char::is_whitespace) {
+            Some(if self.name.is_empty() || self.name.contains(char::is_whitespace) {
                 format!("{:?}", self.name).into()
             } else {
                 self.name.as_str().into()

--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -496,7 +496,7 @@ struct Escape<'s>(&'s str);
 
 impl std::fmt::Display for Escape<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0.contains(char::is_whitespace) {
+        if self.0.is_empty() || self.0.contains(char::is_whitespace) {
             std::fmt::Debug::fmt(self.0, f)
         } else {
             self.0.fmt(f)

--- a/clap_builder/src/output/help_template.rs
+++ b/clap_builder/src/output/help_template.rs
@@ -796,7 +796,7 @@ impl HelpTemplate<'_, '_> {
                 .iter()
                 .map(|dv| dv.to_string_lossy())
                 .map(|dv| {
-                    if dv.contains(char::is_whitespace) {
+                    if dv.is_empty() || dv.contains(char::is_whitespace) {
                         Cow::from(format!("{dv:?}"))
                     } else {
                         dv


### PR DESCRIPTION
Fixes #4976

## Summary
When a default value is an empty string, the help output now displays `[default: ""]` instead of `[default: ]`, making it clear that the default is an empty string rather than appearing to be missing.

## Changes
- `help_template.rs`: Added check for empty strings in default value display
- `possible_value.rs`: Added check for empty strings in `get_visible_quoted_name`  
- `format.rs`: Added check for empty strings in `Escape` Display impl

## Before
```
Options:
      --text <TEXT>  [default: ]
  -h, --help         Print help
```

## After
```
Options:
      --text <TEXT>  [default: ""]
  -h, --help         Print help
```

This is a minimal change that follows the existing pattern of using Rust debug representation for values that need quoting.