### PR TITLE
fix(complete): make zsh function checks ksharrays-safe

### DIFF
--- a/clap_complete/CHANGELOG.md
+++ b/clap_complete/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- *(zsh)* Make generated function checks compatible with `ksharrays`
+
 ## [4.6.5] - 2026-05-11
 
 ### Fixes

--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -62,7 +62,7 @@ fi
 }
 
 // Displays the commands of a subcommand
-// (( $+functions[_[bin_name_underscore]_commands] )) ||
+// (( ${+functions[_[bin_name_underscore]_commands]} )) ||
 // _[bin_name_underscore]_commands() {
 //     local commands; commands=(
 //         '[arg_name]:[arg_help]'
@@ -78,7 +78,7 @@ fi
 //
 // Here's a snippet from rustup:
 //
-// (( $+functions[_rustup_commands] )) ||
+// (( ${+functions[_rustup_commands]} )) ||
 // _rustup_commands() {
 //     local commands; commands=(
 //      'show:Show the active and installed toolchains'
@@ -100,7 +100,7 @@ fn subcommand_details(p: &Command) -> String {
     // First we do ourself
     let parent_text = format!(
         "\
-(( $+functions[_{bin_name_underscore}_commands] )) ||
+(( ${{+functions[_{bin_name_underscore}_commands]}} )) ||
 _{bin_name_underscore}_commands() {{
     local commands; commands=({subcommands_and_args})
     _describe -t commands '{bin_name} commands' commands \"$@\"
@@ -125,7 +125,7 @@ _{bin_name_underscore}_commands() {{
 
         ret.push(format!(
             "\
-(( $+functions[_{bin_name_underscore}_commands] )) ||
+(( ${{+functions[_{bin_name_underscore}_commands]}} )) ||
 _{bin_name_underscore}_commands() {{
     local commands; commands=({subcommands_and_args})
     _describe -t commands '{bin_name} commands' commands \"$@\"

--- a/clap_complete/tests/snapshots/aliases.zsh
+++ b/clap_complete/tests/snapshots/aliases.zsh
@@ -31,7 +31,7 @@ _my-app() {
 && ret=0
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"

--- a/clap_complete/tests/snapshots/basic.zsh
+++ b/clap_complete/tests/snapshots/basic.zsh
@@ -65,7 +65,7 @@ esac
 esac
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=(
 'test:Subcommand with a second line' \
@@ -73,7 +73,7 @@ _my-app_commands() {
     )
     _describe -t commands 'my-app commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help_commands]} )) ||
 _my-app__subcmd__help_commands() {
     local commands; commands=(
 'test:Subcommand with a second line' \
@@ -81,17 +81,17 @@ _my-app__subcmd__help_commands() {
     )
     _describe -t commands 'my-app help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__test_commands]} )) ||
 _my-app__subcmd__help__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help test commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__test_commands]} )) ||
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"

--- a/clap_complete/tests/snapshots/custom_bin_name.zsh
+++ b/clap_complete/tests/snapshots/custom_bin_name.zsh
@@ -65,7 +65,7 @@ esac
 esac
 }
 
-(( $+functions[_bin-name_commands] )) ||
+(( ${+functions[_bin-name_commands]} )) ||
 _bin-name_commands() {
     local commands; commands=(
 'test:Subcommand with a second line' \
@@ -73,7 +73,7 @@ _bin-name_commands() {
     )
     _describe -t commands 'bin-name commands' commands "$@"
 }
-(( $+functions[_bin-name__subcmd__help_commands] )) ||
+(( ${+functions[_bin-name__subcmd__help_commands]} )) ||
 _bin-name__subcmd__help_commands() {
     local commands; commands=(
 'test:Subcommand with a second line' \
@@ -81,17 +81,17 @@ _bin-name__subcmd__help_commands() {
     )
     _describe -t commands 'bin-name help commands' commands "$@"
 }
-(( $+functions[_bin-name__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_bin-name__subcmd__help__subcmd__help_commands]} )) ||
 _bin-name__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'bin-name help help commands' commands "$@"
 }
-(( $+functions[_bin-name__subcmd__help__subcmd__test_commands] )) ||
+(( ${+functions[_bin-name__subcmd__help__subcmd__test_commands]} )) ||
 _bin-name__subcmd__help__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'bin-name help test commands' commands "$@"
 }
-(( $+functions[_bin-name__subcmd__test_commands] )) ||
+(( ${+functions[_bin-name__subcmd__test_commands]} )) ||
 _bin-name__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'bin-name test commands' commands "$@"

--- a/clap_complete/tests/snapshots/external_subcommands.zsh
+++ b/clap_complete/tests/snapshots/external_subcommands.zsh
@@ -62,7 +62,7 @@ esac
 esac
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=(
 'external:An external subcommand' \
@@ -70,12 +70,12 @@ _my-app_commands() {
     )
     _describe -t commands 'my-app commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__external_commands] )) ||
+(( ${+functions[_my-app__subcmd__external_commands]} )) ||
 _my-app__subcmd__external_commands() {
     local commands; commands=()
     _describe -t commands 'my-app external commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help_commands]} )) ||
 _my-app__subcmd__help_commands() {
     local commands; commands=(
 'external:An external subcommand' \
@@ -83,12 +83,12 @@ _my-app__subcmd__help_commands() {
     )
     _describe -t commands 'my-app help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__external_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__external_commands]} )) ||
 _my-app__subcmd__help__subcmd__external_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help external commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -72,7 +72,7 @@ esac
 esac
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=(
 'test:tests things' \
@@ -80,7 +80,7 @@ _my-app_commands() {
     )
     _describe -t commands 'my-app commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help_commands]} )) ||
 _my-app__subcmd__help_commands() {
     local commands; commands=(
 'test:tests things' \
@@ -88,17 +88,17 @@ _my-app__subcmd__help_commands() {
     )
     _describe -t commands 'my-app help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__test_commands]} )) ||
 _my-app__subcmd__help__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help test commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__test_commands]} )) ||
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"

--- a/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
@@ -563,7 +563,7 @@ esac
 esac
 }
 
-(( $+functions[_exhaustive_commands] )) ||
+(( ${+functions[_exhaustive_commands]} )) ||
 _exhaustive_commands() {
     local commands; commands=(
 'empty:' \
@@ -579,22 +579,22 @@ _exhaustive_commands() {
     )
     _describe -t commands 'exhaustive commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__action_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__action_commands]} )) ||
 _exhaustive__subcmd__action_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive action commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__alias_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__alias_commands]} )) ||
 _exhaustive__subcmd__alias_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive alias commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__empty_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__empty_commands]} )) ||
 _exhaustive__subcmd__empty_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive empty commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global_commands]} )) ||
 _exhaustive__subcmd__global_commands() {
     local commands; commands=(
 'one:' \
@@ -603,7 +603,7 @@ _exhaustive__subcmd__global_commands() {
     )
     _describe -t commands 'exhaustive global commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__help_commands() {
     local commands; commands=(
 'one:' \
@@ -612,29 +612,29 @@ _exhaustive__subcmd__global__subcmd__help_commands() {
     )
     _describe -t commands 'exhaustive global help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive global help help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__one_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__help__subcmd__one_commands() {
     local commands; commands=(
 'one-one:' \
     )
     _describe -t commands 'exhaustive global help one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__one__subcmd__one-one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__one__subcmd__one-one_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__help__subcmd__one__subcmd__one-one_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive global help one one-one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__two_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__help__subcmd__two_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__help__subcmd__two_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive global help two commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__one_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__one_commands() {
     local commands; commands=(
 'one-one:' \
@@ -642,7 +642,7 @@ _exhaustive__subcmd__global__subcmd__one_commands() {
     )
     _describe -t commands 'exhaustive global one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__one__subcmd__help_commands() {
     local commands; commands=(
 'one-one:' \
@@ -650,27 +650,27 @@ _exhaustive__subcmd__global__subcmd__one__subcmd__help_commands() {
     )
     _describe -t commands 'exhaustive global one help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__help__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__one__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive global one help help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__help__subcmd__one-one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__help__subcmd__one-one_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__one__subcmd__help__subcmd__one-one_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive global one help one-one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__one-one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__one__subcmd__one-one_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__one__subcmd__one-one_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive global one one-one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__global__subcmd__two_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__global__subcmd__two_commands]} )) ||
 _exhaustive__subcmd__global__subcmd__two_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive global two commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__help_commands() {
     local commands; commands=(
 'empty:' \
@@ -686,22 +686,22 @@ _exhaustive__subcmd__help_commands() {
     )
     _describe -t commands 'exhaustive help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__action_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__action_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__action_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help action commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__alias_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__alias_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__alias_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help alias commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__empty_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__empty_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__empty_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help empty commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__global_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__global_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__global_commands() {
     local commands; commands=(
 'one:' \
@@ -709,39 +709,39 @@ _exhaustive__subcmd__help__subcmd__global_commands() {
     )
     _describe -t commands 'exhaustive help global commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__global__subcmd__one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__global__subcmd__one_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__global__subcmd__one_commands() {
     local commands; commands=(
 'one-one:' \
     )
     _describe -t commands 'exhaustive help global one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__global__subcmd__one__subcmd__one-one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__global__subcmd__one__subcmd__one-one_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__global__subcmd__one__subcmd__one-one_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help global one one-one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__global__subcmd__two_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__global__subcmd__two_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__global__subcmd__two_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help global two commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__hint_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__hint_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__hint_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help hint commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__last_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__last_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__last_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help last commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__pacman_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__pacman_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__pacman_commands() {
     local commands; commands=(
 'one:' \
@@ -749,17 +749,17 @@ _exhaustive__subcmd__help__subcmd__pacman_commands() {
     )
     _describe -t commands 'exhaustive help pacman commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__pacman__subcmd__one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__pacman__subcmd__one_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__pacman__subcmd__one_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help pacman one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__pacman__subcmd__two_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__pacman__subcmd__two_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__pacman__subcmd__two_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help pacman two commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote_commands() {
     local commands; commands=(
 'cmd-single-quotes:Can be '\''always'\'', '\''auto'\'', or '\''never'\''' \
@@ -772,57 +772,57 @@ _exhaustive__subcmd__help__subcmd__quote_commands() {
     )
     _describe -t commands 'exhaustive help quote commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-backslash_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-backslash_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-backslash_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help quote cmd-backslash commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-backticks_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-backticks_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-backticks_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help quote cmd-backticks commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-brackets_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-brackets_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-brackets_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help quote cmd-brackets commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-double-quotes_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-double-quotes_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-double-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help quote cmd-double-quotes commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-expansions_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-expansions_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-expansions_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help quote cmd-expansions commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-single-quotes_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-single-quotes_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote__subcmd__cmd-single-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help quote cmd-single-quotes commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__escape-help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__quote__subcmd__escape-help_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__quote__subcmd__escape-help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help quote escape-help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__help__subcmd__value_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__help__subcmd__value_commands]} )) ||
 _exhaustive__subcmd__help__subcmd__value_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive help value commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__hint_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__hint_commands]} )) ||
 _exhaustive__subcmd__hint_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive hint commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__last_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__last_commands]} )) ||
 _exhaustive__subcmd__last_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive last commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__pacman_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__pacman_commands]} )) ||
 _exhaustive__subcmd__pacman_commands() {
     local commands; commands=(
 'one:' \
@@ -831,7 +831,7 @@ _exhaustive__subcmd__pacman_commands() {
     )
     _describe -t commands 'exhaustive pacman commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__pacman__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__pacman__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__pacman__subcmd__help_commands() {
     local commands; commands=(
 'one:' \
@@ -840,32 +840,32 @@ _exhaustive__subcmd__pacman__subcmd__help_commands() {
     )
     _describe -t commands 'exhaustive pacman help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__pacman__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__pacman__subcmd__help__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__pacman__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive pacman help help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__pacman__subcmd__help__subcmd__one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__pacman__subcmd__help__subcmd__one_commands]} )) ||
 _exhaustive__subcmd__pacman__subcmd__help__subcmd__one_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive pacman help one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__pacman__subcmd__help__subcmd__two_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__pacman__subcmd__help__subcmd__two_commands]} )) ||
 _exhaustive__subcmd__pacman__subcmd__help__subcmd__two_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive pacman help two commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__pacman__subcmd__one_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__pacman__subcmd__one_commands]} )) ||
 _exhaustive__subcmd__pacman__subcmd__one_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive pacman one commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__pacman__subcmd__two_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__pacman__subcmd__two_commands]} )) ||
 _exhaustive__subcmd__pacman__subcmd__two_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive pacman two commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote_commands]} )) ||
 _exhaustive__subcmd__quote_commands() {
     local commands; commands=(
 'cmd-single-quotes:Can be '\''always'\'', '\''auto'\'', or '\''never'\''' \
@@ -879,42 +879,42 @@ _exhaustive__subcmd__quote_commands() {
     )
     _describe -t commands 'exhaustive quote commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__cmd-backslash_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__cmd-backslash_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__cmd-backslash_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote cmd-backslash commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__cmd-backticks_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__cmd-backticks_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__cmd-backticks_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote cmd-backticks commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__cmd-brackets_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__cmd-brackets_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__cmd-brackets_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote cmd-brackets commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__cmd-double-quotes_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__cmd-double-quotes_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__cmd-double-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote cmd-double-quotes commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__cmd-expansions_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__cmd-expansions_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__cmd-expansions_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote cmd-expansions commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__cmd-single-quotes_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__cmd-single-quotes_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__cmd-single-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote cmd-single-quotes commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__escape-help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__escape-help_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__escape-help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote escape-help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help_commands() {
     local commands; commands=(
 'cmd-single-quotes:Can be '\''always'\'', '\''auto'\'', or '\''never'\''' \
@@ -928,47 +928,47 @@ _exhaustive__subcmd__quote__subcmd__help_commands() {
     )
     _describe -t commands 'exhaustive quote help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-backslash_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-backslash_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-backslash_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help cmd-backslash commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-backticks_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-backticks_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-backticks_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help cmd-backticks commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-brackets_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-brackets_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-brackets_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help cmd-brackets commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-double-quotes_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-double-quotes_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-double-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help cmd-double-quotes commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-expansions_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-expansions_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-expansions_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help cmd-expansions commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-single-quotes_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-single-quotes_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__cmd-single-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help cmd-single-quotes commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__escape-help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__escape-help_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__escape-help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help escape-help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__quote__subcmd__help__subcmd__help_commands]} )) ||
 _exhaustive__subcmd__quote__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive quote help help commands' commands "$@"
 }
