### PR TITLE
fix(complete): Do not suggest options after "--"

### DIFF
--- a/clap_complete/src/engine/complete.rs
+++ b/clap_complete/src/engine/complete.rs
@@ -172,9 +172,10 @@ fn complete_arg(
                 .find(|p| p.get_index() == Some(pos_index))
             {
                 completions.extend(complete_arg_value(arg.to_value(), positional, current_dir));
-                if positional
-                    .get_num_args()
-                    .is_some_and(|num_args| num_arg >= num_args.min_values())
+                if !is_escaped
+                    && positional
+                        .get_num_args()
+                        .is_some_and(|num_args| num_arg >= num_args.min_values())
                 {
                     completions.extend(complete_option(arg, cmd, current_dir));
                 }

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -284,6 +284,26 @@ goodbye-world
 }
 
 #[test]
+fn suggest_multiple_positional_after_escape() {
+    let mut cmd =
+        Command::new("exhaustive").arg(clap::Arg::new("hello-world").num_args(0..).value_parser([
+            PossibleValue::new("hello-world"),
+            "hello-moon".into(),
+            "goodbye-world".into(),
+        ]));
+
+    assert_data_eq!(
+        complete!(cmd, "-- hello-moon [TAB]"),
+        snapbox::str![[r#"
+hello-world
+hello-moon
+goodbye-world
+--help	Print help
+"#]],
+    );
+}
+
+#[test]
 fn suggest_argument_value() {
     let mut cmd = Command::new("dynamic")
         .arg(

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -298,7 +298,6 @@ fn suggest_multiple_positional_after_escape() {
 hello-world
 hello-moon
 goodbye-world
---help	Print help
 "#]],
     );
 }


### PR DESCRIPTION
This fixes a surprising behaviour I experienced with the new dynamic completions for just:

    $ _CLAP_COMPLETE_INDEX=2 JUST_COMPLETE=bash just -- just -- ''
    check
    clean
    …

but with an extra argument, long options start to appear again:

    $ _CLAP_COMPLETE_INDEX=3 JUST_COMPLETE=bash just -- just -- test ''
    check
    clean
    …
    --alias-style
    --allow-missing
    …

Related: 8aaf704f5679 ("fix(complete): Do not suggest options after "--"")
Related: 2e13847533d4 ("fix(complete): Missing options in multi-val arg")
