### PR TITLE
fix(complete): Recognise pwsh as PowerShell

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -311,7 +311,7 @@ impl EnvCompleter for Powershell {
         "powershell"
     }
     fn is(&self, name: &str) -> bool {
-        name == "powershell" || name == "powershell_ise"
+        name == "powershell" || name == "powershell_ise" || name == "pwsh"
     }
     fn write_registration(
         &self,
@@ -593,6 +593,14 @@ complete --keep-order --exclusive --command 'dyn\\amic' --arguments "(V=fish /p/
 "#]]
             .raw()
         );
+    }
+
+    #[test]
+    fn powershell_is_recognizes_pwsh() {
+        assert!(Powershell.is("pwsh"), "pwsh should be recognised as PowerShell");
+        assert!(Powershell.is("powershell"), "powershell should still be recognised");
+        assert!(Powershell.is("powershell_ise"), "powershell_ise should still be recognised");
+        assert!(!Powershell.is("bash"), "bash should not be recognised as PowerShell");
     }
 
     #[test]

--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -518,8 +518,8 @@ impl Zsh {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use snapbox::IntoData as _;
     use snapbox::assert_data_eq;
+    use snapbox::IntoData as _;
 
     // This test verifies that fish shell path quoting works with or without spaces in the path.
     #[test]
@@ -597,10 +597,22 @@ complete --keep-order --exclusive --command 'dyn\\amic' --arguments "(V=fish /p/
 
     #[test]
     fn powershell_is_recognizes_pwsh() {
-        assert!(Powershell.is("pwsh"), "pwsh should be recognised as PowerShell");
-        assert!(Powershell.is("powershell"), "powershell should still be recognised");
-        assert!(Powershell.is("powershell_ise"), "powershell_ise should still be recognised");
-        assert!(!Powershell.is("bash"), "bash should not be recognised as PowerShell");
+        assert!(
+            Powershell.is("pwsh"),
+            "pwsh should be recognised as PowerShell"
+        );
+        assert!(
+            Powershell.is("powershell"),
+            "powershell should still be recognised"
+        );
+        assert!(
+            Powershell.is("powershell_ise"),
+            "powershell_ise should still be recognised"
+        );
+        assert!(
+            !Powershell.is("bash"),
+            "bash should not be recognised as PowerShell"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The cross-platform PowerShell executable is named `pwsh` — not `powershell`. Users running `pwsh` via e.g. `brew install powershell` on Linux/macOS received:

```
error: unknown shell `pwsh`, expected one of `bash`, `elvish`, `fish`, `powershell`, `zsh`
```

because `Powershell::is()` only matched `"powershell"` and `"powershell_ise"`.

**Fix:** add `|| name == "pwsh"` to `Powershell::is()` plus a unit test covering all three recognized names.

Fixes #6408