### PR TITLE
fix(ci): Replace the abandoned security audit action

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,15 +24,15 @@ concurrency:
 jobs:
   security_audit:
     permissions:
-      issues: write # to create issues (actions-rs/audit-check)
-      checks: write # to create check (actions-rs/audit-check)
+      issues: write # to create issues (rustsec/audit-check)
+      checks: write # to create check (rustsec/audit-check)
     runs-on: ubuntu-latest
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: true
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
-    - uses: actions-rs/audit-check@v1
+    - uses: rustsec/audit-check@v2.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The security audit workflow uses actions-rs/audit-check, a GitHub Action whose authors archived it in June 2023 — it gets no fixes or updates anymore, and GitHub's runners warn on every run that it is being forced onto newer Node versions it was never built for.

The practical problem: when the audit finds a vulnerability, this action is supposed to open an issue so someone sees it. That hasn't happened in years — the job has been failing quietly (the workflow stays green because of continue-on-error, which this change keeps as is).

rustsec/audit-check is the officially maintained successor, and a drop-in replacement — same token input, same behavior. This just swaps the action name and updates two comments.

Heads up: after this change the job will still fail until the advisories it currently finds are dealt with — but it will start opening issues about them again, which is the point.