### PR TITLE
Escape bin-name hyphens in Bash (A-1)

### DIFF
--- a/clap_complete/src/aot/shells/bash.rs
+++ b/clap_complete/src/aot/shells/bash.rs
@@ -26,7 +26,7 @@ impl Generator for Bash {
             .get_bin_name()
             .expect("crate::generate should have set the bin_name");
 
-        let fn_name = bin_name.replace('-', "__");
+        let fn_name = bin_name.replace('-', CMD_SEP);
 
         write!(
             buf,

--- a/clap_complete/tests/snapshots/aliases.bash
+++ b/clap_complete/tests/snapshots/aliases.bash
@@ -14,7 +14,7 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
             *)
                 ;;
@@ -22,7 +22,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-F -f -O -o -h -V --flg --flag --opt --option --help --version [positional]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/basic.bash
+++ b/clap_complete/tests/snapshots/basic.bash
@@ -14,19 +14,19 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app,test)
-                cmd="my__app__subcmd__test"
+            my__subcmd__app,test)
+                cmd="my__subcmd__app__subcmd__test"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
-            my__app__subcmd__help,test)
-                cmd="my__app__subcmd__help__subcmd__test"
+            my__subcmd__app__subcmd__help,test)
+                cmd="my__subcmd__app__subcmd__help__subcmd__test"
                 ;;
             *)
                 ;;
@@ -34,7 +34,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-c -v -h --help test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/custom_bin_name.bash
+++ b/clap_complete/tests/snapshots/custom_bin_name.bash
@@ -14,19 +14,19 @@ _bin-name() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="bin__name"
+                cmd="bin__subcmd__name"
                 ;;
-            bin__name,help)
-                cmd="bin__name__subcmd__help"
+            bin__subcmd__name,help)
+                cmd="bin__subcmd__name__subcmd__help"
                 ;;
-            bin__name,test)
-                cmd="bin__name__subcmd__test"
+            bin__subcmd__name,test)
+                cmd="bin__subcmd__name__subcmd__test"
                 ;;
-            bin__name__subcmd__help,help)
-                cmd="bin__name__subcmd__help__subcmd__help"
+            bin__subcmd__name__subcmd__help,help)
+                cmd="bin__subcmd__name__subcmd__help__subcmd__help"
                 ;;
-            bin__name__subcmd__help,test)
-                cmd="bin__name__subcmd__help__subcmd__test"
+            bin__subcmd__name__subcmd__help,test)
+                cmd="bin__subcmd__name__subcmd__help__subcmd__test"
                 ;;
             *)
                 ;;
@@ -34,7 +34,7 @@ _bin-name() {
     done
 
     case "${cmd}" in
-        bin__name)
+        bin__subcmd__name)
             opts="-c -v -h --help test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/external_subcommands.bash
+++ b/clap_complete/tests/snapshots/external_subcommands.bash
@@ -14,19 +14,19 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,external)
-                cmd="my__app__subcmd__external"
+            my__subcmd__app,external)
+                cmd="my__subcmd__app__subcmd__external"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app__subcmd__help,external)
-                cmd="my__app__subcmd__help__subcmd__external"
+            my__subcmd__app__subcmd__help,external)
+                cmd="my__subcmd__app__subcmd__help__subcmd__external"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
             *)
                 ;;
@@ -34,7 +34,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --help external help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/feature_sample.bash
+++ b/clap_complete/tests/snapshots/feature_sample.bash
@@ -14,19 +14,19 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app,test)
-                cmd="my__app__subcmd__test"
+            my__subcmd__app,test)
+                cmd="my__subcmd__app__subcmd__test"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
-            my__app__subcmd__help,test)
-                cmd="my__app__subcmd__help__subcmd__test"
+            my__subcmd__app__subcmd__help,test)
+                cmd="my__subcmd__app__subcmd__help__subcmd__test"
                 ;;
             *)
                 ;;
