### PR TITLE
feat(derive): Add #[command(defer)] for lazy subcommand initialization

### DIFF
--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -69,6 +69,23 @@ impl ClapAttr {
             }
         }
     }
+
+    pub(crate) fn lit_bool_or_abort(&self) -> Result<bool, syn::Error> {
+        let value = self.value_or_abort()?;
+        match value {
+            AttrValue::Expr(Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Bool(lit),
+                ..
+            })) => Ok(lit.value()),
+            _ => {
+                abort!(
+                    self.name,
+                    "attribute `{}` can only accept bool literals",
+                    self.name
+                )
+            }
+        }
+    }
 }
 
 impl Parse for ClapAttr {
@@ -102,6 +119,7 @@ impl Parse for ClapAttr {
             "long_help" => Some(MagicAttrName::LongHelp),
             "author" => Some(MagicAttrName::Author),
             "version" => Some(MagicAttrName::Version),
+            "defer" => Some(MagicAttrName::Defer),
             _ => None,
         };
 
@@ -168,6 +186,7 @@ pub(crate) enum MagicAttrName {
     DefaultValuesOsT,
     NextDisplayOrder,
     NextHelpHeading,
+    Defer,
 }
 
 #[derive(Clone)]

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -323,6 +323,14 @@ fn gen_augment(
                     }
                 };
 
