### PR TITLE
fix(clap_mangen): Show required markers for options in required ArgGroups

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -33,40 +33,50 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     let name = cmd.get_bin_name().unwrap_or_else(|| cmd.get_name());
     let mut line = vec![bold(name), roman(" ")];
 
-    let mut opts: Vec<_> = cmd.get_arguments().filter(|i| !i.is_hide_set()).collect();
+    let required_groups: Vec<Vec<&Arg>> = cmd
+        .get_groups()
+        .filter(|g| g.is_required_set())
+        .map(|g| unroll_group_args(cmd, g.get_id()))
+        .filter(|members| !members.is_empty())
+        .collect();
+    let group_members: Vec<&Arg> = required_groups.iter().flatten().copied().collect();
+
+    let mut opts: Vec<_> = cmd
+        .get_arguments()
+        .filter(|i| {
+            !i.is_hide_set()
+                && !i.is_positional()
+                && !group_members.iter().any(|gm| gm.get_id() == i.get_id())
+        })
+        .collect();
 
     opts.sort_by_key(|opt| option_sort_key(opt));
 
-    for opt in opts {
-        let (lhs, rhs) = option_markers(opt);
-        match (opt.get_short(), opt.get_long()) {
-            (Some(short), Some(long)) => {
-                line.push(roman(lhs));
-                line.push(bold(format!("-{short}")));
-                line.push(roman("|"));
-                line.push(bold(format!("--{long}",)));
-                line.push(roman(rhs));
-            }
-            (Some(short), None) => {
-                line.push(roman(lhs));
-                line.push(bold(format!("-{short} ")));
-                line.push(roman(rhs));
-            }
-            (None, Some(long)) => {
-                line.push(roman(lhs));
-                line.push(bold(format!("--{long}")));
-                line.push(roman(rhs));
-            }
-            (None, None) => continue,
-        };
+    for opt in opts.iter().filter(|opt| !opt.is_required_set()) {
+        render_synopsis_option(&mut line, opt);
+    }
 
-        if matches!(opt.get_action(), ArgAction::Count) {
-            line.push(roman("..."));
+    for opt in opts.iter().filter(|opt| opt.is_required_set()) {
+        render_synopsis_option(&mut line, opt);
+    }
+
+    for members in &required_groups {
+        line.push(roman("<"));
+        for (i, arg) in members.iter().enumerate() {
+            if i > 0 {
+                line.push(roman("|"));
+            }
+            line.extend(render_synopsis_arg(arg));
         }
+        line.push(roman(">"));
         line.push(roman(" "));
     }
 
     for arg in cmd.get_positionals() {
+        if group_members.iter().any(|gm| gm.get_id() == arg.get_id()) {
+            continue;
+        }
+
         let (lhs, rhs) = option_markers(arg);
         line.push(roman(lhs));
         if let Some(value) = arg.get_value_names() {
@@ -90,6 +100,82 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
     }
 
     roff.text(line);
+}
+
+fn render_synopsis_option(line: &mut Vec<Inline>, opt: &Arg) {
+    let (lhs, rhs) = option_markers(opt);
+    match (opt.get_short(), opt.get_long()) {
+        (Some(short), Some(long)) => {
+            line.push(roman(lhs));
+            line.push(bold(format!("-{short}")));
+            line.push(roman("|"));
+            line.push(bold(format!("--{long}")));
+            line.push(roman(rhs));
+        }
+        (Some(short), None) => {
+            line.push(roman(lhs));
+            line.push(bold(format!("-{short} ")));
+            line.push(roman(rhs));
+        }
+        (None, Some(long)) => {
+            line.push(roman(lhs));
+            line.push(bold(format!("--{long}")));
+            line.push(roman(rhs));
+        }
+        (None, None) => return,
+    }
+
+    if matches!(opt.get_action(), ArgAction::Count) {
+        line.push(roman("..."));
+    }
+    line.push(roman(" "));
+}
+
+fn unroll_group_args<'a>(cmd: &'a clap::Command, group: &clap::Id) -> Vec<&'a Arg> {
+    let mut g_vec = vec![group];
+    let mut args: Vec<&'a Arg> = vec![];
+
+    while let Some(g) = g_vec.pop() {
+        let Some(grp) = cmd.get_groups().find(|grp| grp.get_id() == g) else {
+            continue;
+        };
+        for n in grp.get_args() {
+            if args.iter().any(|a| a.get_id() == n) {
+                continue;
+            }
+            if let Some(arg) = cmd.get_arguments().find(|a| a.get_id() == n) {
+                args.push(arg);
+            } else {
+                g_vec.push(n);
+            }
+        }
+    }
+
+    args
+}
+
+fn render_synopsis_arg(arg: &Arg) -> Vec<Inline> {
+    if arg.is_positional() {
+        let value = arg
+            .get_value_names()
+            .map(|v| v.join(" "))
+            .unwrap_or_else(|| arg.get_id().as_str().to_owned());
+        return vec![italic(value)];
+    }
+
+    let mut inline = if let Some(long) = arg.get_long() {
+        vec![bold(format!("--{long}"))]
+    } else if let Some(short) = arg.get_short() {
+        vec![bold(format!("-{short}"))]
+    } else {
+        vec![]
+    };
+
+    if matches!(arg.get_action(), ArgAction::Count) {
+        inline.push(roman("..."));
+    }
+
+    inline
 }
 
 pub(crate) fn options(roff: &mut Roff, items: &[&Arg]) {

--- a/clap_mangen/tests/snapshots/boolean_required_group.roff
+++ b/clap_mangen/tests/snapshots/boolean_required_group.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-verbose\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/boolean_required_group.roff
+++ b/clap_mangen/tests/snapshots/boolean_required_group.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR [\fB\-\-verbose\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-verbose\fR> 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/snapshots/count_required_group.roff
+++ b/clap_mangen/tests/snapshots/count_required_group.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-h\fR|\fB\-\-help\fR] 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-verbose\fR...> 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/snapshots/count_required_group.roff
+++ b/clap_mangen/tests/snapshots/count_required_group.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/optional_group.roff
+++ b/clap_mangen/tests/snapshots/optional_group.roff
@@ -1,0 +1,18 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-outfile\fR] [\fB\-\-logfile\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-outfile\fR
+
+.TP
+\fB\-\-logfile\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/positional_required_group.roff
+++ b/clap_mangen/tests/snapshots/positional_required_group.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR [\fB\-\-output\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIinput\fR] 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIinput\fR|\fB\-\-output\fR> 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/snapshots/positional_required_group.roff
+++ b/clap_mangen/tests/snapshots/positional_required_group.roff
@@ -1,0 +1,18 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-output\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIinput\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-output\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+[\fIinput\fR]
+

--- a/clap_mangen/tests/snapshots/required_group.roff
+++ b/clap_mangen/tests/snapshots/required_group.roff
@@ -1,0 +1,18 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-outfile\fR] [\fB\-\-logfile\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-outfile\fR
+
+.TP
+\fB\-\-logfile\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/required_group.roff
+++ b/clap_mangen/tests/snapshots/required_group.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR [\fB\-\-outfile\fR] [\fB\-\-logfile\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-outfile\fR|\fB\-\-logfile\fR> 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/snapshots/required_group_with_required_option.roff
+++ b/clap_mangen/tests/snapshots/required_group_with_required_option.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR <\fB\-\-config\fR> [\fB\-\-outfile\fR] [\fB\-\-logfile\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-config\fR> <\fB\-\-outfile\fR|\fB\-\-logfile\fR> 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/snapshots/required_group_with_required_option.roff
+++ b/clap_mangen/tests/snapshots/required_group_with_required_option.roff
@@ -1,0 +1,21 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR <\fB\-\-config\fR> [\fB\-\-outfile\fR] [\fB\-\-logfile\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-config\fR
+
+.TP
+\fB\-\-outfile\fR
+
+.TP
+\fB\-\-logfile\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/single_required_group.roff
+++ b/clap_mangen/tests/snapshots/single_required_group.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR [\fB\-\-outfile\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-outfile\fR> 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/snapshots/single_required_group.roff
+++ b/clap_mangen/tests/snapshots/single_required_group.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-\-outfile\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-outfile\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -474,3 +474,127 @@ pub(crate) fn default_subcmd_order(name: &'static str) -> clap::Command {
         ),
     ])
 }
+
+pub(crate) fn required_group_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("outfile")
+                .long("outfile")
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
+            clap::Arg::new("logfile")
+                .long("logfile")
+                .action(clap::ArgAction::Set),
+        )
+        .group(
+            clap::ArgGroup::new("output")
+                .required(true)
+                .arg("outfile")
+                .arg("logfile"),
+        )
+}
+
+pub(crate) fn required_group_with_required_option_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("config")
+                .long("config")
+                .required(true)
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
+            clap::Arg::new("outfile")
+                .long("outfile")
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
+            clap::Arg::new("logfile")
+                .long("logfile")
+                .action(clap::ArgAction::Set),
+        )
+        .group(
+            clap::ArgGroup::new("output")
+                .required(true)
+                .arg("outfile")
+                .arg("logfile"),
+        )
+}
+
+pub(crate) fn single_required_group_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("outfile")
+                .long("outfile")
+                .action(clap::ArgAction::Set),
+        )
+        .group(
+            clap::ArgGroup::new("output")
+                .required(true)
+                .arg("outfile"),
+        )
+}
+
+pub(crate) fn optional_group_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("outfile")
+                .long("outfile")
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
+            clap::Arg::new("logfile")
+                .long("logfile")
+                .action(clap::ArgAction::Set),
+        )
+        .group(
+            clap::ArgGroup::new("output")
+                .arg("outfile")
+                .arg("logfile"),
+        )
+}
+
+pub(crate) fn count_required_group_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("verbose")
+                .short('v')
+                .long("verbose")
+                .action(clap::ArgAction::Count),
+        )
+        .group(
+            clap::ArgGroup::new("verbosity")
+                .required(true)
+                .arg("verbose"),
+        )
+}
+
+pub(crate) fn boolean_required_group_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("verbose")
+                .long("verbose")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .group(
+            clap::ArgGroup::new("verbosity")
+                .required(true)
+                .arg("verbose"),
+        )
+}
+
+pub(crate) fn positional_required_group_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(clap::Arg::new("input"))
+        .arg(
+            clap::Arg::new("output")
+                .long("output")
+                .action(clap::ArgAction::Set),
+        )
+        .group(
+            clap::ArgGroup::new("io")
+                .required(true)
+                .arg("input")
+                .arg("output"),
+        )
+}

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -190,3 +190,73 @@ fn default_subcmd_order() {
         cmd,
     );
 }
