### PR TITLE
fix(derive): preserve .0 in float default_value_t help

### DIFF
--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -584,12 +584,25 @@ impl Item {
                             s
                         })
                     } else {
-                        quote_spanned!(attr.name.span()=> {
-                            static DEFAULT_VALUE: ::std::sync::OnceLock<String> = ::std::sync::OnceLock::new();
-                            let s = DEFAULT_VALUE.get_or_init(|| {
+                        let default_string = if is_simple_ty(ty, "f32") || is_simple_ty(ty, "f64") {
+                            quote_spanned!(attr.name.span()=> {
+                                let val: #ty = #val;
+                                let s = val.to_string();
+                                if s.contains('.') || s.contains('e') || s.contains('E') {
+                                    s
+                                } else {
+                                    format!("{s}.0")
+                                }
+                            })
+                        } else {
+                            quote_spanned!(attr.name.span()=> {
                                 let val: #ty = #val;
                                 ::std::string::ToString::to_string(&val)
-                            });
+                            })
+                        };
+                        quote_spanned!(attr.name.span()=> {
+                            static DEFAULT_VALUE: ::std::sync::OnceLock<String> = ::std::sync::OnceLock::new();
+                            let s = DEFAULT_VALUE.get_or_init(|| #default_string);
                             let s: &'static str = &*s;
                             s
                         })

--- a/tests/derive/default_value.rs
+++ b/tests/derive/default_value.rs
@@ -58,6 +58,32 @@ Options:
 }
 
 #[test]
+fn default_value_t_float() {
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(short = 'a', default_value_t = 1.0)]
+        amplify: f32,
+    }
+    assert_eq!(
+        Opt { amplify: 1.0 },
+        Opt::try_parse_from(["test"]).unwrap()
+    );
+
+    let help = utils::get_long_help::<Opt>();
+    assert_data_eq!(help, str![[r#"
+Usage: clap [OPTIONS]
+
+Options:
+  -a <AMPLIFY>
+          [default: 1.0]
+
+  -h, --help
+          Print help
+
+"#]].raw());
+}
+
+#[test]
 fn auto_default_value_t() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {


### PR DESCRIPTION
## Summary

`#[arg(default_value_t = 1.0)]` showed `[default: 1]` in help because `ToString` drops trailing zeros on floats.

Format whole-number floats as `{n}.0` when rendering default values in help text.

Fixes #6249.

## Test plan

- [x] `cargo test --features derive,help,usage --test derive default_value_t_float`