### PR TITLE
fix(complete): Use unique separator for bash subcommand paths

### DIFF
--- a/clap_complete/CHANGELOG.md
+++ b/clap_complete/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- *(bash)* Don't panic when a subcommand's name contains `__`
+
 ## [4.6.0] - 2026-03-12
 
 ### Compatibility

--- a/clap_complete/src/aot/shells/bash.rs
+++ b/clap_complete/src/aot/shells/bash.rs
@@ -7,6 +7,14 @@ use clap::{Arg, Command, ValueHint};
 
 use crate::generator::{Generator, utils};
 
+/// Separator used to join subcommand path segments in the generated script.
+///
+/// Must be distinct from any character sequence that can appear inside a
+/// subcommand name so the joined path can be split back apart unambiguously.
+/// `__` was previously used, which collided with subcommands whose names
+/// contain (or start with) `__`, e.g. `__hidden`.
+const SUBCOMMAND_PATH_SEP: &str = "_subcmd_";
+
 /// Generate bash completion file
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct Bash;
@@ -96,8 +104,9 @@ fn all_subcommands(cmd: &Command, parent_fn_name: &str) -> String {
         subcmds: &mut Vec<(String, String, String)>,
     ) {
         let fn_name = format!(
-            "{parent_fn_name}__{cmd_name}",
+            "{parent_fn_name}{sep}{cmd_name}",
             parent_fn_name = parent_fn_name,
+            sep = SUBCOMMAND_PATH_SEP,
             cmd_name = cmd.get_name().to_string().replace('-', "__")
         );
         subcmds.push((
@@ -140,7 +149,7 @@ fn subcommand_details(cmd: &Command) -> String {
     let mut subcmd_dets = vec![String::new()];
     let mut scs = utils::all_subcommands(cmd)
         .iter()
-        .map(|x| x.1.replace(' ', "__"))
+        .map(|x| x.1.replace(' ', SUBCOMMAND_PATH_SEP))
         .collect::<Vec<_>>();
 
     scs.sort();
@@ -164,7 +173,7 @@ fn subcommand_details(cmd: &Command) -> String {
             ;;",
             subcmd = sc.replace('-', "__"),
             sc_opts = all_options_for_path(cmd, sc),
-            level = sc.split("__").map(|_| 1).sum::<u64>(),
+            level = sc.split(SUBCOMMAND_PATH_SEP).map(|_| 1).sum::<u64>(),
             opts_details = option_details_for_path(cmd, sc)
         )
     }));
@@ -175,7 +184,8 @@ fn subcommand_details(cmd: &Command) -> String {
 fn option_details_for_path(cmd: &Command, path: &str) -> String {
     debug!("option_details_for_path: path={path}");
 
-    let p = utils::find_subcommand_with_path(cmd, path.split("__").skip(1).collect());
+    let p =
+        utils::find_subcommand_with_path(cmd, path.split(SUBCOMMAND_PATH_SEP).skip(1).collect());
     let mut opts = vec![String::new()];
 
     for o in p.get_opts() {
@@ -280,7 +290,8 @@ fn vals_for(o: &Arg) -> String {
 fn all_options_for_path(cmd: &Command, path: &str) -> String {
     debug!("all_options_for_path: path={path}");
 
-    let p = utils::find_subcommand_with_path(cmd, path.split("__").skip(1).collect());
+    let p =
+        utils::find_subcommand_with_path(cmd, path.split(SUBCOMMAND_PATH_SEP).skip(1).collect());
 
     let mut opts = String::new();
     for short in utils::shorts_and_visible_aliases(p) {

--- a/clap_complete/tests/snapshots/basic.bash
+++ b/clap_complete/tests/snapshots/basic.bash
@@ -17,16 +17,16 @@ _my-app() {
                 cmd="my__app"
                 ;;
             my__app,help)
-                cmd="my__app__help"
+                cmd="my__app_subcmd_help"
                 ;;
             my__app,test)
-                cmd="my__app__test"
+                cmd="my__app_subcmd_test"
                 ;;
-            my__app__help,help)
-                cmd="my__app__help__help"
+            my__app_subcmd_help,help)
+                cmd="my__app_subcmd_help_subcmd_help"
                 ;;
-            my__app__help,test)
-                cmd="my__app__help__test"
+            my__app_subcmd_help,test)
+                cmd="my__app_subcmd_help_subcmd_test"
                 ;;
             *)
                 ;;
@@ -48,7 +48,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help)
+        my__app_subcmd_help)
             opts="test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -62,7 +62,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__help)