+                let sub_augment = if parent_item.defer() {
+                    quote! {
+                        #subcommand_var.defer(|#subcommand_var| { #sub_augment })
+                    }
+                } else {
+                    sub_augment
+                };
+
                 let deprecations = if !override_required {
                     item.deprecations()
                 } else {

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -50,6 +50,7 @@ pub(crate) struct Item {
     group_id: Name,
     group_methods: Vec<Method>,
     kind: Sp<Kind>,
+    defer: bool,
 }
 
 impl Item {
@@ -279,6 +280,7 @@ impl Item {
             group_id,
             group_methods: vec![],
             kind,
+            defer: cfg!(feature = "unstable-v5"),
         }
     }
 
@@ -835,6 +837,11 @@ impl Item {
                     self.skip_group = true;
                 }
 
+                Some(MagicAttrName::Defer) => {
+                    assert_attr_kind(attr, &[AttrKind::Command])?;
+                    self.defer = attr.lit_bool_or_abort()?;
+                }
+
                 None
                 // Magic only for the default, otherwise just forward to the builder
                 | Some(MagicAttrName::Short)
@@ -1089,6 +1096,10 @@ impl Item {
 
     pub(crate) fn skip_group(&self) -> bool {
         self.skip_group
+    }
+
+    pub(crate) fn defer(&self) -> bool {
+        self.defer
     }
 }
 

--- a/tests/derive/defer.rs
+++ b/tests/derive/defer.rs
@@ -1,0 +1,257 @@
+// Tests for subcommand initialization behavior.
+//
+// These tests establish the current (eager) behavior as a baseline.
+// A subsequent commit will add `#[command(defer = true)]` to enable lazy
+// initialization, and the test diffs will show how behavior changes.
+//
+// See: https://github.com/clap-rs/clap/issues/4959
+
+use clap::{Args, CommandFactory, Parser, Subcommand};
+
+#[test]
+fn subcommand_with_named_fields() {
+    #[derive(Parser, Debug)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: Commands,
+    }
+
+    #[derive(Subcommand, Debug)]
+    enum Commands {
+        /// Add a file
+        Add {
+            #[arg(long)]
+            file: String,
+        },
+        /// Remove a file
+        Remove {
+            #[arg(long)]
+            force: bool,
+        },
+    }
+
+    let cmd = Cli::command();
+    let add_cmd = cmd
+        .get_subcommands()
+        .find(|s| s.get_name() == "add")
+        .expect("add subcommand should exist");
+    assert_eq!(
+        add_cmd.get_about().map(|s| s.to_string()),
+        Some("Add a file".to_string()),
+    );
+
+    let remove_cmd = cmd
+        .get_subcommands()
+        .find(|s| s.get_name() == "remove")
+        .expect("remove should exist");
+    assert_eq!(
+        remove_cmd.get_about().map(|s| s.to_string()),
+        Some("Remove a file".to_string()),
+    );
+
+    let user_args: Vec<_> = add_cmd
+        .get_arguments()
+        .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+        .map(|a| a.get_id().as_str())
+        .collect();
+    assert!(
+        user_args.contains(&"file"),
+        "args should be immediately visible, got: {user_args:?}"
+    );
+}
+
+#[test]
+fn nested_subcommands() {
+    #[derive(Parser, Debug, PartialEq)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: Option<TopLevel>,
+    }
+
+    #[derive(Subcommand, Debug, PartialEq)]
+    enum TopLevel {
+        /// Account operations
+        Account(AccountArgs),
+    }
+
+    #[derive(Args, Debug, PartialEq)]
+    struct AccountArgs {
+        /// Account ID
+        account_id: Option<String>,
+        #[command(subcommand)]
+        action: Option<AccountAction>,
+    }
+
+    #[derive(Subcommand, Debug, PartialEq)]
+    enum AccountAction {
+        /// View account
+        View {
+            #[arg(long)]
+            verbose: bool,
+        },
+    }
+
+    let cmd = Cli::command();
+
+    let account = cmd
+        .get_subcommands()
+        .find(|s| s.get_name() == "account")
+        .expect("account should exist");
+    let args: Vec<_> = account
+        .get_arguments()
+        .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+        .map(|a| a.get_id().as_str())
+        .collect();
+    assert!(
+        args.contains(&"account_id"),
+        "account_id should be visible, got: {args:?}"
+    );
+
+    let parsed = Cli::try_parse_from(["test", "account", "alice", "view"]).unwrap();
+    assert_eq!(
+        parsed,
+        Cli {
+            cmd: Some(TopLevel::Account(AccountArgs {
+                account_id: Some("alice".to_string()),
+                action: Some(AccountAction::View { verbose: false })
+            }))
+        }
+    );
+
+    let parsed = Cli::try_parse_from(["test", "account", "alice", "view", "--verbose"]).unwrap();
+    assert_eq!(
+        parsed,
+        Cli {
+            cmd: Some(TopLevel::Account(AccountArgs {
+                account_id: Some("alice".to_string()),
+                action: Some(AccountAction::View { verbose: true })
+            }))
+        }
+    );
+}
+
+#[test]
+fn flatten_args_in_subcommand_are_eager() {
+    #[derive(Parser, Debug, PartialEq)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: Commands,
+    }
+
+    #[derive(Subcommand, Debug, PartialEq)]
+    enum Commands {
+        Add(FlattenedArgs),
+    }
+
+    #[derive(Args, Debug, PartialEq)]
+    struct FlattenedArgs {
+        #[arg(long)]
+        file: String,
+        #[command(flatten)]
+        common: CommonArgs,
+    }
+
+    #[derive(Args, Debug, PartialEq)]
+    struct CommonArgs {
+        #[arg(long)]
+        verbose: bool,
+    }
+
+    let cmd = Cli::command();
+    let add = cmd
+        .get_subcommands()
+        .find(|s| s.get_name() == "add")
+        .expect("add should exist");
+
+    let user_args: Vec<_> = add
+        .get_arguments()
+        .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+        .map(|a| a.get_id().as_str())
+        .collect();
+    assert!(
+        user_args.contains(&"file"),
+        "file should be visible, got: {user_args:?}"
+    );
+    assert!(
+        user_args.contains(&"verbose"),
+        "flattened args should be visible, got: {user_args:?}"
+    );
+
+    let parsed =
+        Cli::try_parse_from(["test", "add", "--file", "config.toml", "--verbose"]).unwrap();
+    assert_eq!(
+        parsed,
+        Cli {
+            cmd: Commands::Add(FlattenedArgs {
+                file: "config.toml".to_string(),
+                common: CommonArgs { verbose: true },
+            }),
+        }
+    );
+}
+
+#[test]
+fn enum_variant_with_inline_args() {
+    #[derive(Parser, Debug, PartialEq)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: Cmd,
+    }
+
+    #[derive(Subcommand, Debug, PartialEq)]
+    enum Cmd {
+        Sub {
+            #[arg(long)]
+            flag: bool,
+        },
+    }
+
+    let parsed = Cli::try_parse_from(["test", "sub", "--flag"]).unwrap();
+    assert_eq!(
+        parsed,
+        Cli {
+            cmd: Cmd::Sub { flag: true }
+        }
+    );
+
+    let parsed = Cli::try_parse_from(["test", "sub"]).unwrap();
+    assert_eq!(
+        parsed,
+        Cli {
+            cmd: Cmd::Sub { flag: false }
+        }
+    );
+}
+
+#[test]
+fn default_behavior_is_eager() {
+    #[derive(Parser, Debug)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: Commands,
+    }
+
+    #[derive(Subcommand, Debug)]
+    enum Commands {
+        Add {
+            #[arg(long)]
+            file: String,
+        },
+    }
+
+    let cmd = Cli::command();
+    let add_cmd = cmd
+        .get_subcommands()
+        .find(|s| s.get_name() == "add")
+        .expect("add should exist");
+
+    let user_args: Vec<_> = add_cmd
+        .get_arguments()
+        .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+        .map(|a| a.get_id().as_str())
+        .collect();
+    assert!(
+        user_args.contains(&"file"),
+        "default: args should be immediately visible"
+    );
+}

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -139,6 +139,9 @@ fn app_help_heading_flattened() {
         .unwrap();
     assert_eq!(should_be_in_section_b.get_help_heading(), Some("HEADING B"));
 
+    let mut cmd = cmd;
+    cmd.build();
+
     let sub_a_two = cmd.find_subcommand("sub-a-two").unwrap();
 
     let should_be_in_sub_a = sub_a_two
@@ -376,7 +379,9 @@ fn derive_order_no_next_order() {
     let mut cmd = Args::command();
 
     let help = cmd.render_help().to_string();
-    assert_data_eq!(help, str![[r#"
+    assert_data_eq!(
+        help,
+        str![[r#"
 Usage: test [OPTIONS]
 
 Options:
@@ -387,7 +392,8 @@ Options:
       --option-b <OPTION_B>  second option
   -V, --version              Print version
 
-"#]]);
+"#]]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds `#[command(defer = true)]` to the derive API, enabling lazy initialization of subcommand arguments via `Command::defer()`. This closes the gap between the builder API (which has had `Command::defer` since #4792) and the derive API.

- Subcommand metadata (`.about()`, `.version()`, etc.) is applied **eagerly**, so `--help` displays subcommand descriptions without needing `build()`
- Subcommand **args and nested subcommands** are wrapped in `Command::defer()` and only materialized when needed
- Defaults to `false` in v4, `true` under `unstable-v5`

## Motivation

CLIs with many deeply nested subcommands pay a steep startup cost because clap eagerly initializes every subcommand and all their args — even when only one is invoked. For a CLI with ~330 subcommands, this was measured at **4–6 seconds of startup time, reduced to ~12ms** with deferred initialization.

See #4959 for the original feature request.

## Prior art

This picks up the work from #6225 by @frol, restructured to follow the project's contribution guidelines. Key differences from the original PR:
- `gen_augment` accepts a `skip_top_level_methods` parameter so metadata and args are each generated exactly once (no duplication)
- Commit history follows CONTRIBUTING.md conventions (refactor → baseline tests → feature)

## Example

```rust
#[derive(Subcommand)]
#[command(defer = true)]
enum Commands {
    /// Add a file
    Add { #[arg(long)] file: String },
    /// Remove a file  
    Remove { #[arg(long)] force: bool },
}
```

Partially addresses #4959