### PR TITLE
fix(completions/zsh): Add exclusion pattern for optional positionals

### DIFF
--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -654,8 +654,18 @@ fn write_positionals_of(p: &Command) -> String {
             ""
         };
 
+        // For optional positionals, add an exclusion pattern `(-*)` to prevent them
+        // from being matched when the current word starts with `-` (i.e., when the user
+        // is trying to complete an option). This fixes issue #6282.
+        let exclusion = if !arg.is_required_set() && !is_multi_valued {
+            "(-*)"
+        } else {
+            ""
+        };
+
         let a = format!(
-            "'{cardinality}:{name}{help}:{value_completion}' \\",
+            "'{exclusion}{cardinality}:{name}{help}:{value_completion}' \\",
+            exclusion = exclusion,
             cardinality = cardinality,
             name = arg.get_id(),
             help = arg

--- a/clap_complete/tests/snapshots/aliases.zsh
+++ b/clap_complete/tests/snapshots/aliases.zsh
@@ -27,7 +27,7 @@ _my-app() {
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-'::positional:_default' \
+'(-*)::positional:_default' \
 && ret=0
 }
 

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -23,8 +23,8 @@ _my-app() {
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-'::file -- some input file:_files' \
-'::choice:(first second)' \
+'(-*)::file -- some input file:_files' \
+'(-*)::choice:(first second)' \
 ":: :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -23,8 +23,8 @@ _my-app() {
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-'::file -- some input file:_files' \
-'::choice:(first second)' \
+'(-*)::file -- some input file:_files' \
+'(-*)::choice:(first second)' \
 ":: :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -23,8 +23,8 @@ _my-app() {
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-'::file -- some input file:_files' \
-'::choice:(first second)' \
+'(-*)::file -- some input file:_files' \
+'(-*)::choice:(first second)' \
 ":: :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0

--- a/clap_complete/tests/snapshots/subcommand_last.zsh
+++ b/clap_complete/tests/snapshots/subcommand_last.zsh
@@ -17,7 +17,7 @@ _my-app() {
     _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
-'::free:_default' \
+'(-*)::free:_default' \
 ":: :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0


### PR DESCRIPTION
This PR fixes issue #6282 by adding an exclusion pattern for optional positionals in zsh completions.\n\n## Changes\n- Added exclusion pattern to handle optional positional arguments correctly in zsh completion scripts\n\nFixes #6282