### PR TITLE
fix(derive): Track Cargo env vars for incremental rebuilds

### DIFF
--- a/clap_derive/src/derives/parser.rs
+++ b/clap_derive/src/derives/parser.rs
@@ -30,12 +30,20 @@ pub(crate) fn derive_parser(input: &DeriveInput) -> Result<TokenStream, syn::Err
     let ident = &input.ident;
     let pkg_name = std::env::var("CARGO_PKG_NAME").ok().unwrap_or_default();
 
+    let pkg_name_tokens = if pkg_name.is_empty() {
+        quote!(#pkg_name)
+    } else {
+        quote!({
+            let _ = ::core::env!("CARGO_PKG_NAME");
+            #pkg_name })
+    };
+
     match input.data {
         Data::Struct(DataStruct {
             fields: Fields::Named(ref fields),
             ..
         }) => {
-            let name = Name::Assigned(quote!(#pkg_name));
+            let name = Name::Assigned(pkg_name_tokens.clone());
             let item = Item::from_args_struct(input, name)?;
             let fields = collect_args_fields(&item, fields)?;
             gen_for_struct(&item, ident, &input.generics, &fields)
@@ -44,7 +52,7 @@ pub(crate) fn derive_parser(input: &DeriveInput) -> Result<TokenStream, syn::Err
             fields: Fields::Unit,
             ..
         }) => {
-            let name = Name::Assigned(quote!(#pkg_name));
+            let name = Name::Assigned(pkg_name_tokens.clone());
             let item = Item::from_args_struct(input, name)?;
             let fields = Punctuated::<Field, Comma>::new();
             let fields = fields
@@ -57,7 +65,7 @@ pub(crate) fn derive_parser(input: &DeriveInput) -> Result<TokenStream, syn::Err
             gen_for_struct(&item, ident, &input.generics, &fields)
         }
         Data::Enum(ref e) => {
-            let name = Name::Assigned(quote!(#pkg_name));
+            let name = Name::Assigned(pkg_name_tokens);
             let item = Item::from_subcommand_enum(input, name)?;
             let variants = e
                 .variants

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -1263,7 +1263,14 @@ impl Method {
             lit = LitStr::new(&edited, lit.span());
         }
 
-        Ok(Some(Method::new(ident, quote!(#lit))))
+        let env_var_lit = LitStr::new(env_var, ident.span());
+        Ok(Some(Method::new(
+            ident,
+            quote!({
+                let _ = ::core::env!(#env_var_lit);
+                #lit
+            }),
+        )))
     }
 
     pub(crate) fn args(&self) -> &TokenStream {


### PR DESCRIPTION
Closes #6333.

`clap_derive` reads `CARGO_PKG_NAME`, `CARGO_PKG_AUTHORS`, `CARGO_PKG_VERSION`, and `CARGO_PKG_DESCRIPTION` via `std::env::var()` during macro expansion.
Since `proc_macro::tracked_env::var` is still unstable, `rustc` never learns about these reads, so Cargo won't rebuild when the values change in `Cargo.toml`.

Fix by injecting no-op `let _ = ::core::option_env!("CARGO_PKG_...");` into the generated code for each consumed env var. `rustc` tracks these at compile time and tells Cargo to rebuild on change. `option_env!` is used (instead of `env!`) so the generated code doesn't fail in non-Cargo builds.

The tracking is emitted even when the var is currently empty, which is the exact bug scenario:
use `#[command(author)]` but no `authors` field yet, adds it to `Cargo.toml`, and expects a rebuild without `cargo clean`.