### PR TITLE
fix(complete): recognise pwsh as PowerShell in dynamic completion

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -311,7 +311,7 @@ impl EnvCompleter for Powershell {
         "powershell"
     }
     fn is(&self, name: &str) -> bool {
-        name == "powershell" || name == "powershell_ise"
+        name == "powershell" || name == "powershell_ise" || name == "pwsh"
     }
     fn write_registration(
         &self,
@@ -593,6 +593,14 @@ complete --keep-order --exclusive --command 'dyn\\amic' --arguments "(V=fish /p/
 "#]]
             .raw()
         );
+    }
+
+    #[test]
+    fn powershell_is_recognizes_pwsh() {
+        assert!(Powershell.is("pwsh"), "pwsh should be recognised as PowerShell");
+        assert!(Powershell.is("powershell"), "powershell should still be recognised");
+        assert!(Powershell.is("powershell_ise"), "powershell_ise should still be recognised");
+        assert!(!Powershell.is("bash"), "bash should not be recognised as PowerShell");
     }
 
     #[test]


### PR DESCRIPTION
## What

`Powershell::is()` only matched `"powershell"` and `"powershell_ise"` but not `"pwsh"`, the cross-platform PowerShell executable name used on Linux, macOS, and modern Windows.

## Why

Users running `pwsh` (e.g. installed via `brew install powershell` on macOS/Linux) get:

```
error: unknown shell `pwsh`, expected one of `bash`, `elvish`, `fish`, `powershell`, `zsh`
```

because `CompleteEnv` reads `argv[0]` and calls `Powershell::is()`, which never matched `"pwsh"`.

## Fix

Added `|| name == "pwsh"` to `Powershell::is()` in `clap_complete/src/env/shells.rs` and a unit test verifying all three variants are recognised.

Fixes #6408