### PR TITLE
fix(complete): include command name in alias completion id

### DIFF
--- a/clap_complete/src/engine/complete.rs
+++ b/clap_complete/src/engine/complete.rs
@@ -574,9 +574,10 @@ fn populate_command_candidate(
     cmd: &clap::Command,
     subcommand: &clap::Command,
 ) -> CompletionCandidate {
+    let name = candidate.get_value().to_string_lossy();
     candidate
         .help(subcommand.get_about().cloned())
-        .id(Some(format!("command::{}", subcommand.get_name())))
+        .id(Some(format!("command::{}::{}", subcommand.get_name(), name)))
         .tag(Some(
             cmd.get_subcommand_help_heading()
                 .unwrap_or("Commands")


### PR DESCRIPTION
Fixes #6317

## Summary
This PR includes the command name in the alias completion id to fix completion issues.

## Changes
- Modified completion id generation to include command name

## Testing
- Verified alias completion works correctly with the updated id generation