+        my__app_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -76,7 +76,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__test)
+        my__app_subcmd_help_subcmd_test)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -90,7 +90,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__test)
+        my__app_subcmd_test)
             opts="-d -c -h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/custom_bin_name.bash
+++ b/clap_complete/tests/snapshots/custom_bin_name.bash
@@ -17,16 +17,16 @@ _bin-name() {
                 cmd="bin__name"
                 ;;
             bin__name,help)
-                cmd="bin__name__help"
+                cmd="bin__name_subcmd_help"
                 ;;
             bin__name,test)
-                cmd="bin__name__test"
+                cmd="bin__name_subcmd_test"
                 ;;
-            bin__name__help,help)
-                cmd="bin__name__help__help"
+            bin__name_subcmd_help,help)
+                cmd="bin__name_subcmd_help_subcmd_help"
                 ;;
-            bin__name__help,test)
-                cmd="bin__name__help__test"
+            bin__name_subcmd_help,test)
+                cmd="bin__name_subcmd_help_subcmd_test"
                 ;;
             *)
                 ;;
@@ -48,7 +48,7 @@ _bin-name() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        bin__name__help)
+        bin__name_subcmd_help)
             opts="test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -62,7 +62,7 @@ _bin-name() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        bin__name__help__help)
+        bin__name_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -76,7 +76,7 @@ _bin-name() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        bin__name__help__test)
+        bin__name_subcmd_help_subcmd_test)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -90,7 +90,7 @@ _bin-name() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        bin__name__test)
+        bin__name_subcmd_test)
             opts="-d -c -h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/external_subcommands.bash
+++ b/clap_complete/tests/snapshots/external_subcommands.bash
@@ -17,16 +17,16 @@ _my-app() {
                 cmd="my__app"
                 ;;
             my__app,external)
-                cmd="my__app__external"
+                cmd="my__app_subcmd_external"
                 ;;
             my__app,help)
-                cmd="my__app__help"
+                cmd="my__app_subcmd_help"
                 ;;
-            my__app__help,external)
-                cmd="my__app__help__external"
+            my__app_subcmd_help,external)
+                cmd="my__app_subcmd_help_subcmd_external"
                 ;;
-            my__app__help,help)
-                cmd="my__app__help__help"
+            my__app_subcmd_help,help)
+                cmd="my__app_subcmd_help_subcmd_help"
                 ;;
             *)
                 ;;
@@ -48,7 +48,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__external)
+        my__app_subcmd_external)
             opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -62,7 +62,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help)
+        my__app_subcmd_help)
             opts="external help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -76,7 +76,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__external)
+        my__app_subcmd_help_subcmd_external)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -90,7 +90,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__help)
+        my__app_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/feature_sample.bash
+++ b/clap_complete/tests/snapshots/feature_sample.bash
@@ -17,16 +17,16 @@ _my-app() {
                 cmd="my__app"
                 ;;
             my__app,help)
-                cmd="my__app__help"
+                cmd="my__app_subcmd_help"
                 ;;
             my__app,test)
-                cmd="my__app__test"
+                cmd="my__app_subcmd_test"
                 ;;
-            my__app__help,help)
-                cmd="my__app__help__help"
+            my__app_subcmd_help,help)
+                cmd="my__app_subcmd_help_subcmd_help"
                 ;;
-            my__app__help,test)
-                cmd="my__app__help__test"
+            my__app_subcmd_help,test)
+                cmd="my__app_subcmd_help_subcmd_test"
                 ;;
             *)
                 ;;
@@ -48,7 +48,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help)
+        my__app_subcmd_help)
             opts="test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -62,7 +62,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__help)
+        my__app_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -76,7 +76,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__test)
+        my__app_subcmd_help_subcmd_test)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -90,7 +90,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__test)
+        my__app_subcmd_test)
             opts="-h -V --case --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/special_commands.bash
