### PR TITLE
chore: improve clap maintenance path

### DIFF
--- a/clap_builder/src/parser/features/suggestions.rs
+++ b/clap_builder/src/parser/features/suggestions.rs
@@ -175,4 +175,29 @@ mod test {
             Some(("alignmentScore".to_owned(), None))
         );
     }
+
+    #[test]
+    fn empty_candidate_list() {
+        let p_vals: &[&str] = &[];
+        assert_eq!(did_you_mean("test", p_vals.iter()), Vec::<String>::new());
+    }
+
+    #[test]
+    fn identical_string() {
+        let p_vals = ["test"];
+        assert_eq!(did_you_mean("test", p_vals.iter()), vec!["test"]);
+    }
+
+    #[test]
+    fn very_long_input() {
+        let long = "a".repeat(1000);
+        let p_vals = [long.as_str()];
+        assert_eq!(did_you_mean(&long, p_vals.iter()), vec![long]);
+    }
+
+    #[test]
+    fn non_ascii() {
+        let p_vals = ["test", "tëst", "typhoon"];
+        assert_eq!(did_you_mean("tëst", p_vals.iter()), vec!["test", "tëst"]);
+    }
 }

--- a/clap_builder/src/util/str_to_bool.rs
+++ b/clap_builder/src/util/str_to_bool.rs
@@ -19,3 +19,47 @@ pub(crate) fn str_to_bool(val: impl AsRef<str>) -> Option<bool> {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(str_to_bool(""), None);
+    }
+
+    #[test]
+    fn whitespace_only() {
+        assert_eq!(str_to_bool(" "), None);
+        assert_eq!(str_to_bool("\t"), None);
+        assert_eq!(str_to_bool("\n"), None);
+    }
+
+    #[test]
+    fn whitespace_padded() {
+        assert_eq!(str_to_bool(" true "), None);
+        assert_eq!(str_to_bool("false "), None);
+        assert_eq!(str_to_bool(" yes"), None);
+    }
+
+    #[test]
+    fn mixed_case() {
+        assert_eq!(str_to_bool("TrUe"), Some(true));
+        assert_eq!(str_to_bool("FALSE"), Some(false));
+        assert_eq!(str_to_bool("Yes"), Some(true));
+        assert_eq!(str_to_bool("nO"), Some(false));
+        assert_eq!(str_to_bool("ON"), Some(true));
+        assert_eq!(str_to_bool("Off"), Some(false));
+    }
+
+    #[test]
+    fn unicode_lookalikes() {
+        // Fullwidth characters
+        assert_eq!(str_to_bool("\u{FF54}\u{FF52}\u{FF55}\u{FF45}"), None);
+        // Cyrillic lookalike (U+0435)
+        assert_eq!(str_to_bool("tru\u{0435}"), None);
+        // Zero-width space
+        assert_eq!(str_to_bool("true\u{200B}"), None);
+    }
+}


### PR DESCRIPTION
Summary:
- Add focused unit tests for edge cases in `str_to_bool` (whitespace, mixed case, empty string, unicode lookalikes) and for `suggestions::did_you_mean` (empty candidate list, identical strings, very long inputs, non-ASCII) to lock down current behavior and improve branch coverage in these small utility modules.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.