### PR TITLE
feat(derive): Support `#[command(flatten = "prefix")]` for prefixed argument flattening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- *(derive)* Support `#[command(flatten = "prefix-")]` to flatten args with a prefix
+
 ## [4.6.0] - 2026-03-12
 
 ### Compatibility

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -259,6 +259,10 @@ impl Command {
     ///
     /// This does not affect the built-in `--help` or `--version` arguments.
     ///
+    /// If you are using the derive API, you can use
+    /// `#[command(flatten = "prefix")]` instead of manually prefixing
+    /// arguments with `mut_args`.
+    ///
     /// # Examples
     ///
     #[cfg_attr(feature = "string", doc = "```")]

--- a/clap_builder/src/derive.rs
+++ b/clap_builder/src/derive.rs
@@ -217,6 +217,10 @@ pub trait FromArgMatches: Sized {
 /// with:
 /// - `#[command(flatten)] args: ChildArgs`: Attribute can only be used with struct fields that impl
 ///   `Args`.
+/// - `#[command(flatten = "prefix-")] args: ChildArgs`: Like `flatten`, but prepends `"prefix-"` to
+///   each argument's `--long` name and ID, allowing the same `Args` type to be reused with
+///   different prefixes (e.g. `--source-host` and `--dest-host` from a single struct).
+///   Requires the `string` feature. Short flags are not supported with prefixed flatten.
 /// - `Variant(ChildArgs)`: No attribute is used with enum variants that impl `Args`.
 ///
 /// <div class="warning">

--- a/clap_builder/src/parser/matches/arg_matches.rs
+++ b/clap_builder/src/parser/matches/arg_matches.rs
@@ -7,7 +7,7 @@ use std::slice::Iter;
 
 // Internal
 use crate::INTERNAL_ERROR_MSG;
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "string"))]
 use crate::builder::Str;
 use crate::parser::MatchedArg;
 use crate::parser::MatchesError;
