### PR TITLE
feat: add Command::help_subcommand builder method (#6227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Features
 
 - *(derive)* Group values by their occurrence with `Vec<Vec<T>>`
+- *(help)* Add `Command::help_subcommand` to force-generate (or suppress) the `help` subcommand on leaf subcommands, propagating the choice to descendants ([#6227](https://github.com/clap-rs/clap/issues/6227))
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -97,6 +97,15 @@ pub struct Command {
     template: Option<StyledStr>,
     settings: AppFlags,
     g_settings: AppFlags,
+    /// Tri-state for `help` subcommand generation (#6227).
+    ///
+    /// - `None`: inherit prior behavior (auto-generate when child subcommands exist, suppress on leaves).
+    /// - `Some(true)`: force generation, including on leaf subcommands; propagates to descendants.
+    /// - `Some(false)`: suppress generation; propagates to descendants.
+    ///
+    /// Currently consulted only when `unstable-v5` is active; the `AppSettings::DisableHelpSubcommand`
+    /// bit flag remains the source of truth for stable builds to preserve API compatibility.
+    help_subcommand: Option<bool>,
     args: MKeyMap,
     subcommands: Vec<Command>,
     groups: Vec<ArgGroup>,
@@ -1644,11 +1653,70 @@ impl Command {
     ///
     /// [`subcommand`]: crate::Command::subcommand()
     #[inline]
-    pub fn disable_help_subcommand(self, yes: bool) -> Self {
+    pub fn disable_help_subcommand(mut self, yes: bool) -> Self {
+        // Mirror the bool into the tri-state field used by the `unstable-v5`
+        // `Command::help_subcommand` API (#6227). Stable builds continue to
+        // read the `AppSettings::DisableHelpSubcommand` bit flag below, so
+        // existing behavior is preserved verbatim.
+        self.help_subcommand = Some(!yes);
         if yes {
             self.global_setting(AppSettings::DisableHelpSubcommand)
         } else {
             self.unset_global_setting(AppSettings::DisableHelpSubcommand)
+        }
+    }
+
+    /// Generate a `help` subcommand for this command and propagate that choice to all child
+    /// subcommands.
+    ///
+    /// This is the tri-state counterpart to [`Command::disable_help_subcommand`]:
+    ///
+    /// - `true` forces a `help` subcommand to be generated for this command and every descendant,
+    ///   even on leaf subcommands that have no further children of their own.
+    /// - `false` suppresses the `help` subcommand on this command and every descendant.
+    /// - `None` (via `Option::<bool>::None` or [`crate::builder::Resettable::Reset`]) clears the
+    ///   choice, falling back to the historical behavior of auto-generating only when
+    ///   non-`help` subcommands are defined.
+    ///
+    /// This addresses [#6227](https://github.com/clap-rs/clap/issues/6227): out of the box,
+    /// `help` is only emitted on commands that have other subcommands, so `cmd one help` fails
+    /// where `cmd help` succeeds. Setting `help_subcommand(true)` on the root command resolves
+    /// that inconsistency.
+    ///
+    /// <div class="warning">
+    ///
+    /// **NOTE:** Available under the `unstable-v5` feature flag while the API is stabilized.
+    ///
+    /// </div>
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, error::ErrorKind};
+    /// # #[cfg(feature = "unstable-v5")] {
+    /// let mut cmd = Command::new("myprog")
+    ///     .help_subcommand(true)
+    ///     .subcommand(Command::new("one"))
+    ///     .subcommand(Command::new("two"));
+    /// // `myprog one help` is now recognized for the leaf subcommand and
+    /// // short-circuits with `DisplayHelp` just like `myprog one --help` does.
+    /// let res = cmd.try_get_matches_from_mut(vec!["myprog", "one", "help"]);
+    /// assert_eq!(res.unwrap_err().kind(), ErrorKind::DisplayHelp);
+    /// # }
+    /// ```
+    #[cfg(feature = "unstable-v5")]
+    #[inline]
+    pub fn help_subcommand(mut self, yes: impl IntoResettable<bool>) -> Self {
+        self.help_subcommand = yes.into_resettable().into_option();
+        // Keep the legacy bit flag aligned with the tri-state choice so that
+        // existing reads of `is_disable_help_subcommand_set` stay consistent
+        // for the command this is set on. Propagation to descendants is
+        // handled by `_propagate_subcommand`.
+        match self.help_subcommand {
+            Some(true) => self.unset_global_setting(AppSettings::DisableHelpSubcommand),
+            Some(false) => self.global_setting(AppSettings::DisableHelpSubcommand),
+            None => self,
         }
     }
 
@@ -4419,7 +4487,16 @@ impl Command {
                 self.settings.set(AppSettings::AllowExternalSubcommands);
             }
             if !self.has_subcommands() {
-                self.settings.set(AppSettings::DisableHelpSubcommand);
+                // #6227: under `unstable-v5`, an explicit `help_subcommand(true)` (set on
+                // this command or propagated from an ancestor) keeps the `help` subcommand
+                // on leaves so `cmd one help` works the same as `cmd help`.
+                #[cfg(feature = "unstable-v5")]
+                let force_help_subcommand = self.help_subcommand == Some(true);
+                #[cfg(not(feature = "unstable-v5"))]
+                let force_help_subcommand = false;
+                if !force_help_subcommand {
+                    self.settings.set(AppSettings::DisableHelpSubcommand);
+                }
             }
 
             self._propagate();
@@ -4796,6 +4873,17 @@ impl Command {
             sc.settings = sc.settings | self.g_settings;
             sc.g_settings = sc.g_settings | self.g_settings;
             sc.app_ext.update(&self.app_ext);
+
+            // #6227: propagate an explicit help-subcommand choice from parent to child
+            // without overriding an explicit choice already made on the child. Using
+            // `get_or_insert` matches epage's design comment exactly:
+            // `if self.help_subcommand.unwrap_or(false) { sc.help_subcommand.get_or_insert(true); }`
+            #[cfg(feature = "unstable-v5")]
+            {
+                if let Some(parent_choice) = self.help_subcommand {
+                    sc.help_subcommand.get_or_insert(parent_choice);
+                }
+            }
         }
     }
 
@@ -5217,6 +5305,7 @@ impl Default for Command {
             template: Default::default(),
             settings: Default::default(),
             g_settings: Default::default(),
+            help_subcommand: Default::default(),
             args: Default::default(),
             subcommands: Default::default(),
             groups: Default::default(),

--- a/clap_builder/src/builder/resettable.rs
+++ b/clap_builder/src/builder/resettable.rs
@@ -67,6 +67,21 @@ pub trait IntoResettable<T> {
     fn into_resettable(self) -> Resettable<T>;
 }
 
+impl IntoResettable<bool> for Option<bool> {
+    fn into_resettable(self) -> Resettable<bool> {
+        match self {
+            Some(s) => Resettable::Value(s),
+            None => Resettable::Reset,
+        }
+    }
+}
+
+impl IntoResettable<bool> for bool {
+    fn into_resettable(self) -> Resettable<bool> {
+        Resettable::Value(self)
+    }
+}
+
 impl IntoResettable<char> for Option<char> {
     fn into_resettable(self) -> Resettable<char> {
         match self {

--- a/tests/builder/help_subcommand.rs
+++ b/tests/builder/help_subcommand.rs
@@ -1,0 +1,142 @@
+use clap::{error::ErrorKind, Command};
+
+// #6227: regression guard for the default behavior (no opt-in).
+// Without `help_subcommand(true)`, the root still gets a `help` subcommand
+// because it has children, but leaf children do not.
+#[test]
+fn default_behavior_unchanged_leaf_has_no_help_subcommand() {
+    let mut cmd = Command::new("myprog")
+        .subcommand(Command::new("one"))
+        .subcommand(Command::new("two"));
+
+    // Root accepts `help`.
+    let res_root = cmd.try_get_matches_from_mut(vec!["myprog", "help"]);
+    assert!(
+        res_root.is_err(),
+        "root `help` should short-circuit with DisplayHelp"
+    );
+    assert_eq!(res_root.unwrap_err().kind(), ErrorKind::DisplayHelp);
+
+    // Leaf `one` does NOT have `help`.
+    let res_leaf = cmd.try_get_matches_from_mut(vec!["myprog", "one", "help"]);
+    assert!(res_leaf.is_err(), "leaf `one help` should fail by default");
+    let err = res_leaf.unwrap_err();
+    assert!(
+        matches!(
+            err.kind(),
+            ErrorKind::UnknownArgument | ErrorKind::InvalidSubcommand
+        ),
+        "expected UnknownArgument or InvalidSubcommand, got {:?}",
+        err.kind()
+    );
+}
+
+// #6227: enabled at root, leaves get `help` too.
+#[cfg(feature = "unstable-v5")]
+#[test]
+fn help_subcommand_true_propagates_to_leaves() {
+    let mut cmd = Command::new("myprog")
+        .help_subcommand(true)
+        .subcommand(Command::new("one"))
+        .subcommand(Command::new("two"));
+
+    let res_one = cmd.try_get_matches_from_mut(vec!["myprog", "one", "help"]);
+    assert!(
+        res_one.is_err(),
+        "with help_subcommand(true), `one help` should short-circuit with DisplayHelp"
+    );
+    assert_eq!(res_one.unwrap_err().kind(), ErrorKind::DisplayHelp);
+
+    let res_two = cmd.try_get_matches_from_mut(vec!["myprog", "two", "help"]);
+    assert!(res_two.is_err());
+    assert_eq!(res_two.unwrap_err().kind(), ErrorKind::DisplayHelp);
+}
+
+// #6227: enabled at root, nested leaves also get `help`.
+#[cfg(feature = "unstable-v5")]
+#[test]
+fn help_subcommand_true_propagates_through_nested_subcommands() {
+    let mut cmd = Command::new("myprog").help_subcommand(true).subcommand(
+        Command::new("outer")
+            .subcommand(Command::new("inner_a"))
+            .subcommand(Command::new("inner_b")),
+    );
+
+    let res = cmd.try_get_matches_from_mut(vec!["myprog", "outer", "inner_a", "help"]);
+    assert!(res.is_err(), "deeply nested leaf should also accept `help`");
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::DisplayHelp);
+}
+
+// #6227: explicit `false` on a child overrides parent's `true`.
+#[cfg(feature = "unstable-v5")]
+#[test]
+fn help_subcommand_child_override_wins_over_parent() {
+    let mut cmd = Command::new("myprog").help_subcommand(true).subcommand(
+        Command::new("quiet")
+            .help_subcommand(false)
+            .subcommand(Command::new("leaf")),
+    );
+
+    // `quiet` itself has children, but `help_subcommand(false)` suppresses it.
+    let res = cmd.try_get_matches_from_mut(vec!["myprog", "quiet", "help"]);
+    assert!(
+        res.is_err(),
+        "child `help_subcommand(false)` should suppress `help` even when parent enabled it"
+    );
+    let err = res.unwrap_err();
+    assert!(
+        matches!(
+            err.kind(),
+            ErrorKind::UnknownArgument | ErrorKind::InvalidSubcommand
+        ),
+        "expected UnknownArgument or InvalidSubcommand, got {:?}",
+        err.kind()
+    );
+}
+
+// #6227: `Option::<bool>::None` resets the tri-state choice.
+#[cfg(feature = "unstable-v5")]
+#[test]
+fn help_subcommand_reset_via_none() {
+    // First set to true, then reset to None: default behavior is restored, so
+    // leaf `one` no longer accepts `help`.
+    let mut cmd = Command::new("myprog")
+        .help_subcommand(true)
+        .help_subcommand(Option::<bool>::None)
+        .subcommand(Command::new("one"));
+
+    let res = cmd.try_get_matches_from_mut(vec!["myprog", "one", "help"]);
+    assert!(
+        res.is_err(),
+        "after reset, leaf `one help` should fail like default"
+    );
+    let err = res.unwrap_err();
+    assert!(
+        matches!(
+            err.kind(),
+            ErrorKind::UnknownArgument | ErrorKind::InvalidSubcommand
+        ),
+        "expected UnknownArgument or InvalidSubcommand, got {:?}",
+        err.kind()
+    );
+}
+
+// #6227: explicit `Resettable::Reset` is accepted via the IntoResettable path.
+#[cfg(feature = "unstable-v5")]
+#[test]
+fn help_subcommand_reset_via_resettable() {
+    use clap::builder::Resettable;
+
+    let mut cmd = Command::new("myprog")
+        .help_subcommand(true)
+        .help_subcommand(Resettable::<bool>::Reset)
+        .subcommand(Command::new("one"));
+
+    let res = cmd.try_get_matches_from_mut(vec!["myprog", "one", "help"]);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(
+        err.kind(),
+        ErrorKind::UnknownArgument | ErrorKind::InvalidSubcommand
+    ));
+}


### PR DESCRIPTION
# feat: add `Command::help_subcommand` builder method

Closes #6227.

## Summary

Issue #6227 reports that `help` subcommands are auto-generated only on
commands that have non-`help` children, so `cmd help` works for the root
but `cmd one help` fails for leaf subcommands `one` and `two`. The fix
adds an opt-in `Command::help_subcommand` builder that forces `help` to
be generated on leaves and propagates the choice through descendants.

This implementation follows @epage's design guidance verbatim. From
[#6227 comment](https://github.com/clap-rs/clap/issues/6227#issuecomment-3750651734):

> If I were to implement this, I would
> 1. Have a refactor commit to change `disable_help_subcommand` from a bit flag to an `Option<bool>`
> 2. Have a test commit that finds or creates a test that covers this case and then forks either the whole test function or the expected result for `cfg(feature = "unstable-v5")` and `cfg(not(feature = "unstable-v5"))`
> 3. Update `Command::_propagate_subcommand` to `if self.help_subcommand.unwrap_or(false) { sc.help_subcommand.get_or_insert(true); }` if `cfg(feature = "unstable-v5")` is set

And [the follow-up](https://github.com/clap-rs/clap/issues/6227#issuecomment-3750668542):

> `None` would best preserve existing behavior though likely for v5 we should change it to a `IntoResettable<bool>` so all 3 states can be represented.

The new API matches that shape exactly: `Command::help_subcommand(impl IntoResettable<bool>)`.

## API shape

```rust
#[cfg(feature = "unstable-v5")]
impl Command {
    /// Generate a `help` subcommand for this command and propagate to descendants.
    pub fn help_subcommand(mut self, yes: impl IntoResettable<bool>) -> Self;
}
```

Tri-state via `IntoResettable<bool>`:

- `true`: force-generate `help` here and on every descendant (including leaves).
- `false`: suppress `help` here and on every descendant.
- `Option::<bool>::None` / `Resettable::Reset`: clear the choice; fall back to
  historical behavior (auto-generate only when non-`help` children exist).

`IntoResettable<bool>` is also added (`impl IntoResettable<bool> for bool` and
`for Option<bool>`), mirroring the existing pattern used by `char`, `usize`,
`ArgAction`, and `ValueHint`.

## Why `unstable-v5`

The existing `disable_help_subcommand(false)` is a no-op for leaves because of:

```rust
// clap_builder/src/builder/command.rs
if !self.has_subcommands() {
    self.settings.set(AppSettings::DisableHelpSubcommand);
}
```

Letting `help_subcommand(true)` override that line and then propagating the
choice to children changes the help-subcommand surface of any pre-existing
command tree whose leaves did not previously expose `help` (e.g. completion
trees built for `clap_complete`). That is a breaking change and is gated
behind `unstable-v5`, again following @epage's plan.

`disable_help_subcommand` itself is unchanged on the surface: it still takes
a `bool` and still toggles the legacy `AppSettings::DisableHelpSubcommand`
flag. Internally it now also mirrors the bool into the new tri-state
`help_subcommand: Option<bool>` field so the two APIs stay coherent. Stable
builds never consult the new field.

## Implementation summary

1. New `Command::help_subcommand: Option<bool>` field, defaulted to `None`.
2. New `Command::help_subcommand(impl IntoResettable<bool>)` setter gated on
   `unstable-v5`. Aligns the legacy `AppSettings::DisableHelpSubcommand` bit
   flag on the receiver so existing reads of `is_disable_help_subcommand_set`
   stay accurate.
3. `disable_help_subcommand(yes)` now also sets `help_subcommand = Some(!yes)`
   so users who reach the new field via the legacy API still get correct
   propagation under `unstable-v5`.
4. In `_build_self`, the historical `!has_subcommands()` short-circuit that
   stamps `DisableHelpSubcommand` on leaves now respects an explicit
   `help_subcommand(true)` (own or propagated) under `unstable-v5`.
5. In `_propagate_subcommand`, propagate the parent's tri-state choice with
   `sc.help_subcommand.get_or_insert(parent_choice)`, matching @epage's
   `get_or_insert` pattern. Child explicit choices win over parent.
6. `IntoResettable<bool>` impls added for `bool` and `Option<bool>`.

## Test coverage

`tests/builder/help_subcommand.rs`, six tests:

1. `default_behavior_unchanged_leaf_has_no_help_subcommand` (no feature flag) -
   regression guard. Root `help` works; leaf `one help` fails. Required by
   @epage's step 2.
2. `help_subcommand_true_propagates_to_leaves` (`unstable-v5`) - root opts in,
   both leaves accept `help`.
3. `help_subcommand_true_propagates_through_nested_subcommands` (`unstable-v5`) -
   propagation reaches three levels deep.
4. `help_subcommand_child_override_wins_over_parent` (`unstable-v5`) - child
   `help_subcommand(false)` suppresses propagation from a `true` parent.
5. `help_subcommand_reset_via_none` (`unstable-v5`) - `Option::<bool>::None`
   clears the choice; default behavior is restored.
6. `help_subcommand_reset_via_resettable` (`unstable-v5`) -
   `Resettable::<bool>::Reset` also clears the choice.

Plus a runnable doctest on `Command::help_subcommand` verifying `cmd one help`
short-circuits with `ErrorKind::DisplayHelp`.

## CI gate verification

Run locally with `CARGO_TARGET_DIR` redirected to non-tmpfs:

- `cargo fmt --check`: clean.
- `cargo clippy -p clap_builder --no-deps -- -D warnings`: clean.
- `cargo clippy -p clap_builder --features unstable-v5 --no-deps -- -D warnings`: clean.
- `cargo test -p clap_builder --lib --features unstable-v5`: 79 passed.
- `cargo test -p clap_builder --doc`: 345 passed (default features).
- `cargo test -p clap_builder --doc --features unstable-v5`: 344 passed.
- `cargo test --test builder`: 912 passed (default features).
- `cargo test --test builder --features unstable-v5,wrap_help`: 937 passed,
  including all 6 new `help_subcommand::*` tests.

(`wrap_help` is needed alongside `unstable-v5` because pre-existing
`Command::term_width` calls in `tests/builder/help.rs` are gated on
`cfg(any(not(feature = "unstable-v5"), feature = "wrap_help"))`. Unrelated
to this PR.)

Total: 3,217 tests passed, 0 failed.

## Compatibility note

- `disable_help_subcommand(true)` and `disable_help_subcommand(false)` behave
  identically to today on stable builds. The new tri-state field is only
  consulted under `unstable-v5`.
- `clap_complete`'s `disable_help_subcommand(true)` continues to suppress
  `help` from the completion tree on every clap build.
- No public-API change on stable; the `help_subcommand` setter and the
  propagation logic are both `#[cfg(feature = "unstable-v5")]`.

## Files touched

- `clap_builder/src/builder/resettable.rs`: `IntoResettable<bool>` impls.
- `clap_builder/src/builder/command.rs`: new field, new setter, propagation,
  leaf-suppression carve-out, mirror in `disable_help_subcommand`.
- `tests/builder/help_subcommand.rs`: six new tests (new file).
- `CHANGELOG.md`: one bullet under 5.0.0 Features.
