### PR TITLE
fix(complete): avoid zsh rest argument conflict

### DIFF
--- a/clap_complete/src/aot/shells/zsh.rs
+++ b/clap_complete/src/aot/shells/zsh.rs
@@ -313,7 +313,7 @@ fn parser_of<'cmd>(parent: &'cmd Command, bin_name: &str) -> Option<&'cmd Comman
 //         '(-h --help --verbose)-v[Enable verbose output]' \
 //         '(-V -v --version --verbose --help)-h[Print help information]' \
 //      # ... snip for brevity
-//         ':: :_rustup_commands' \    # <-- displays subcommands
+//         ': :_rustup_commands' \     # <-- displays subcommands
 //         '*::: :->rustup' \          # <-- displays subcommand args and child subcommands
 //     && ret=0
 //
@@ -346,7 +346,7 @@ fn get_args_of(parent: &Command, p_global: Option<&Command>) -> String {
             .get_bin_name()
             .expect("crate::generate should have set the bin_name");
         let subcommand_bin_name = format!(
-            "\":: :_{name}_commands\" \\",
+            "\": :_{name}_commands\" \\",
             name = parent_bin_name.replace(' ', CMD_SEP)
         );
         segments.push(subcommand_bin_name);

--- a/clap_complete/tests/snapshots/basic.zsh
+++ b/clap_complete/tests/snapshots/basic.zsh
@@ -19,7 +19,7 @@ _my-app() {
 '(-c)-v[]' \
 '-h[Print help]' \
 '--help[Print help]' \
-":: :_my-app_commands" \
+": :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -38,7 +38,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help_commands" \
+": :_my-app__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/custom_bin_name.zsh
+++ b/clap_complete/tests/snapshots/custom_bin_name.zsh
@@ -19,7 +19,7 @@ _bin-name() {
 '(-c)-v[]' \
 '-h[Print help]' \
 '--help[Print help]' \
-":: :_bin-name_commands" \
+": :_bin-name_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -38,7 +38,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_bin-name__subcmd__help_commands" \
+": :_bin-name__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/external_subcommands.zsh
+++ b/clap_complete/tests/snapshots/external_subcommands.zsh
@@ -17,7 +17,7 @@ _my-app() {
     _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
-":: :_my-app_commands" \
+": :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -35,7 +35,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help_commands" \
+": :_my-app__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/feature_sample.zsh
+++ b/clap_complete/tests/snapshots/feature_sample.zsh
@@ -25,7 +25,7 @@ _my-app() {
 '--version[Print version]' \
 '::file -- some input file:_files' \
 '::choice:(first second)' \
-":: :_my-app_commands" \
+": :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -45,7 +45,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help_commands" \
+": :_my-app__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/static/exhaustive/zsh/zsh/_exhaustive
@@ -19,7 +19,7 @@ _exhaustive() {
 '--empty-choice=[]: :()' \
 '-h[Print help]' \
 '--help[Print help]' \
-":: :_exhaustive_commands" \
+": :_exhaustive_commands" \
 "*::: :->exhaustive" \
 && ret=0
     case $state in
@@ -39,7 +39,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-":: :_exhaustive__subcmd__global_commands" \
+": :_exhaustive__subcmd__global_commands" \
 "*::: :->global" \
 && ret=0
 
@@ -56,7 +56,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-":: :_exhaustive__subcmd__global__subcmd__one_commands" \
+": :_exhaustive__subcmd__global__subcmd__one_commands" \
 "*::: :->one" \
 && ret=0
 
@@ -77,7 +77,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__global__subcmd__one__subcmd__help_commands" \
+": :_exhaustive__subcmd__global__subcmd__one__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -114,7 +114,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__global__subcmd__help_commands" \
+": :_exhaustive__subcmd__global__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -126,7 +126,7 @@ _arguments "${_arguments_options[@]}" : \
         case $line[1] in
             (one)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__global__subcmd__help__subcmd__one_commands" \
+": :_exhaustive__subcmd__global__subcmd__help__subcmd__one_commands" \
 "*::: :->one" \
 && ret=0
 
@@ -184,7 +184,7 @@ zsh\:"zsh shell"))' \
 '--expansions[Execute the shell command with \$SHELL]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-":: :_exhaustive__subcmd__quote_commands" \
+": :_exhaustive__subcmd__quote_commands" \
 "*::: :->quote" \
 && ret=0
 
@@ -238,7 +238,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__quote__subcmd__help_commands" \
+": :_exhaustive__subcmd__quote__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -302,7 +302,7 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 '-h[Print help]' \
 '--help[Print help]' \
-":: :_exhaustive__subcmd__pacman_commands" \
+": :_exhaustive__subcmd__pacman_commands" \
 "*::: :->pacman" \
 && ret=0
 
@@ -326,7 +326,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__pacman__subcmd__help_commands" \
+": :_exhaustive__subcmd__pacman__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -408,7 +408,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__help_commands" \
+": :_exhaustive__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -424,7 +424,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (global)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__help__subcmd__global_commands" \
+": :_exhaustive__subcmd__help__subcmd__global_commands" \
 "*::: :->global" \
 && ret=0
 
@@ -436,7 +436,7 @@ _arguments "${_arguments_options[@]}" : \
         case $line[1] in
             (one)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__help__subcmd__global__subcmd__one_commands" \
+": :_exhaustive__subcmd__help__subcmd__global__subcmd__one_commands" \
 "*::: :->one" \
 && ret=0
 
@@ -468,7 +468,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (quote)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__help__subcmd__quote_commands" \
+": :_exhaustive__subcmd__help__subcmd__quote_commands" \
 "*::: :->quote" \
 && ret=0
 
@@ -516,7 +516,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (pacman)
 _arguments "${_arguments_options[@]}" : \
-":: :_exhaustive__subcmd__help__subcmd__pacman_commands" \
+": :_exhaustive__subcmd__help__subcmd__pacman_commands" \
 "*::: :->pacman" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/quoting.zsh
+++ b/clap_complete/tests/snapshots/quoting.zsh
@@ -25,7 +25,7 @@ _my-app() {
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-":: :_my-app_commands" \
+": :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -72,7 +72,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help_commands" \
+": :_my-app__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/special_commands.zsh
+++ b/clap_complete/tests/snapshots/special_commands.zsh
@@ -25,7 +25,7 @@ _my-app() {
 '--version[Print version]' \
 '::file -- some input file:_files' \
 '::choice:(first second)' \
-":: :_my-app_commands" \
+": :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -71,7 +71,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help_commands" \
+": :_my-app__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/sub_subcommands.zsh
+++ b/clap_complete/tests/snapshots/sub_subcommands.zsh
@@ -25,7 +25,7 @@ _my-app() {
 '--version[Print version]' \
 '::file -- some input file:_files' \
 '::choice:(first second)' \
-":: :_my-app_commands" \
+": :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -49,7 +49,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-":: :_my-app__subcmd__some_cmd_commands" \
+": :_my-app__subcmd__some_cmd_commands" \
 "*::: :->some_cmd" \
 && ret=0
 
@@ -71,7 +71,7 @@ Second\ to\ trigger\ display\ of\ options\:""))' \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__some_cmd__subcmd__help_commands" \
+": :_my-app__subcmd__some_cmd__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -103,7 +103,7 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help]' \
 '-V[Print version]' \
 '--version[Print version]' \
-":: :_my-app__subcmd__some_cmd_commands" \
+": :_my-app__subcmd__some_cmd_commands" \
 "*::: :->some_cmd" \
 && ret=0
 
@@ -125,7 +125,7 @@ Second\ to\ trigger\ display\ of\ options\:""))' \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__some_cmd__subcmd__help_commands" \
+": :_my-app__subcmd__some_cmd__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -153,7 +153,7 @@ esac
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help_commands" \
+": :_my-app__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 
@@ -169,7 +169,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (some_cmd)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help__subcmd__some_cmd_commands" \
+": :_my-app__subcmd__help__subcmd__some_cmd_commands" \
 "*::: :->some_cmd" \
 && ret=0
 

--- a/clap_complete/tests/snapshots/subcommand_last.zsh
+++ b/clap_complete/tests/snapshots/subcommand_last.zsh
@@ -18,7 +18,7 @@ _my-app() {
 '-h[Print help]' \
 '--help[Print help]' \
 '::free:_default' \
-":: :_my-app_commands" \
+": :_my-app_commands" \
 "*::: :->my-app" \
 && ret=0
     case $state in
@@ -41,7 +41,7 @@ _arguments "${_arguments_options[@]}" : \
 ;;
 (help)
 _arguments "${_arguments_options[@]}" : \
-":: :_my-app__subcmd__help_commands" \
+": :_my-app__subcmd__help_commands" \
 "*::: :->help" \
 && ret=0
 


### PR DESCRIPTION
Fixes #6401

The zsh completion generator currently emits a double-colon positional subcommand placeholder before the `*:::` state transition for subcommand arguments. zsh treats the double-colon form as a rest argument in this context, so generated completion scripts can hit a `doubled rest argument definition` error when completion runs.

This changes the generated subcommand placeholder to a regular positional argument while keeping the following state transition intact. The zsh snapshots were updated to cover the generated output, including the shell-registration fixture.

Validation:
- `cargo test -p clap_complete zsh --locked` - passed
- `cargo test -p clap_complete -F unstable-shell-tests zsh --locked` - passed
- `cargo test -p clap_complete --locked` - passed
- `cargo fmt --check` - passed
- `cargo clippy -p clap_complete --all-targets --all-features --locked -- -Dwarnings` - passed

Blockers:
- None.
