### PR TITLE
feat(complete): Support require_equals in completion engine

### DIFF
--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -1443,6 +1443,59 @@ pos-c
     );
 }
 
+#[test]
+fn suggest_require_equals() {
+    let mut cmd = Command::new("exhaustive")
+        .arg(
+            clap::Arg::new("format")
+                .long("format")
+                .require_equals(true)
+                .value_parser(["json", "yaml", "toml"]),
+        )
+        .arg(
+            clap::Arg::new("name")
+                .long("name")
+                .short('n'),
+        );
+
+    // When completing after an empty input, --format should appear with = appended
+    assert_data_eq!(
+        complete!(cmd, " [TAB]"),
+        snapbox::str![[r#"
+--format
+--name
+--help	Print help
+"#]]
+    );
+
+    // Should complete values after --format=
+    assert_data_eq!(
+        complete!(cmd, "--format=[TAB]"),
+        snapbox::str![[r#"
+--format=json
+--format=yaml
+--format=toml
+"#]]
+    );
+
+    // Should complete values after --format=j
+    assert_data_eq!(
+        complete!(cmd, "--format=j[TAB]"),
+        snapbox::str!["--format=json"]
+    );
+
+    // When typing --format (space), should NOT suggest values since require_equals forbids it
+    // Current behavior: suggests values (this will change with the fix)
+    assert_data_eq!(
+        complete!(cmd, "--format [TAB]"),
+        snapbox::str![[r#"
+json
+yaml
+toml
+"#]]
+    );
+}
+
 fn complete(cmd: &mut Command, args: impl AsRef<str>, current_dir: Option<&Path>) -> String {
     let input = args.as_ref();
     let mut args = vec![std::ffi::OsString::from(cmd.get_name())];

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -1462,7 +1462,7 @@ fn suggest_require_equals() {
     assert_data_eq!(
         complete!(cmd, " [TAB]"),
         snapbox::str![[r#"
---format
+--format=
 --name
 --help	Print help
 "#]]
@@ -1485,13 +1485,12 @@ fn suggest_require_equals() {
     );
 
     // When typing --format (space), should NOT suggest values since require_equals forbids it
-    // Current behavior: suggests values (this will change with the fix)
     assert_data_eq!(
         complete!(cmd, "--format [TAB]"),
         snapbox::str![[r#"
-json
-yaml
-toml
+--format=
+--name
+--help	Print help
 "#]]
     );
 }


### PR DESCRIPTION
> This PR was generated with the assistance of an AI agent and reviewed by me.

Resolves #3923

## Summary

When an argument has `require_equals(true)` set, the completion engine now:

- Shows `--flag=` (with trailing `=`) instead of `--flag` when listing options
- No longer suggests values after `--flag ` (space-separated), since the parser would reject that form

## Changes

**`clap_complete/src/engine/complete.rs`:**

1. Parsing loop: skip entering `ParseState::Opt` for `require_equals` options encountered space-separated
1. `longs_and_visible_aliases()` / `hidden_longs_aliases()`: append `=` to candidates for `require_equals` args

**`clap_complete/tests/testsuite/engine.rs`:** Added `suggest_require_equals` test

## Test plan

- [x] `cargo test -p clap_complete --features unstable-dynamic` — all 108 tests pass
- [x] `cargo clippy -p clap_complete --features unstable-dynamic` — clean