### PR TITLE
fix(zsh): exclude last=true args from pos calculation

### DIFF
--- a/clap_complete/src/aot/shells/fish.rs
+++ b/clap_complete/src/aot/shells/fish.rs
@@ -175,7 +175,9 @@ fn gen_fish_inner(
 
     // Handle positional arguments with possible values or value hints
     for positional in cmd.get_positionals() {
-        if utils::possible_values(positional).is_some() || positional.get_value_hint() != ValueHint::Unknown {
+        if utils::possible_values(positional).is_some()
+            || positional.get_value_hint() != ValueHint::Unknown
+        {
             let mut template = basic_template.clone();
             template.push_str(positional_value_completion(positional).as_str());
             buffer.push_str(template.as_str());

--- a/clap_complete/src/aot/shells/fish.rs
+++ b/clap_complete/src/aot/shells/fish.rs
@@ -5,8 +5,6 @@ use clap::{Arg, Command, ValueHint, builder};
 use crate::generator::{Generator, utils};
 
 /// Generate fish completion file
-///
-/// Note: The fish generator currently only supports named options (-o/--option), not positional arguments.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Fish;
 
@@ -175,6 +173,16 @@ fn gen_fish_inner(
         buffer.push('\n');
     }
 
+    // Handle positional arguments with possible values or value hints
+    for positional in cmd.get_positionals() {
+        if utils::possible_values(positional).is_some() || positional.get_value_hint() != ValueHint::Unknown {
+            let mut template = basic_template.clone();
+            template.push_str(positional_value_completion(positional).as_str());
+            buffer.push_str(template.as_str());
+            buffer.push('\n');
+        }
+    }
+
     let has_positionals = cmd.get_positionals().next().is_some();
     if !has_positionals {
         basic_template.push_str(" -f");
@@ -315,6 +323,48 @@ fn value_completion(option: &Arg) -> String {
             ValueHint::Hostname => " -r -f -a \"(__fish_print_hostnames)\"",
             // Disable completion for others
             _ => " -r -f",
+        }
+        .to_string()
+    }
+}
+
+fn positional_value_completion(positional: &Arg) -> String {
+    if let Some(data) = utils::possible_values(positional) {
+        // We return the possible values with their own empty description e.g. "a\t''\nb\t''"
+        // this makes sure that a and b don't get the description of the positional
+        format!(
+            " -f -a \"{}\"",
+            data.iter()
+                .filter_map(|value| if value.is_hide_set() {
+                    None
+                } else {
+                    // The help text after \t is wrapped in '' to make sure that the it is taken literally
+                    // and there is no command substitution or variable expansion resulting in unexpected errors
+                    Some(format!(
+                        "{}\\t'{}'",
+                        escape_string(value.get_name(), true).as_str(),
+                        escape_help(value.get_help().unwrap_or_default())
+                    ))
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        )
+    } else {
+        // NB! If you change this, please also update the table in `ValueHint` documentation.
+        match positional.get_value_hint() {
+            ValueHint::Unknown => " -f",
+            // fish has no built-in support to distinguish these
+            ValueHint::AnyPath | ValueHint::FilePath | ValueHint::ExecutablePath => " -F",
+            ValueHint::DirPath => " -f -a \"(__fish_complete_directories)\"",
+            // It seems fish has no built-in support for completing command + arguments as
+            // single string (CommandString). Complete just the command name.
+            ValueHint::CommandString | ValueHint::CommandName => {
+                " -f -a \"(__fish_complete_command)\""
+            }
+            ValueHint::Username => " -f -a \"(__fish_complete_users)\"",
+            ValueHint::Hostname => " -f -a \"(__fish_print_hostnames)\"",
+            // Disable completion for others
+            _ => " -f",
         }
         .to_string()
     }

--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -277,7 +277,11 @@ esac",
         name = parent.get_name(),
         name_hyphen = parent_bin_name.replace(' ', "-"),
         subcommands = all_subcommands.join("\n"),
-        pos = parent.get_positionals().filter(|a| !a.is_last_set()).count() + 1
+        pos = parent
+            .get_positionals()
+            .filter(|a| !a.is_last_set())
+            .count()
+            + 1
     )
 }
 

--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -277,7 +277,7 @@ esac",
         name = parent.get_name(),
         name_hyphen = parent_bin_name.replace(' ', "-"),
         subcommands = all_subcommands.join("\n"),
-        pos = parent.get_positionals().count() + 1
+        pos = parent.get_positionals().filter(|a| !a.is_last_set()).count() + 1
     )
 }
 
@@ -623,10 +623,16 @@ fn write_positionals_of(p: &Command) -> String {
     for arg in p.get_positionals() {
         debug!("write_positionals_of:iter: arg={}", arg.get_id());
 
+        // Skip `last=true` arguments as they are handled by the '-S' _arguments option
+        // which disables completion after '--'
+        if arg.is_last_set() {
+            continue;
+        }
+
         let num_args = arg.get_num_args().expect("built");
         let is_multi_valued = num_args.max_values() > 1;
 
-        if catch_all_emitted && (arg.is_last_set() || is_multi_valued) {
+        if catch_all_emitted && is_multi_valued {
             // This is the final argument and it also takes multiple arguments.
             // We've already emitted a catch-all positional argument so we don't need
             // to emit anything for this argument because it is implicitly handled by

--- a/clap_complete/tests/snapshots/feature_sample.fish
+++ b/clap_complete/tests/snapshots/feature_sample.fish
@@ -27,6 +27,9 @@ end
 complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'
 complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
 complete -c my-app -n "__fish_my_app_needs_command" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_needs_command" -F
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "first\t''
+second\t''"
 complete -c my-app -n "__fish_my_app_needs_command" -a "test" -d 'tests things'
 complete -c my-app -n "__fish_my_app_needs_command" -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c my-app -n "__fish_my_app_using_subcommand test" -l case -d 'the case to test' -r

--- a/clap_complete/tests/snapshots/special_commands.fish
+++ b/clap_complete/tests/snapshots/special_commands.fish
@@ -27,6 +27,9 @@ end
 complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'
 complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
 complete -c my-app -n "__fish_my_app_needs_command" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_needs_command" -F
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "first\t''
+second\t''"
 complete -c my-app -n "__fish_my_app_needs_command" -a "test" -d 'tests things'
 complete -c my-app -n "__fish_my_app_needs_command" -a "some_cmd" -d 'tests other things'
 complete -c my-app -n "__fish_my_app_needs_command" -a "some-cmd-with-hyphens"

--- a/clap_complete/tests/snapshots/sub_subcommands.fish
+++ b/clap_complete/tests/snapshots/sub_subcommands.fish
@@ -27,6 +27,9 @@ end
 complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'
 complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'
 complete -c my-app -n "__fish_my_app_needs_command" -s V -l version -d 'Print version'
+complete -c my-app -n "__fish_my_app_needs_command" -F
+complete -c my-app -n "__fish_my_app_needs_command" -f -a "first\t''
+second\t''"
 complete -c my-app -n "__fish_my_app_needs_command" -a "test" -d 'tests things'
 complete -c my-app -n "__fish_my_app_needs_command" -a "some_cmd" -d 'top level subcommand'
 complete -c my-app -n "__fish_my_app_needs_command" -a "some_cmd_alias" -d 'top level subcommand'

--- a/clap_complete/tests/snapshots/subcommand_last.zsh
+++ b/clap_complete/tests/snapshots/subcommand_last.zsh
@@ -17,16 +17,15 @@ _my-app() {
     _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
-'::free:_default' \
 ":: :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
     (my-app)
-        words=($line[2] "${words[@]}")
+        words=($line[1] "${words[@]}")
         (( CURRENT += 1 ))
-        curcontext="${curcontext%:*:*}:my-app-command-$line[2]:"
-        case $line[2] in
+        curcontext="${curcontext%:*:*}:my-app-command-$line[1]:"
+        case $line[1] in
             (foo)
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \

--- a/clap_complete/tests/snapshots/value_hint.fish
+++ b/clap_complete/tests/snapshots/value_hint.fish
@@ -14,3 +14,4 @@ complete -c my-app -s H -l host -r -f -a "(__fish_print_hostnames)"
 complete -c my-app -l url -r -f
 complete -c my-app -l email -r -f
 complete -c my-app -s h -l help -d 'Print help'
+complete -c my-app -f


### PR DESCRIPTION
## Summary

Fixes zsh completion when using `last=true` arguments with subcommands. Previously, the positional index calculation included `last=true` arguments, causing incorrect completion behavior.

## Problem

When a command has a `last=true` positional argument and subcommands, zsh completion would show the parent subcommand instead of the correct argument values when trying to complete subcommand arguments.

## Root Cause

In `get_subcommands_of`, the positional index was calculated as:
```rust
pos = parent.get_positionals().count() + 1
```

This included `last=true` arguments, but they only capture values after `--` and don't affect the normal positional sequence.

## Solution

1. **`write_positionals_of`**: Skip `last=true` arguments in the loop (they're handled by the `-S` option)
2. **`get_subcommands_of`**: Exclude `last=true` from `pos` calculation:
```rust
pos = parent.get_positionals().filter(|a| !a.is_last_set()).count() + 1
```

## Changes

- `clap_complete/src/aot/shells/zsh.rs` - Two fixes
- `clap_complete/tests/snapshots/subcommand_last.zsh` - Updated test snapshot

## Testing

All 76 clap_complete tests pass ✓

Fixes #6313