### PR TITLE
Allow groups of groups (`ArgGroup::member`/`members`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Features
+
+- Allow an `ArgGroup` to contain other `ArgGroup`s (groups of groups) via `ArgGroup::member`/`ArgGroup::members`; `ArgGroup::arg`/`ArgGroup::args` are soft-deprecated in favor of them
+
+### Behavior Changes
+
+- An argument's enclosing groups are now resolved transitively, so an outer group that contains a nested group is marked present and propagates its conflicts/requirements when an argument of the nested group is used
+
 ## [4.6.1] - 2026-04-15
 
 ### Fixes

--- a/clap_bench/benches/rustup.rs
+++ b/clap_bench/benches/rustup.rs
@@ -271,7 +271,7 @@ fn build_cli() -> Command {
                         .action(ArgAction::SetTrue)
                         .help("Standard library API documentation"),
                 )
-                .group(ArgGroup::new("page").args(["book", "std"])),
+                .group(ArgGroup::new("page").members(["book", "std"])),
         )
         .subcommand(
             Command::new("man")

--- a/clap_builder/src/builder/arg_group.rs
+++ b/clap_builder/src/builder/arg_group.rs
@@ -109,7 +109,11 @@ impl ArgGroup {
         self
     }
 
-    /// Adds an [argument] to this group by name
+    /// Adds an [argument] or [group] to this group by name
+    ///
+    /// The name may refer to an [`Arg`] or to another [`ArgGroup`].  Naming a group makes all of
+    /// that group's members (recursively) members of this group as well, allowing groups of
+    /// groups.
     ///
     /// # Examples
     ///
@@ -124,8 +128,8 @@ impl ArgGroup {
     ///         .short('c')
     ///         .action(ArgAction::SetTrue))
     ///     .group(ArgGroup::new("req_flags")
-    ///         .arg("flag")
-    ///         .arg("color"))
+    ///         .member("flag")
+    ///         .member("color"))
     ///     .get_matches_from(vec!["myprog", "-f"]);
     /// // maybe we don't know which of the two flags was used...
     /// assert!(m.contains_id("req_flags"));
@@ -133,17 +137,21 @@ impl ArgGroup {
     /// assert!(m.contains_id("flag"));
     /// ```
     /// [argument]: crate::Arg
+    /// [group]: crate::ArgGroup
+    /// [`Arg`]: crate::Arg
     #[must_use]
-    pub fn arg(mut self, arg_id: impl IntoResettable<Id>) -> Self {
-        if let Some(arg_id) = arg_id.into_resettable().into_option() {
-            self.args.push(arg_id);
+    pub fn member(mut self, id: impl IntoResettable<Id>) -> Self {
+        if let Some(id) = id.into_resettable().into_option() {
+            self.args.push(id);
         } else {
             self.args.clear();
         }
         self
     }
 
-    /// Adds multiple [arguments] to this group by name
+    /// Adds multiple [arguments] or [groups] to this group by name
+    ///
+    /// Each name may refer to an [`Arg`] or to another [`ArgGroup`], allowing groups of groups.
     ///
     /// # Examples
     ///
@@ -158,7 +166,7 @@ impl ArgGroup {
     ///         .short('c')
     ///         .action(ArgAction::SetTrue))
     ///     .group(ArgGroup::new("req_flags")
-    ///         .args(["flag", "color"]))
+    ///         .members(["flag", "color"]))
     ///     .get_matches_from(vec!["myprog", "-f"]);
     /// // maybe we don't know which of the two flags was used...
     /// assert!(m.contains_id("req_flags"));
@@ -166,12 +174,37 @@ impl ArgGroup {
     /// assert!(m.contains_id("flag"));
     /// ```
     /// [arguments]: crate::Arg
+    /// [groups]: crate::ArgGroup
+    /// [`Arg`]: crate::Arg
     #[must_use]
-    pub fn args(mut self, ns: impl IntoIterator<Item = impl Into<Id>>) -> Self {
+    pub fn members(mut self, ns: impl IntoIterator<Item = impl Into<Id>>) -> Self {
         for n in ns {
-            self = self.arg(n);
+            self = self.member(n);
         }
         self
+    }
+
+    /// Adds an [argument] to this group by name
+    ///
+    /// Deprecated in [Issue #5711](https://github.com/clap-rs/clap/issues/5711), replaced with
+    /// [`ArgGroup::member`], which also accepts the name of another [`ArgGroup`] (groups of groups).
+    ///
+    /// [argument]: crate::Arg
+    #[must_use]
+    pub fn arg(self, arg_id: impl IntoResettable<Id>) -> Self {
+        self.member(arg_id)
+    }
+
+    /// Adds multiple [arguments] to this group by name
+    ///
+    /// Deprecated in [Issue #5711](https://github.com/clap-rs/clap/issues/5711), replaced with
+    /// [`ArgGroup::members`], which also accepts the names of other [`ArgGroup`]s (groups of
+    /// groups).
+    ///
+    /// [arguments]: crate::Arg
+    #[must_use]
+    pub fn args(self, ns: impl IntoIterator<Item = impl Into<Id>>) -> Self {
+        self.members(ns)
     }
 
     /// Getters for all args. It will return a vector of `Id`
@@ -583,6 +616,26 @@ mod test {
         assert_eq!(g2.args, args);
         assert_eq!(g2.requires, reqs);
         assert_eq!(g2.conflicts, confs);
+    }
+
+    #[test]
+    fn members() {
+        let g = ArgGroup::new("test")
+            .member("a1")
+            .member("a4")
+            .members(["a2", "a3"]);
+
+        let args: Vec<Id> = vec!["a1".into(), "a4".into(), "a2".into(), "a3".into()];
+
+        assert_eq!(g.args, args);
+    }
+
+    #[test]
+    fn member_args_parity() {
+        let with_member = ArgGroup::new("test").member("a1").members(["a2", "a3"]);
+        let with_arg = ArgGroup::new("test").arg("a1").args(["a2", "a3"]);
+
+        assert_eq!(with_member.args, with_arg.args);
     }
 
     // This test will *fail to compile* if ArgGroup is not Send + Sync

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -5012,13 +5012,14 @@ impl Command {
         self.args.args().any(|x| x.get_id() == id) || self.groups.iter().any(|x| x.id == *id)
     }
 
-    /// Iterate through the groups this arg is member of.
+    /// Iterate through the groups this arg is a member of, including transitively through nested
+    /// groups (groups of groups).
     pub(crate) fn groups_for_arg<'a>(&'a self, arg: &Id) -> impl Iterator<Item = Id> + 'a {
         debug!("Command::groups_for_arg: id={arg:?}");
         let arg = arg.clone();
         self.groups
             .iter()
-            .filter(move |grp| grp.args.iter().any(|a| a == &arg))
+            .filter(move |grp| self.unroll_args_in_group(&grp.id).contains(&arg))
             .map(|grp| grp.id.clone())
     }
 
@@ -5056,6 +5057,9 @@ impl Command {
     pub(crate) fn unroll_args_in_group(&self, group: &Id) -> Vec<Id> {
         debug!("Command::unroll_args_in_group: group={group:?}");
         let mut g_vec = vec![group];
+        // Track expanded groups so a cycle of nested groups can't loop forever.  Debug assertions
+        // reject such cycles outright, but they are compiled out in release builds.
+        let mut seen = vec![group];
         let mut args = vec![];
 
         while let Some(g) = g_vec.pop() {
@@ -5072,9 +5076,10 @@ impl Command {
                     if self.find(n).is_some() {
                         debug!("Command::unroll_args_in_group:iter: this is an arg");
                         args.push(n.clone());
-                    } else {
+                    } else if !seen.contains(&n) {
                         debug!("Command::unroll_args_in_group:iter: this is a group");
                         g_vec.push(n);
+                        seen.push(n);
                     }
                 }
             }

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -6,7 +6,7 @@ use crate::builder::ValueRange;
 use crate::mkeymap::KeyType;
 use crate::util::FlatSet;
 use crate::util::Id;
-use crate::{Arg, Command, ValueHint};
+use crate::{Arg, ArgGroup, Command, ValueHint};
 
 pub(crate) fn assert_app(cmd: &Command) {
     debug!("Command::_debug_asserts");
@@ -306,16 +306,21 @@ pub(crate) fn assert_app(cmd: &Command) {
             group.get_id(),
         );
 
-        for arg in &group.args {
-            // Args listed inside groups should exist
+        for member in &group.args {
+            // Members listed inside groups should exist as an argument or a group
             assert!(
-                cmd.get_arguments().any(|x| x.get_id() == arg),
+                cmd.get_arguments().any(|x| x.get_id() == member)
+                    || cmd.find_group(member).is_some(),
                 "Command {}: Argument group '{}' contains non-existent argument '{}'",
                 cmd.get_name(),
                 group.get_id(),
-                arg
+                member
             );
         }
+
+        // A group must not be a member of itself, directly or through a cycle of nested groups,
+        // as that would cause infinite recursion when unrolling its members.
+        assert_group_acyclic(cmd, group);
 
         for arg in &group.requires {
             // Args listed inside groups should exist
@@ -394,6 +399,39 @@ pub(crate) fn assert_app(cmd: &Command) {
 
     cmd._panic_on_missing_help(cmd.is_help_expected_set());
     assert_app_flags(cmd);
+}
+
+// Walk the nested-group membership reachable from `group` and panic if `group` is reachable from
+// itself.  Running this for every group catches any cycle, since every group in a cycle can reach
+// itself.
+fn assert_group_acyclic(cmd: &Command, group: &ArgGroup) {
+    let start = group.get_id();
+    let mut stack: Vec<&Id> = Vec::new();
+    let mut seen: Vec<&Id> = Vec::new();
+    for member in &group.args {
+        if cmd.find_group(member).is_some() {
+            stack.push(member);
+        }
+    }
+    while let Some(current) = stack.pop() {
+        assert!(
+            current != start,
+            "Command {}: Argument group '{}' must not be a member of itself",
+            cmd.get_name(),
+            start,
+        );
+        if seen.contains(&current) {
+            continue;
+        }
+        seen.push(current);
+        if let Some(current_group) = cmd.find_group(current) {
+            for member in &current_group.args {
+                if cmd.find_group(member).is_some() {
+                    stack.push(member);
+                }
+            }
+        }
+    }
 }
 
 fn duplicate_tip(cmd: &Command, first: &Arg, second: &Arg) -> &'static str {

--- a/clap_builder/src/parser/validator.rs
+++ b/clap_builder/src/parser/validator.rs
@@ -508,9 +508,20 @@ fn gather_arg_direct_conflicts(cmd: &Command, arg: &Arg) -> Vec<Id> {
         conf.extend(group.conflicts.iter().cloned());
         if !group.multiple {
             for member_id in &group.args {
-                if member_id != arg.get_id() {
-                    conf.push(member_id.clone());
+                if member_id == arg.get_id() {
+                    continue;
                 }
+                // A nested group that (transitively) contains this arg is part of the arg's own
+                // membership chain, not a sibling to be made mutually exclusive with it.
+                if cmd.find_group(member_id).is_some()
+                    && cmd
+                        .unroll_args_in_group(member_id)
+                        .iter()
+                        .any(|a| a == arg.get_id())
+                {
+                    continue;
+                }
+                conf.push(member_id.clone());
             }
         }
     }

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -425,7 +425,7 @@ pub(crate) fn gen_augment(
                 clap::ArgGroup::new(#group_id)
                     .multiple(true)
                     #group_methods
-                    .args(#literal_group_members)
+                    .members(#literal_group_members)
             )
         )
     };

--- a/tests/builder/groups.rs
+++ b/tests/builder/groups.rs
@@ -411,3 +411,191 @@ fn issue_1794() {
     assert!(*m.get_one::<bool>("option1").expect("defaulted by clap"));
 }
 */
+
+#[test]
+fn member_parity_with_arg() {
+    let with_member = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("grp").member("a").members(["b"]))
+        .try_get_matches_from(vec!["prog", "--a"]);
+    assert!(with_member.is_ok(), "{}", with_member.unwrap_err());
+
+    let with_arg = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("grp").arg("a").args(["b"]))
+        .try_get_matches_from(vec!["prog", "--a"]);
+    assert!(with_arg.is_ok(), "{}", with_arg.unwrap_err());
+
+    let m = with_member.unwrap();
+    assert!(m.contains_id("grp"));
+    assert_eq!(m.get_one::<Id>("grp").map(|v| v.as_str()), Some("a"));
+}
+
+#[test]
+fn group_of_groups_builds_and_marks_outer_present() {
+    let res = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("inner").members(["a", "b"]).multiple(true))
+        .group(ArgGroup::new("outer").member("inner"))
+        .try_get_matches_from(vec!["prog", "--a"]);
+    assert!(res.is_ok(), "{}", res.unwrap_err());
+
+    let m = res.unwrap();
+    assert!(m.contains_id("inner"));
+    assert!(m.contains_id("outer"));
+    assert_eq!(m.get_one::<Id>("outer").map(|v| v.as_str()), Some("a"));
+}
+
+#[test]
+fn group_of_groups_required_missing() {
+    let res = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("inner").members(["a", "b"]).multiple(true))
+        .group(ArgGroup::new("outer").member("inner").required(true))
+        .try_get_matches_from(vec!["prog"]);
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
+}
+
+#[test]
+fn group_of_groups_required_satisfied_by_nested_arg() {
+    let res = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("inner").members(["a", "b"]).multiple(true))
+        .group(ArgGroup::new("outer").member("inner").required(true))
+        .try_get_matches_from(vec!["prog", "--b"]);
+    assert!(res.is_ok(), "{}", res.unwrap_err());
+}
+
+#[test]
+fn group_of_groups_conflict_inherited_from_outer() {
+    let res = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .arg(arg!(--c))
+        .group(ArgGroup::new("inner").members(["a", "b"]).multiple(true))
+        .group(ArgGroup::new("outer").member("inner").conflicts_with("c"))
+        .try_get_matches_from(vec!["prog", "--a", "--c"]);
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn group_of_groups_requires_inherited_from_outer() {
+    let cmd = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .arg(arg!(--needed))
+        .group(ArgGroup::new("inner").members(["a", "b"]).multiple(true))
+        .group(ArgGroup::new("outer").member("inner").requires("needed"));
+
+    let missing = cmd
+        .clone()
+        .try_get_matches_from(vec!["prog", "--a"]);
+    assert!(missing.is_err());
+    assert_eq!(missing.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
+
+    let satisfied = cmd.try_get_matches_from(vec!["prog", "--a", "--needed"]);
+    assert!(satisfied.is_ok(), "{}", satisfied.unwrap_err());
+}
+
+#[test]
+fn group_of_groups_single_use_is_exclusive_across_nested_groups() {
+    let res = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("g1").member("a"))
+        .group(ArgGroup::new("g2").member("b"))
+        .group(ArgGroup::new("outer").members(["g1", "g2"]))
+        .try_get_matches_from(vec!["prog", "--a", "--b"]);
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn group_of_groups_single_use_allows_one_nested_arg() {
+    // A single nested arg must not be reported as conflicting with its own ancestor group.
+    let res = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("g1").member("a"))
+        .group(ArgGroup::new("g2").member("b"))
+        .group(ArgGroup::new("outer").members(["g1", "g2"]))
+        .try_get_matches_from(vec!["prog", "--a"]);
+    assert!(res.is_ok(), "{}", res.unwrap_err());
+}
+
+#[test]
+fn group_of_groups_inner_multiple_allows_its_own_members() {
+    // `outer` is `multiple(false)`, but `inner` is `multiple(true)`, so two of `inner`'s args are
+    // allowed together (they are the same outer member).
+    let res = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("inner").members(["a", "b"]).multiple(true))
+        .group(ArgGroup::new("outer").member("inner"))
+        .try_get_matches_from(vec!["prog", "--a", "--b"]);
+    assert!(res.is_ok(), "{}", res.unwrap_err());
+}
+
+#[test]
+#[cfg(feature = "error-context")]
+fn group_of_groups_required_usage_string() {
+    let cmd = Command::new("prog")
+        .arg(arg!(--all "use all"))
+        .arg(arg!(--delete "delete"))
+        .group(ArgGroup::new("inner").members(["all", "delete"]).multiple(true))
+        .group(ArgGroup::new("outer").member("inner").required(true));
+
+    utils::assert_output(
+        cmd,
+        "prog",
+        str![[r#"
+error: the following required arguments were not provided:
+  <--all|--delete>
+
+Usage: prog <--all|--delete>
+
+For more information, try '--help'.
+
+"#]],
+        true,
+    );
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic = "Argument group 'g' contains non-existent argument 'nope'"]
+fn group_non_existent_member() {
+    let _ = Command::new("prog")
+        .arg(arg!(--a))
+        .group(ArgGroup::new("g").members(["a", "nope"]))
+        .try_get_matches_from(vec!["prog", "--a"]);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic = "Argument group 'g' must not be a member of itself"]
+fn group_member_self_reference() {
+    let _ = Command::new("prog")
+        .arg(arg!(--a))
+        .group(ArgGroup::new("g").member("a").member("g"))
+        .try_get_matches_from(vec!["prog", "--a"]);
+}
+
+#[cfg(debug_assertions)]
+#[test]
+#[should_panic = "must not be a member of itself"]
+fn group_member_cycle() {
+    let _ = Command::new("prog")
+        .arg(arg!(--a))
+        .arg(arg!(--b))
+        .group(ArgGroup::new("g1").members(["a", "g2"]))
+        .group(ArgGroup::new("g2").members(["b", "g1"]))
+        .try_get_matches_from(vec!["prog", "--a"]);
+}


### PR DESCRIPTION
Closes #5711

## What

Allows an `ArgGroup` to contain other `ArgGroup`s as members ("groups of groups").

- Adds `ArgGroup::member` and `ArgGroup::members`, which accept the id of an `Arg` **or** of another `ArgGroup`.
- `ArgGroup::arg` / `ArgGroup::args` now delegate to `member` / `members` and are soft-deprecated in their docs (no `#[deprecated]` attribute yet — that can follow in a point release, per the deprecation flow in `CONTRIBUTING.md`).
- `clap_derive` now builds groups with `.members(...)`.

## How it works

- `Command::groups_for_arg` is now transitive: an outer group that contains a nested group is returned for that nested group's args. This makes an outer group be marked present and propagate its `requires` / `conflicts` when an argument of a nested group is used. Because the parser and most of the validator already route group resolution through `unroll_args_in_group` (which already recursed), those sites needed no changes.
- `Command::unroll_args_in_group` gained a `seen` guard so a cycle of nested groups cannot loop forever in release builds (where debug assertions are compiled out).
- Debug assertions: the "member must exist" check now accepts an arg **or** a group (the panic message is unchanged), and a new check rejects a group that is a member of itself, directly or via a cycle of nested groups.

## Open question — outer `multiple(false)` semantics

When an **outer** group has `multiple(false)` and contains nested groups, this PR treats each of the outer group's direct members (a nested group counting as a single unit) as mutually exclusive: at most one outer member may be used, while a nested `multiple(true)` group still allows several of its own args together. A single nested arg is **not** reported as conflicting with its own ancestor group.

This seemed like the natural default, and it is locked by tests (`group_of_groups_single_use_is_exclusive_across_nested_groups`, `group_of_groups_single_use_allows_one_nested_arg`, `group_of_groups_inner_multiple_allows_its_own_members`). Happy to adjust if you'd prefer different semantics.

Nested groups in usage are rendered as their expanded list of args (the existing behavior of `unroll_args_in_group`) — e.g. a required group-of-groups shows `<--all|--delete>`.

## Out of scope

Re-enabling the derive flatten HACK (`clap_derive` empties a group's members when flattening) is left for #4697; here the derive only gets the mechanical `.args` → `.members` rename, keeping the HACK and its comment.

## Testing

Built and tested locally with Rust 1.96:

- `cargo test --features "deprecated derive cargo env unicode string wrap_help unstable-ext" --workspace` — passes
- `cargo test --doc -p clap_builder` — passes
- `cargo clippy --features "…" --workspace -- -D warnings -A deprecated` — clean for the changed crates
- `cargo fmt --check` — clean

New tests cover: `member` / `members` parity with `arg` / `args`, a group-of-groups building and marking the outer group present, a required outer group satisfied by a nested arg (and the missing case), conflicts inherited from an outer group, the `multiple(false)` exclusivity plus the no-false-conflict positive case, and the debug panics for self-reference, cycles, and non-existent members. A `CHANGELOG.md` entry is included.
