### PR TITLE
fix(parser): args_conflicts_with_subcommands satisfies subcommand_required

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -3298,6 +3298,16 @@ impl Command {
     /// * `<cmd> <subcmd> [subcmd_args]`
     /// * `<cmd> [cmd_args]`
     ///
+    /// <div class="warning">
+    ///
+    /// **NOTE:** With the `unstable-v5` feature, providing a top-level argument
+    /// also satisfies [`Command::subcommand_required`] (so exclusive flags like
+    /// `--about` can stand in for a required subcommand). Without that feature
+    /// flag the historical behavior remains (still errors with
+    /// [`ErrorKind::MissingSubcommand`]).
+    ///
+    /// </div>
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/clap_builder/src/parser/validator.rs
+++ b/clap_builder/src/parser/validator.rs
@@ -37,18 +37,33 @@ impl<'cmd> Validator<'cmd> {
             }
         }
         if !has_subcmd && self.cmd.is_subcommand_required_set() {
-            let bn = self.cmd.get_bin_name_fallback();
-            return Err(Error::missing_subcommand(
-                self.cmd,
-                bn.to_owned(),
-                self.cmd
-                    .all_subcommand_names()
-                    .map(|s| s.to_owned())
-                    .collect::<Vec<_>>(),
-                Usage::new(self.cmd)
-                    .required(&self.required)
-                    .create_usage_with_title(&[]),
-            ));
+            // With `args_conflicts_with_subcommands`, a top-level argument is a
+            // valid alternative to a subcommand (see usage dual-line rendering).
+            // Until v5 this was still rejected by `subcommand_required`; gate the
+            // behavior change behind `unstable-v5` (#5358 / #3974).
+            #[cfg(feature = "unstable-v5")]
+            let skip_missing_subcommand = self.cmd.is_args_conflicts_with_subcommands_set()
+                && matcher
+                    .args()
+                    .filter(|(_, matched)| matched.check_explicit(&ArgPredicate::IsPresent))
+                    .any(|(id, _)| self.cmd.find(id).is_some());
+            #[cfg(not(feature = "unstable-v5"))]
+            let skip_missing_subcommand = false;
+
+            if !skip_missing_subcommand {
+                let bn = self.cmd.get_bin_name_fallback();
+                return Err(Error::missing_subcommand(
+                    self.cmd,
+                    bn.to_owned(),
+                    self.cmd
+                        .all_subcommand_names()
+                        .map(|s| s.to_owned())
+                        .collect::<Vec<_>>(),
+                    Usage::new(self.cmd)
+                        .required(&self.required)
+                        .create_usage_with_title(&[]),
+                ));
+            }
         }
 
         ok!(self.validate_conflicts(matcher, &conflicts));

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -944,6 +944,57 @@ fn subcommand_conflict_negates_required() {
 }
 
 #[test]
+#[cfg(feature = "unstable-v5")]
+fn args_conflicts_with_subcommands_satisfies_subcommand_required() {
+    let cmd = Command::new("expenses")
+        .subcommand_required(true)
+        .args_conflicts_with_subcommands(true)
+        .arg(arg!(--about "Print about"))
+        .subcommand(Command::new("manage"))
+        .subcommand(Command::new("track"));
+
+    // Flag only → OK (top-level exclusive arg stands in for a subcommand)
+    let m = cmd
+        .clone()
+        .try_get_matches_from(["expenses", "--about"])
+        .unwrap();
+    assert!(*m.get_one::<bool>("about").expect("present"));
+    assert!(m.subcommand_name().is_none());
+
+    // Subcommand → OK
+    let m = cmd
+        .clone()
+        .try_get_matches_from(["expenses", "manage"])
+        .unwrap();
+    assert_eq!(m.subcommand_name(), Some("manage"));
+
+    // Neither → still MissingSubcommand
+    let err = cmd.try_get_matches_from(["expenses"]).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::MissingSubcommand);
+}
+
+#[test]
+#[cfg(all(feature = "error-context", feature = "unstable-v5"))]
+fn args_conflicts_with_subcommands_satisfies_subcommand_required_error() {
+    static ERROR: &str = "\
+error: 'expenses' requires a subcommand but one was not provided
+  [subcommands: manage, track, help]
+
+Usage: expenses [OPTIONS]
+       expenses <COMMAND>
+
+For more information, try '--help'.
+";
+    let cmd = Command::new("expenses")
+        .subcommand_required(true)
+        .args_conflicts_with_subcommands(true)
+        .arg(arg!(--about))
+        .subcommand(Command::new("manage"))
+        .subcommand(Command::new("track"));
+    utils::assert_output(cmd, "expenses", ERROR, true);
+}
+
+#[test]
 fn args_negate_subcommands_one_level() {
     let res = Command::new("disablehelp")
         .args_conflicts_with_subcommands(true)


### PR DESCRIPTION
## Summary
- When `args_conflicts_with_subcommands` is set, a present top-level argument is a valid alternative to a required subcommand (matches dual-line usage rendering).
- Behavior change is gated behind `unstable-v5` per the 5.0 / #3974 caution.
- Adds focused regression tests for flag-only / subcommand / neither.

Fixes #5358

## Test plan
- [ ] `cargo test --features "error-context unstable-v5" args_conflicts_with_subcommands_satisfies_subcommand_required`
- [ ] Without `unstable-v5`, historical `MissingSubcommand` behavior is unchanged
