### PR TITLE
fix: Make ui_tests test conditional on env feature

### DIFF
--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -2,6 +2,7 @@
 #[cfg(feature = "help")]
 #[cfg(feature = "error-context")]
 #[cfg(feature = "usage")]
+#[cfg(feature = "env")]
 fn ui_tests() {
     let t = trycmd::TestCases::new();
     let features = [


### PR DESCRIPTION
`cargo test --test ui` is failing both locally on CI, I think because it expects the env feature, which is not a default feature.

This PR adds `#[cfg(feature = "env")]` to `ui_tests`, disabling the test when the feature is unavailable.

`cargo test` and `cargo test --features env` now both pass.