### PR TITLE
fix(bash completions): allows workbearks [clap_complete/unstable-dynamic]

### DIFF
--- a/clap_complete/src/env/mod.rs
+++ b/clap_complete/src/env/mod.rs
@@ -154,7 +154,7 @@ impl<'s, F: Fn() -> clap::Command> CompleteEnv<'s, F> {
             var: "COMPLETE",
             bin: None,
             completer: None,
-            skip_wordbreaks: HashSet::from([':', '=']),
+            skip_wordbreaks: HashSet::from(['=']),
             shells: Shells::builtins(),
         }
     }

--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -491,6 +491,7 @@ mod tests {
                 "ignored-name",
                 "/ignored/bin",
                 completer_bin,
+                "",
                 &mut buf,
             )
             .expect("write_registration failed");

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
@@ -29,9 +29,9 @@ _clap_complete_exhaustive() {
     fi
 }
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -o nospace -o bashdefault -o nosort -F _clap_complete_exhaustive exhaustive
+    COMP_WORDBREAKS=${COMP_WORDBREAKS//[=]/} complete -o nospace -o bashdefault -o nosort -F _clap_complete_exhaustive exhaustive
 else
-    complete -o nospace -o bashdefault -F _clap_complete_exhaustive exhaustive
+    COMP_WORDBREAKS=${COMP_WORDBREAKS//[=]/} complete -o nospace -o bashdefault -F _clap_complete_exhaustive exhaustive
 fi
 
 


### PR DESCRIPTION
This pr tries to solve all the related issues with the Bash default `COMP_WORDBREAKS`

- issue #6280 
- issue #3920

A prior pr with a similar approach is #6264. but this is a more general approach.

> [!Note]
> I may need help with a new test set, but it is very difficult because the behavior 
> is changed in bash rather than inside of the lib.