### PR TITLE
fix(complete): Prefer subcommand names over aliases

### DIFF
--- a/clap_complete/src/engine/complete.rs
+++ b/clap_complete/src/engine/complete.rs
@@ -467,7 +467,6 @@ fn complete_subcommand(value: &str, cmd: &clap::Command) -> Vec<CompletionCandid
         }
     }
 
-    scs.sort();
     scs.dedup();
     scs
 }

--- a/clap_complete/tests/testsuite/engine.rs
+++ b/clap_complete/tests/testsuite/engine.rs
@@ -112,6 +112,17 @@ hello-moon
 }
 
 #[test]
+fn prefer_subcommand_name_over_visible_alias() {
+    let mut cmd = Command::new("exhaustive")
+        .subcommand(Command::new("install").visible_alias("i"))
+        .subcommand(Command::new("remove").visible_alias("rm"));
+
+    assert_data_eq!(complete!(cmd, "i[TAB]"), snapbox::str!["install"]);
+    assert_data_eq!(complete!(cmd, "in[TAB]"), snapbox::str!["install"]);
+    assert_data_eq!(complete!(cmd, "rm[TAB]"), snapbox::str!["rm"]);
+}
+
+#[test]
 fn suggest_hidden_possible_value() {
     let mut cmd = Command::new("exhaustive").arg(
         clap::Arg::new("possible_value").long("test").value_parser([


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

## Summary
- keep dynamic subcommand completion candidates in declaration/display order before id de-duplication
- prefer a subcommand's primary name over a matching visible alias when only one candidate is shown
- add a regression test for `install` / visible alias `i`

Fixes #6317

## Testing
- `cargo fmt --all --check`
- `cargo test -p clap_complete --features unstable-dynamic --test testsuite engine::`
- `cargo test -p clap_complete --features unstable-dynamic --test testsuite`
- `cargo test -p clap_complete --features unstable-dynamic`
