### PR TITLE
docs: add configurable command alias example

### DIFF
--- a/examples/git-derive.md
+++ b/examples/git-derive.md
@@ -135,6 +135,19 @@ Calling out to "custom-tool" with ["arg1", "--foo", "bar"]
 
 ```
 
+Configurable aliases:
+Aliases loaded from application configuration can expand into built-in commands
+and arguments. Built-in commands take precedence over configured aliases.
+
+```console
+$ git-derive last ./src
+Diffing HEAD~..HEAD ./src (color=auto)
+
+$ git-derive stage Cargo.toml Cargo.lock
+Adding ["Cargo.toml", "Cargo.lock"]
+
+```
+
 Last argument:
 ```console
 $ git-derive diff --help

--- a/examples/git-derive.rs
+++ b/examples/git-derive.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -98,8 +99,48 @@ struct StashPushArgs {
     message: Option<String>,
 }
 
+fn aliases() -> HashMap<&'static str, Vec<&'static str>> {
+    HashMap::from([
+        ("last", vec!["diff", "HEAD~", "HEAD", "--"]),
+        ("stage", vec!["add"]),
+    ])
+}
+
+fn parse_aliases() -> Result<Cli, clap::Error> {
+    let args = Cli::try_parse()?;
+    expand_aliases(args, Vec::new())
+}
+
+fn expand_aliases(args: Cli, mut expanded: Vec<String>) -> Result<Cli, clap::Error> {
+    let Commands::External(external_args) = &args.command else {
+        return Ok(args);
+    };
+    let Some(name) = external_args.first().and_then(|name| name.to_str()) else {
+        return Ok(args);
+    };
+
+    let aliases = aliases();
+    let Some(alias) = aliases.get(name) else {
+        return Ok(args);
+    };
+    if expanded.iter().any(|expanded| expanded == name) {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::InvalidSubcommand,
+            format!("recursive alias `{}`", expanded[0]),
+        ));
+    }
+    expanded.push(name.to_owned());
+
+    let mut alias_args = vec![OsString::from("git")];
+    alias_args.extend(alias.iter().map(OsString::from));
+    alias_args.extend(external_args.iter().skip(1).cloned());
+    let args = Cli::try_parse_from(alias_args)?;
+
+    expand_aliases(args, expanded)
+}
+
 fn main() {
-    let args = Cli::parse();
+    let args = parse_aliases().unwrap_or_else(|error| error.exit());
 
     match args.command {
         Commands::Clone { remote } => {

--- a/examples/git.md
+++ b/examples/git.md
@@ -133,6 +133,19 @@ Calling out to "custom-tool" with ["arg1", "--foo", "bar"]
 
 ```
 
+Configurable aliases:
+Aliases loaded from application configuration can expand into built-in commands
+and arguments. Built-in commands take precedence over configured aliases.
+
+```console
+$ git last ./src
+Diffing HEAD~..HEAD ./src (color=auto)
+
+$ git stage Cargo.toml Cargo.lock
+Adding ["Cargo.toml", "Cargo.lock"]
+
+```
+
 Last argument:
 ```console
 $ git diff --help

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use clap::{Command, arg};
+use clap::{ArgMatches, Command, arg};
 
 fn cli() -> Command {
     Command::new("git")
@@ -57,8 +58,56 @@ fn push_args() -> Vec<clap::Arg> {
     vec![arg!(-m --message <MESSAGE>)]
 }
 
+fn aliases() -> HashMap<&'static str, Vec<&'static str>> {
+    HashMap::from([
+        ("last", vec!["diff", "HEAD~", "HEAD", "--"]),
+        ("stage", vec!["add"]),
+    ])
+}
+
+fn parse_aliases() -> Result<ArgMatches, clap::Error> {
+    let matches = cli().try_get_matches()?;
+    expand_aliases(matches, Vec::new())
+}
+
+fn expand_aliases(
+    matches: ArgMatches,
+    mut expanded: Vec<String>,
+) -> Result<ArgMatches, clap::Error> {
+    let Some((name, sub_matches)) = matches.subcommand() else {
+        return Ok(matches);
+    };
+    if cli().find_subcommand(name).is_some() {
+        return Ok(matches);
+    }
+
+    let aliases = aliases();
+    let Some(alias) = aliases.get(name) else {
+        return Ok(matches);
+    };
+    let mut args = alias.iter().map(OsString::from).collect::<Vec<_>>();
+    args.extend(
+        sub_matches
+            .get_many::<OsString>("")
+            .into_iter()
+            .flatten()
+            .cloned(),
+    );
+    let matches = cli().no_binary_name(true).try_get_matches_from(args)?;
+    let new_name = matches.subcommand_name().expect("subcommand required");
+    expanded.push(name.to_owned());
+    if expanded.iter().any(|name| name == new_name) {
+        return Err(clap::Error::raw(
+            clap::error::ErrorKind::InvalidSubcommand,
+            format!("recursive alias `{}`", expanded[0]),
+        ));
+    }
+
+    expand_aliases(matches, expanded)
+}
+
 fn main() {
-    let matches = cli().get_matches();
+    let matches = parse_aliases().unwrap_or_else(|error| error.exit());
 
     match matches.subcommand() {
         Some(("clone", sub_matches)) => {

--- a/src/_cookbook/mod.rs
+++ b/src/_cookbook/mod.rs
@@ -28,6 +28,7 @@
 //!   - Optional subcommands
 //!   - Default subcommands
 //!   - [`last`][crate::Arg::last]
+//!   - Configurable command aliases
 //!
 //! pacman-like interface: [builder][pacman]
 //! - Topics:


### PR DESCRIPTION
Closes #3679.

Adds configurable aliases to both `git` cookbook examples. They recursively reparse expanded aliases, preserve trailing arguments, support alias chains, and keep built-in commands ahead of configured aliases.

Tests:

- `cargo test --test examples --all-features -- example_tests trycmd=git`
- `cargo clippy --example git-derive --all-features -- -D warnings`
- `cargo doc --all-features --no-deps --document-private-items`