@@ -34,7 +34,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-C -c -h -V --conf --config --help --version [file] first second test help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/hyphenated_bin_name.bash
+++ b/clap_complete/tests/snapshots/hyphenated_bin_name.bash
@@ -14,19 +14,19 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app,thunder)
-                cmd="my__app__subcmd__thunder"
+            my__subcmd__app,thunder)
+                cmd="my__subcmd__app__subcmd__thunder"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
-            my__app__subcmd__help,thunder)
-                cmd="my__app__subcmd__help__subcmd__thunder"
+            my__subcmd__app__subcmd__help,thunder)
+                cmd="my__subcmd__app__subcmd__help__subcmd__thunder"
                 ;;
             *)
                 ;;
@@ -34,7 +34,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --help thunder help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/hyphenated_bin_name.bash
+++ b/clap_complete/tests/snapshots/hyphenated_bin_name.bash
@@ -1,0 +1,114 @@
+_my-app() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
+    cmd=""
+    opts=""
+
+    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="my__app"
+                ;;
+            my__app,help)
+                cmd="my__app__subcmd__help"
+                ;;
+            my__app,thunder)
+                cmd="my__app__subcmd__thunder"
+                ;;
+            my__app__subcmd__help,help)
+                cmd="my__app__subcmd__help__subcmd__help"
+                ;;
+            my__app__subcmd__help,thunder)
+                cmd="my__app__subcmd__help__subcmd__thunder"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        my__app)
+            opts="-h --help thunder help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        my__subcmd__app__subcmd__help)
+            opts="thunder help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        my__subcmd__app__subcmd__help__subcmd__help)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        my__subcmd__app__subcmd__help__subcmd__thunder)
+            opts=""
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        my__subcmd__app__subcmd__thunder)
+            opts="-h --lightning --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _my-app -o nosort -o bashdefault -o default my-app
+else
+    complete -F _my-app -o bashdefault -o default my-app
+fi

--- a/clap_complete/tests/snapshots/multi_value_option.bash
+++ b/clap_complete/tests/snapshots/multi_value_option.bash
@@ -14,7 +14,7 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
             *)
                 ;;
@@ -22,7 +22,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --options --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/optional_multi_value_option.bash
+++ b/clap_complete/tests/snapshots/optional_multi_value_option.bash
@@ -14,7 +14,7 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
             *)
                 ;;
@@ -22,7 +22,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --options --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/optional_value_option.bash
+++ b/clap_complete/tests/snapshots/optional_value_option.bash
@@ -14,7 +14,7 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
             *)
                 ;;
@@ -22,7 +22,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --options --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/quoting.bash
+++ b/clap_complete/tests/snapshots/quoting.bash
@@ -14,49 +14,49 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,cmd-backslash)
-                cmd="my__app__subcmd__cmd__subcmd__backslash"
+            my__subcmd__app,cmd-backslash)
+                cmd="my__subcmd__app__subcmd__cmd__subcmd__backslash"
                 ;;
-            my__app,cmd-backticks)
-                cmd="my__app__subcmd__cmd__subcmd__backticks"
+            my__subcmd__app,cmd-backticks)
+                cmd="my__subcmd__app__subcmd__cmd__subcmd__backticks"
                 ;;
-            my__app,cmd-brackets)
-                cmd="my__app__subcmd__cmd__subcmd__brackets"
+            my__subcmd__app,cmd-brackets)
+                cmd="my__subcmd__app__subcmd__cmd__subcmd__brackets"
                 ;;
-            my__app,cmd-double-quotes)
-                cmd="my__app__subcmd__cmd__subcmd__double__subcmd__quotes"
+            my__subcmd__app,cmd-double-quotes)
+                cmd="my__subcmd__app__subcmd__cmd__subcmd__double__subcmd__quotes"
                 ;;
-            my__app,cmd-expansions)
-                cmd="my__app__subcmd__cmd__subcmd__expansions"
+            my__subcmd__app,cmd-expansions)
+                cmd="my__subcmd__app__subcmd__cmd__subcmd__expansions"
                 ;;
