### PR TITLE
examples: add environment variable fallback example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,12 @@ required-features = ["derive"]
 doc-scrape-examples = true
 
 [[example]]
+name = "environment"
+path = "examples/environment.rs"
+required-features = ["derive", "env"]
+doc-scrape-examples = true
+
+[[example]]
 name = "01_quick"
 path = "examples/tutorial_builder/01_quick.rs"
 required-features = ["cargo"]

--- a/examples/environment.md
+++ b/examples/environment.md
@@ -1,0 +1,21 @@
+```console
+$ environment --help
+A CLI that reads configuration from arguments, environment variables, or defaults (in that priority order).
+
+Usage: environment[EXE] [OPTIONS]
+
+Options:
+      --host <HOST>  Address to bind to [env: APP_HOST=] [default: 127.0.0.1]
+  -p, --port <PORT>  Port to listen on [env: APP_PORT=] [default: 3000]
+  -v, --verbose      Enable verbose output [env: APP_VERBOSE=]
+  -h, --help         Print help
+  -V, --version      Print version
+
+$ environment
+Listening on 127.0.0.1:3000
+
+$ environment --host 0.0.0.0 --port 8080
+Listening on 0.0.0.0:8080
+
+```
+*(version number and `.exe` extension on windows replaced by placeholders)*

--- a/examples/environment.rs
+++ b/examples/environment.rs
@@ -1,0 +1,39 @@
+use clap::Parser;
+
+/// A CLI that reads configuration from arguments, environment variables, or
+/// defaults (in that priority order).
+///
+/// Try running:
+///
+///     cargo run --example environment -- --host 0.0.0.0
+///     APP_HOST=0.0.0.0 cargo run --example environment
+///     APP_HOST=0.0.0.0 cargo run --example environment -- --host 127.0.0.1
+///
+#[derive(Parser, Debug)]
+#[command(version, about)]
+struct Args {
+    /// Address to bind to
+    #[arg(long, env = "APP_HOST", default_value = "127.0.0.1")]
+    host: String,
+
+    /// Port to listen on
+    #[arg(short, long, env = "APP_PORT", default_value_t = 3000)]
+    port: u16,
+
+    /// Enable verbose output
+    #[arg(short, long, env = "APP_VERBOSE")]
+    verbose: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    if args.verbose {
+        println!("Configuration:");
+        println!("  host:    {}", args.host);
+        println!("  port:    {}", args.port);
+        println!("  verbose: {}", args.verbose);
+    }
+
+    println!("Listening on {}:{}", args.host, args.port);
+}


### PR DESCRIPTION
## Summary

- Adds an `environment` example demonstrating the `env` attribute for derive-based CLI apps
- Shows the priority chain: CLI args > environment variables > defaults
- Includes a companion `.md` file with usage output, matching the existing example conventions

### Motivation

The `env` feature is widely used in 12-factor style applications, but no standalone example covers it. Existing tutorials mention `env()` briefly, but there's no copy-paste-ready example that developers can reference.

### Checklist

- [x] `cargo build --example environment --features derive,env`
- [x] `cargo run --example environment --features derive,env`
- [x] Tested: default values, env var override, CLI arg override
- [x] `cargo fmt --check`