@@ -1234,6 +1234,59 @@ impl ArgMatches {
     pub fn try_clear_id(&mut self, id: &str) -> Result<bool, MatchesError> {
         ok!(self.verify_arg(id));
         Ok(self.args.remove_entry(id).is_some())
+    }
+
+    /// Extract all arguments whose IDs start with `prefix` into a new [`ArgMatches`],
+    /// stripping the prefix from each ID.
+    ///
+    /// This is used internally by `#[command(flatten = "prefix")]` to allow a flattened
+    /// struct's [`FromArgMatches`][crate::FromArgMatches] implementation to find its
+    /// arguments under unprefixed names.
+    ///
+    /// Entries are moved out of `self` into the returned [`ArgMatches`].
+    #[cfg(feature = "string")]
+    pub fn take_prefixed(&mut self, prefix: &str) -> ArgMatches {
+        let mut new_args = FlatMap::new();
+        #[cfg(debug_assertions)]
+        let mut new_valid = Vec::new();
+
+        // Collect matching keys first to avoid borrow issues
+        let matching_keys: Vec<Id> = self
+            .args
+            .keys()
+            .filter(|k| k.as_str().starts_with(prefix))
+            .cloned()
+            .collect();
+
+        for key in matching_keys {
+            if let Some((_id, matched)) = self.args.remove_entry(key.as_str()) {
+                let stripped = &key.as_str()[prefix.len()..];
+                let new_id = Id::from(Str::from(stripped.to_owned()));
+                new_args.insert(new_id, matched);
+            }
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            self.valid_args.retain(|id| {
+                if id.as_str().starts_with(prefix) {
+                    let stripped = &id.as_str()[prefix.len()..];
+                    new_valid.push(Id::from(Str::from(stripped.to_owned())));
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+
+        ArgMatches {
+            #[cfg(debug_assertions)]
+            valid_args: new_valid,
+            #[cfg(debug_assertions)]
+            valid_subcommands: Default::default(),
+            args: new_args,
+            subcommand: None,
+        }
     }
 }
 

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -235,7 +235,67 @@ pub(crate) fn gen_augment(
                 } else {
                     quote! {}
                 };
-                if override_required {
+
+                if let Some(prefix_lit) = item.flatten_prefix() {
+                    let augment_call = if override_required {
+                        quote_spanned! { kind.span()=>
+                            <#inner_type as clap::Args>::augment_args_for_update
+                        }
+                    } else {
+                        quote_spanned! { kind.span()=>
+                            <#inner_type as clap::Args>::augment_args
+                        }
+                    };
+                    Some(quote_spanned! { kind.span()=>
+                        #flatten_group_assert
+                        let #app_var = #app_var
+                            #next_help_heading
+                            #next_display_order;
+                        let #app_var = {
+                            let __clap_prefix: &str = #prefix_lit;
+                            let __clap_tmp = #augment_call(clap::Command::new("__flatten_tmp"));
+                            let mut __clap_cmd = #app_var;
+                            // Copy arguments with prefixed IDs and long names
+                            for __clap_arg in __clap_tmp.get_arguments() {
+                                if __clap_arg.get_id() == "help" || __clap_arg.get_id() == "version" {
+                                    continue;
+                                }
+                                if __clap_arg.get_short().is_some() {
+                                    panic!(
+                                        "cannot use `flatten = \"{}\"` with argument `{}` that has a short flag; \
+                                         short flags cannot be prefixed",
+                                        __clap_prefix,
+                                        __clap_arg.get_id()
+                                    );
+                                }
+                                let __clap_prefixed_id = format!("{}{}", __clap_prefix, __clap_arg.get_id());
+                                let __clap_new_arg = __clap_arg.clone().id(__clap_prefixed_id);
+                                let __clap_new_arg = if let Some(__clap_long) = __clap_arg.get_long() {
+                                    __clap_new_arg.long(format!("{}{}", __clap_prefix, __clap_long))
+                                } else {
+                                    __clap_new_arg
+                                };
+                                __clap_cmd = __clap_cmd.arg(__clap_new_arg);
+                            }
+                            // Copy groups with prefixed IDs and arg references
+                            for __clap_group in __clap_tmp.get_groups() {
+                                if __clap_group.get_id() == "help" || __clap_group.get_id() == "version" {
+                                    continue;
+                                }
+                                let __clap_prefixed_group_id = format!("{}{}", __clap_prefix, __clap_group.get_id());
+                                let __clap_prefixed_args: Vec<clap::Id> = __clap_group
+                                    .get_args()
+                                    .map(|__clap_a| clap::Id::from(format!("{}{}", __clap_prefix, __clap_a)))
+                                    .collect();
+                                let __clap_new_group = clap::ArgGroup::new(__clap_prefixed_group_id)
+                                    .args(__clap_prefixed_args)
+                                    .multiple(true);
+                                __clap_cmd = __clap_cmd.group(__clap_new_group);
+                            }
+                            __clap_cmd
+                        };
+                    })
+                } else if override_required {
                     Some(quote_spanned! { kind.span()=>
                         #flatten_group_assert
                         let #app_var = #app_var
@@ -498,10 +558,38 @@ pub(crate) fn gen_constructor(fields: &[(&Field, Item)]) -> Result<TokenStream, 
                     (Ty::Option, Some(sub_type)) => sub_type,
                     _ => &field.ty,
                 };
+                let prefix_lit = item.flatten_prefix();
                 match **ty {
+                    Ty::Other if prefix_lit.is_some() => {
+                        let prefix_lit = prefix_lit.unwrap();
+                        quote_spanned! { kind.span()=>
+                            #field_name: {
+                                let mut __clap_prefixed = #arg_matches.take_prefixed(#prefix_lit);
+                                <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(&mut __clap_prefixed)?
+                            }
+                        }
+                    },
                     Ty::Other => {
                         quote_spanned! { kind.span()=>
                             #field_name: <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(#arg_matches)?
+                        }
+                    },
+                    Ty::Option if prefix_lit.is_some() => {
+                        let prefix_lit = prefix_lit.unwrap();
+                        quote_spanned! { kind.span()=>
+                            #field_name: {
+                                let __clap_group_id = <#inner_type as clap::Args>::group_id()
+                                    .expect("asserted during `Arg` creation");
+                                let __clap_prefixed_group_id = format!("{}{}", #prefix_lit, __clap_group_id.as_str());
+                                if #arg_matches.contains_id(__clap_prefixed_group_id.as_str()) {
+                                    let mut __clap_prefixed = #arg_matches.take_prefixed(#prefix_lit);
+                                    Some(
+                                        <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(&mut __clap_prefixed)?
+                                    )
+                                } else {
+                                    None
+                                }
+                            }
                         }
                     },
                     Ty::Option => {
@@ -616,23 +704,48 @@ pub(crate) fn gen_updater(
                     _ => &field.ty,
                 };
 
-                let updater = quote_spanned! { ty.span()=>
-                    <#inner_type as clap::FromArgMatches>::update_from_arg_matches_mut(#field_name, #arg_matches)?;
-                };
+                let prefix_lit = item.flatten_prefix();
 
-                let updater = match **ty {
-                    Ty::Option => quote_spanned! { kind.span()=>
-                        if let Some(#field_name) = #field_name.as_mut() {
-                            #updater
-                        } else {
-                            *#field_name = Some(<#inner_type as clap::FromArgMatches>::from_arg_matches_mut(
-                                #arg_matches
-                            )?);
-                        }
-                    },
-                    _ => quote_spanned! { kind.span()=>
-                        #updater
-                    },
+                let updater = if let Some(prefix_lit) = prefix_lit {
+                    let base_updater = quote_spanned! { ty.span()=>
+                        let mut __clap_prefixed = #arg_matches.take_prefixed(#prefix_lit);
+                        <#inner_type as clap::FromArgMatches>::update_from_arg_matches_mut(#field_name, &mut __clap_prefixed)?;
+                    };
+
+                    match **ty {
+                        Ty::Option => quote_spanned! { kind.span()=>
+                            if let Some(#field_name) = #field_name.as_mut() {
+                                #base_updater
+                            } else {
+                                let mut __clap_prefixed = #arg_matches.take_prefixed(#prefix_lit);
+                                *#field_name = Some(<#inner_type as clap::FromArgMatches>::from_arg_matches_mut(
+                                    &mut __clap_prefixed
+                                )?);
+                            }
+                        },
+                        _ => quote_spanned! { kind.span()=>
+                            #base_updater
+                        },
+                    }
+                } else {
+                    let base_updater = quote_spanned! { ty.span()=>
+                        <#inner_type as clap::FromArgMatches>::update_from_arg_matches_mut(#field_name, #arg_matches)?;
+                    };
+
+                    match **ty {
+                        Ty::Option => quote_spanned! { kind.span()=>
+                            if let Some(#field_name) = #field_name.as_mut() {
+                                #base_updater
+                            } else {
+                                *#field_name = Some(<#inner_type as clap::FromArgMatches>::from_arg_matches_mut(
+                                    #arg_matches
+                                )?);
+                            }
+                        },
+                        _ => quote_spanned! { kind.span()=>
+                            #base_updater
+                        },
+                    }
                 };
 
                 quote_spanned! { kind.span()=>

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -275,6 +275,19 @@ pub(crate) fn gen_augment(
                                 } else {
                                     __clap_new_arg
                                 };
+                                #[cfg(feature = "env")]
+                                let __clap_new_arg = if let Some(__clap_env) = __clap_arg.get_env() {
+                                    let __clap_env_prefix = __clap_prefix
+                                        .to_uppercase()
+                                        .replace('-', "_");
+                                    __clap_new_arg.env(format!(
+                                        "{}{}",
+                                        __clap_env_prefix,
+                                        __clap_env.to_string_lossy()
+                                    ))
+                                } else {
+                                    __clap_new_arg
+                                };
                                 __clap_cmd = __clap_cmd.arg(__clap_new_arg);
                             }
                             // Copy groups with prefixed IDs and arg references

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -50,6 +50,7 @@ pub(crate) struct Item {
     group_id: Name,
     group_methods: Vec<Method>,
     kind: Sp<Kind>,
+    flatten_prefix: Option<LitStr>,
 }
 
 impl Item {
@@ -279,6 +280,7 @@ impl Item {
             group_id,
             group_methods: vec![],
             kind,
+            flatten_prefix: None,
         }
     }
 
@@ -387,10 +389,19 @@ impl Item {
                     let kind = Sp::new(Kind::ExternalSubcommand, attr.name.span());
                     Some(kind)
                 }
-                Some(MagicAttrName::Flatten) if attr.value.is_none() => {
-                    if attr.value.is_some() {
-                        let expr = attr.value_or_abort()?;
-                        abort!(expr, "attribute `{}` does not accept a value", attr.name);
+                Some(MagicAttrName::Flatten) => {
+                    if let Some(value) = &attr.value {
+                        match value {
+                            AttrValue::LitStr(lit) => {
+                                self.flatten_prefix = Some(lit.clone());
+                            }
+                            _ => {
+                                abort!(
+                                    attr.name,
+                                    "attribute `flatten` expects a string literal prefix, e.g. `flatten = \"prefix_\"`"
+                                );
+                            }
+                        }
                     }
                     let ty = self
                         .kind()
@@ -1067,6 +1078,10 @@ impl Item {
 
     pub(crate) fn kind(&self) -> Sp<Kind> {
         self.kind.clone()
+    }
+
+    pub(crate) fn flatten_prefix(&self) -> Option<&LitStr> {
+        self.flatten_prefix.as_ref()
     }
 
     pub(crate) fn is_positional(&self) -> bool {

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -41,6 +41,9 @@
 //!     #[command(flatten)]
 //!     delegate: Struct,
 //!
+//!     #[command(flatten = "prefix_")]
+//!     prefixed_delegate: Struct,
+//!
 //!     #[command(subcommand)]
 //!     command: Command,
 //! }
@@ -188,6 +191,16 @@
 //!   - **Tip:** Though we do apply a flattened [`Args`][crate::Args]'s Parent Command Attributes, this
 //!     makes reuse harder. Generally prefer putting the cmd attributes on the
 //!     [`Parser`][crate::Parser] or on the flattened field.
+//! - `flatten = "prefix"`: Like `flatten`, but prepends `prefix` to each argument's `--long` name
+//!   and internal ID, allowing the same [`Args`][crate::Args] type to be flattened multiple times
+//!   with different prefixes. Requires the [`string` feature][crate::_features].
+//!   - Short flags are not supported; a runtime panic is raised if the flattened type contains any.
+//!   - Env variable names are prefixed with the SCREAMING_SNAKE_CASE version of the prefix
+//!     (e.g. prefix `source-` turns env `HOST` into `SOURCE_HOST`).
+//!   - Long aliases and arg relationships (`conflicts_with`, `requires`, etc.)
+//!     defined on the inner type are not automatically prefixed and may not behave as expected.
+//!     Define these on the parent struct instead.
+//!   - Example: `#[command(flatten = "source-")] source: Opts` turns `--host` into `--source-host`.
 //! - `subcommand`: Delegates definition of subcommands to the field (must implement
 //!   [`Subcommand`][crate::Subcommand])
 //!   - When `Option<T>`, the subcommand becomes optional

--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -453,4 +453,44 @@ mod flatten_prefix {
             })
         );
     }
+
+    #[cfg(feature = "env")]
+    #[test]
+    fn prefix_env_variables() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long, env = "HOST")]
+            host: String,
+            #[arg(long, env = "USERNAME")]
+            username: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+        }
+
+        // Env vars should be prefixed as SOURCE_HOST, SOURCE_USERNAME
+        unsafe {
+            std::env::set_var("SOURCE_HOST", "localhost");
+            std::env::set_var("SOURCE_USERNAME", "admin");
+        }
+
+        let cli = Cli::try_parse_from(["test"]).unwrap();
+        assert_eq!(
+            cli,
+            Cli {
+                source: StorageOptions {
+                    host: "localhost".into(),
+                    username: "admin".into(),
+                }
+            }
+        );
+
+        unsafe {
+            std::env::remove_var("SOURCE_HOST");
+            std::env::remove_var("SOURCE_USERNAME");
+        }
+    }
 }

