### PR TITLE
fix(mangen): Avoid marking fixed values as variadic

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -119,10 +119,11 @@ pub(crate) fn options(roff: &mut Roff, items: &[&Arg]) {
 
                     let mut val = format!("<{name}>");
 
-                    // If this is the last value and it's variadic, add "..."
                     let is_last = i == value_names.len() - 1;
+                    let is_variadic = arg_range.max_values() == usize::MAX;
 
-                    if is_last && arg_range.max_values() > value_names.len() {
+                    // If this is the last value and it's variadic, add "..."
+                    if is_last && is_variadic {
                         val.push_str("...");
                     }
                     header.push(italic(val));

--- a/clap_mangen/tests/snapshots/fixed_values_with_multiple_names.bash.roff
+++ b/clap_mangen/tests/snapshots/fixed_values_with_multiple_names.bash.roff
@@ -8,7 +8,7 @@ my\-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-\fB\-\-config\fR \fI<FILE>...\fR
+\fB\-\-config\fR \fI<FILE1>\fR\fI \fR\fI<FILE2>\fR
 Config files
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/clap_mangen/tests/snapshots/fixed_values_with_one_name.bash.roff
+++ b/clap_mangen/tests/snapshots/fixed_values_with_one_name.bash.roff
@@ -8,7 +8,7 @@ my\-app
 .SH DESCRIPTION
 .SH OPTIONS
 .TP
-\fB\-\-config\fR \fI<FILE>...\fR
+\fB\-\-config\fR \fI<FILE>\fR
 Config files
 .TP
 \fB\-h\fR, \fB\-\-help\fR

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -435,10 +435,29 @@ pub(crate) fn variadic_values(name: &'static str) -> clap::Command {
     clap::Command::new(name).arg(
         clap::Arg::new("config")
             .long("config")
+            .value_name("FILE")
+            .num_args(1..)
+            .help("Config files"),
+    )
+}
+
+pub(crate) fn fixed_values_with_multiple_names(name: &'static str) -> clap::Command {
+    clap::Command::new(name).arg(
+        clap::Arg::new("config")
+            .long("config")
             .value_names(["FILE1", "FILE2"])
-            .require_equals(false)
             .num_args(3)
-            .help("Optional config file"),
+            .help("Config files"),
+    )
+}
+
+pub(crate) fn fixed_values_with_one_name(name: &'static str) -> clap::Command {
+    clap::Command::new(name).arg(
+        clap::Arg::new("config")
+            .long("config")
+            .value_name("FILE")
+            .num_args(3)
+            .help("Config files"),
     )
 }
 

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -162,6 +162,26 @@ fn variadic_values() {
 }
 
 #[test]
+fn fixed_values_with_multiple_names() {
+    let name = "my-app";
+    let cmd = common::fixed_values_with_multiple_names(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/fixed_values_with_multiple_names.bash.roff"],
+        cmd,
+    );
+}
+
+#[test]
+fn fixed_values_with_one_name() {
+    let name = "my-app";
+    let cmd = common::fixed_values_with_one_name(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/fixed_values_with_one_name.bash.roff"],
+        cmd,
+    );
+}
+
+#[test]
 fn configured_display_order_args() {
     let name = "my-app";
     let cmd = common::configured_display_order_args(name);


### PR DESCRIPTION
Appends `...` only for unbounded value ranges. Adds regression tests for this behavior.

Fixes: #3359