+++ b/clap_complete/tests/snapshots/special_commands.bash
@@ -17,34 +17,34 @@ _my-app() {
                 cmd="my__app"
                 ;;
             my__app,help)
-                cmd="my__app__help"
+                cmd="my__app_subcmd_help"
                 ;;
             my__app,some-cmd-with-hyphens)
-                cmd="my__app__some__cmd__with__hyphens"
+                cmd="my__app_subcmd_some__cmd__with__hyphens"
                 ;;
             my__app,some-hidden-cmd)
-                cmd="my__app__some__hidden__cmd"
+                cmd="my__app_subcmd_some__hidden__cmd"
                 ;;
             my__app,some_cmd)
-                cmd="my__app__some_cmd"
+                cmd="my__app_subcmd_some_cmd"
                 ;;
             my__app,test)
-                cmd="my__app__test"
+                cmd="my__app_subcmd_test"
                 ;;
-            my__app__help,help)
-                cmd="my__app__help__help"
+            my__app_subcmd_help,help)
+                cmd="my__app_subcmd_help_subcmd_help"
                 ;;
-            my__app__help,some-cmd-with-hyphens)
-                cmd="my__app__help__some__cmd__with__hyphens"
+            my__app_subcmd_help,some-cmd-with-hyphens)
+                cmd="my__app_subcmd_help_subcmd_some__cmd__with__hyphens"
                 ;;
-            my__app__help,some-hidden-cmd)
-                cmd="my__app__help__some__hidden__cmd"
+            my__app_subcmd_help,some-hidden-cmd)
+                cmd="my__app_subcmd_help_subcmd_some__hidden__cmd"
                 ;;
-            my__app__help,some_cmd)
-                cmd="my__app__help__some_cmd"
+            my__app_subcmd_help,some_cmd)
+                cmd="my__app_subcmd_help_subcmd_some_cmd"
                 ;;
-            my__app__help,test)
-                cmd="my__app__help__test"
+            my__app_subcmd_help,test)
+                cmd="my__app_subcmd_help_subcmd_test"
                 ;;
             *)
                 ;;
@@ -66,7 +66,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help)
+        my__app_subcmd_help)
             opts="test some_cmd some-cmd-with-hyphens some-hidden-cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -80,7 +80,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__help)
+        my__app_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -94,7 +94,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__some__cmd__with__hyphens)
+        my__app_subcmd_help_subcmd_some__cmd__with__hyphens)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -108,7 +108,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__some__hidden__cmd)
+        my__app_subcmd_help_subcmd_some__hidden__cmd)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -122,7 +122,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__some_cmd)
+        my__app_subcmd_help_subcmd_some_cmd)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -136,7 +136,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__test)
+        my__app_subcmd_help_subcmd_test)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -150,7 +150,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some__cmd__with__hyphens)
+        my__app_subcmd_some__cmd__with__hyphens)
             opts="-h -V --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -164,7 +164,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some__hidden__cmd)
+        my__app_subcmd_some__hidden__cmd)
             opts="-h -V --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -178,7 +178,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some_cmd)
+        my__app_subcmd_some_cmd)
             opts="-h -V --config --help --version [path]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -196,7 +196,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__test)
+        my__app_subcmd_test)
             opts="-h -V --case --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/sub_subcommands.bash
+++ b/clap_complete/tests/snapshots/sub_subcommands.bash
@@ -17,40 +17,40 @@ _my-app() {
                 cmd="my__app"
                 ;;
             my__app,help)
-                cmd="my__app__help"
+                cmd="my__app_subcmd_help"
                 ;;
             my__app,some_cmd)
-                cmd="my__app__some_cmd"
+                cmd="my__app_subcmd_some_cmd"
                 ;;
             my__app,some_cmd_alias)
-                cmd="my__app__some_cmd"
+                cmd="my__app_subcmd_some_cmd"
                 ;;
             my__app,test)
-                cmd="my__app__test"
+                cmd="my__app_subcmd_test"
                 ;;
-            my__app__help,help)
-                cmd="my__app__help__help"
+            my__app_subcmd_help,help)
+                cmd="my__app_subcmd_help_subcmd_help"
                 ;;
