### PR TITLE
Fix fish indentations

### DIFF
--- a/clap_complete/src/aot/shells/fish.rs
+++ b/clap_complete/src/aot/shells/fish.rs
@@ -247,31 +247,34 @@ fn gen_subcommand_helpers(
     let optspecs_fn_name = format!("__fish_{bin_name}_global_optspecs");
     write!(
         buf,
-        "\
-        # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.\n\
-        function {optspecs_fn_name}\n\
-        \tstring join \\n{optspecs}\n\
-        end\n\n\
-        function {needs_fn_name}\n\
-        \t# Figure out if the current invocation already has a command.\n\
-        \tset -l cmd (commandline -opc)\n\
-        \tset -e cmd[1]\n\
-        \targparse -s ({optspecs_fn_name}) -- $cmd 2>/dev/null\n\
-        \tor return\n\
-        \tif set -q argv[1]\n\
-        \t\t# Also print the command, so this can be used to figure out what it is.\n\
-        \t\techo $argv[1]\n\
-        \t\treturn 1\n\
-        \tend\n\
-        \treturn 0\n\
-        end\n\n\
-        function {using_fn_name}\n\
-        \tset -l cmd ({needs_fn_name})\n\
-        \ttest -z \"$cmd\"\n\
-        \tand return 1\n\
-        \tcontains -- $cmd[1] $argv\n\
-        end\n\n\
-    ").expect("failed to write completion file");
+        "# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function {optspecs_fn_name}
+    string join \\n{optspecs}
+end
+
+function {needs_fn_name}
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s ({optspecs_fn_name}) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
+end
+
+function {using_fn_name}
+    set -l cmd ({needs_fn_name})
+    test -z \"$cmd\"
+    and return 1
+    contains -- $cmd[1] $argv
+end
+
+"
+        ).expect("failed to write completion file");
 }
 
 fn value_completion(option: &Arg) -> String {

--- a/clap_complete/tests/snapshots/basic.fish
+++ b/clap_complete/tests/snapshots/basic.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_my_app_global_optspecs
-	string join \n c v h/help
+    string join \n c v h/help
 end
 
 function __fish_my_app_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_my_app_using_subcommand
-	set -l cmd (__fish_my_app_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_my_app_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c my-app -n "__fish_my_app_needs_command" -s c

--- a/clap_complete/tests/snapshots/custom_bin_name.fish
+++ b/clap_complete/tests/snapshots/custom_bin_name.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_bin_name_global_optspecs
-	string join \n c v h/help
+    string join \n c v h/help
 end
 
 function __fish_bin_name_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_bin_name_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_bin_name_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_bin_name_using_subcommand
-	set -l cmd (__fish_bin_name_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_bin_name_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c bin-name -n "__fish_bin_name_needs_command" -s c

--- a/clap_complete/tests/snapshots/external_subcommands.fish
+++ b/clap_complete/tests/snapshots/external_subcommands.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_my_app_global_optspecs
-	string join \n h/help
+    string join \n h/help
 end
 
 function __fish_my_app_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_my_app_using_subcommand
-	set -l cmd (__fish_my_app_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_my_app_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'

--- a/clap_complete/tests/snapshots/feature_sample.fish
+++ b/clap_complete/tests/snapshots/feature_sample.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_my_app_global_optspecs
-	string join \n c/config h/help V/version
+    string join \n c/config h/help V/version
 end
 
 function __fish_my_app_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_my_app_using_subcommand
-	set -l cmd (__fish_my_app_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_my_app_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'

--- a/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/fish/fish/completions/exhaustive.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_exhaustive_global_optspecs
-	string join \n generate= empty-choice= h/help
+    string join \n generate= empty-choice= h/help
 end
 
 function __fish_exhaustive_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_exhaustive_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_exhaustive_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_exhaustive_using_subcommand
-	set -l cmd (__fish_exhaustive_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_exhaustive_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c exhaustive -n "__fish_exhaustive_needs_command" -l generate -d 'generate' -r -f -a "bash\t''

--- a/clap_complete/tests/snapshots/quoting.fish
+++ b/clap_complete/tests/snapshots/quoting.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_my_app_global_optspecs
-	string join \n single-quotes double-quotes backticks backslash brackets expansions h/help V/version
+    string join \n single-quotes double-quotes backticks backslash brackets expansions h/help V/version
 end
 
 function __fish_my_app_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_my_app_using_subcommand
-	set -l cmd (__fish_my_app_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_my_app_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c my-app -n "__fish_my_app_needs_command" -l single-quotes -d 'Can be \'always\', \'auto\', or \'never\''

--- a/clap_complete/tests/snapshots/special_commands.fish
+++ b/clap_complete/tests/snapshots/special_commands.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_my_app_global_optspecs
-	string join \n c/config h/help V/version
+    string join \n c/config h/help V/version
 end
 
 function __fish_my_app_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_my_app_using_subcommand
-	set -l cmd (__fish_my_app_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_my_app_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'

--- a/clap_complete/tests/snapshots/sub_subcommands.fish
+++ b/clap_complete/tests/snapshots/sub_subcommands.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_my_app_global_optspecs
-	string join \n c/config h/help V/version
+    string join \n c/config h/help V/version
 end
 
 function __fish_my_app_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_my_app_using_subcommand
-	set -l cmd (__fish_my_app_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_my_app_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c my-app -n "__fish_my_app_needs_command" -s c -s C -l config -l conf -d 'some config file'

--- a/clap_complete/tests/snapshots/subcommand_last.fish
+++ b/clap_complete/tests/snapshots/subcommand_last.fish
@@ -1,27 +1,27 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_my_app_global_optspecs
-	string join \n h/help
+    string join \n h/help
 end
 
 function __fish_my_app_needs_command
-	# Figure out if the current invocation already has a command.
-	set -l cmd (commandline -opc)
-	set -e cmd[1]
-	argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
-	or return
-	if set -q argv[1]
-		# Also print the command, so this can be used to figure out what it is.
-		echo $argv[1]
-		return 1
-	end
-	return 0
+    # Figure out if the current invocation already has a command.
+    set -l cmd (commandline -opc)
+    set -e cmd[1]
+    argparse -s (__fish_my_app_global_optspecs) -- $cmd 2>/dev/null
+    or return
+    if set -q argv[1]
+        # Also print the command, so this can be used to figure out what it is.
+        echo $argv[1]
+        return 1
+    end
+    return 0
 end
 
 function __fish_my_app_using_subcommand
-	set -l cmd (__fish_my_app_needs_command)
-	test -z "$cmd"
-	and return 1
-	contains -- $cmd[1] $argv
+    set -l cmd (__fish_my_app_needs_command)
+    test -z "$cmd"
+    and return 1
+    contains -- $cmd[1] $argv
 end
 
 complete -c my-app -n "__fish_my_app_needs_command" -s h -l help -d 'Print help'


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

The completion scripts for the fish shell are the only onces, where clap_complete still had tab characters in use for indentation. This PR addresses this cosmetic oversight.
