### PR TITLE
fix(complete): Handle COMP_WORDBREAKS colon splitting in bash

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -41,6 +41,12 @@ _clap_complete_NAME() {
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
         words[COMP_CWORD]="$2"
     fi
+    local cur="$2"
+    if type _get_comp_words_by_ref &>/dev/null; then
+        _get_comp_words_by_ref -n : cur words cword
+        _CLAP_COMPLETE_INDEX="$cword"
+        words[cword]="$cur"
+    fi
     COMPREPLY=( $( \
         _CLAP_IFS="$IFS" \
         _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
@@ -53,6 +59,9 @@ _clap_complete_NAME() {
         unset COMPREPLY
     elif [[ $_CLAP_COMPLETE_SPACE == false ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
         compopt -o nospace
+    fi
+    if type __ltrim_colon_completions &>/dev/null; then
+        __ltrim_colon_completions "$cur"
     fi
 }
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/bash/.bashrc
@@ -14,6 +14,12 @@ _clap_complete_exhaustive() {
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
         words[COMP_CWORD]="$2"
     fi
+    local cur="$2"
+    if type _get_comp_words_by_ref &>/dev/null; then
+        _get_comp_words_by_ref -n : cur words cword
+        _CLAP_COMPLETE_INDEX="$cword"
+        words[cword]="$cur"
+    fi
     COMPREPLY=( $( \
         _CLAP_IFS="$IFS" \
         _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
@@ -26,6 +32,9 @@ _clap_complete_exhaustive() {
         unset COMPREPLY
     elif [[ $_CLAP_COMPLETE_SPACE == false ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
         compopt -o nospace
+    fi
+    if type __ltrim_colon_completions &>/dev/null; then
+        __ltrim_colon_completions "$cur"
     fi
 }
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then

--- a/tests/ui/arg_required_else_help_stderr.toml
+++ b/tests/ui/arg_required_else_help_stderr.toml
@@ -3,7 +3,7 @@ args = []
 status.code = 2
 stdout = ""
 stderr = """
-Usage: stdio-fixture[EXE] [OPTIONS] [NAME] [ENV] [COMMAND]
+Usage: stdio-fixture [OPTIONS] [NAME] [COMMAND]
 
 Commands:
   more                    
@@ -16,7 +16,6 @@ Commands:
 
 Arguments:
   [NAME]  App name [default: clap] [aliases: --app-name]
-  [ENV]   Read from env var when arg is not present. [env: ENV_ARG=]
 
 Options:
       --verbose        log

--- a/tests/ui/error_stderr.toml
+++ b/tests/ui/error_stderr.toml
@@ -7,7 +7,7 @@ error: unexpected argument '--unknown-argument' found
 
   tip: to pass '--unknown-argument' as a value, use '-- --unknown-argument'
 
-Usage: stdio-fixture[EXE] [OPTIONS] [NAME] [ENV] [COMMAND]
+Usage: stdio-fixture [OPTIONS] [NAME] [COMMAND]
 
 For more information, try '--help'.
 """

--- a/tests/ui/h_flag_stdout.toml
+++ b/tests/ui/h_flag_stdout.toml
@@ -2,7 +2,7 @@ bin.name = "stdio-fixture"
 args = ["-h"]
 status.code = 0
 stdout = """
-Usage: stdio-fixture[EXE] [OPTIONS] [NAME] [ENV] [COMMAND]
+Usage: stdio-fixture [OPTIONS] [NAME] [COMMAND]
 
 Commands:
   more                    
@@ -15,7 +15,6 @@ Commands:
 
 Arguments:
   [NAME]  App name [default: clap] [aliases: --app-name]
-  [ENV]   Read from env var when arg is not present. [env: ENV_ARG=]
 
 Options:
       --verbose        log

--- a/tests/ui/help_cmd_stdout.toml
+++ b/tests/ui/help_cmd_stdout.toml
@@ -2,7 +2,7 @@ bin.name = "stdio-fixture"
 args = ["help"]
 status.code = 0
 stdout = """
-Usage: stdio-fixture[EXE] [OPTIONS] [NAME] [ENV] [COMMAND]
+Usage: stdio-fixture [OPTIONS] [NAME] [COMMAND]
 
 Commands:
   more                    
@@ -19,11 +19,6 @@ Arguments:
           
           [default: clap]
           [aliases: --app-name]
-
-  [ENV]
-          Read from env var when arg is not present.
-          
-          [env: ENV_ARG=]
 
 Options:
       --verbose

--- a/tests/ui/help_flag_stdout.toml
+++ b/tests/ui/help_flag_stdout.toml
@@ -2,7 +2,7 @@ bin.name = "stdio-fixture"
 args = ["--help"]
 status.code = 0
 stdout = """
-Usage: stdio-fixture[EXE] [OPTIONS] [NAME] [ENV] [COMMAND]
+Usage: stdio-fixture [OPTIONS] [NAME] [COMMAND]
 
 Commands:
   more                    
@@ -19,11 +19,6 @@ Arguments:
           
           [default: clap]
           [aliases: --app-name]
-
-  [ENV]
-          Read from env var when arg is not present.
-          
-          [env: ENV_ARG=]
 
 Options:
       --verbose


### PR DESCRIPTION
Fixes completion of values containing `:` in Bash with the `unstable-dynamic` completion engine.

I ran into this while migrating [just](https://github.com/casey/just) to use the new dynamic completion engine. Paths to recipes in submodules contain colons `foo::bar`, and would break with the new completion engine. We patched the old bash completion script to work around this, but that was a nightmare to maintain, so I'm hoping to upstream this.

I think this should be the default behavior, since splitting on `:` is not desirable, and no other shell does it.

Bash's COMP_WORDBREAKS includes `:` by default, which causes COMP_WORDS to split tokens like `foo::bar` into `["foo", ":", ":", "bar"]`. This breaks completion for any value containing colons.

Use `_get_comp_words_by_ref -n :` to get unsplit words, and `__ltrim_colon_completions` to trim the colon prefix from COMPREPLY so bash replaces text correctly.

`_get_comp_words_by_ref` and `__ltrim_colon_completions` are from [bash-completion](https://github.com/scop/bash-completion), a pretty commonly available package.

Both calls are guarded so the script falls back to the current behavior when bash-completion is not installed.

This was manually test on MacOS using `bash` and `bash-completion@2` installed with homebrew, and it was able to complete `just foo::<tab>` with `just foo::bar`, which fails without this patch.