--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -303,3 +303,154 @@ fn flatten_skipped_group() {
 
     Cli::try_parse_from(["test"]).unwrap();
 }
+
+#[cfg(feature = "string")]
+mod flatten_prefix {
+    use super::*;
+
+    #[test]
+    fn basic_prefix() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: String,
+            #[arg(long)]
+            username: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+        }
+
+        assert_eq!(
+            Cli {
+                source: StorageOptions {
+                    host: "localhost".into(),
+                    username: "admin".into(),
+                }
+            },
+            Cli::try_parse_from([
+                "test",
+                "--source-host",
+                "localhost",
+                "--source-username",
+                "admin"
+            ])
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn duplicate_flatten_with_different_prefixes() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: String,
+            #[arg(long)]
+            username: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+            #[command(flatten = "dest-")]
+            dest: StorageOptions,
+        }
+
+        assert_eq!(
+            Cli {
+                source: StorageOptions {
+                    host: "src.example.com".into(),
+                    username: "reader".into(),
+                },
+                dest: StorageOptions {
+                    host: "dst.example.com".into(),
+                    username: "writer".into(),
+                },
+            },
+            Cli::try_parse_from([
+                "test",
+                "--source-host",
+                "src.example.com",
+                "--source-username",
+                "reader",
+                "--dest-host",
+                "dst.example.com",
+                "--dest-username",
+                "writer",
+            ])
+            .unwrap()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "short flags cannot be prefixed")]
+    fn prefix_with_short_flag_panics() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Opts {
+            #[arg(short, long)]
+            verbose: bool,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            opts: Opts,
+        }
+
+        // The panic happens during command construction (augment_args)
+        let _ = Cli::try_parse_from(["test"]);
+    }
+
+    #[test]
+    fn prefix_help_shows_prefixed_flags() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+        }
+
+        let help = utils::get_help::<Cli>();
+        assert!(
+            help.contains("--source-host"),
+            "Help should contain --source-host, got:\n{help}"
+        );
+    }
+
+    #[test]
+    fn prefix_with_optional_flatten() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            source: Option<StorageOptions>,
+        }
+
+        // Without args, the optional should be None
+        let cli = Cli::try_parse_from(["test"]).unwrap();
+        assert_eq!(cli.source, None);
+
+        // With args, the optional should be Some
+        let cli = Cli::try_parse_from(["test", "--src-host", "localhost"]).unwrap();
+        assert_eq!(
+            cli.source,
+            Some(StorageOptions {
+                host: Some("localhost".into())
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds flattening with prefix support to clap. In places where you flatten argument structs, you can optionally pass a prefix, which causes the arguments in the struct to be prefixed with that prefix. 

- Add `#[command(flatten = "prefix")]` syntax to prepend a prefix to all `--long` names and argument IDs when flattening, allowing the same `Args` struct to be flattened multiple times with different prefixes
- Env variable names are prefixed with the SCREAMING_SNAKE_CASE version of the prefix (e.g. `source-` prefix becomes `SOURCE_` prefix for env variables)
- Short flags in a prefixed flatten are rejected with a runtime panic (there is no reasonable way to prefix these)
- Currently doesn't handle some things (`required`, etc) because those fields are not augmented with the prefix.  
- This change is backwards-compatible.

## Motivation

A common pattern is having a tool that operates on two instances of the same kind of resource — for example, copying from one storage to another. Today, you'd need to define separate structs or manually name each argument:

```rust
struct SourceStorage {
    #[arg(long)]
    source_host: String,
    #[arg(long)]
    source_username: String,
}

struct DestStorage {
    #[arg(long)]
    dest_host: String,
    #[arg(long)]
    dest_username: String,
}
```

With this PR, you define the struct once and flatten it twice:

```rust
#[derive(Args)]
struct StorageOptions {
    #[arg(long)]
    host: String,
    #[arg(long, env = "USERNAME")]
    username: String,
}

#[derive(Parser)]
struct Cli {
    #[command(flatten = "source-")]
    source: StorageOptions,
    #[command(flatten = "dest-")]
    dest: StorageOptions,
}
// Produces: --source-host, --source-username, --dest-host, --dest-username
// Env vars: SOURCE_USERNAME, DEST_USERNAME
```

At least for me, this is a feature I have a lot of use-cases for and would like to see clap support. Others have requested such a feature as well:

- #3513
- #3117 (caveat: this PR only implements prefixing, not adding suffixes)
- #2293
- #3443

I have checked, and as far as I can tell, there has not been a PR with similar functionality.

## Implementation

The implementation spans `clap_builder` and `clap_derive`:

**clap_builder** (`ArgMatches::take_prefixed`): A new method that extracts all entries whose IDs start with a given prefix into a new `ArgMatches`, stripping the prefix from each ID. This lets the inner type's `FromArgMatches` implementation find its arguments under their original unprefixed names. Gated behind `cfg(feature = "string")`, because prefixed argument IDs and long names are built at runtime as String.

**clap_derive** (attribute parsing): The `flatten` attribute in `infer_kind()` now accepts an optional string literal value. `#[command(flatten)]` continues to work as before; `#[command(flatten = "prefix")]` stores the prefix on the `Item`.

**clap_derive** (code generation): When a prefix is present:
- *Augmentation*: `augment_args` builds arguments on a temporary `Command`, then copies each arg and group to the real command with prefixed IDs and `--long` names. Env variable names are prefixed with the SCREAMING_SNAKE_CASE conversion (uppercased, hyphens replaced with underscores). Args with short flags cause a panic with a descriptive message.
- *Matching*: `from_arg_matches` calls `take_prefixed()` to extract the prefixed entries before delegating to the inner type's `FromArgMatches`.
- *Updating*: `update_from_arg_matches` uses the same `take_prefixed()` approach.

## Limitations

- Requires the `string` feature (for runtime `format!()` of prefixed names)
- Short flags cannot be prefixed and are rejected at runtime
- Long aliases and arg relationships (`conflicts_with`, `requires`, etc.) defined on the inner type are not automatically prefixed. These need to be defined on the parent struct instead. We could add some code to trigger an error when these are used for better UX.
- The way this is implemented does not support setting a postfix. For me personally, prefix is the thing I care about. If we want to support suffix, we may want a different syntax than `#[clap(flatten = "prefix-")]`, like `#[clap(flatten, flatten_prefix = "prefix-", flatten_suffix = "-suffix")]` or something.

## Test plan

- [x] Basic prefix flattening (`--source-host`)
- [x] Duplicate flatten with different prefixes (`--source-host` + `--dest-host`)
- [x] Short flag rejection (should_panic test)
- [x] Help text shows prefixed flags
- [x] `Option<Args>` with prefix
- [x] Env variable prefixing (`HOST` → `SOURCE_HOST`)
- [x] All existing flatten tests still pass
- [x] Full test suite (`make test-full`), clippy (`make clippy-full`), docs (`make doc`) all clean