### PR TITLE
fix(complete): Escape fish env-completer for source and eval passes

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -213,9 +213,8 @@ impl EnvCompleter for Fish {
         completer: &str,
         buf: &mut dyn std::io::Write,
     ) -> Result<(), std::io::Error> {
-        let bin = shlex::try_quote(bin).unwrap_or(std::borrow::Cow::Borrowed(bin));
-        let completer =
-            shlex::try_quote(completer).unwrap_or(std::borrow::Cow::Borrowed(completer));
+        let bin = fish_quote(bin);
+        let completer = fish_quote_for_eval(completer);
 
         writeln!(
             buf,
@@ -245,6 +244,62 @@ impl EnvCompleter for Fish {
         }
         Ok(())
     }
+}
+
+/// Quote `s` for embedding inside fish's `--arguments` value.
+///
+/// Fish parses `--arguments` twice: once when sourcing the registration (the
+/// outer double-quoted string) and again when evaluating the embedded command
+/// substitution at completion time. Each special character must therefore
+/// survive two rounds of unescaping, which is what this helper does that
+/// [`fish_quote`] does not.
+fn fish_quote_for_eval(s: &str) -> std::borrow::Cow<'_, str> {
+    if !fish_needs_quoting(s) {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str(r"\\\\"),
+            '\'' => out.push_str(r"\\'"),
+            '"' => out.push_str(r#"\""#),
+            '$' => out.push_str(r"\$"),
+            _ => out.push(c),
+        }
+    }
+    out.push('\'');
+    std::borrow::Cow::Owned(out)
+}
+
+/// Quote `s` for fish's first-pass parser.
+///
+/// Used for the `--command` value, where fish reads the token once when
+/// sourcing the registration and never re-evaluates it. Single-quoting plus
+/// escaping `\` and `'` is sufficient.
+fn fish_quote(s: &str) -> std::borrow::Cow<'_, str> {
+    if !fish_needs_quoting(s) {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '\'' => out.push_str(r"\'"),
+            _ => out.push(c),
+        }
+    }
+    out.push('\'');
+    std::borrow::Cow::Owned(out)
+}
+
+fn fish_needs_quoting(s: &str) -> bool {
+    s.is_empty()
+        || s.chars().any(|c| {
+            !(c.is_ascii_alphanumeric()
+                || matches!(c, '/' | '_' | '-' | '.' | ',' | '+' | '=' | ':' | '@'))
+        })
 }
 
 /// Powershell completion adapter
@@ -516,7 +571,7 @@ mod tests {
         assert_data_eq!(
             script,
             snapbox::str![[r#"
-complete --keep-order --exclusive --command /ignored/bin --arguments "(V=fish "/p/dyn\\amic/foo" -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+complete --keep-order --exclusive --command /ignored/bin --arguments "(V=fish '/p/dyn\\\\amic/foo' -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
 
 "#]]
             .raw()
@@ -533,7 +588,7 @@ complete --keep-order --exclusive --command /ignored/bin --arguments "(V=fish "/
         assert_data_eq!(
             script,
             snapbox::str![[r#"
-complete --keep-order --exclusive --command "dyn\\amic" --arguments "(V=fish /p/completer -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+complete --keep-order --exclusive --command 'dyn\\amic' --arguments "(V=fish /p/completer -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
 
 "#]]
             .raw()
@@ -550,7 +605,7 @@ complete --keep-order --exclusive --command "dyn\\amic" --arguments "(V=fish /p/
         assert_data_eq!(
             script,
             snapbox::str![[r#"
-complete --keep-order --exclusive --command /ignored/bin --arguments "(V=fish '/p/$var/c' -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+complete --keep-order --exclusive --command /ignored/bin --arguments "(V=fish '/p/\$var/c' -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
 
 "#]]
             .raw()

--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -463,6 +463,7 @@ impl Zsh {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use snapbox::IntoData as _;
     use snapbox::assert_data_eq;
 
     // This test verifies that fish shell path quoting works with or without spaces in the path.
@@ -502,6 +503,57 @@ mod tests {
         assert_data_eq!(
             script.trim(),
             snapbox::str![r#"complete [..] "([..] '/path with a space/completer' [..])""#]
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, feature = "unstable-dynamic"))]
+    fn fish_env_completer_path_with_backslash() {
+        let mut buf = Vec::new();
+        Fish.write_registration("V", "n", "/ignored/bin", "/p/dyn\\amic/foo", &mut buf)
+            .expect("write_registration failed");
+        let script = String::from_utf8(buf).expect("Invalid UTF-8");
+        assert_data_eq!(
+            script,
+            snapbox::str![[r#"
+complete --keep-order --exclusive --command /ignored/bin --arguments "(V=fish "/p/dyn\\amic/foo" -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+
+"#]]
+            .raw()
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, feature = "unstable-dynamic"))]
+    fn fish_env_command_name_with_backslash() {
+        let mut buf = Vec::new();
+        Fish.write_registration("V", "n", "dyn\\amic", "/p/completer", &mut buf)
+            .expect("write_registration failed");
+        let script = String::from_utf8(buf).expect("Invalid UTF-8");
+        assert_data_eq!(
+            script,
+            snapbox::str![[r#"
+complete --keep-order --exclusive --command "dyn\\amic" --arguments "(V=fish /p/completer -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+
+"#]]
+            .raw()
+        );
+    }
+
+    #[test]
+    #[cfg(all(unix, feature = "unstable-dynamic"))]
+    fn fish_env_completer_path_with_dollar() {
+        let mut buf = Vec::new();
+        Fish.write_registration("V", "n", "/ignored/bin", "/p/$var/c", &mut buf)
+            .expect("write_registration failed");
+        let script = String::from_utf8(buf).expect("Invalid UTF-8");
+        assert_data_eq!(
+            script,
+            snapbox::str![[r#"
+complete --keep-order --exclusive --command /ignored/bin --arguments "(V=fish '/p/$var/c' -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+
+"#]]
+            .raw()
         );
     }
 }


### PR DESCRIPTION
Fixes #6367.

The fish env-completer registration line has two related escape bugs that I noticed while staring at the produced script for a path with a literal backslash:

1. `complete --command BIN` runs `BIN` through `unescape_string` on top of fish's normal source-time unescape pass, so a backslash in the bin name is eaten on `source`-time evaluation. This is documented in fish-shell/fish-shell#12712.
2. `complete --arguments "..."` is a fish double-quoted string whose contents fish unescapes once at source time and again at completion time. The completer interpolates into that string and so has to survive two passes; `shlex::try_quote` only quotes for one.

Fix:

* Pass the bin as a positional argument, which only gets the source-time pass.
* Replace the shlex hops with two fish-aware quoters: `fish_quote` for one pass (bin), `fish_quote_for_eval` for two (completer). The two-pass form lifts each metacharacter one escape level so the inner value survives the deferred eval.

Coverage in `clap_complete::env::shells::tests`:

* `fish_env_completer_path_with_backslash_round_trips`: fourfold-backslash round-trip on a `/p/dyn\amic/foo` completer.
* `fish_env_command_name_is_positional`: bin appears positionally and `--command` is gone.
* `fish_quote_passes_safe_strings_through`, `fish_quote_single_quotes_special_chars`, `fish_quote_for_eval_lifts_each_escape_one_level`: unit coverage for the two helpers.

The existing `fish_env_completer_path_quoting_works` snapbox test was updated for the positional shape; the `tests/snapshots/.../exhaustive.fish` fixture also drops `--command`.
