### PR TITLE
feat(complete): Add per-candidate trailing space control

### DIFF
--- a/clap_complete/src/engine/candidate.rs
+++ b/clap_complete/src/engine/candidate.rs
@@ -12,6 +12,7 @@ pub struct CompletionCandidate {
     tag: Option<StyledStr>,
     display_order: Option<usize>,
     hidden: bool,
+    nospace: bool,
 }
 
 impl CompletionCandidate {
@@ -60,6 +61,16 @@ impl CompletionCandidate {
         self
     }
 
+    /// Suppress trailing space after this candidate
+    ///
+    /// This is useful for completions like directory paths (ending in `/`),
+    /// `--flag=` values, and delimiter-separated values where a trailing space
+    /// would be incorrect.
+    pub fn nospace(mut self, nospace: bool) -> Self {
+        self.nospace = nospace;
+        self
+    }
+
     /// Add a prefix to the value of completion candidate
     ///
     /// This is generally used for post-process by [`complete`][crate::engine::complete()] for
@@ -103,6 +114,11 @@ impl CompletionCandidate {
     /// Get the visibility of the completion candidate
     pub fn is_hide_set(&self) -> bool {
         self.hidden
+    }
+
+    /// Get whether trailing space should be suppressed
+    pub fn is_nospace_set(&self) -> bool {
+        self.nospace
     }
 }
 

--- a/clap_complete/src/engine/custom.rs
+++ b/clap_complete/src/engine/custom.rs
@@ -336,7 +336,8 @@ pub(crate) fn complete_path(
             let mut suggestion = prefix.join(&raw_file_name);
             suggestion.push(""); // Ensure trailing `/`
             let candidate = CompletionCandidate::new(suggestion.as_os_str().to_owned())
-                .hide(is_hidden(&raw_file_name));
+                .hide(is_hidden(&raw_file_name))
+                .nospace(true);
 
             if is_wanted(&entry.path()) {
                 completions.push(candidate);

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
@@ -24,8 +24,11 @@ _clap_complete_exhaustive() {
     ) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
-    elif [[ $_CLAP_COMPLETE_SPACE == false ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
-        compopt -o nospace
+    elif [[ $_CLAP_COMPLETE_SPACE == false ]]; then
+        if [[ ${#COMPREPLY[@]} -gt 0 ]] && [[ "${COMPREPLY[-1]}" == "_CLAP_COMPLETE_NOSPACE" ]]; then
+            unset 'COMPREPLY[-1]'
+            compopt -o nospace
+        fi
     fi
 }
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/elvish/elvish/rc.elv
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/elvish/elvish/rc.elv
@@ -5,7 +5,13 @@ set edit:completion:arg-completer[exhaustive] = { |@words|
     var index = (count $words)
     set index = (- $index 1)
 
-    put (env _CLAP_IFS="\n" _CLAP_COMPLETE_INDEX=(to-string $index) COMPLETE="elvish" exhaustive -- $@words) | to-lines
+    env _CLAP_IFS="\n" _CLAP_COMPLETE_INDEX=(to-string $index) COMPLETE="elvish" exhaustive -- $@words | from-lines | each { |line|
+        if (str:has-prefix $line "\x1f") {
+            var value = (str:trim-prefix $line "\x1f")
+            edit:complex-candidate $value &code-suffix=''
+        } else {
+            put $line
+        }
+    }
 }
-
 

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
@@ -11,24 +11,18 @@ function _clap_dynamic_completer_exhaustive() {
     )}")
 
     if [[ -n $completions ]]; then
-        local -a dirs=()
+        local -a nospace=()
         local -a other=()
         local completion
         for completion in $completions; do
-            local value="${completion%%:*}"
-            if [[ "$value" == */ ]]; then
-                local dir_no_slash="${value%/}"
-                if [[ "$completion" == *:* ]]; then
-                    local desc="${completion#*:}"
-                    dirs+=("$dir_no_slash:$desc")
-                else
-                    dirs+=("$dir_no_slash")
-                fi
+            if [[ "$completion" == $'\x1f'* ]]; then
+                completion="${completion:1}"
+                nospace+=("$completion")
             else
                 other+=("$completion")
             fi
         done
-        [[ -n $dirs ]] && _describe 'values' dirs -S '/' -r '/'
+        [[ -n $nospace ]] && _describe 'values' nospace -S ''
         [[ -n $other ]] && _describe 'values' other
     fi
 }

--- a/clap_complete/tests/snapshots/register_minimal.bash
+++ b/clap_complete/tests/snapshots/register_minimal.bash
@@ -1,6 +1,6 @@
 
 _clap_complete_my_app() {
-    local IFS=$'/013'
+    local IFS=$'\013'
     local _CLAP_COMPLETE_INDEX=${COMP_CWORD}
     local _CLAP_COMPLETE_COMP_TYPE=${COMP_TYPE}
     if compopt +o nospace 2> /dev/null; then
@@ -8,17 +8,20 @@ _clap_complete_my_app() {
     else
         local _CLAP_COMPLETE_SPACE=true
     fi
-    COMPREPLY=( $( /
-        IFS="$IFS" /
-        _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" /
-        _CLAP_COMPLETE_COMP_TYPE="$_CLAP_COMPLETE_COMP_TYPE" /
-        _CLAP_COMPLETE_SPACE="$_CLAP_COMPLETE_SPACE" /
-        "my-app" complete bash -- "${COMP_WORDS[@]}" /
+    COMPREPLY=( $( \
+        IFS="$IFS" \
+        _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
+        _CLAP_COMPLETE_COMP_TYPE="$_CLAP_COMPLETE_COMP_TYPE" \
+        _CLAP_COMPLETE_SPACE="$_CLAP_COMPLETE_SPACE" \
+        "my-app" complete bash -- "${COMP_WORDS[@]}" \
     ) )
     if [[ $? != 0 ]]; then
         unset COMPREPLY
-    elif [[ $_CLAP_COMPLETE_SPACE == false ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
-        compopt -o nospace
+    elif [[ $_CLAP_COMPLETE_SPACE == false ]]; then
+        if [[ ${#COMPREPLY[@]} -gt 0 ]] && [[ "${COMPREPLY[-1]}" == "_CLAP_COMPLETE_NOSPACE" ]]; then
+            unset 'COMPREPLY[-1]'
+            compopt -o nospace
+        fi
     fi
 }
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then


### PR DESCRIPTION
> This PR was generated with the assistance of an AI agent and reviewed by me.

## Summary

Adds a `nospace` field to `CompletionCandidate` so the engine can tell shells "don't add a trailing space after this completion." Each shell adapter translates this into its native mechanism, replacing ad-hoc heuristics.

Fixes #5587

## Changes

- **`clap_complete/src/engine/candidate.rs`:** Add `nospace: bool` field with builder `.nospace(bool)` and getter `.is_nospace_set()`.
- **`clap_complete/src/engine/custom.rs`:** Set `nospace(true)` on directory candidates in `complete_path()`.
- **`clap_complete/src/engine/complete.rs`:** Set `nospace(true)` on `--flag=value` completions, `-F=value` completions, delimiter-prefixed completions, and `require_equals` options with `=` suffix.
- **`clap_complete/src/env/shells.rs`:**
  - **Bash:** Output `_CLAP_COMPLETE_NOSPACE` sentinel; registration script detects it and calls `compopt -o nospace`. Replaces the `[=/:]$` regex heuristic.
  - **Zsh:** Nospace candidates prefixed with `\x1f`; registration script splits into `nospace`/`other` groups using `_describe 'values' nospace -S ''`. Replaces directory-only split.
  - **Elvish:** Nospace candidates prefixed with `\x1f`; registration script wraps them in `edit:complex-candidate $value &code-suffix=''`.
  - **Fish/PowerShell:** No changes needed.
- **`clap_complete/tests/testsuite/engine.rs`:** 5 new tests for nospace on directories, equals values, short equals, `require_equals`, and delimiters.
- **Snapshot files:** Updated registration snapshots for Bash, Zsh, and Elvish.

## Test Plan

- `cargo test -p clap_complete --features unstable-dynamic` — 112 tests pass
- `cargo clippy -p clap_complete --features unstable-dynamic` — no warnings
- `cargo fmt -p clap_complete --check` — clean