-            my__app__help,some_cmd)
-                cmd="my__app__help__some_cmd"
+            my__app_subcmd_help,some_cmd)
+                cmd="my__app_subcmd_help_subcmd_some_cmd"
                 ;;
-            my__app__help,test)
-                cmd="my__app__help__test"
+            my__app_subcmd_help,test)
+                cmd="my__app_subcmd_help_subcmd_test"
                 ;;
-            my__app__help__some_cmd,sub_cmd)
-                cmd="my__app__help__some_cmd__sub_cmd"
+            my__app_subcmd_help_subcmd_some_cmd,sub_cmd)
+                cmd="my__app_subcmd_help_subcmd_some_cmd_subcmd_sub_cmd"
                 ;;
-            my__app__some_cmd,help)
-                cmd="my__app__some_cmd__help"
+            my__app_subcmd_some_cmd,help)
+                cmd="my__app_subcmd_some_cmd_subcmd_help"
                 ;;
-            my__app__some_cmd,sub_cmd)
-                cmd="my__app__some_cmd__sub_cmd"
+            my__app_subcmd_some_cmd,sub_cmd)
+                cmd="my__app_subcmd_some_cmd_subcmd_sub_cmd"
                 ;;
-            my__app__some_cmd__help,help)
-                cmd="my__app__some_cmd__help__help"
+            my__app_subcmd_some_cmd_subcmd_help,help)
+                cmd="my__app_subcmd_some_cmd_subcmd_help_subcmd_help"
                 ;;
-            my__app__some_cmd__help,sub_cmd)
-                cmd="my__app__some_cmd__help__sub_cmd"
+            my__app_subcmd_some_cmd_subcmd_help,sub_cmd)
+                cmd="my__app_subcmd_some_cmd_subcmd_help_subcmd_sub_cmd"
                 ;;
             *)
                 ;;
@@ -72,7 +72,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help)
+        my__app_subcmd_help)
             opts="test some_cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -86,7 +86,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__help)
+        my__app_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -100,7 +100,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__some_cmd)
+        my__app_subcmd_help_subcmd_some_cmd)
             opts="sub_cmd"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -114,7 +114,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__some_cmd__sub_cmd)
+        my__app_subcmd_help_subcmd_some_cmd_subcmd_sub_cmd)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -128,7 +128,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__test)
+        my__app_subcmd_help_subcmd_test)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -142,7 +142,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some_cmd)
+        my__app_subcmd_some_cmd)
             opts="-h -V --help --version sub_cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -156,7 +156,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some_cmd__help)
+        my__app_subcmd_some_cmd_subcmd_help)
             opts="sub_cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -170,7 +170,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some_cmd__help__help)
+        my__app_subcmd_some_cmd_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -184,7 +184,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some_cmd__help__sub_cmd)
+        my__app_subcmd_some_cmd_subcmd_help_subcmd_sub_cmd)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -198,7 +198,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__some_cmd__sub_cmd)
+        my__app_subcmd_some_cmd_subcmd_sub_cmd)
             opts="-h -V --config --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -216,7 +216,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__test)
+        my__app_subcmd_test)
             opts="-h -V --case --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/subcommand_last.bash
+++ b/clap_complete/tests/snapshots/subcommand_last.bash
@@ -17,22 +17,22 @@ _my-app() {
                 cmd="my__app"
                 ;;
             my__app,bar)
-                cmd="my__app__bar"
+                cmd="my__app_subcmd_bar"
                 ;;
             my__app,foo)
-                cmd="my__app__foo"
+                cmd="my__app_subcmd_foo"
                 ;;
             my__app,help)
-                cmd="my__app__help"
+                cmd="my__app_subcmd_help"
                 ;;
-            my__app__help,bar)
-                cmd="my__app__help__bar"
+            my__app_subcmd_help,bar)
+                cmd="my__app_subcmd_help_subcmd_bar"
                 ;;
-            my__app__help,foo)
-                cmd="my__app__help__foo"
+            my__app_subcmd_help,foo)
+                cmd="my__app_subcmd_help_subcmd_foo"
                 ;;
-            my__app__help,help)
-                cmd="my__app__help__help"
+            my__app_subcmd_help,help)
+                cmd="my__app_subcmd_help_subcmd_help"
                 ;;
             *)
                 ;;
