### PR TITLE
docs: Add help-for-review example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,11 @@ path = "examples/multicall-hostname.rs"
 doc-scrape-examples = true
 
 [[example]]
+name = "pacman"
+test = true
+doc-scrape-examples = true
+
+[[example]]
 name = "repl"
 path = "examples/repl.rs"
 required-features = ["help"]

--- a/examples/pacman.md
+++ b/examples/pacman.md
@@ -81,3 +81,14 @@ For more information, try '--help'.
 Let's make a quick program to illustrate.
 
 </div>
+
+## Reviewing help output
+
+The test renders every command's long help.
+Each Markdown heading contains the complete command path.
+Generated `help` subcommands are skipped.
+`term_width(0)` prevents terminal-dependent wrapping.
+
+[`snapbox`](https://docs.rs/snapbox) compares this output with a snapshot.
+The resulting diff makes CLI changes easy to review.
+Set `SNAPSHOTS=overwrite` to accept intentional changes.

--- a/examples/pacman.rs
+++ b/examples/pacman.rs
@@ -1,7 +1,7 @@
 use clap::{Arg, ArgAction, Command};
 
-fn main() {
-    let matches = Command::new("pacman")
+fn cli() -> Command {
+    Command::new("pacman")
         .about("package manager utility")
         .version("5.2.1")
         .subcommand_required(true)
@@ -66,7 +66,10 @@ fn main() {
                         .num_args(1..),
                 ),
         )
-        .get_matches();
+}
+
+fn main() {
+    let matches = cli().get_matches();
 
     match matches.subcommand() {
         Some(("sync", sync_matches)) => {
@@ -106,5 +109,50 @@ fn main() {
             }
         }
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachable
+    }
+}
+
+#[cfg(all(test, feature = "help", feature = "usage"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn help_output_is_stable() {
+        snapbox::assert_data_eq!(
+            render_reference(cli()),
+            snapbox::file!["snapshots/pacman.txt"].raw()
+        );
+    }
+
+    fn render_reference(mut command: Command) -> String {
+        command = command.term_width(0);
+        command.build();
+
+        let mut buffer = String::new();
+        write_help(&mut buffer, &mut command, String::new());
+
+        buffer
+    }
+
+    fn write_help(buffer: &mut String, cmd: &mut Command, mut path: String) {
+        let header = if path.is_empty() { "#" } else { "##" };
+        path.push(' ');
+        path.push_str(cmd.get_name());
+
+        buffer.push_str(header);
+        buffer.push_str(&path);
+        buffer.push_str("\n\n");
+        buffer.push_str(&cmd.render_long_help().to_string());
+
+        let has_generated_help = !cmd.is_disable_help_subcommand_set();
+        for subcommand in cmd.get_subcommands_mut() {
+            // Generated `help` nodes proxy other commands.
+            if has_generated_help && subcommand.get_name() == "help" {
+                continue;
+            }
+
+            buffer.push('\n');
+            write_help(buffer, subcommand, path.clone());
+        }
     }
 }

--- a/examples/snapshots/pacman.txt
+++ b/examples/snapshots/pacman.txt
@@ -1,0 +1,53 @@
+# pacman
+
+package manager utility
+
+Usage: pacman <COMMAND>
+
+Commands:
+  query, -Q, --query  Query the package database.
+  sync, -S, --sync    Synchronize packages.
+  help                Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help
+
+  -V, --version
+          Print version
+
+## pacman query
+
+Query the package database.
+
+Usage: pacman {query|--query|-Q} [OPTIONS]
+
+Options:
+  -s, --search <search>...
+          search locally installed packages for matching strings
+
+  -i, --info <info>...
+          view package information
+
+  -h, --help
+          Print help
+
+## pacman sync
+
+Synchronize packages.
+
+Usage: pacman {sync|--sync|-S} [OPTIONS] [package]...
+
+Arguments:
+  [package]...
+          packages
+
+Options:
+  -s, --search <search>...
+          search remote repositories for matching strings
+
+  -i, --info
+          view package information
+
+  -h, --help
+          Print help

--- a/src/_cookbook/mod.rs
+++ b/src/_cookbook/mod.rs
@@ -33,6 +33,7 @@
 //! - Topics:
 //!   - Flag subcommands
 //!   - Conflicting arguments
+//!   - Visualizing help output changes through snapshot testing
 //!
 //! Escaped positionals with `--`: [builder][escaped_positional], [derive][escaped_positional_derive]
 //!

--- a/src/_cookbook/pacman.rs
+++ b/src/_cookbook/pacman.rs
@@ -1,3 +1,6 @@
+// The included source defines a snapshot test.
+#![allow(clippy::test_attr_in_doctest)]
+
 //! # Example: pacman-like CLI (Builder API)
 //!
 //! ```rust


### PR DESCRIPTION
Adds a cookbook example for rendering command help into a reviewable Markdown snapshot.

Closes #3934