### PR TITLE
fix: correct typos in comments

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -1146,7 +1146,7 @@ impl Command {
 
     pub(crate) fn render_usage_(&mut self) -> Option<StyledStr> {
         // If there are global arguments, or settings we need to propagate them down to subcommands
-        // before parsing incase we run into a subcommand
+        // before parsing in case we run into a subcommand
         self._build_self(false);
 
         Usage::new(self).create_usage_with_title(&[])

--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -190,7 +190,7 @@ fn subcommands_of(p: &Command) -> String {
     segments.join("\n")
 }
 
-// Get's the subcommand section of a completion file
+// Gets the subcommand section of a completion file
 // This looks roughly like:
 //
 // case $state in

--- a/clap_complete/src/engine/candidate.rs
+++ b/clap_complete/src/engine/candidate.rs
@@ -63,7 +63,7 @@ impl CompletionCandidate {
     /// Add a prefix to the value of completion candidate
     ///
     /// This is generally used for post-process by [`complete`][crate::engine::complete()] for
-    /// things like pre-pending flags, merging delimiter-separated values, etc.
+    /// things like prepending flags, merging delimiter-separated values, etc.
     pub fn add_prefix(mut self, prefix: impl Into<OsString>) -> Self {
         let suffix = self.value;
         let mut value = prefix.into();


### PR DESCRIPTION
Fix three typos found in code comments:

- `Get's` → `Gets` in `clap_complete/src/aot/shells/zsh.rs`
- `incase` → `in case` in `clap_builder/src/builder/command.rs`
- `pre-pending` → `prepending` in `clap_complete/src/engine/candidate.rs`