@@ -54,7 +54,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__bar)
+        my__app_subcmd_bar)
             opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -68,7 +68,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__foo)
+        my__app_subcmd_foo)
             opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -82,7 +82,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help)
+        my__app_subcmd_help)
             opts="foo bar help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -96,7 +96,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__bar)
+        my__app_subcmd_help_subcmd_bar)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -110,7 +110,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__foo)
+        my__app_subcmd_help_subcmd_foo)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -124,7 +124,7 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app__help__help)
+        my__app_subcmd_help_subcmd_help)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/underscore_subcommand.bash
+++ b/clap_complete/tests/snapshots/underscore_subcommand.bash
@@ -16,47 +16,41 @@ _my-app() {
             ",$1")
                 cmd="my__app"
                 ;;
-            my__app,cmd-backslash)
-                cmd="my__app_subcmd_cmd__backslash"
-                ;;
-            my__app,cmd-backticks)
-                cmd="my__app_subcmd_cmd__backticks"
-                ;;
-            my__app,cmd-brackets)
-                cmd="my__app_subcmd_cmd__brackets"
-                ;;
-            my__app,cmd-double-quotes)
-                cmd="my__app_subcmd_cmd__double__quotes"
-                ;;
-            my__app,cmd-expansions)
-                cmd="my__app_subcmd_cmd__expansions"
-                ;;
-            my__app,cmd-single-quotes)
-                cmd="my__app_subcmd_cmd__single__quotes"
+            my__app,group)
+                cmd="my__app_subcmd_group"
                 ;;
             my__app,help)
                 cmd="my__app_subcmd_help"
                 ;;
-            my__app_subcmd_help,cmd-backslash)
-                cmd="my__app_subcmd_help_subcmd_cmd__backslash"
+            my__app_subcmd_group,__hidden)
+                cmd="my__app_subcmd_group_subcmd___hidden"
                 ;;
-            my__app_subcmd_help,cmd-backticks)
-                cmd="my__app_subcmd_help_subcmd_cmd__backticks"
+            my__app_subcmd_group,help)
+                cmd="my__app_subcmd_group_subcmd_help"
                 ;;
-            my__app_subcmd_help,cmd-brackets)
-                cmd="my__app_subcmd_help_subcmd_cmd__brackets"
+            my__app_subcmd_group,normal)
+                cmd="my__app_subcmd_group_subcmd_normal"
                 ;;
-            my__app_subcmd_help,cmd-double-quotes)
-                cmd="my__app_subcmd_help_subcmd_cmd__double__quotes"
+            my__app_subcmd_group_subcmd_help,__hidden)
+                cmd="my__app_subcmd_group_subcmd_help_subcmd___hidden"
                 ;;
-            my__app_subcmd_help,cmd-expansions)
-                cmd="my__app_subcmd_help_subcmd_cmd__expansions"
+            my__app_subcmd_group_subcmd_help,help)
+                cmd="my__app_subcmd_group_subcmd_help_subcmd_help"
                 ;;
-            my__app_subcmd_help,cmd-single-quotes)
-                cmd="my__app_subcmd_help_subcmd_cmd__single__quotes"
+            my__app_subcmd_group_subcmd_help,normal)
+                cmd="my__app_subcmd_group_subcmd_help_subcmd_normal"
+                ;;
+            my__app_subcmd_help,group)
+                cmd="my__app_subcmd_help_subcmd_group"
                 ;;
             my__app_subcmd_help,help)
                 cmd="my__app_subcmd_help_subcmd_help"
+                ;;
+            my__app_subcmd_help_subcmd_group,__hidden)
+                cmd="my__app_subcmd_help_subcmd_group_subcmd___hidden"
+                ;;
+            my__app_subcmd_help_subcmd_group,normal)
+                cmd="my__app_subcmd_help_subcmd_group_subcmd_normal"
                 ;;
             *)
                 ;;
