### PR TITLE
docs: note that empty ValueRange also panics

### DIFF
--- a/clap_builder/src/builder/range.rs
+++ b/clap_builder/src/builder/range.rs
@@ -33,7 +33,9 @@ impl ValueRange {
     ///
     /// # Panics
     ///
-    /// If the end is less than the start (debug builds)
+    /// In debug builds, if the range accepts no values. For an exclusive range
+    /// (`start..end`) that means `end` must be greater than `start`, so both
+    /// reversed ranges like `10..5` and empty ranges like `5..5` panic.
     ///
     /// # Examples
     ///
@@ -48,11 +50,16 @@ impl ValueRange {
     /// let range = ValueRange::new(..=10);
     /// ```
     ///
-    /// While this will panic:
+    /// While these will panic:
     /// ```should_panic
     /// # use clap_builder as clap;
     /// # use clap::builder::ValueRange;
-    /// let range = ValueRange::new(10..5);  // Panics!
+    /// let range = ValueRange::new(10..5);  // Panics! (reversed)
+    /// ```
+    /// ```should_panic
+    /// # use clap_builder as clap;
+    /// # use clap::builder::ValueRange;
+    /// let range = ValueRange::new(5..5);  // Panics! (empty)
     /// ```
     pub fn new(range: impl Into<Self>) -> Self {
         range.into()


### PR DESCRIPTION
`ValueRange::new` documents a debug-build panic only "if the end is less than the start", and gives `10..5` as the sole panicking example. But an exclusive range is converted with `end.saturating_sub(1)`, so an empty range such as `5..5` becomes `raw(5, 4)` and also trips the `start <= end` debug assert.

This clarifies that an exclusive range needs `end > start` — so both reversed (`10..5`) and empty (`5..5`) ranges panic in debug builds — and adds a `5..5` example. Docs only; no behavior change.

Verified with `cargo test --doc -p clap_builder`: both `should_panic` examples pass.

<sub>Drafted with Claude Code; reviewed and verified by me.</sub>
