### PR TITLE
 fix(parser): Allow --help to propagate up through subcommands with ignore_erros

### DIFF
--- a/clap_builder/src/parser/parser.rs
+++ b/clap_builder/src/parser/parser.rs
@@ -744,7 +744,7 @@ impl<'cmd> Parser<'cmd> {
                     p.flag_subcmd_skip = self.flag_subcmd_skip;
                 }
                 if let Err(error) = p.get_matches_with(&mut sc_matcher, raw_args, args_cursor) {
-                    if partial_parsing_enabled {
+                    if partial_parsing_enabled && error.use_stderr() {
                         debug!("Parser::parse_subcommand: ignored error in subcommand {sc_name}: {error:?}");
                     } else {
                         return Err(error);

--- a/tests/builder/ignore_errors.rs
+++ b/tests/builder/ignore_errors.rs
@@ -229,7 +229,18 @@ fn help_flag_subcommand() {
         .subcommand(Command::new("sub"))
         .ignore_errors(true);
 
-    cmd.try_get_matches_from(["test", "sub", "--help"]).unwrap();
+    utils::assert_output(
+        cmd,
+        "test sub --help",
+        str![[r#"
+Usage: test sub
+
+Options:
+  -h, --help  Print help
+
+"#]],
+        false,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #6275