### PR TITLE
fix(mangen): mark an option required when it's the sole member of a required ArgGroup

### DIFF
--- a/clap_mangen/src/lib.rs
+++ b/clap_mangen/src/lib.rs
@@ -265,7 +265,7 @@ impl Man {
 
         if !args.is_empty() {
             roff.control("SH", ["OPTIONS"]);
-            render::options(roff, &args);
+            render::options(roff, &self.cmd, &args);
         }
 
         for heading in help_headings {
@@ -275,7 +275,7 @@ impl Man {
                 .partition(|&a| a.get_help_heading() == Some(heading));
 
             roff.control("SH", [heading.to_uppercase().as_str()]);
-            render::options(roff, &args);
+            render::options(roff, &self.cmd, &args);
         }
     }
 

--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -38,7 +38,7 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     opts.sort_by_key(|opt| option_sort_key(opt));
 
     for opt in opts {
-        let (lhs, rhs) = option_markers(opt);
+        let (lhs, rhs) = option_markers(cmd, opt);
         match (opt.get_short(), opt.get_long()) {
             (Some(short), Some(long)) => {
                 line.push(roman(lhs));
@@ -67,7 +67,7 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     }
 
     for arg in cmd.get_positionals() {
-        let (lhs, rhs) = option_markers(arg);
+        let (lhs, rhs) = option_markers(cmd, arg);
         line.push(roman(lhs));
         if let Some(value) = arg.get_value_names() {
             line.push(italic(value.join(" ")));
@@ -92,7 +92,7 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     roff.text(line);
 }
 
-pub(crate) fn options(roff: &mut Roff, items: &[&Arg]) {
+pub(crate) fn options(roff: &mut Roff, cmd: &clap::Command, items: &[&Arg]) {
     let mut sorted_items = items.to_vec();
     sorted_items.sort_by_key(|opt| option_sort_key(opt));
 
@@ -158,7 +158,7 @@ pub(crate) fn options(roff: &mut Roff, items: &[&Arg]) {
 
     for pos in items.iter().filter(|a| a.is_positional()) {
         let mut header = vec![];
-        let (lhs, rhs) = option_markers(pos);
+        let (lhs, rhs) = option_markers(cmd, pos);
         header.push(roman(lhs));
         if let Some(value) = pos.get_value_names() {
             header.push(italic(value.join(" ")));
@@ -256,8 +256,17 @@ fn subcommand_markers(cmd: &clap::Command) -> (&'static str, &'static str) {
     markers(cmd.is_subcommand_required_set())
 }
 
-fn option_markers(opt: &Arg) -> (&'static str, &'static str) {
-    markers(opt.is_required_set())
+fn option_markers(cmd: &clap::Command, opt: &Arg) -> (&'static str, &'static str) {
+    markers(opt.is_required_set() || is_in_required_group(cmd, opt))
+}
+
+// An arg that isn't itself `required` can still always be required in practice, if it is the
+// only member of a `required` `ArgGroup`. `clap`'s own usage string treats such groups
+// specially (rendering the whole group's alternatives between the required-markers), but a
+// single-member group is equivalent to the member itself being required.
+fn is_in_required_group(cmd: &clap::Command, opt: &Arg) -> bool {
+    cmd.get_groups()
+        .any(|group| group.is_required_set() && group.get_args().eq([opt.get_id()]))
 }
 
 fn markers(required: bool) -> (&'static str, &'static str) {

--- a/clap_mangen/tests/snapshots/required_arg_group.roff
+++ b/clap_mangen/tests/snapshots/required_arg_group.roff
@@ -1,0 +1,18 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR <\fB\-\-foo\fR> [\fB\-\-bar\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-foo\fR
+
+.TP
+\fB\-\-bar\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -460,6 +460,21 @@ pub(crate) fn configured_subcmd_order(name: &'static str) -> clap::Command {
         ])
 }
 
+pub(crate) fn required_arg_group(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("foo")
+                .long("foo")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            clap::Arg::new("bar")
+                .long("bar")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .group(clap::ArgGroup::new("group").args(["foo"]).required(true))
+}
+
 pub(crate) fn default_subcmd_order(name: &'static str) -> clap::Command {
     clap::Command::new(name).version("1").subcommands(vec![
         clap::Command::new("b1").about("blah b1").arg(

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -162,6 +162,16 @@ fn variadic_values() {
 }
 
 #[test]
+fn required_arg_group() {
+    let name = "my-app";
+    let cmd = common::required_arg_group(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/required_arg_group.roff"],
+        cmd,
+    );
+}
+
+#[test]
 fn configured_display_order_args() {
     let name = "my-app";
     let cmd = common::configured_display_order_args(name);


### PR DESCRIPTION
Fixes #3357.

`clap_mangen`'s synopsis and positional-arg header rendering only checked `Arg::is_required_set()` to decide between `<required>` and `[optional]` markers. It never looked at `ArgGroup` membership, so an option that is the sole member of a `required` `ArgGroup` — and is therefore always required in practice, exactly as `clap`'s own generated `--help`/usage string treats it — was rendered as optional in the generated man page.

## Fix
- Added `is_in_required_group()` in `clap_mangen/src/render.rs`, checking `cmd.get_groups()` for a required group whose only member is the given arg.
- `option_markers()` now also considers this when picking `<>` vs `[]`.
- Threaded `cmd: &clap::Command` through `render::options()` (previously only `synopsis()` had access to it) so the positional-arg header in the OPTIONS section can use the same check.

## Scope note
This only covers **single-member** required groups. A required group with multiple members means "at least one of these," not "each of these" — marking every member individually required would be misleading. `clap`'s own usage-string generator handles that case specially by rendering the whole group as one grouped alternative (e.g. `<--foo|--bar>`) instead of marking each member required individually. Reproducing that in `clap_mangen` would need broader changes to the synopsis renderer, so it's left as-is (unchanged pre-existing behavior, not a regression).

## Testing
- Added `required_arg_group` test in `clap_mangen/tests/testsuite/roff.rs` with a new `required_arg_group` command builder in `common.rs`, covering a single-member required group (rendered `<--foo>`) alongside an unrelated optional arg (rendered `[--bar]`, unaffected).
- Full `clap_mangen` test suite passes locally: `cargo test -p clap_mangen` (21/21 + 2 doctests).
- `cargo fmt -p clap_mangen --check` and `cargo clippy -p clap_mangen --all-targets` are both clean.

---
This PR was prepared with the assistance of Claude Code (Anthropic's CLI-based coding agent). The root-cause analysis, fix design, and verification steps above were reviewed and confirmed by me before submitting.