-(( $+functions[_exhaustive__subcmd__value_commands] )) ||
+(( ${+functions[_exhaustive__subcmd__value_commands]} )) ||
 _exhaustive__subcmd__value_commands() {
     local commands; commands=()
     _describe -t commands 'exhaustive value commands' commands "$@"

--- a/clap_complete/tests/snapshots/multi_value_option.zsh
+++ b/clap_complete/tests/snapshots/multi_value_option.zsh
@@ -21,7 +21,7 @@ _my-app() {
 && ret=0
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"

--- a/clap_complete/tests/snapshots/optional_multi_value_option.zsh
+++ b/clap_complete/tests/snapshots/optional_multi_value_option.zsh
@@ -21,7 +21,7 @@ _my-app() {
 && ret=0
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"

--- a/clap_complete/tests/snapshots/optional_value_option.zsh
+++ b/clap_complete/tests/snapshots/optional_value_option.zsh
@@ -21,7 +21,7 @@ _my-app() {
 && ret=0
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -119,7 +119,7 @@ esac
 esac
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=(
 'cmd-single-quotes:Can be '\''always'\'', '\''auto'\'', or '\''never'\''' \
@@ -132,37 +132,37 @@ _my-app_commands() {
     )
     _describe -t commands 'my-app commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__cmd-backslash_commands] )) ||
+(( ${+functions[_my-app__subcmd__cmd-backslash_commands]} )) ||
 _my-app__subcmd__cmd-backslash_commands() {
     local commands; commands=()
     _describe -t commands 'my-app cmd-backslash commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__cmd-backticks_commands] )) ||
+(( ${+functions[_my-app__subcmd__cmd-backticks_commands]} )) ||
 _my-app__subcmd__cmd-backticks_commands() {
     local commands; commands=()
     _describe -t commands 'my-app cmd-backticks commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__cmd-brackets_commands] )) ||
+(( ${+functions[_my-app__subcmd__cmd-brackets_commands]} )) ||
 _my-app__subcmd__cmd-brackets_commands() {
     local commands; commands=()
     _describe -t commands 'my-app cmd-brackets commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__cmd-double-quotes_commands] )) ||
+(( ${+functions[_my-app__subcmd__cmd-double-quotes_commands]} )) ||
 _my-app__subcmd__cmd-double-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'my-app cmd-double-quotes commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__cmd-expansions_commands] )) ||
+(( ${+functions[_my-app__subcmd__cmd-expansions_commands]} )) ||
 _my-app__subcmd__cmd-expansions_commands() {
     local commands; commands=()
     _describe -t commands 'my-app cmd-expansions commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__cmd-single-quotes_commands] )) ||
+(( ${+functions[_my-app__subcmd__cmd-single-quotes_commands]} )) ||
 _my-app__subcmd__cmd-single-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'my-app cmd-single-quotes commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help_commands]} )) ||
 _my-app__subcmd__help_commands() {
     local commands; commands=(
 'cmd-single-quotes:Can be '\''always'\'', '\''auto'\'', or '\''never'\''' \
@@ -175,37 +175,37 @@ _my-app__subcmd__help_commands() {
     )
     _describe -t commands 'my-app help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__cmd-backslash_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__cmd-backslash_commands]} )) ||
 _my-app__subcmd__help__subcmd__cmd-backslash_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help cmd-backslash commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__cmd-backticks_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__cmd-backticks_commands]} )) ||
 _my-app__subcmd__help__subcmd__cmd-backticks_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help cmd-backticks commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__cmd-brackets_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__cmd-brackets_commands]} )) ||
 _my-app__subcmd__help__subcmd__cmd-brackets_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help cmd-brackets commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__cmd-double-quotes_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__cmd-double-quotes_commands]} )) ||
 _my-app__subcmd__help__subcmd__cmd-double-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help cmd-double-quotes commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__cmd-expansions_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__cmd-expansions_commands]} )) ||
 _my-app__subcmd__help__subcmd__cmd-expansions_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help cmd-expansions commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__cmd-single-quotes_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__cmd-single-quotes_commands]} )) ||
 _my-app__subcmd__help__subcmd__cmd-single-quotes_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help cmd-single-quotes commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -110,7 +110,7 @@ esac
 esac
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=(
 'test:tests things' \
@@ -121,7 +121,7 @@ _my-app_commands() {
     )
     _describe -t commands 'my-app commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help_commands]} )) ||
 _my-app__subcmd__help_commands() {
     local commands; commands=(
 'test:tests things' \
@@ -132,47 +132,47 @@ _my-app__subcmd__help_commands() {
     )
     _describe -t commands 'my-app help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__some-cmd-with-hyphens_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__some-cmd-with-hyphens_commands]} )) ||
 _my-app__subcmd__help__subcmd__some-cmd-with-hyphens_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help some-cmd-with-hyphens commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__some-hidden-cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__some-hidden-cmd_commands]} )) ||
 _my-app__subcmd__help__subcmd__some-hidden-cmd_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help some-hidden-cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__some_cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__some_cmd_commands]} )) ||
 _my-app__subcmd__help__subcmd__some_cmd_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help some_cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__test_commands]} )) ||
 _my-app__subcmd__help__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help test commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some-cmd-with-hyphens_commands] )) ||
