### PR TITLE
fix(parser): exclude hidden subcommands from suggestions

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -5024,11 +5024,13 @@ impl Command {
     /// Iterate through all the names of all subcommands (not recursively), including aliases.
     /// Used for suggestions.
     pub(crate) fn all_subcommand_names(&self) -> impl Iterator<Item = &str> + Captures<'_> {
-        self.get_subcommands().flat_map(|sc| {
-            let name = sc.get_name();
-            let aliases = sc.get_all_aliases();
-            std::iter::once(name).chain(aliases)
-        })
+        self.get_subcommands()
+            .filter(|sc| !sc.is_hide_set())
+            .flat_map(|sc| {
+                let name = sc.get_name();
+                let aliases = sc.get_all_aliases();
+                std::iter::once(name).chain(aliases)
+            })
     }
 
     pub(crate) fn required_graph(&self) -> ChildGraph<Id> {

--- a/tests/builder/subcommands.rs
+++ b/tests/builder/subcommands.rs
@@ -139,6 +139,24 @@ For more information, try '--help'.
 #[test]
 #[cfg(feature = "suggestions")]
 #[cfg(feature = "error-context")]
+fn subcmd_did_you_mean_hidden_not_suggested() {
+    static DYM_SUBCMD_HIDDEN: &str = "\
+error: unrecognized subcommand 'tes'
+
+Usage: dym [COMMAND]
+
+For more information, try '--help'.
+";
+
+    let cmd = Command::new("dym")
+        .subcommand(Command::new("test").hide(true))
+        .subcommand(Command::new("other"));
+    utils::assert_output(cmd, "dym tes", DYM_SUBCMD_HIDDEN, true);
+}
+
+#[test]
+#[cfg(feature = "suggestions")]
+#[cfg(feature = "error-context")]
 fn subcmd_did_you_mean_output_arg() {
     static EXPECTED: &str = "\
 error: unexpected argument '--subcmarg' found
@@ -502,7 +520,10 @@ For more information, try 'help'.
     #[cfg(feature = "suggestions")]
     {
         let err = cmd.clone().try_get_matches_from(["baz"]).unwrap_err();
-        utils::assert_error(err, ErrorKind::InvalidSubcommand, str![[r#"
+        utils::assert_error(
+            err,
+            ErrorKind::InvalidSubcommand,
+            str![[r#"
 error: unrecognized subcommand 'baz'
 
   tip: a similar subcommand exists: 'bar'
@@ -511,7 +532,9 @@ Usage: <COMMAND>
 
 For more information, try 'help'.
 
-"#]], true);
+"#]],
+            true,
+        );
     }
 
     // Verify whatever we did to get the above to work didn't disable `--help` and `--version`.


### PR DESCRIPTION
## Description

Fixes an issue where hidden subcommands (marked with `.hide(true)`) were still appearing in "did you mean" suggestions when users typed similar unrecognized commands.

## Problem

When a subcommand is explicitly hidden using `.hide(true)`, it correctly doesn't appear in help text. However, when a user types an unrecognized command similar to the hidden subcommand, clap would still suggest it in the error message.

## Solution

Modified `all_subcommand_names()` in `clap_builder/src/builder/command.rs` to filter out hidden subcommands. This maintains consistency with help text behavior where hidden commands are not displayed.

The function is only used in two places:
1. Parser - for generating "did you mean" suggestions
2. Validator - for listing available subcommands in error messages

Both are user-facing error messages where hidden commands should not appear.

## Testing

- Added new test case `subcmd_did_you_mean_hidden_not_suggested`
- All existing tests pass (138 subcommand-related tests)
- Verified hidden commands can still be invoked directly (only suggestions are affected)