### PR TITLE
fix(bash): exclude last=true args from completion options when there are subcommands

### DIFF
--- a/clap_complete/src/aot/shells/bash.rs
+++ b/clap_complete/src/aot/shells/bash.rs
@@ -290,6 +290,11 @@ fn all_options_for_path(cmd: &Command, path: &str) -> String {
         write!(&mut opts, "--{long} ").expect("writing to String is infallible");
     }
     for pos in p.get_positionals() {
+        // Skip `last=true` arguments when there are subcommands, as they only capture
+        // values after '--' and would interfere with subcommand completion
+        if pos.is_last_set() && p.get_subcommands().next().is_some() {
+            continue;
+        }
         if let Some(vals) = utils::possible_values(pos) {
             for value in vals {
                 write!(&mut opts, "{} ", value.get_name())

--- a/clap_complete/tests/snapshots/subcommand_last.bash
+++ b/clap_complete/tests/snapshots/subcommand_last.bash
@@ -41,7 +41,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-h --help [free] foo bar help"
+            opts="-h --help foo bar help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0


### PR DESCRIPTION
## Description

When generating bash completion scripts, last=true arguments should be excluded from the completion options list when there are subcommands. This is because last=true arguments only capture values after '--' and would interfere with subcommand completion.

Previously, the bash completion generator included last=true arguments like `[free]` in the options, causing misleading completion suggestions when the user would expect to complete subcommands.

## Related Issues

This fix aligns bash behavior with the zsh fix (#6313) that excludes last=true arguments from positional calculations for subcommand handling.

## Changes

- Modified `all_options_for_path` function in `clap_complete/src/aot/shells/bash.rs` to skip last=true arguments when there are subcommands
- Updated snapshot for `subcommand_last` test to reflect the correct behavior

## Testing

All tests pass after the change.