### PR TITLE
[codex] Clamp RawArgs cursor at the end

### DIFF
--- a/clap_lex/src/lib.rs
+++ b/clap_lex/src/lib.rs
@@ -197,7 +197,11 @@ impl RawArgs {
     /// Advance the cursor, returning a raw argument value.
     pub fn next_os<'s>(&'s self, cursor: &mut ArgCursor) -> Option<&'s OsStr> {
         let next = self.items.get(cursor.cursor).map(|s| s.as_os_str());
-        cursor.cursor = cursor.cursor.saturating_add(1);
+        if next.is_some() {
+            cursor.cursor += 1;
+        } else {
+            cursor.cursor = self.items.len();
+        }
         next
     }
 

--- a/clap_lex/tests/testsuite/lexer.rs
+++ b/clap_lex/tests/testsuite/lexer.rs
@@ -21,6 +21,23 @@ fn insert() {
 }
 
 #[test]
+fn next_at_end_stays_at_end() {
+    let mut raw = clap_lex::RawArgs::new(["bin"]);
+    let mut cursor = raw.cursor();
+
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("bin")));
+    assert_eq!(raw.next_os(&mut cursor), None);
+    assert_eq!(raw.next_os(&mut cursor), None);
+
+    let rest = raw.remaining(&mut cursor).collect::<Vec<_>>();
+    assert!(rest.is_empty());
+
+    raw.insert(&cursor, ["tail"]);
+    assert_eq!(raw.next_os(&mut cursor), Some(std::ffi::OsStr::new("tail")));
+    assert_eq!(raw.next_os(&mut cursor), None);
+}
+
+#[test]
 fn zero_copy_parsing() {
     use clap_lex::RawArgs;
     use std::ffi::OsStr;


### PR DESCRIPTION
## Summary
- Keep RawArgs cursor at the end after next_os returns None so later remaining and insert calls stay stable.

## Validation
- cargo test -p clap_lex, cargo fmt check, and diff check passed in Docker.

## Notes
- Opened as a draft PR for maintainer review.
