### PR TITLE
feat(error): Make Error::set_source public

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -311,7 +311,43 @@ impl<F: ErrorFormatter> Error<F> {
         self
     }
 
-    pub(crate) fn set_source(mut self, source: Box<dyn error::Error + Send + Sync>) -> Self {
+    /// Attach an underlying error that should be reported with this [`Error`].
+    ///
+    /// Unlike [`Error::raw`], a source participates in clap's normal error formatting when
+    /// context is present (argument name, invalid value, help hint, etc.). This is intended
+    /// for custom [`TypedValueParser`](crate::builder::TypedValueParser) implementations that
+    /// need the same diagnostics as clap's built-in parsers.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[cfg(feature = "error-context")] {
+    /// # use clap_builder as clap;
+    /// use clap::error::{ContextKind, ContextValue, ErrorKind};
+    /// use clap::Command;
+    ///
+    /// let cmd = Command::new("my-command");
+    ///
+    /// let mut err = clap::Error::new(ErrorKind::ValueValidation)
+    ///     .set_source(Box::<dyn std::error::Error + Send + Sync>::from(
+    ///         "Decimals are not supported in durations",
+    ///     ))
+    ///     .with_cmd(&cmd);
+    /// err.insert(
+    ///     ContextKind::InvalidArg,
+    ///     ContextValue::String("--duration".into()),
+    /// );
+    /// err.insert(
+    ///     ContextKind::InvalidValue,
+    ///     ContextValue::String("0.5sec".into()),
+    /// );
+    ///
+    /// assert!(err.to_string().contains("invalid value '0.5sec' for '--duration'"));
+    /// assert!(err.to_string().contains("Decimals are not supported in durations"));
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn set_source(mut self, source: Box<dyn error::Error + Send + Sync>) -> Self {
         self.inner.source = Some(source);
         self
     }

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -329,9 +329,7 @@ impl<F: ErrorFormatter> Error<F> {
     /// let cmd = Command::new("my-command");
     ///
     /// let mut err = clap::Error::new(ErrorKind::ValueValidation)
-    ///     .set_source(Box::<dyn std::error::Error + Send + Sync>::from(
-    ///         "Decimals are not supported in durations",
-    ///     ))
+    ///     .set_source("Decimals are not supported in durations".into())
     ///     .with_cmd(&cmd);
     /// err.insert(
     ///     ContextKind::InvalidArg,

--- a/tests/builder/error.rs
+++ b/tests/builder/error.rs
@@ -344,3 +344,32 @@ For more information, try '--help'.
 "#]];
     assert_error(err, expected_kind, message, true);
 }
+
+#[test]
+#[cfg(feature = "error-context")]
+fn set_source_keeps_context_in_message() {
+    use clap::error::{ContextKind, ContextValue};
+
+    let cmd = Command::new("my-command");
+    let mut err = clap::Error::new(ErrorKind::ValueValidation)
+        .set_source("Decimals are not supported in durations".into())
+        .with_cmd(&cmd);
+    err.insert(
+        ContextKind::InvalidArg,
+        ContextValue::String("--duration".into()),
+    );
+    err.insert(
+        ContextKind::InvalidValue,
+        ContextValue::String("0.5sec".into()),
+    );
+
+    let message = err.to_string();
+    assert!(
+        message.contains("invalid value '0.5sec' for '--duration'"),
+        "{message}"
+    );
+    assert!(
+        message.contains("Decimals are not supported in durations"),
+        "{message}"
+    );
+}


### PR DESCRIPTION
## Summary
Makes \Error::set_source\ public so custom \TypedValueParser\ impls can attach an underlying error and still get clap's normal context formatting (arg name, invalid value, help hint).

This matches what was already discussed on #5065: export \set_source\, not the private constructors.

## Test plan
- [x] Added \set_source_keeps_context_in_message\ in \	ests/builder/error.rs- [ ] \cargo test --features error-context --test builder set_source_keeps_context_in_message- [ ] Doctest on \Error::set_source
Fixes #5065
