### PR TITLE
Fix value completion for aliased options

### DIFF
--- a/clap_complete/src/engine/complete.rs
+++ b/clap_complete/src/engine/complete.rs
@@ -77,15 +77,7 @@ pub fn complete(
             }
         } else if let Some((flag, value)) = arg.to_long() {
             if let Ok(flag) = flag {
-                let opt = current_cmd.get_arguments().find(|a| {
-                    let longs = a.get_long_and_visible_aliases();
-                    let is_find = longs.map(|v| {
-                        let mut iter = v.into_iter();
-                        let s = iter.find(|s| *s == flag);
-                        s.is_some()
-                    });
-                    is_find.unwrap_or(false)
-                });
+                let opt = find_long_arg(current_cmd, flag);
 
                 if let Some(opt) = opt {
                     if opt.get_num_args().expect("built").takes_values() && value.is_none() {
@@ -268,7 +260,7 @@ fn complete_option(
     } else if let Some((flag, value)) = arg.to_long() {
         if let Ok(flag) = flag {
             if let Some(value) = value {
-                if let Some(arg) = cmd.get_arguments().find(|a| a.get_long() == Some(flag)) {
+                if let Some(arg) = find_long_arg(cmd, flag) {
                     completions.extend(
                         complete_arg_value(value.to_str().ok_or(value), arg, current_dir)
                             .into_iter()
@@ -504,6 +496,15 @@ fn hidden_longs_aliases(p: &clap::Command) -> Vec<CompletionCandidate> {
         .collect()
 }
 
+fn find_long_arg<'a>(cmd: &'a clap::Command, long: &str) -> Option<&'a clap::Arg> {
+    cmd.get_arguments().find(|arg| {
+        arg.get_long() == Some(long)
+            || arg
+                .get_aliases()
+                .is_some_and(|aliases| aliases.into_iter().any(|alias| alias == long))
+    })
+}
+
 /// Gets all the short options, their visible aliases and flags of a [`clap::Command`].
 /// Includes `h` and `V` depending on the [`clap::Command`] settings.
 fn shorts_and_visible_aliases(p: &clap::Command) -> Vec<CompletionCandidate> {
@@ -523,6 +524,15 @@ fn shorts_and_visible_aliases(p: &clap::Command) -> Vec<CompletionCandidate> {
         })
         .flatten()
         .collect()
+}
+
+fn find_short_arg(cmd: &clap::Command, short: char) -> Option<&clap::Arg> {
+    cmd.get_arguments().find(|arg| {
+        arg.get_short() == Some(short)
+            || arg
+                .get_all_short_aliases()
+                .is_some_and(|aliases| aliases.into_iter().any(|alias| alias == short))
+    })
 }
 
 fn populate_arg_candidate(candidate: CompletionCandidate, arg: &clap::Arg) -> CompletionCandidate {
@@ -600,15 +610,7 @@ fn parse_shortflags<'c, 's>(
         match short.next_flag() {
             Some(Ok(opt)) => {
                 leading_flags.push(opt);
-                let opt = cmd.get_arguments().find(|a| {
-                    let shorts = a.get_short_and_visible_aliases();
-                    let is_find = shorts.map(|v| {
-                        let mut iter = v.into_iter();
-                        let c = iter.find(|c| *c == opt);
-                        c.is_some()
-                    });
-                    is_find.unwrap_or(false)
-                });
+                let opt = find_short_arg(cmd, opt);
                 if opt
                     .map(|o| o.get_num_args().expect("built").takes_values())
                     .unwrap_or(false)

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -166,6 +166,42 @@ fn suggest_hidden_long_flag_aliases() {
 }
 
 #[test]
+fn complete_hidden_long_flag_alias_value() {
+    let mut cmd = Command::new("exhaustive").arg(
+        clap::Arg::new("format")
+            .long("format")
+            .alias("hidden-format")
+            .value_parser(["json", "yaml"]),
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "--hidden-format=[TAB]"),
+        snapbox::str![[r#"
+--hidden-format=json
+--hidden-format=yaml
+"#]],
+    );
+}
+
+#[test]
+fn complete_hidden_short_flag_alias_value() {
+    let mut cmd = Command::new("exhaustive").arg(
+        clap::Arg::new("format")
+            .short('f')
+            .short_alias('x')
+            .value_parser(["json", "yaml"]),
+    );
+
+    assert_data_eq!(
+        complete!(cmd, "-x [TAB]"),
+        snapbox::str![[r#"
+json
+yaml
+"#]],
+    );
+}
+
+#[test]
 fn suggest_long_flag_subset() {
     let mut cmd = Command::new("exhaustive")
         .arg(


### PR DESCRIPTION

**Repo:** clap-rs/clap (⭐ 16000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +57/-19

## What
This patch fixes `clap_complete`'s dynamic completion engine so option value completion works when the user invokes an option through an alias instead of only through its canonical name. The engine now resolves both long and short aliases consistently while parsing prior arguments and while completing inline `--flag=value` input, and it adds regression tests for hidden long and short aliases.

## Why
Before this change, aliased options were handled inconsistently: hidden long aliases could be suggested, but value completion could still fail because the engine only matched canonical long names in some paths and only visible short aliases in others. That made shell completion unreliable for applications that expose alternate option spellings, especially hidden compatibility aliases.

## Testing
Ran `cargo fmt --all --check` successfully. Attempted `cargo test -p clap_complete --test testsuite --features unstable-dynamic complete_hidden_`, but it could not run in this environment because Cargo needed to resolve `automod` from `crates.io` and network access is blocked.

## Risk
Low: the change is scoped to alias lookup inside `clap_complete`'s dynamic engine and is covered by focused regression tests.
