### PR TITLE
fix(complete): Wrap zsh script in emulate -L zsh

### DIFF
--- a/clap_complete/CHANGELOG.md
+++ b/clap_complete/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- *(zsh)* Make generated completion scripts source cleanly when `ksharrays` is set
+
 ## [4.6.4] - 2026-05-10
 
 ### Fixes

--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -28,9 +28,14 @@ impl Generator for Zsh {
             buf,
             "#compdef {name}
 
+() {{
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _{name}() {{
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -46,6 +51,7 @@ _{name}() {{
 }}
 
 {subcommand_details}
+}}
 
 if [ \"$funcstack[1]\" = \"_{name}\" ]; then
     _{name} \"$@\"

--- a/clap_complete/tests/snapshots/aliases.zsh
+++ b/clap_complete/tests/snapshots/aliases.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -35,6 +40,7 @@ _my-app() {
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/basic.zsh
+++ b/clap_complete/tests/snapshots/basic.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -95,6 +100,7 @@ _my-app__subcmd__help__subcmd__test_commands() {
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/custom_bin_name.zsh
+++ b/clap_complete/tests/snapshots/custom_bin_name.zsh
@@ -1,8 +1,13 @@
 #compdef bin-name
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _bin-name() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -95,6 +100,7 @@ _bin-name__subcmd__help__subcmd__test_commands() {
 _bin-name__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'bin-name test commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_bin-name" ]; then

--- a/clap_complete/tests/snapshots/external_subcommands.zsh
+++ b/clap_complete/tests/snapshots/external_subcommands.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -92,6 +97,7 @@ _my-app__subcmd__help__subcmd__external_commands() {
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -102,6 +107,7 @@ _my-app__subcmd__help__subcmd__test_commands() {
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
@@ -1,8 +1,13 @@
 #compdef exhaustive
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _exhaustive() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -972,6 +977,7 @@ _exhaustive__subcmd__quote__subcmd__help__subcmd__help_commands() {
 _exhaustive__subcmd__value_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive value commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_exhaustive" ]; then

--- a/clap_complete/tests/snapshots/multi_value_option.zsh
+++ b/clap_complete/tests/snapshots/multi_value_option.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -25,6 +30,7 @@ _my-app() {
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/optional_multi_value_option.zsh
+++ b/clap_complete/tests/snapshots/optional_multi_value_option.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -25,6 +30,7 @@ _my-app() {
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/optional_value_option.zsh
+++ b/clap_complete/tests/snapshots/optional_value_option.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -25,6 +30,7 @@ _my-app() {
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -209,6 +214,7 @@ _my-app__subcmd__help__subcmd__cmd-single-quotes_commands() {
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -176,6 +181,7 @@ _my-app__subcmd__some_cmd_commands() {
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -276,6 +281,7 @@ _my-app__subcmd__some_cmd__subcmd__sub_cmd_commands() {
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/subcommand_last.zsh
+++ b/clap_complete/tests/snapshots/subcommand_last.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -114,6 +119,7 @@ _my-app__subcmd__help__subcmd__foo_commands() {
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.zsh
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -25,6 +30,7 @@ _my-app() {
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/value_hint.zsh
+++ b/clap_complete/tests/snapshots/value_hint.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -45,6 +50,7 @@ _my-app() {
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then

--- a/clap_complete/tests/snapshots/value_terminator.zsh
+++ b/clap_complete/tests/snapshots/value_terminator.zsh
@@ -1,8 +1,13 @@
 #compdef my-app
 
+() {
+emulate -L zsh -o no_ksharrays
+
 autoload -U is-at-least
 
 _my-app() {
+    emulate -L zsh -o no_ksharrays
+
     typeset -A opt_args
     typeset -a _arguments_options
     local ret=1
@@ -25,6 +30,7 @@ _my-app() {
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"
+}
 }
 
 if [ "$funcstack[1]" = "_my-app" ]; then


### PR DESCRIPTION
Sourcing a generated zsh completion under `setopt ksharrays` errors at every `(( $+functions[..._commands] ))` line.

Wraps the source-time function definitions in an `emulate -L zsh -o no_ksharrays` IIFE and starts `_<name>` with the same emulate. The caller's options are preserved after sourcing.

Fixes #6372