### PR TITLE
fix(complete): Update Elvish registration to modern syntax

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -160,7 +160,10 @@ set edit:completion:arg-completer[BIN] = { |@words|
     var index = (count $words)
     set index = (- $index 1)
 
-    put (env _CLAP_IFS="\n" _CLAP_COMPLETE_INDEX=(to-string $index) VAR="elvish" COMPLETER -- $@words) | to-lines
+    tmp E:_CLAP_IFS = "\n"
+    tmp E:_CLAP_COMPLETE_INDEX = (to-string $index)
+    tmp E:VAR = "elvish"
+    put (COMPLETER -- $@words) | to-lines
 }
 "#
         .replace("COMPLETER", &completer)

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/elvish/elvish/rc.elv
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/elvish/elvish/rc.elv
@@ -5,7 +5,10 @@ set edit:completion:arg-completer[exhaustive] = { |@words|
     var index = (count $words)
     set index = (- $index 1)
 
-    put (env _CLAP_IFS="\n" _CLAP_COMPLETE_INDEX=(to-string $index) COMPLETE="elvish" exhaustive -- $@words) | to-lines
+    tmp E:_CLAP_IFS = "\n"
+    tmp E:_CLAP_COMPLETE_INDEX = (to-string $index)
+    tmp E:COMPLETE = "elvish"
+    put (exhaustive -- $@words) | to-lines
 }
 
 


### PR DESCRIPTION
> This PR was generated with the assistance of an AI agent and reviewed by me.

Resolves #5729

## Summary

Updates the Elvish dynamic completion registration script to use `tmp E:VAR = value` instead of the deprecated `env VAR=value command` pattern. The old syntax was deprecated in Elvish 0.18 and removed entirely in 0.21.

## Changes

**`clap_complete/src/env/shells.rs`**: The Elvish `write_registration` template now uses `tmp E:` for temporary environment variables. The `tmp` command automatically restores previous values when the enclosing lambda returns.

No dedicated unit test was added because the existing integration tests in `elvish.rs` lready
validate the Elvish completion flow end-to-end through completest_pty::ElvishRuntimeBuilder`.

## Test plan

- [x] `cargo test -p clap_complete --features unstable-dynamic` — all 107 tests pass
- [x] `cargo clippy -p clap_complete --features unstable-dynamic` — clean