### PR TITLE
Constant fold control-flow branch that is known to always be taken

### DIFF
--- a/clap_builder/src/error/format.rs
+++ b/clap_builder/src/error/format.rs
@@ -85,10 +85,8 @@ impl ErrorFormatter for RichFormatter {
         let mut suggested = false;
         if let Some(valid) = error.get(ContextKind::SuggestedSubcommand) {
             styled.push_str("\n");
-            if !suggested {
-                styled.push_str("\n");
-                suggested = true;
-            }
+            styled.push_str("\n");
+            suggested = true;
             did_you_mean(&mut styled, styles, "subcommand", valid);
         }
         if let Some(valid) = error.get(ContextKind::SuggestedArg) {


### PR DESCRIPTION
In the first case, we statically know that `suggested` will always be false when reaching the if-statement, so we can safely constant-fold it.

The second case just makes the code a little more idiomatic.

CC @nunoplopes