### PR TITLE
docs: Recommend lazy-loading fish completions

### DIFF
--- a/clap_complete/src/env/mod.rs
+++ b/clap_complete/src/env/mod.rs
@@ -47,7 +47,7 @@
 //!
 //! **Fish**
 //! ```fish
-//! echo "COMPLETE=fish your_program | source" >> ~/.config/fish/config.fish
+//! echo "COMPLETE=fish your_program | source" >> ~/.config/fish/completions/your_program.fish
 //! ```
 //!
 //! **Powershell**


### PR DESCRIPTION
The file `~/.config/fish/config.fish` is executed eagerly at shell startup. Loading the completions there impacts shell startup time unnecessarily. Fish uses the special `~/.config/fish/completions/<prograg-name>.fish` files to load completions only the first time some program is completed in a shell session.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
