### PR TITLE
fix(clap_complete_nushell): disable generating last arguments

### DIFF
--- a/clap_complete_nushell/examples/test.rs
+++ b/clap_complete_nushell/examples/test.rs
@@ -95,6 +95,15 @@ fn cli() -> clap::Command {
             ]),
             clap::Command::new("last")
                 .args([clap::Arg::new("first"), clap::Arg::new("free").last(true)]),
+            clap::Command::new("last-hint").args([
+                clap::Arg::new("first")
+                    .value_parser(["bash", "fish", "zsh"])
+                    .required(true),
+                clap::Arg::new("free")
+                    .value_parser(["nushell", "powershell"])
+                    .required(true)
+                    .last(true),
+            ]),
             clap::Command::new("alias").args([
                 clap::Arg::new("flag")
                     .short('f')

--- a/clap_complete_nushell/src/lib.rs
+++ b/clap_complete_nushell/src/lib.rs
@@ -136,6 +136,11 @@ fn append_argument(arg: &Arg, name: &str, s: &mut String) {
 
     if arg.is_positional() {
         // rest arguments
+        if arg.is_last_set() {
+            // skipped, as it's not currently supported by nushell
+            return;
+        }
+
         if matches!(arg.get_action(), ArgAction::Append) {
             s.push_str(format!("    ...{}", arg.get_id()).as_str());
         } else {
@@ -205,6 +210,11 @@ fn generate_completion(completions: &mut String, cmd: &Command, is_subcommand: b
     let name = cmd.get_bin_name().expect("Failed to get bin name");
 
     for arg in cmd.get_arguments() {
+        if arg.is_last_set() {
+            // skipped, as it's not currently supported by nushell
+            continue;
+        }
+
         append_value_completion_defs(arg, name, completions);
     }
 

--- a/clap_complete_nushell/tests/common.rs
+++ b/clap_complete_nushell/tests/common.rs
@@ -267,6 +267,65 @@ pub(crate) fn value_hint_command(name: &'static str) -> Command {
         )
 }
 
+pub(crate) fn last_args_command(name: &'static str) -> Command {
+    Command::new(name).subcommands([
+        Command::new("single")
+            .arg(Arg::new("arg").required(true))
+            .arg(Arg::new("last_arg").required(true).last(true)),
+        Command::new("multiple")
+            .arg(Arg::new("args").num_args(1..))
+            .arg(Arg::new("last_args").num_args(1..).last(true)),
+        Command::new("choice")
+            .arg(
+                Arg::new("arg")
+                    .required(true)
+                    .value_parser(["bash", "zsh", "fish"]),
+            )
+            .arg(
+                Arg::new("last_arg")
+                    .required(true)
+                    .value_parser(["nushell", "powershell"])
+                    .last(true),
+            ),
+        Command::new("multiple-choice")
+            .arg(
+                Arg::new("args")
+                    .num_args(1..)
+                    .value_parser(["bash", "zsh", "fish"]),
+            )
+            .arg(
+                Arg::new("last_args")
+                    .num_args(1..)
+                    .value_parser(["nushell", "powershell"])
+                    .last(true),
+            ),
+        Command::new("any-path")
+            .arg(
+                Arg::new("arg")
+                    .required(true)
+                    .value_hint(ValueHint::AnyPath),
+            )
+            .arg(
+                Arg::new("last_arg")
+                    .required(true)
+                    .value_hint(ValueHint::AnyPath)
+                    .last(true),
+            ),
+        Command::new("multiple-any-path")
+            .arg(
+                Arg::new("args")
+                    .num_args(1..)
+                    .value_hint(ValueHint::AnyPath),
+            )
+            .arg(
+                Arg::new("last_args")
+                    .num_args(1..)
+                    .value_hint(ValueHint::AnyPath)
+                    .last(true),
+            ),
+    ])
+}
+
 pub(crate) fn assert_matches(
     expected: impl IntoData,
     generator: impl clap_complete::Generator,

--- a/clap_complete_nushell/tests/completion.rs
+++ b/clap_complete_nushell/tests/completion.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+use std::fs;
+
 use snapbox::assert_data_eq;
 
 #[test]
@@ -102,11 +104,27 @@ zsh
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 
+    let mut dir = fs::read_dir(runtime.home())
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| {
+            let name = entry.file_name().display().to_string();
+            if entry.path().is_dir() {
+                format!("{name}/")
+            } else {
+                name
+            }
+        })
+        .collect::<Vec<_>>();
+    dir.sort();
+
     let input = "test last-hint bash \t";
-    let expected = r#"% test last-hint bash 
-nushell
-powershell
-"#;
+    let expected = format!(
+        r#"% test last-hint bash 
+{}
+"#,
+        dir.join("\n")
+    );
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }

--- a/clap_complete_nushell/tests/completion.rs
+++ b/clap_complete_nushell/tests/completion.rs
@@ -87,3 +87,26 @@ zsh
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }
+
+#[test]
+fn completion_last_hint() {
+    let term = completest::Term::new();
+    let mut runtime = common::load_runtime::<completest_nu::NuRuntimeBuilder>("static", "test");
+
+    let input = "test last-hint \t";
+    let expected = r#"% test last-hint 
+bash
+fish
+zsh
+"#;
+    let actual = runtime.complete(input, &term).unwrap();
+    assert_data_eq!(actual, expected);
+
+    let input = "test last-hint bash \t";
+    let expected = r#"% test last-hint bash 
+nushell
+powershell
+"#;
+    let actual = runtime.complete(input, &term).unwrap();
+    assert_data_eq!(actual, expected);
+}

--- a/clap_complete_nushell/tests/nushell.rs
+++ b/clap_complete_nushell/tests/nushell.rs
@@ -95,3 +95,15 @@ fn positional_index() {
         name,
     );
 }
+
+#[test]
+fn last_args() {
+    let name = "my-app";
+    let cmd = common::last_args_command(name);
+    common::assert_matches(
+        snapbox::file!["snapshots/last_args.nu"],
+        clap_complete_nushell::Nushell,
+        cmd,
+        name,
+    );
+}

--- a/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
+++ b/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
@@ -157,6 +157,22 @@ module completions {
     free?: string
   ]
 
+  def "nu-complete test last-hint first" [] {
+    [ "bash" "fish" "zsh" ]
+  }
+
+  def "nu-complete test last-hint free" [] {
+    [ "nushell" "powershell" ]
+  }
+
+  export extern "test last-hint" [
+    --global                  # everywhere
+    --help(-h)                # Print help
+    --version(-V)             # Print version
+    first: string@"nu-complete test last-hint first"
+    free: string@"nu-complete test last-hint free"
+  ]
+
   export extern "test alias" [
     --flag(-f)                # cmd flag
     --flg                     # cmd flag
@@ -241,6 +257,9 @@ module completions {
   ]
 
   export extern "test help last" [
+  ]
+
+  export extern "test help last-hint" [
   ]
 
   export extern "test help alias" [

--- a/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
+++ b/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
@@ -154,15 +154,10 @@ module completions {
     --help(-h)                # Print help
     --version(-V)             # Print version
     first?: string
-    free?: string
   ]
 
   def "nu-complete test last-hint first" [] {
     [ "bash" "fish" "zsh" ]
-  }
-
-  def "nu-complete test last-hint free" [] {
-    [ "nushell" "powershell" ]
   }
 
   export extern "test last-hint" [
@@ -170,7 +165,6 @@ module completions {
     --help(-h)                # Print help
     --version(-V)             # Print version
     first: string@"nu-complete test last-hint first"
-    free: string@"nu-complete test last-hint free"
   ]
 
   export extern "test alias" [

--- a/clap_complete_nushell/tests/snapshots/last_args.nu
+++ b/clap_complete_nushell/tests/snapshots/last_args.nu
@@ -7,53 +7,39 @@ module completions {
   export extern "my-app single" [
     --help(-h)                # Print help
     arg: string
-    last_arg: string
   ]
 
   export extern "my-app multiple" [
     --help(-h)                # Print help
     ...args: string
-    ...last_args: string
   ]
 
   def "nu-complete my-app choice arg" [] {
     [ "bash" "zsh" "fish" ]
   }
 
-  def "nu-complete my-app choice last_arg" [] {
-    [ "nushell" "powershell" ]
-  }
-
   export extern "my-app choice" [
     --help(-h)                # Print help
     arg: string@"nu-complete my-app choice arg"
-    last_arg: string@"nu-complete my-app choice last_arg"
   ]
 
   def "nu-complete my-app multiple-choice args" [] {
     [ "bash" "zsh" "fish" ]
   }
 
-  def "nu-complete my-app multiple-choice last_args" [] {
-    [ "nushell" "powershell" ]
-  }
-
   export extern "my-app multiple-choice" [
     --help(-h)                # Print help
     ...args: string@"nu-complete my-app multiple-choice args"
-    ...last_args: string@"nu-complete my-app multiple-choice last_args"
   ]
 
   export extern "my-app any-path" [
     --help(-h)                # Print help
     arg: path
-    last_arg: path
   ]
 
   export extern "my-app multiple-any-path" [
     --help(-h)                # Print help
     ...args: path
-    ...last_args: path
   ]
 
   # Print this message or the help of the given subcommand(s)

--- a/clap_complete_nushell/tests/snapshots/last_args.nu
+++ b/clap_complete_nushell/tests/snapshots/last_args.nu
@@ -1,0 +1,87 @@
+module completions {
+
+  export extern my-app [
+    --help(-h)                # Print help
+  ]
+
+  export extern "my-app single" [
+    --help(-h)                # Print help
+    arg: string
+    last_arg: string
+  ]
+
+  export extern "my-app multiple" [
+    --help(-h)                # Print help
+    ...args: string
+    ...last_args: string
+  ]
+
+  def "nu-complete my-app choice arg" [] {
+    [ "bash" "zsh" "fish" ]
+  }
+
+  def "nu-complete my-app choice last_arg" [] {
+    [ "nushell" "powershell" ]
+  }
+
+  export extern "my-app choice" [
+    --help(-h)                # Print help
+    arg: string@"nu-complete my-app choice arg"
+    last_arg: string@"nu-complete my-app choice last_arg"
+  ]
+
+  def "nu-complete my-app multiple-choice args" [] {
+    [ "bash" "zsh" "fish" ]
+  }
+
+  def "nu-complete my-app multiple-choice last_args" [] {
+    [ "nushell" "powershell" ]
+  }
+
+  export extern "my-app multiple-choice" [
+    --help(-h)                # Print help
+    ...args: string@"nu-complete my-app multiple-choice args"
+    ...last_args: string@"nu-complete my-app multiple-choice last_args"
+  ]
+
+  export extern "my-app any-path" [
+    --help(-h)                # Print help
+    arg: path
+    last_arg: path
+  ]
+
+  export extern "my-app multiple-any-path" [
+    --help(-h)                # Print help
+    ...args: path
+    ...last_args: path
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "my-app help" [
+  ]
+
+  export extern "my-app help single" [
+  ]
+
+  export extern "my-app help multiple" [
+  ]
+
+  export extern "my-app help choice" [
+  ]
+
+  export extern "my-app help multiple-choice" [
+  ]
+
+  export extern "my-app help any-path" [
+  ]
+
+  export extern "my-app help multiple-any-path" [
+  ]
+
+  # Print this message or the help of the given subcommand(s)
+  export extern "my-app help help" [
+  ]
+
+}
+
+export use completions *


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
> Ideally in fixing this, someone would write integration tests with completest-nu
> 
> 
> 
> Please add the tests in the first commit with them passing, showing the current bug.  The following commit would fix the behavior and update the test so it still passes. 

Fixed as requested.

Closes #5592 