+
+#[test]
+fn required_group() {
+    let name = "my-app";
+    let cmd = common::required_group_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/required_group.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn required_group_with_required_option() {
+    let name = "my-app";
+    let cmd = common::required_group_with_required_option_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/required_group_with_required_option.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn single_required_group() {
+    let name = "my-app";
+    let cmd = common::single_required_group_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/single_required_group.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn optional_group() {
+    let name = "my-app";
+    let cmd = common::optional_group_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/optional_group.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn count_required_group() {
+    let name = "my-app";
+    let cmd = common::count_required_group_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/count_required_group.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn boolean_required_group() {
+    let name = "my-app";
+    let cmd = common::boolean_required_group_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/boolean_required_group.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn positional_required_group() {
+    let name = "my-app";
+    let cmd = common::positional_required_group_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/positional_required_group.roff"],
+        cmd,
+    );
+}


### PR DESCRIPTION
When rendering man pages, options belonging to a required `ArgGroup` were shown as `[optional]` instead of a required one-of-many group.

```rust
clap::Command::new("myapp")
    .arg(clap::Arg::new("outfile").long("outfile").action(clap::ArgAction::Set))
    .arg(clap::Arg::new("logfile").long("logfile").action(clap::ArgAction::Set))
    .group(clap::ArgGroup::new("output").required(true).arg("outfile").arg("logfile"))
```
Before:
```console
myapp [--outfile] [--logfile]
```
After:
```console
myapp <--outfile|--logfile>
```

Fixes #3357