### PR TITLE
fix(derive): preserve .0 in float default_value_t help

### DIFF
--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -584,12 +584,25 @@ impl Item {
                             s
                         })
                     } else {
-                        quote_spanned!(attr.name.span()=> {
-                            static DEFAULT_VALUE: ::std::sync::OnceLock<String> = ::std::sync::OnceLock::new();
-                            let s = DEFAULT_VALUE.get_or_init(|| {
+                        let default_string = if is_simple_ty(ty, "f32") || is_simple_ty(ty, "f64") {
+                            quote_spanned!(attr.name.span()=> {
+                                let val: #ty = #val;
+                                let s = ::std::string::ToString::to_string(&val);
+                                if s.contains('.') || s.contains('e') || s.contains('E') {
+                                    s
+                                } else {
+                                    format!("{s}.0")
+                                }
+                            })
+                        } else {
+                            quote_spanned!(attr.name.span()=> {
                                 let val: #ty = #val;
                                 ::std::string::ToString::to_string(&val)
-                            });
+                            })
+                        };
+                        quote_spanned!(attr.name.span()=> {
+                            static DEFAULT_VALUE: ::std::sync::OnceLock<String> = ::std::sync::OnceLock::new();
+                            let s = DEFAULT_VALUE.get_or_init(|| #default_string);
                             let s: &'static str = &*s;
                             s
                         })

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -588,7 +588,15 @@ impl Item {
                             quote_spanned!(attr.name.span()=> {
                                 let val: #ty = #val;
                                 let s = ::std::string::ToString::to_string(&val);
-                                if s.contains('.') || s.contains('e') || s.contains('E') {
+                                // Only append a ".0" suffix when the stringified value
+                                // looks like a finite numeric literal (starts with a
+                                // digit, or a '-' followed by a digit). This avoids
+                                // appending ".0" to the non-finite representations
+                                // "NaN", "inf" and "-inf" produced by f32/f64 Display.
+                                let starts_numeric = s.as_bytes().first().is_some_and(|&b| b.is_ascii_digit())
+                                    || (s.as_bytes().first() == Some(&b'-')
+                                        && s.as_bytes().get(1).is_some_and(|&b| b.is_ascii_digit()));
+                                if s.contains('.') || s.contains('e') || s.contains('E') || !starts_numeric {
                                     s
                                 } else {
                                     format!("{s}.0")

--- a/tests/derive/default_value.rs
+++ b/tests/derive/default_value.rs
@@ -83,6 +83,42 @@ Options:
 "#]].raw());
 }
 
+// Non-finite f64 defaults (NaN, +inf, -inf) stringify to "NaN"/"inf"/"-inf",
+// which contain no '.', 'e', or 'E'. Without the numeric-prefix guard the
+// derive would append ".0" and render "[default: NaN.0]" etc. in the help.
+// These regressions assert the non-finite representations are left intact.
+#[test]
+fn default_value_t_float_non_finite() {
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(long, default_value_t = f64::NAN)]
+        nan: f64,
+        #[arg(long, default_value_t = f64::INFINITY)]
+        pos_inf: f64,
+        #[arg(long, default_value_t = f64::NEG_INFINITY)]
+        neg_inf: f64,
+    }
+
+    let help = utils::get_long_help::<Opt>();
+    assert_data_eq!(help, str![[r#"
+Usage: clap [OPTIONS]
+
+Options:
+      --nan <NAN>
+          [default: NaN]
+
+      --neg-inf <NEG_INF>
+          [default: -inf]
+
+      --pos-inf <POS_INF>
+          [default: inf]
+
+  -h, --help
+          Print help
+
+"#]].raw());
+}
+
 #[test]
 fn auto_default_value_t() {
     #[derive(Parser, PartialEq, Debug)]

--- a/tests/derive/default_value.rs
+++ b/tests/derive/default_value.rs
@@ -58,6 +58,32 @@ Options:
 }
 
 #[test]
+fn default_value_t_float() {
+    #[derive(Parser, PartialEq, Debug)]
+    struct Opt {
+        #[arg(short = 'a', default_value_t = 1.0)]
+        amplify: f32,
+    }
+    assert_eq!(
+        Opt { amplify: 1.0 },
+        Opt::try_parse_from(["test"]).unwrap()
+    );
+
+    let help = utils::get_long_help::<Opt>();
+    assert_data_eq!(help, str![[r#"
+Usage: clap [OPTIONS]
+
+Options:
+  -a <AMPLIFY>
+          [default: 1.0]
+
+  -h, --help
+          Print help
+
+"#]].raw());
+}
+
+#[test]
 fn auto_default_value_t() {
     #[derive(Parser, PartialEq, Debug)]
     struct Opt {


### PR DESCRIPTION
Fixes #6249

## Description

`#[arg(default_value_t = 1.0)]` for `f32`/`f64` currently renders `[default: 1]` in help text instead of `[default: 1.0]`, because `default_value_t` relies on `Display`, which drops the trailing `.0` for whole-number floats.

This detects `f32`/`f64` types (via the existing `is_simple_ty` helper, already imported in `item.rs`) and appends `.0` when the rendered value contains no decimal point or exponent, so `1.0` displays as `[default: 1.0]` while values already containing `.`, `e`, or `E` (e.g. `1.5`, `1e10`) are left unchanged.

The approach mirrors the previously-proposed #6383, which was closed for non-technical reasons (the contributor was spamming invalid PRs), not because the fix was wrong. The code at `clap_derive/src/item.rs` is structurally identical to #6383's base, so this applies cleanly.

## Testing

- `cargo test --features derive,help,usage --test derive default_value_t_float`
- Full suite: `make test-full` / `make clippy-full` / `make doc`

Added `default_value_t_float` test in `tests/derive/default_value.rs` asserting the long help shows `[default: 1.0]`.