+(( ${+functions[_my-app__subcmd__some-cmd-with-hyphens_commands]} )) ||
 _my-app__subcmd__some-cmd-with-hyphens_commands() {
     local commands; commands=()
     _describe -t commands 'my-app some-cmd-with-hyphens commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some-hidden-cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__some-hidden-cmd_commands]} )) ||
 _my-app__subcmd__some-hidden-cmd_commands() {
     local commands; commands=()
     _describe -t commands 'my-app some-hidden-cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some_cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__some_cmd_commands]} )) ||
 _my-app__subcmd__some_cmd_commands() {
     local commands; commands=()
     _describe -t commands 'my-app some_cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__test_commands]} )) ||
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -200,7 +200,7 @@ esac
 esac
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=(
 'test:tests things' \
@@ -210,7 +210,7 @@ _my-app_commands() {
     )
     _describe -t commands 'my-app commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help_commands]} )) ||
 _my-app__subcmd__help_commands() {
     local commands; commands=(
 'test:tests things' \
@@ -219,29 +219,29 @@ _my-app__subcmd__help_commands() {
     )
     _describe -t commands 'my-app help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__some_cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__some_cmd_commands]} )) ||
 _my-app__subcmd__help__subcmd__some_cmd_commands() {
     local commands; commands=(
 'sub_cmd:sub-subcommand' \
     )
     _describe -t commands 'my-app help some_cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__some_cmd__subcmd__sub_cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__some_cmd__subcmd__sub_cmd_commands]} )) ||
 _my-app__subcmd__help__subcmd__some_cmd__subcmd__sub_cmd_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help some_cmd sub_cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__test_commands]} )) ||
 _my-app__subcmd__help__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help test commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some_cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__some_cmd_commands]} )) ||
 _my-app__subcmd__some_cmd_commands() {
     local commands; commands=(
 'sub_cmd:sub-subcommand' \
@@ -249,7 +249,7 @@ _my-app__subcmd__some_cmd_commands() {
     )
     _describe -t commands 'my-app some_cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some_cmd__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__some_cmd__subcmd__help_commands]} )) ||
 _my-app__subcmd__some_cmd__subcmd__help_commands() {
     local commands; commands=(
 'sub_cmd:sub-subcommand' \
@@ -257,22 +257,22 @@ _my-app__subcmd__some_cmd__subcmd__help_commands() {
     )
     _describe -t commands 'my-app some_cmd help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some_cmd__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__some_cmd__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__some_cmd__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app some_cmd help help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some_cmd__subcmd__help__subcmd__sub_cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__some_cmd__subcmd__help__subcmd__sub_cmd_commands]} )) ||
 _my-app__subcmd__some_cmd__subcmd__help__subcmd__sub_cmd_commands() {
     local commands; commands=()
     _describe -t commands 'my-app some_cmd help sub_cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__some_cmd__subcmd__sub_cmd_commands] )) ||
+(( ${+functions[_my-app__subcmd__some_cmd__subcmd__sub_cmd_commands]} )) ||
 _my-app__subcmd__some_cmd__subcmd__sub_cmd_commands() {
     local commands; commands=()
     _describe -t commands 'my-app some_cmd sub_cmd commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__test_commands] )) ||
+(( ${+functions[_my-app__subcmd__test_commands]} )) ||
 _my-app__subcmd__test_commands() {
     local commands; commands=()
     _describe -t commands 'my-app test commands' commands "$@"

--- a/clap_complete/tests/snapshots/subcommand_last.zsh
+++ b/clap_complete/tests/snapshots/subcommand_last.zsh
@@ -72,7 +72,7 @@ esac
 esac
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=(
 'foo:' \
@@ -81,17 +81,17 @@ _my-app_commands() {
     )
     _describe -t commands 'my-app commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__bar_commands] )) ||
+(( ${+functions[_my-app__subcmd__bar_commands]} )) ||
 _my-app__subcmd__bar_commands() {
     local commands; commands=()
     _describe -t commands 'my-app bar commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__foo_commands] )) ||
+(( ${+functions[_my-app__subcmd__foo_commands]} )) ||
 _my-app__subcmd__foo_commands() {
     local commands; commands=()
     _describe -t commands 'my-app foo commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help_commands]} )) ||
 _my-app__subcmd__help_commands() {
     local commands; commands=(
 'foo:' \
@@ -100,17 +100,17 @@ _my-app__subcmd__help_commands() {
     )
     _describe -t commands 'my-app help commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__bar_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__bar_commands]} )) ||
 _my-app__subcmd__help__subcmd__bar_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help bar commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__foo_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__foo_commands]} )) ||
 _my-app__subcmd__help__subcmd__foo_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help foo commands' commands "$@"
 }
-(( $+functions[_my-app__subcmd__help__subcmd__help_commands] )) ||
+(( ${+functions[_my-app__subcmd__help__subcmd__help_commands]} )) ||
 _my-app__subcmd__help__subcmd__help_commands() {
     local commands; commands=()
     _describe -t commands 'my-app help help commands' commands "$@"

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.zsh
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.zsh
@@ -21,7 +21,7 @@ _my-app() {
 && ret=0
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"

--- a/clap_complete/tests/snapshots/value_hint.zsh
+++ b/clap_complete/tests/snapshots/value_hint.zsh
@@ -41,7 +41,7 @@ _my-app() {
 && ret=0
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"

--- a/clap_complete/tests/snapshots/value_terminator.zsh
+++ b/clap_complete/tests/snapshots/value_terminator.zsh
@@ -21,7 +21,7 @@ _my-app() {
 && ret=0
 }
 
-(( $+functions[_my-app_commands] )) ||
+(( ${+functions[_my-app_commands]} )) ||
 _my-app_commands() {
     local commands; commands=()
     _describe -t commands 'my-app commands' commands "$@"

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -192,6 +192,18 @@ fn subcommand_last() {
 }
 
 #[test]
+fn function_existence_checks_are_ksharrays_safe() {
+    let name = "my-app";
+    let mut cmd = common::basic_command(name);
+    let mut buf = vec![];
+    clap_complete::generate(clap_complete::shells::Zsh, &mut cmd, name, &mut buf);
+    let actual = String::from_utf8(buf).unwrap();
+
+    assert!(actual.contains("(( ${+functions[_my-app_commands]} )) ||"));
+    assert!(!actual.contains("(( $+functions["));
+}
+
+#[test]
 #[cfg(unix)]
 #[cfg(feature = "unstable-shell-tests")]
 fn register_completion() {


### PR DESCRIPTION
Fixes #6372.

### What changed

- Emit zsh function existence checks as `${+functions[...]}` so generated completions keep working when `ksharrays` is enabled.
- Refresh the zsh completion snapshots to use the brace form.
- Add a regression test for the generated function guard and a `clap_complete` changelog entry.

### Verification

- Red test before the fix: `CARGO_HOME=/tmp/clap-6372-cargo-home CARGO_TARGET_DIR=/tmp/clap-6372-target cargo test -p clap_complete --test testsuite function_existence_checks_are_ksharrays_safe -- --nocapture`
- `CARGO_HOME=/tmp/clap-6372-cargo-home CARGO_TARGET_DIR=/tmp/clap-6372-target cargo test -p clap_complete --test testsuite zsh:: -- --nocapture`
- `zsh -fc 'autoload -Uz compinit; compinit -D; setopt ksharrays; source clap_complete/tests/snapshots/basic.zsh'`
- `CARGO_HOME=/tmp/clap-6372-cargo-home CARGO_TARGET_DIR=/tmp/clap-6372-target cargo test -p clap_complete --test testsuite`
- `CARGO_HOME=/tmp/clap-6372-cargo-home CARGO_TARGET_DIR=/tmp/clap-6372-target cargo test -p clap_complete`
- `CARGO_HOME=/tmp/clap-6372-cargo-home CARGO_TARGET_DIR=/tmp/clap-6372-target cargo clippy -p clap_complete --all-targets -- -D warnings`
- `CARGO_HOME=/tmp/clap-6372-cargo-home CARGO_TARGET_DIR=/tmp/clap-6372-target cargo fmt --all -- --check`
- `git diff --check`
