### PR TITLE
fix(complete): preserve candidate order in zsh completions

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -393,8 +393,8 @@ function _clap_dynamic_completer_NAME() {
                 other+=("$completion")
             fi
         done
-        [[ -n $dirs ]] && _describe 'values' dirs -S '/' -r '/'
-        [[ -n $other ]] && _describe 'values' other
+        [[ -n $dirs ]] && _describe -V 'values' dirs -S '/' -r '/'
+        [[ -n $other ]] && _describe -V 'values' other
     fi
 }
 

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
@@ -28,8 +28,8 @@ function _clap_dynamic_completer_exhaustive() {
                 other+=("$completion")
             fi
         done
-        [[ -n $dirs ]] && _describe 'values' dirs -S '/' -r '/'
-        [[ -n $other ]] && _describe 'values' other
+        [[ -n $dirs ]] && _describe -V 'values' dirs -S '/' -r '/'
+        [[ -n $other ]] && _describe -V 'values' other
     fi
 }
 

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -251,11 +251,11 @@ fn complete_dynamic_env_toplevel() {
     let input = "exhaustive \t\t";
     let expected = snapbox::str![[r#"
 % exhaustive
+help            -- Print this message or the help of the given subcommand(s)
 --generate      -- generate
 --help          -- Print help
-help            -- Print this message or the help of the given subcommand(s)
---empty-choice  alias           global          last            quote           
-action          empty           hint            pacman          value           
+empty           action          value           last            hint            
+global          quote           pacman          alias           --empty-choice  
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
@@ -430,7 +430,7 @@ fn complete_dynamic_dir_no_trailing_space() {
     let input = "exhaustive hint --file tests/\t\t";
     let expected = snapbox::str![[r#"
 % exhaustive hint --file tests/
-tests/examples.rs  tests/snapshots    tests/testsuite
+tests/snapshots    tests/testsuite    tests/examples.rs
 "#]];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);


### PR DESCRIPTION
Use `_describe -V` (unsorted group) instead of `_describe` in the zsh dynamic completion registration script. Without `-V`, zsh sorts completions alphabetically, ignoring the order returned by the completer.

The `-V` flag tells zsh to use an unsorted completion group, which preserves the original order of candidates as returned by the completion engine.

Fixes #5752