@@ -65,7 +59,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-h -V --single-quotes --double-quotes --backticks --backslash --brackets --expansions --help --version cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help"
+            opts="-h --help group help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -78,8 +72,8 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_cmd__backslash)
-            opts="-h --help"
+        my__app_subcmd_group)
+            opts="-h --help normal __hidden help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -92,9 +86,9 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_cmd__backticks)
+        my__app_subcmd_group_subcmd___hidden)
             opts="-h --help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -106,9 +100,9 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_cmd__brackets)
-            opts="-h --help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+        my__app_subcmd_group_subcmd_help)
+            opts="normal __hidden help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -120,9 +114,9 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_cmd__double__quotes)
-            opts="-h --help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+        my__app_subcmd_group_subcmd_help_subcmd___hidden)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -134,9 +128,9 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_cmd__expansions)
-            opts="-h --help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+        my__app_subcmd_group_subcmd_help_subcmd_help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -148,9 +142,23 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_cmd__single__quotes)
+        my__app_subcmd_group_subcmd_help_subcmd_normal)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        my__app_subcmd_group_subcmd_normal)
             opts="-h --help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -163,7 +171,7 @@ _my-app() {
             return 0
             ;;
         my__app_subcmd_help)
-            opts="cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help"
+            opts="group help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -176,8 +184,8 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_help_subcmd_cmd__backslash)
-            opts=""
+        my__app_subcmd_help_subcmd_group)
+            opts="normal __hidden"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -190,9 +198,9 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_help_subcmd_cmd__backticks)
+        my__app_subcmd_help_subcmd_group_subcmd___hidden)
             opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -204,51 +212,9 @@ _my-app() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        my__app_subcmd_help_subcmd_cmd__brackets)
+        my__app_subcmd_help_subcmd_group_subcmd_normal)
             opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        my__app_subcmd_help_subcmd_cmd__double__quotes)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        my__app_subcmd_help_subcmd_cmd__expansions)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        my__app_subcmd_help_subcmd_cmd__single__quotes)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -191,6 +191,20 @@ fn subcommand_last() {
     );
 }
 
+/// Regression test for [#6339](https://github.com/clap-rs/clap/issues/6339):
+/// a subcommand whose name contains `__` must not panic the bash generator.
+#[test]
+fn underscore_subcommand() {
+    let name = "my-app";
+    let cmd = common::underscore_subcommand_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/underscore_subcommand.bash"],
+        clap_complete::shells::Bash,
+        cmd,
+        name,
+    );
+}
+
 #[test]
 #[cfg(unix)]
 #[cfg(feature = "unstable-shell-tests")]

--- a/clap_complete/tests/testsuite/common.rs
+++ b/clap_complete/tests/testsuite/common.rs
@@ -320,6 +320,17 @@ pub(crate) fn subcommand_last(name: &'static str) -> clap::Command {
         .subcommands([clap::Command::new("foo"), clap::Command::new("bar")])
 }
 
+/// Regression fixture for <https://github.com/clap-rs/clap/issues/6339>: a
+/// subcommand whose name contains `__` used to make the bash generator panic
+/// because `__` was also the internal path separator.
+pub(crate) fn underscore_subcommand_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name).subcommand(
+        clap::Command::new("group")
+            .subcommand(clap::Command::new("normal"))
+            .subcommand(clap::Command::new("__hidden").hide(true)),
+    )
+}
+
 pub(crate) fn assert_matches(
     expected: impl IntoData,
     generator: impl clap_complete::Generator,


### PR DESCRIPTION
Fixes #6339.

The bash generator joins the subcommand path with `__` and later splits it back apart to look up the original `clap::Command`. Any subcommand whose name contains (or starts with) `__` — the reporter's case was `__hidden` — survives the join but not the split: `"myapp__group____hidden"` splits into `["myapp", "group", "", "hidden"]`, the empty segment misses the lookup, and `find_subcommand_with_path` unwraps a `None`.

Per @epage's note in #6339, switched the separator from `__` to `_subcmd_`. `__` is still used inside a segment to keep the generated bash identifiers hyphen-free, but it's no longer overloaded as a delimiter, so encode/decode round-trips cleanly no matter what the subcommand is called.

Includes a regression test that mirrors the reporter's repro (a hidden `__hidden` leaf under a `group` parent), and the existing bash snapshots have been refreshed to use the new separator. Spot-checked the regenerated snapshots with `bash -n`; they all parse.