-            my__app,cmd-single-quotes)
-                cmd="my__app__subcmd__cmd__subcmd__single__subcmd__quotes"
+            my__subcmd__app,cmd-single-quotes)
+                cmd="my__subcmd__app__subcmd__cmd__subcmd__single__subcmd__quotes"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app__subcmd__help,cmd-backslash)
-                cmd="my__app__subcmd__help__subcmd__cmd__subcmd__backslash"
+            my__subcmd__app__subcmd__help,cmd-backslash)
+                cmd="my__subcmd__app__subcmd__help__subcmd__cmd__subcmd__backslash"
                 ;;
-            my__app__subcmd__help,cmd-backticks)
-                cmd="my__app__subcmd__help__subcmd__cmd__subcmd__backticks"
+            my__subcmd__app__subcmd__help,cmd-backticks)
+                cmd="my__subcmd__app__subcmd__help__subcmd__cmd__subcmd__backticks"
                 ;;
-            my__app__subcmd__help,cmd-brackets)
-                cmd="my__app__subcmd__help__subcmd__cmd__subcmd__brackets"
+            my__subcmd__app__subcmd__help,cmd-brackets)
+                cmd="my__subcmd__app__subcmd__help__subcmd__cmd__subcmd__brackets"
                 ;;
-            my__app__subcmd__help,cmd-double-quotes)
-                cmd="my__app__subcmd__help__subcmd__cmd__subcmd__double__subcmd__quotes"
+            my__subcmd__app__subcmd__help,cmd-double-quotes)
+                cmd="my__subcmd__app__subcmd__help__subcmd__cmd__subcmd__double__subcmd__quotes"
                 ;;
-            my__app__subcmd__help,cmd-expansions)
-                cmd="my__app__subcmd__help__subcmd__cmd__subcmd__expansions"
+            my__subcmd__app__subcmd__help,cmd-expansions)
+                cmd="my__subcmd__app__subcmd__help__subcmd__cmd__subcmd__expansions"
                 ;;
-            my__app__subcmd__help,cmd-single-quotes)
-                cmd="my__app__subcmd__help__subcmd__cmd__subcmd__single__subcmd__quotes"
+            my__subcmd__app__subcmd__help,cmd-single-quotes)
+                cmd="my__subcmd__app__subcmd__help__subcmd__cmd__subcmd__single__subcmd__quotes"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
             *)
                 ;;
@@ -64,7 +64,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h -V --single-quotes --double-quotes --backticks --backslash --brackets --expansions --help --version cmd-single-quotes cmd-double-quotes cmd-backticks cmd-backslash cmd-brackets cmd-expansions help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/special_commands.bash
+++ b/clap_complete/tests/snapshots/special_commands.bash
@@ -14,37 +14,37 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app,some-cmd-with-hyphens)
-                cmd="my__app__subcmd__some__subcmd__cmd__subcmd__with__subcmd__hyphens"
+            my__subcmd__app,some-cmd-with-hyphens)
+                cmd="my__subcmd__app__subcmd__some__subcmd__cmd__subcmd__with__subcmd__hyphens"
                 ;;
-            my__app,some-hidden-cmd)
-                cmd="my__app__subcmd__some__subcmd__hidden__subcmd__cmd"
+            my__subcmd__app,some-hidden-cmd)
+                cmd="my__subcmd__app__subcmd__some__subcmd__hidden__subcmd__cmd"
                 ;;
-            my__app,some_cmd)
-                cmd="my__app__subcmd__some_cmd"
+            my__subcmd__app,some_cmd)
+                cmd="my__subcmd__app__subcmd__some_cmd"
                 ;;
-            my__app,test)
-                cmd="my__app__subcmd__test"
+            my__subcmd__app,test)
+                cmd="my__subcmd__app__subcmd__test"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
-            my__app__subcmd__help,some-cmd-with-hyphens)
-                cmd="my__app__subcmd__help__subcmd__some__subcmd__cmd__subcmd__with__subcmd__hyphens"
+            my__subcmd__app__subcmd__help,some-cmd-with-hyphens)
+                cmd="my__subcmd__app__subcmd__help__subcmd__some__subcmd__cmd__subcmd__with__subcmd__hyphens"
                 ;;
