### PR TITLE
Added no_std support for derived code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ debug = ["clap_builder/debug", "clap_derive?/debug"] # Enables debug messages
 unstable-doc = ["clap_builder/unstable-doc", "derive"] # for docs.rs
 
 # Used in default
-std = ["clap_builder/std"] # support for no_std in a backwards-compatible way
+std = ["clap_builder/std", "clap_derive?/std"] # support for no_std in a backwards-compatible way
 color = ["clap_builder/color"]
 help = ["clap_builder/help"]
 usage = ["clap_builder/usage"]

--- a/clap_derive/Cargo.toml
+++ b/clap_derive/Cargo.toml
@@ -38,7 +38,8 @@ pulldown-cmark = { version = "0.13.0", default-features = false, optional = true
 anstyle = {version ="1.0.10", optional = true}
 
 [features]
-default = []
+default = ["std"]
+std = []
 debug = []
 unstable-v5 = ["deprecated"]
 deprecated = []

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -19,6 +19,7 @@ use syn::{
     Fields, FieldsNamed, Generics,
 };
 
+use crate::derives::ALLOC_CRATE;
 use crate::item::{Item, Kind, Name};
 use crate::utils::{inner_type, sub_type, Sp, Ty};
 
@@ -108,24 +109,24 @@ pub(crate) fn gen_for_struct(
         )]
         #[automatically_derived]
         impl #impl_generics clap::FromArgMatches for #item_name #ty_generics #where_clause {
-            fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
+            fn from_arg_matches(__clap_arg_matches: &clap::ArgMatches) -> ::core::result::Result<Self, clap::Error> {
                 Self::from_arg_matches_mut(&mut __clap_arg_matches.clone())
             }
 
-            fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
+            fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::core::result::Result<Self, clap::Error> {
                 #raw_deprecated
                 let v = #item_name #constructor;
-                ::std::result::Result::Ok(v)
+                ::core::result::Result::Ok(v)
             }
 
