### PR TITLE
docs: hint at clippy::missing_docs_in_private_items lint

### DIFF
--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -520,6 +520,7 @@
 //!   [`Command::debug_assert`][crate::Command::debug_assert] in a test
 //!   ([example][_tutorial#testing])
 //! - Always remember to [document](#doc-comments) args and commands with `#![deny(missing_docs)]`
+//!   or `#[deny(clippy::missing_docs_in_private_items)]`
 
 // Point people here that search for attributes that don't exist in the derive (a subset of magic
 // attributes)


### PR DESCRIPTION
`#![deny(missing_docs)]` doesn't work when deriving a parser from a
private struct. This is commonly the case when specifying the parser in
`main.rs`.

`#[deny(clippy::missing_docs_in_private_items)]` helps with that.
