### PR TITLE
fix(zsh): Escape quotes in possible value help

### DIFF
--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -381,8 +381,9 @@ fn value_completion(arg: &Arg) -> Option<String> {
                             Some(format!(
                                 r#"{name}\:"{tooltip}""#,
                                 name = escape_value(value.get_name()),
-                                tooltip =
-                                    escape_help(&value.get_help().unwrap_or_default().to_string()),
+                                tooltip = escape_value_help(
+                                    &value.get_help().unwrap_or_default().to_string()
+                                ),
                             ))
                         }
                     })
@@ -437,6 +438,17 @@ fn escape_help(string: &str) -> String {
         .replace('$', "\\$")
         .replace('`', "\\`")
         .replace('\n', " ")
+}
+
+/// Escape a possible-value's help, which is emitted inside double quotes as
+/// `value\:"help"` rather than inside `[...]` like every other help string.
+///
+/// [`escape_help`] deliberately leaves `"` alone — that is correct in the bracket
+/// form, which sits inside single quotes and renders a quote literally. Here an
+/// unescaped `"` closes the tooltip early and zsh reports `unmatched "` when the
+/// spec is evaluated.
+fn escape_value_help(string: &str) -> String {
+    escape_help(string).replace('"', "\\\"")
 }
 
 /// Escape value string inside single quotes and parentheses
@@ -682,7 +694,7 @@ const CMD_SEP: &str = "__subcmd__";
 
 #[cfg(test)]
 mod tests {
-    use super::{escape_help, escape_value};
+    use super::{escape_help, escape_value, escape_value_help};
 
     #[test]
     fn test_escape_value() {
@@ -698,6 +710,29 @@ mod tests {
         let raw_string = "\\ [foo]() `bar https://$PATH";
         assert_eq!(
             escape_help(raw_string),
+            "\\\\ \\[foo\\]() \\`bar https\\://\\$PATH"
+        );
+    }
+
+    #[test]
+    fn test_escape_value_help() {
+        // A possible value's help is emitted inside double quotes, so an unescaped `"`
+        // closes it early and zsh reports `unmatched "` when the spec is evaluated.
+        // The bracket form keeps a bare `"`, which is why this is separate from
+        // `escape_help` rather than folded into it.
+        assert_eq!(
+            escape_value_help(r#"a double quote " here"#),
+            r#"a double quote \" here"#
+        );
+        assert_eq!(
+            escape_help(r#"a double quote " here"#),
+            r#"a double quote " here"#
+        );
+
+        // everything escape_help already handles is still handled
+        let raw_string = "\\ [foo]() `bar https://$PATH";
+        assert_eq!(
+            escape_value_help(raw_string),
             "\\\\ \\[foo\\]() \\`bar https\\://\\$PATH"
         );
     }


### PR DESCRIPTION
Fixes #4053.

### The reported input is already fixed

That issue blames rustdoc intra-doc links (`[metric scale](formatter::METRIC)`) in `ValueEnum` variant docs. On `master` that input generates and completes fine — driving a real zsh via `zpty`:

```
binary  -- Display the value with a unit suffix in [binary scale](formatter:
metric  -- Display the value with a unit suffix in [metric scale](formatter:
plain   -- Display the value as-is
```

### What still reproduces

`escape_help` escapes `\ ' [ ] : $` and backtick, but not `"`. That is correct for the bracket form — `'--flag=[help " here]'` sits inside single quotes and zsh renders the bare quote correctly (verified). But a possible value's help is emitted **inside double quotes**:

```rust
r#"{name}\:"{tooltip}""#,
    name = escape_value(value.get_name()),
    tooltip = escape_help(...),
```

so a `"` there closes the tooltip early. Given a variant documented `/// a double quote " here`:

```
d-quote\:"a double quote " here"
```

and completion fails with the exact error from the issue:

```
(eval):5: unmatched "
```

The two helpers already escape for different surroundings — `escape_value` adds `(`, `)` and space on top of `escape_help` — and the tooltip's double-quote context was covered by neither.

### Change

Adds `escape_value_help`, which is `escape_help` plus the `"` escape, used only at the tooltip call site. `escape_help` is deliberately left alone so the bracket form keeps rendering a bare quote rather than a stray backslash.

Verified end-to-end in zsh after the change — same input, same harness:

```
balanced     -- balanced [foo](bar) parens
close-paren  -- unbalanced close paren ) here
d-quote      -- a double quote " here
```

### Tests

Added `test_escape_value_help`, asserting the `"` is escaped, that `escape_help` still leaves it bare, and that everything `escape_help` already handles is unchanged.

Worth flagging: `common::quoting_command` exercises quoting in arg help and subcommand `about`, but has no possible value with help — which is why this survived. Adding one there would be the stronger regression, but it churns the `quoting.*` snapshots for every shell plus `clap_mangen`, so I left it out of this PR. Happy to do it as a follow-up if you want the coverage.

### Verification

- `cargo test -p clap_complete` — 10 unit, 1 integration, 76 snapshot, 8 doctests, all pass
- `cargo clippy -p clap_complete --all-targets` clean
- `cargo fmt --all --check` clean