-            fn update_from_arg_matches(&mut self, __clap_arg_matches: &clap::ArgMatches) -> ::std::result::Result<(), clap::Error> {
+            fn update_from_arg_matches(&mut self, __clap_arg_matches: &clap::ArgMatches) -> ::core::result::Result<(), clap::Error> {
                 self.update_from_arg_matches_mut(&mut __clap_arg_matches.clone())
             }
 
-            fn update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<(), clap::Error> {
+            fn update_from_arg_matches_mut(&mut self, __clap_arg_matches: &mut clap::ArgMatches) -> ::core::result::Result<(), clap::Error> {
                 #raw_deprecated
                 #updater
-                ::std::result::Result::Ok(())
+                ::core::result::Result::Ok(())
             }
         }
 
@@ -719,13 +720,13 @@ fn gen_parsers(
 
         Ty::VecVec => quote_spanned! { ty.span()=>
             #arg_matches.#get_occurrences(#id)
-                .map(|g| g.map(::std::iter::Iterator::collect).collect::<Vec<Vec<_>>>())
+                .map(|g| g.map(::core::iter::Iterator::collect).collect::<Vec<Vec<_>>>())
                 .unwrap_or_else(Vec::new)
         },
 
         Ty::OptionVecVec => quote_spanned! { ty.span()=>
             #arg_matches.#get_occurrences(#id)
-                .map(|g| g.map(::std::iter::Iterator::collect).collect::<Vec<Vec<_>>>())
+                .map(|g| g.map(::core::iter::Iterator::collect).collect::<Vec<Vec<_>>>())
         },
 
         Ty::Other => {
@@ -735,7 +736,7 @@ fn gen_parsers(
                 Name::Assigned(_) => {
                     quote_spanned! { ty.span()=>
                         #arg_matches.#get_one(#id)
-                            .ok_or_else(|| clap::Error::raw(clap::error::ErrorKind::MissingRequiredArgument, format!("the following required argument was not provided: {}", #id)))?
+                            .ok_or_else(|| clap::Error::raw(clap::error::ErrorKind::MissingRequiredArgument, #ALLOC_CRATE::format!("the following required argument was not provided: {}", #id)))?
                     }
                 }
                 Name::Derived(_) => {

--- a/clap_derive/src/derives/value_enum.rs
+++ b/clap_derive/src/derives/value_enum.rs
@@ -119,7 +119,7 @@ fn gen_to_possible_value(item: &Item, lits: &[(TokenStream, Ident)]) -> TokenStr
     let deprecations = item.deprecations();
 
     quote! {
-        fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::builder::PossibleValue> {
+        fn to_possible_value<'a>(&self) -> ::core::option::Option<clap::builder::PossibleValue> {
             #deprecations
             match self {
                 #(Self::#variant => Some(#lit),)*

--- a/clap_derive/src/dummies.rs
+++ b/clap_derive/src/dummies.rs
@@ -33,10 +33,10 @@ pub(crate) fn from_arg_matches(name: &Ident) -> proc_macro2::TokenStream {
     quote! {
         #[automatically_derived]
         impl clap::FromArgMatches for #name {
-            fn from_arg_matches(_m: &clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
+            fn from_arg_matches(_m: &clap::ArgMatches) -> ::core::result::Result<Self, clap::Error> {
                 unimplemented!()
             }
-            fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> ::std::result::Result<(), clap::Error>{
+            fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> ::core::result::Result<(), clap::Error>{
                 unimplemented!()
             }
         }
@@ -88,10 +88,10 @@ pub(crate) fn value_enum(name: &Ident) -> proc_macro2::TokenStream {
             fn value_variants<'a>() -> &'a [Self]{
                 unimplemented!()
             }
-            fn from_str(_input: &str, _ignore_case: bool) -> ::std::result::Result<Self, String> {
+            fn from_str(_input: &str, _ignore_case: bool) -> ::core::result::Result<Self, String> {
                 unimplemented!()
             }
-            fn to_possible_value<'a>(&self) -> ::std::option::Option<clap::builder::PossibleValue>{
+            fn to_possible_value<'a>(&self) -> ::core::option::Option<clap::builder::PossibleValue>{
                 unimplemented!()
             }
         }

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -550,6 +550,15 @@ impl Item {
                 }
 
                 Some(MagicAttrName::DefaultValueT) => {
+                    #[cfg(not(feature = "std"))]
+                    abort!(
+                        attr.name.clone(),
+                        "#[arg(default_value_t)] require feature `std`",
+
+                        note = "see \
+                            https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes"
+                    );
+
                     assert_attr_kind(attr, &[AttrKind::Arg])?;
 
                     let ty = if let Some(ty) = self.ty.as_ref() {
@@ -600,6 +609,14 @@ impl Item {
                 }
 
                 Some(MagicAttrName::DefaultValuesT) => {
+                    #[cfg(not(feature = "std"))]
+                    abort!(
+                        attr.name.clone(),
+                        "#[arg(default_values_t)] require feature `std`",
+
+                        note = "see \
+                            https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes"
+                    );
                     assert_attr_kind(attr, &[AttrKind::Arg])?;
 
                     let ty = if let Some(ty) = self.ty.as_ref() {
@@ -678,6 +695,15 @@ impl Item {
                 }
 
                 Some(MagicAttrName::DefaultValueOsT) => {
+                    #[cfg(not(feature = "std"))]
+                    abort!(
+                        attr.name.clone(),
+                        "#[arg(default_value_os_t)] require feature `std`",
+
+                        note = "see \
+                            https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes"
+                    );
+
                     assert_attr_kind(attr, &[AttrKind::Arg])?;
 
                     let ty = if let Some(ty) = self.ty.as_ref() {
@@ -728,6 +754,15 @@ impl Item {
                 }
 
                 Some(MagicAttrName::DefaultValuesOsT) => {
+                    #[cfg(not(feature = "std"))]
+                    abort!(
+                        attr.name.clone(),
+                        "#[arg(default_values_os_t)] require feature `std`",
+
+                        note = "see \
+                            https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes"
+                    );
+
                     assert_attr_kind(attr, &[AttrKind::Arg])?;
 
                     let ty = if let Some(ty) = self.ty.as_ref() {

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -255,17 +255,22 @@
 //! - `skip [= <expr>]`: Ignore this field, filling in with `<expr>`
 //!   - Without `<expr>`: fills the field with `Default::default()`
 //! - `default_value = <str>`: [`Arg::default_value`][crate::Arg::default_value] and [`Arg::required(false)`][crate::Arg::required]
+//!   - Requires `std` feature
 //! - `default_value_t [= <expr>]`: [`Arg::default_value`][crate::Arg::default_value] and [`Arg::required(false)`][crate::Arg::required]
+//!   - Requires `std` feature
 //!   - Requires `std::fmt::Display` that roundtrips correctly with the
 //!     [`Arg::value_parser`][crate::Arg::value_parser] or `#[arg(value_enum)]`
 //!   - Without `<expr>`, relies on `Default::default()`
 //! - `default_values_t = <expr>`: [`Arg::default_values`][crate::Arg::default_values] and [`Arg::required(false)`][crate::Arg::required]
+//!   - Requires `std` feature
 //!   - Requires field arg to be of type `Vec<T>` and `T` to implement `std::fmt::Display` or `#[arg(value_enum)]`
 //!   - `<expr>` must implement `IntoIterator<T>`
 //! - `default_value_os_t [= <expr>]`: [`Arg::default_value_os`][crate::Arg::default_value_os] and [`Arg::required(false)`][crate::Arg::required]
+//!   - Requires `std` feature
 //!   - Requires `std::convert::Into<OsString>` or `#[arg(value_enum)]`
 //!   - Without `<expr>`, relies on `Default::default()`
 //! - `default_values_os_t = <expr>`: [`Arg::default_values_os`][crate::Arg::default_values_os] and [`Arg::required(false)`][crate::Arg::required]
+//!   - Requires `std` feature
 //!   - Requires field arg to be of type `Vec<T>` and `T` to implement `std::convert::Into<OsString>` or `#[arg(value_enum)]`
 //!   - `<expr>` must implement `IntoIterator<T>`
 //!


### PR DESCRIPTION
Hi,

I added no_std support for derived code where possible with minimal changes.

The added `std` feature (which is default) derives compatible code (`::std` -> `::core`, for core types, which is valid in `std` code)

Without it, it also changes the path of `alloc` types (`::std` -> `::alloc` for vec, string).
Also, the default arg attributes are not available in this mode (they rely on `::std::sync::OnceLock` or use `OsString`).
So `default_value_t`, `default_values_t`, `default_value_os_t`, `default_values_os_t` will produce an error when used without `std` feature.

Do you think this can be merged in the mainstream ?

Best regards,