### PR TITLE
fix(complete/bash): don't emit usage placeholder for plain positionals

### DIFF
--- a/clap_complete/src/aot/shells/bash.rs
+++ b/clap_complete/src/aot/shells/bash.rs
@@ -291,9 +291,11 @@ fn all_options_for_path(cmd: &Command, path: &str) -> String {
                 write!(&mut opts, "{} ", value.get_name())
                     .expect("writing to String is infallible");
             }
-        } else {
-            write!(&mut opts, "{pos} ").expect("writing to String is infallible");
         }
+        // A positional without possible values has no literal completion word to
+        // offer here; emitting its `<NAME>`/`[NAME]` usage placeholder would make
+        // bash glob-expand the brackets (#6407), so leave it to the `-o default`
+        // (filename) fallback instead.
     }
     for (sc, _) in utils::subcommands(p) {
         write!(&mut opts, "{sc} ").expect("writing to String is infallible");

--- a/clap_complete/tests/snapshots/aliases.bash
+++ b/clap_complete/tests/snapshots/aliases.bash
@@ -23,7 +23,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-F -f -O -o -h -V --flg --flag --opt --option --help --version [positional]"
+            opts="-F -f -O -o -h -V --flg --flag --opt --option --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/feature_sample.bash
+++ b/clap_complete/tests/snapshots/feature_sample.bash
@@ -35,7 +35,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-C -c -h -V --conf --config --help --version [file] first second test help"
+            opts="-C -c -h -V --conf --config --help --version first second test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/bash/.bashrc
@@ -264,7 +264,7 @@ _exhaustive() {
             return 0
             ;;
         exhaustive__subcmd__alias)
-            opts="-F -f -O -o -h --flg --flag --opt --option --help [positional]"
+            opts="-F -f -O -o -h --flg --flag --opt --option --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -798,7 +798,7 @@ _exhaustive() {
             return 0
             ;;
         exhaustive__subcmd__hint)
-            opts="-p -f -d -e -c -u -H -h --choice --unknown --other --path --file --dir --exe --cmd-name --cmd --user --host --url --email --help [command_with_args]..."
+            opts="-p -f -d -e -c -u -H -h --choice --unknown --other --path --file --dir --exe --cmd-name --cmd --user --host --url --email --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -923,7 +923,7 @@ _exhaustive() {
             return 0
             ;;
         exhaustive__subcmd__last)
-            opts="-h --help [first] [free]"
+            opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1277,7 +1277,7 @@ _exhaustive() {
             return 0
             ;;
         exhaustive__subcmd__value)
-            opts="-h --delim --tuple --require-eq --help [term]..."
+            opts="-h --delim --tuple --require-eq --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/special_commands.bash
+++ b/clap_complete/tests/snapshots/special_commands.bash
@@ -53,7 +53,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-C -c -h -V --conf --config --help --version [file] first second test some_cmd some-cmd-with-hyphens some-hidden-cmd help"
+            opts="-C -c -h -V --conf --config --help --version first second test some_cmd some-cmd-with-hyphens some-hidden-cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -179,7 +179,7 @@ _my-app() {
             return 0
             ;;
         my__subcmd__app__subcmd__some_cmd)
-            opts="-h -V --config --help --version [path]..."
+            opts="-h -V --config --help --version"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/sub_subcommands.bash
+++ b/clap_complete/tests/snapshots/sub_subcommands.bash
@@ -59,7 +59,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-C -c -h -V --conf --config --help --version [file] first second test some_cmd some_cmd_alias help"
+            opts="-C -c -h -V --conf --config --help --version first second test some_cmd some_cmd_alias help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/subcommand_last.bash
+++ b/clap_complete/tests/snapshots/subcommand_last.bash
@@ -41,7 +41,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-h --help [free] foo bar help"
+            opts="-h --help foo bar help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
@@ -23,7 +23,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-h --help [first]... [second]..."
+            opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -23,7 +23,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-p -f -d -e -c -u -H -h --choice --unknown --other --path --file --dir --exe --cmd-name --cmd --user --host --url --email --help [command_with_args]..."
+            opts="-p -f -d -e -c -u -H -h --choice --unknown --other --path --file --dir --exe --cmd-name --cmd --user --host --url --email --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/clap_complete/tests/snapshots/value_terminator.bash
+++ b/clap_complete/tests/snapshots/value_terminator.bash
@@ -23,7 +23,7 @@ _my-app() {
 
     case "${cmd}" in
         my__app)
-            opts="-h --help [arguments]..."
+            opts="-h --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0


### PR DESCRIPTION
## Summary
Fixes #6407. The generated bash completion script glob-expands bracket characters when completing a positional argument that has no possible values, e.g. `[ARG]` matches files named `A`, `R`, or `G` in the current directory (worse under `nullglob`/`failglob`).

## Root cause
`all_options_for_path` in `clap_complete/src/aot/shells/bash.rs` wrote the `Display` placeholder of a bare positional (e.g. `[ARG]` or `<ARG>`) directly into the `opts` word list:

```rust
for pos in p.get_positionals() {
    if let Some(vals) = utils::possible_values(pos) {
        for value in vals {
            write!(&mut opts, "{} ", value.get_name())...
        }
    } else {
        write!(&mut opts, "{pos} ").expect(...);  // <-- literal "[ARG]"
    }
}
```

That string ends up unquoted inside `COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )`, so bash performs pathname expansion on it. `[ARG]` is not a valid value for the argument anyway — it's just a usage-style placeholder.

## Fix
Stop emitting a completion word for positionals with no `possible_values`. They now fall through to the existing `-o default` fallback (filename completion), which is also what the zsh generator already does in the equivalent case.

## Tests
Existing bash snapshot tests (`aliases`, `feature_sample`, `special_commands`, `sub_subcommands`, `subcommand_last`, `two_multi_valued_arguments`, `value_hint`, `value_terminator`) covered this code path; their snapshots are updated to drop the placeholder text, and `cargo test -p clap_complete --test testsuite bash::` passes (15/15).