### PR TITLE
fix(builder): Take `&self` in `ArgGroup::is_multiple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- *(builder)* `ArgGroup::is_multiple` now takes `&self`, allowing it to be called on a shared reference (e.g. one from `Command::groups`)
+
 ## [4.6.1] - 2026-04-15
 
 ### Fixes

--- a/clap_builder/src/builder/arg_group.rs
+++ b/clap_builder/src/builder/arg_group.rs
@@ -254,13 +254,13 @@ impl ArgGroup {
     /// ```rust
     /// # use clap_builder as clap;
     /// # use clap::{ArgGroup};
-    /// let mut group = ArgGroup::new("myprog")
+    /// let group = ArgGroup::new("myprog")
     ///     .args(["f", "c"])
     ///     .multiple(true);
     ///
     /// assert!(group.is_multiple());
     /// ```
-    pub fn is_multiple(&mut self) -> bool {
+    pub fn is_multiple(&self) -> bool {
         self.multiple
     }
 
@@ -596,10 +596,14 @@ mod test {
     fn arg_group_expose_is_multiple_helper() {
         let args: Vec<Id> = vec!["a1".into(), "a4".into()];
 
-        let mut grp_multiple = ArgGroup::new("test_multiple").args(&args).multiple(true);
+        let grp_multiple = ArgGroup::new("test_multiple").args(&args).multiple(true);
         assert!(grp_multiple.is_multiple());
+        // The getter is callable through a shared reference, e.g. one obtained
+        // from `Command::groups`.
+        let grp_multiple_ref: &ArgGroup = &grp_multiple;
+        assert!(grp_multiple_ref.is_multiple());
 
-        let mut grp_not_multiple = ArgGroup::new("test_multiple").args(&args).multiple(false);
+        let grp_not_multiple = ArgGroup::new("test_multiple").args(&args).multiple(false);
         assert!(!grp_not_multiple.is_multiple());
     }
 


### PR DESCRIPTION
Fixes #4708.

`ArgGroup::is_multiple` is a getter that just returns `self.multiple`, but it
required `&mut self`. That made it impossible to call on a shared reference,
such as one obtained from `Command::groups`.

This relaxes the receiver to `&self`, which is backwards compatible (existing
callers holding a `&mut ArgGroup` can still call it). The doc example and unit
test are updated accordingly, and the test now also exercises calling the getter
through a `&ArgGroup`.

`cargo test -p clap_builder`, `--doc`, `cargo clippy --all-features` and
`cargo fmt --check` all pass.