-            my__app__subcmd__help,some-hidden-cmd)
-                cmd="my__app__subcmd__help__subcmd__some__subcmd__hidden__subcmd__cmd"
+            my__subcmd__app__subcmd__help,some-hidden-cmd)
+                cmd="my__subcmd__app__subcmd__help__subcmd__some__subcmd__hidden__subcmd__cmd"
                 ;;
-            my__app__subcmd__help,some_cmd)
-                cmd="my__app__subcmd__help__subcmd__some_cmd"
+            my__subcmd__app__subcmd__help,some_cmd)
+                cmd="my__subcmd__app__subcmd__help__subcmd__some_cmd"
                 ;;
-            my__app__subcmd__help,test)
-                cmd="my__app__subcmd__help__subcmd__test"
+            my__subcmd__app__subcmd__help,test)
+                cmd="my__subcmd__app__subcmd__help__subcmd__test"
                 ;;
             *)
                 ;;
@@ -52,7 +52,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-C -c -h -V --conf --config --help --version [file] first second test some_cmd some-cmd-with-hyphens some-hidden-cmd help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/sub_subcommands.bash
+++ b/clap_complete/tests/snapshots/sub_subcommands.bash
@@ -14,43 +14,43 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app,some_cmd)
-                cmd="my__app__subcmd__some_cmd"
+            my__subcmd__app,some_cmd)
+                cmd="my__subcmd__app__subcmd__some_cmd"
                 ;;
-            my__app,some_cmd_alias)
-                cmd="my__app__subcmd__some_cmd"
+            my__subcmd__app,some_cmd_alias)
+                cmd="my__subcmd__app__subcmd__some_cmd"
                 ;;
-            my__app,test)
-                cmd="my__app__subcmd__test"
+            my__subcmd__app,test)
+                cmd="my__subcmd__app__subcmd__test"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
-            my__app__subcmd__help,some_cmd)
-                cmd="my__app__subcmd__help__subcmd__some_cmd"
+            my__subcmd__app__subcmd__help,some_cmd)
+                cmd="my__subcmd__app__subcmd__help__subcmd__some_cmd"
                 ;;
-            my__app__subcmd__help,test)
-                cmd="my__app__subcmd__help__subcmd__test"
+            my__subcmd__app__subcmd__help,test)
+                cmd="my__subcmd__app__subcmd__help__subcmd__test"
                 ;;
-            my__app__subcmd__help__subcmd__some_cmd,sub_cmd)
-                cmd="my__app__subcmd__help__subcmd__some_cmd__subcmd__sub_cmd"
+            my__subcmd__app__subcmd__help__subcmd__some_cmd,sub_cmd)
+                cmd="my__subcmd__app__subcmd__help__subcmd__some_cmd__subcmd__sub_cmd"
                 ;;
-            my__app__subcmd__some_cmd,help)
-                cmd="my__app__subcmd__some_cmd__subcmd__help"
+            my__subcmd__app__subcmd__some_cmd,help)
+                cmd="my__subcmd__app__subcmd__some_cmd__subcmd__help"
                 ;;
-            my__app__subcmd__some_cmd,sub_cmd)
-                cmd="my__app__subcmd__some_cmd__subcmd__sub_cmd"
+            my__subcmd__app__subcmd__some_cmd,sub_cmd)
+                cmd="my__subcmd__app__subcmd__some_cmd__subcmd__sub_cmd"
                 ;;
-            my__app__subcmd__some_cmd__subcmd__help,help)
-                cmd="my__app__subcmd__some_cmd__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__some_cmd__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__some_cmd__subcmd__help__subcmd__help"
                 ;;
-            my__app__subcmd__some_cmd__subcmd__help,sub_cmd)
-                cmd="my__app__subcmd__some_cmd__subcmd__help__subcmd__sub_cmd"
+            my__subcmd__app__subcmd__some_cmd__subcmd__help,sub_cmd)
+                cmd="my__subcmd__app__subcmd__some_cmd__subcmd__help__subcmd__sub_cmd"
                 ;;
             *)
                 ;;
