### PR TITLE
fix(help): Render partially-optional values with []

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4721,8 +4721,17 @@ impl Arg {
         }
 
         debug_assert!(self.is_takes_value_set());
+        let min_vals = num_vals.min_values();
         for (n, val_name) in val_names.iter().enumerate() {
-            let arg_name = if self.is_positional() && (num_vals.min_values() == 0 || !required) {
+            let is_optional_val = min_vals == 0;
+            let is_past_min = min_vals <= n;
+            let is_optional = if self.is_positional() {
+                !required || is_past_min
+            } else {
+                // The caller already brackets an optional value; avoid `[[name]]`
+                !is_optional_val && is_past_min
+            };
+            let arg_name = if is_optional {
                 format!("[{val_name}]")
             } else {
                 format!("<{val_name}>")
@@ -5003,7 +5012,7 @@ mod test {
             .value_names(["file", "name"]);
         o._build();
 
-        assert_eq!(o.to_string(), "-o <file> <name>...");
+        assert_eq!(o.to_string(), "-o <file> [name]...");
     }
 
     #[test]
@@ -5015,7 +5024,7 @@ mod test {
             .value_names(["FOO", "BAR"]);
         o._build();
 
-        assert_eq!(o.to_string(), "--example <FOO> <BAR>");
+        assert_eq!(o.to_string(), "--example <FOO> [BAR]");
     }
 
     #[test]
@@ -5029,7 +5038,7 @@ mod test {
             .value_names(["FOO", "BAR"]);
         o._build();
 
-        assert_eq!(o.to_string(), "--example=<FOO> <BAR>");
+        assert_eq!(o.to_string(), "--example=<FOO> [BAR]");
     }
 
     #[test]
@@ -5041,7 +5050,7 @@ mod test {
             .value_names(["A", "B"]);
         o._build();
 
-        assert_eq!(o.to_string(), "--example <A> <B>...");
+        assert_eq!(o.to_string(), "--example <A> [B]...");
     }
 
     #[test]

--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -5007,6 +5007,44 @@ mod test {
     }
 
     #[test]
+    fn option_display_partially_optional_values() {
+        let mut o = Arg::new("opt")
+            .long("example")
+            .action(ArgAction::Set)
+            .num_args(1..=2)
+            .value_names(["FOO", "BAR"]);
+        o._build();
+
+        assert_eq!(o.to_string(), "--example <FOO> <BAR>");
+    }
+
+    #[test]
+    fn option_display_partially_optional_values_require_equals() {
+        let mut o = Arg::new("opt")
+            .long("example")
+            .action(ArgAction::Set)
+            .num_args(1..=2)
+            .require_equals(true)
+            .value_delimiter(',')
+            .value_names(["FOO", "BAR"]);
+        o._build();
+
+        assert_eq!(o.to_string(), "--example=<FOO> <BAR>");
+    }
+
+    #[test]
+    fn option_display_partially_optional_values_with_extra_values() {
+        let mut o = Arg::new("opt")
+            .long("example")
+            .action(ArgAction::Set)
+            .num_args(1..=3)
+            .value_names(["A", "B"]);
+        o._build();
+
+        assert_eq!(o.to_string(), "--example <A> <B>...");
+    }
+
+    #[test]
     fn option_display_single_alias() {
         let mut o = Arg::new("opt")
             .long("option")
@@ -5073,6 +5111,14 @@ mod test {
     #[test]
     fn positional_display_zero_or_more_values() {
         let mut p = Arg::new("pos").index(1).num_args(0..);
+        p._build();
+
+        assert_eq!(p.to_string(), "[pos]...");
+    }
+
+    #[test]
+    fn positional_display_zero_or_more_values_required() {
+        let mut p = Arg::new("pos").index(1).num_args(0..).required(true);
         p._build();
 
         assert_eq!(p.to_string(), "[pos]...");

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -4824,7 +4824,7 @@ fn partially_optional_value_names() {
 Usage: prog [OPTIONS]
 
 Options:
-      --example <FOO> <BAR>  Takes one or two values
+      --example <FOO> [BAR]  Takes one or two values
   -h, --help                 Print help
 
 "#]];

--- a/tests/builder/help.rs
+++ b/tests/builder/help.rs
@@ -4810,3 +4810,23 @@ Options:
 "#]];
     utils::assert_output(cmd, "myprog --help", expected, false);
 }
+
+#[test]
+fn partially_optional_value_names() {
+    let cmd = Command::new("prog").arg(
+        Arg::new("example")
+            .long("example")
+            .num_args(1..=2)
+            .help("Takes one or two values")
+            .value_names(["FOO", "BAR"]),
+    );
+    let expected = str![[r#"
+Usage: prog [OPTIONS]
+
+Options:
+      --example <FOO> <BAR>  Takes one or two values
+  -h, --help                 Print help
+
+"#]];
+    utils::assert_output(cmd, "prog --help", expected, false);
+}


### PR DESCRIPTION
Fixes #4847.

While looking through the open help-rendering issues, I noticed this bug had already been tackled twice. #4910 
went stale after accumulating conflicts, and #6376 was withdrawn because it lacked a regression test. The 
underlying fix was straightforward, so I picked it up and completed it with the missing test coverage.

The issue was that options using a value-count range, such as `num_args(1..=2)` with named values, rendered 
every value name as required:
```bash
    --example <FOO> <BAR>
```
even though the parser accepts fewer values (for example, `--example FOO`). This caused the help output to 
contradict the parser's behavior. With this change, only the required values are rendered as required, while 
additional values are shown as optional:
```bash
    --example <FOO> [BAR]
```
Value names beyond the minimum required count are now wrapped in `[]`. Options whose entire value is optional 
(`min == 0`) are already bracketed by the caller, so they continue to render as `<name>` to avoid producing 
`[[...]]`.

I also added unit tests covering ranged, `require_equals`, and unbounded (`1..=3`) cases, along with a help 
snapshot test to prevent regressions. The full workspace test suite, `cargo fmt`, and `cargo clippy` all pass.

