### PR TITLE
Fall back to file completion in zsh

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -450,8 +450,14 @@ function _clap_dynamic_completer_NAME() {
                 other+=("$completion")
             fi
         done
+        local _before=$compstate[nmatches]
         [[ -n $dirs ]] && _describe -V 'values' dirs -S '/' -r '/'
         [[ -n $other ]] && _describe -V 'values' other
+        if (( compstate[nmatches] == _before )); then
+            _path_files
+        fi
+    else
+        _path_files
     fi
 }
 

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
@@ -28,8 +28,14 @@ function _clap_dynamic_completer_exhaustive() {
                 other+=("$completion")
             fi
         done
+        local _before=$compstate[nmatches]
         [[ -n $dirs ]] && _describe -V 'values' dirs -S '/' -r '/'
         [[ -n $other ]] && _describe -V 'values' other
+        if (( compstate[nmatches] == _before )); then
+            _path_files
+        fi
+    else
+        _path_files
     fi
 }
 

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -355,7 +355,7 @@ fn complete_dynamic_empty_subcommand() {
     let mut runtime = common::load_runtime::<RuntimeBuilder>("dynamic-env", "exhaustive");
 
     let input = "exhaustive empty \t\t";
-    let expected = snapbox::str!["% exhaustive empty "];
+    let expected = snapbox::str!["% exhaustive empty[..]\n..."];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }
@@ -375,6 +375,56 @@ fn complete_dynamic_empty_option_value() {
     let expected = snapbox::str!["% exhaustive --empty="];
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
+}
+
+#[test]
+#[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
+fn dynamic_env_explicitly_falls_back_to_files_without_matches() {
+    use clap_complete::env::EnvCompleter as _;
+
+    if std::process::Command::new(CMD).arg("--version").output().is_err() {
+        return;
+    }
+
+    let mut registration = Vec::new();
+    clap_complete::env::Zsh
+        .write_registration(
+            "COMPLETE",
+            "exhaustive",
+            "exhaustive",
+            "clap-completer",
+            &mut registration,
+        )
+        .unwrap();
+    let registration = String::from_utf8(registration).unwrap();
+
+    for completer in ["clap-completer() { :; }", "clap-completer() { print candidate; }"] {
+        let script = format!(
+            r#"
+compdef() {{ :; }}
+_describe() {{ :; }}
+_path_files() {{ print path-fallback; }}
+{completer}
+typeset -A compstate
+compstate[nmatches]=0
+words=(exhaustive value)
+CURRENT=2
+{registration}
+_clap_dynamic_completer_exhaustive
+"#
+        );
+        let output = std::process::Command::new(CMD)
+            .args(["-f", "-c", &script])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "zsh failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(output.stdout, b"path-fallback\n");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- fall back to zsh's `_path_files` when the dynamic completer returns no candidates
- also fall back when `_describe` receives candidates but adds no matches
- add a behavioral zsh regression test covering both paths

## Why this matters

The generated zsh function previously ended without explicitly invoking native file completion when semantic completion produced no usable matches. That made path completion depend on the user's surrounding zsh configuration and could prevent ordinary file and tilde completion.

Semantic completions remain preferred: `_path_files` runs only when the completion match count does not increase.

This addresses the zsh file-fallback gap discussed in #3916.

## Validation

- `cargo test -p clap_complete -F unstable-dynamic -F unstable-shell-tests explicitly_falls_back`
- `cargo test -p clap_complete -F unstable-dynamic -F unstable-shell-tests`
- `cargo fmt --all -- --check`
- `cargo clippy -p clap_complete --all-targets -F unstable-dynamic -F unstable-shell-tests -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p clap_complete --no-deps -F unstable-dynamic -F unstable-shell-tests`

The focused regression test fails without the generated fallback and passes with this change.