@@ -58,7 +58,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-C -c -h -V --conf --config --help --version [file] first second test some_cmd some_cmd_alias help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/subcommand_last.bash
+++ b/clap_complete/tests/snapshots/subcommand_last.bash
@@ -14,25 +14,25 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
-            my__app,bar)
-                cmd="my__app__subcmd__bar"
+            my__subcmd__app,bar)
+                cmd="my__subcmd__app__subcmd__bar"
                 ;;
-            my__app,foo)
-                cmd="my__app__subcmd__foo"
+            my__subcmd__app,foo)
+                cmd="my__subcmd__app__subcmd__foo"
                 ;;
-            my__app,help)
-                cmd="my__app__subcmd__help"
+            my__subcmd__app,help)
+                cmd="my__subcmd__app__subcmd__help"
                 ;;
-            my__app__subcmd__help,bar)
-                cmd="my__app__subcmd__help__subcmd__bar"
+            my__subcmd__app__subcmd__help,bar)
+                cmd="my__subcmd__app__subcmd__help__subcmd__bar"
                 ;;
-            my__app__subcmd__help,foo)
-                cmd="my__app__subcmd__help__subcmd__foo"
+            my__subcmd__app__subcmd__help,foo)
+                cmd="my__subcmd__app__subcmd__help__subcmd__foo"
                 ;;
-            my__app__subcmd__help,help)
-                cmd="my__app__subcmd__help__subcmd__help"
+            my__subcmd__app__subcmd__help,help)
+                cmd="my__subcmd__app__subcmd__help__subcmd__help"
                 ;;
             *)
                 ;;
@@ -40,7 +40,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --help [free] foo bar help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
@@ -14,7 +14,7 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
             *)
                 ;;
@@ -22,7 +22,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --help [first]... [second]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -14,7 +14,7 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
             *)
                 ;;
@@ -22,7 +22,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-p -f -d -e -c -u -H -h --choice --unknown --other --path --file --dir --exe --cmd-name --cmd --user --host --url --email --help [command_with_args]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/snapshots/value_terminator.bash
+++ b/clap_complete/tests/snapshots/value_terminator.bash
@@ -14,7 +14,7 @@ _my-app() {
     do
         case "${cmd},${i}" in
             ",$1")
-                cmd="my__app"
+                cmd="my__subcmd__app"
                 ;;
             *)
                 ;;
@@ -22,7 +22,7 @@ _my-app() {
     done
 
     case "${cmd}" in
-        my__app)
+        my__subcmd__app)
             opts="-h --help [arguments]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -23,6 +23,28 @@ fn basic() {
 }
 
 #[test]
+fn hyphenated_bin_name() {
+    // When the bin name contains a hyphen, the parser loop records the subcommand
+    // as `cmd="my__app__subcmd__thunder"` while the option block is emitted under
+    // `my__subcmd__app__subcmd__thunder)`. The keys never match, so
+    // `my-app thunder --<TAB>` reaches no option block and completes nothing.
+    let name = "my-app";
+    let cmd = clap::Command::new(name).subcommand(
+        clap::Command::new("thunder").arg(
+            clap::Arg::new("lightning")
+                .long("lightning")
+                .action(clap::ArgAction::SetTrue),
+        ),
+    );
+    common::assert_matches(
+        snapbox::file!["../snapshots/hyphenated_bin_name.bash"],
+        clap_complete::shells::Bash,
+        cmd,
+        name,
+    );
+}
+
+#[test]
 fn feature_sample() {
     let name = "my-app";
     let cmd = common::feature_sample_command(name);


### PR DESCRIPTION
Fixes #6421

In bash, a hyphenated bin name (e.g. ast-grep) with a subcommand completes nothing past the subcommand. Top level completion works but the subcommand's options never appear

```console
# my-app thunder --<TAB>
subcommand = []                    # before
subcommand = [--lightning --help]  # after
```

- First commit adds a passing `hyphenated_bin_name` snapshot test capturing the current broken output
- Second commit fixes. This updates other Bash snapshots

Alternatively, hyphen replacement can be reverted from `CMD_SEP = "__subcmd__"` to `"__"`