### PR TITLE
fix(complete): Recognise pwsh as PowerShell

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -311,7 +311,7 @@ impl EnvCompleter for Powershell {
         "powershell"
     }
     fn is(&self, name: &str) -> bool {
-        name == "powershell" || name == "powershell_ise"
+        name == "powershell" || name == "powershell_ise" || name == "pwsh"
     }
     fn write_registration(
         &self,
@@ -593,6 +593,14 @@ complete --keep-order --exclusive --command 'dyn\\amic' --arguments "(V=fish /p/
 "#]]
             .raw()
         );
+    }
+
+    #[test]
+    fn powershell_is_recognizes_pwsh() {
+        assert!(Powershell.is("pwsh"));
+        assert!(Powershell.is("powershell"));
+        assert!(Powershell.is("powershell_ise"));
+        assert!(!Powershell.is("bash"));
     }
 
     #[test]


### PR DESCRIPTION
The cross-platform PowerShell executable is named `pwsh` — not `powershell`. Users running it (e.g. `brew install powershell` on Linux/macOS) received:

```
error: unknown shell `pwsh`, expected one of `bash`, `elvish`, `fish`, `powershell`, `zsh`
```

because `Powershell::is()` only matched `"powershell"` and `"powershell_ise"`.

**Fix:** add `|| name == "pwsh"` to `Powershell::is()` with a unit test covering all three recognised names plus a negative case.

Fixes #6408