### PR TITLE
refactor(builder): Rename internal blacklist field to conflicts

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -63,7 +63,7 @@ pub struct Arg {
     pub(crate) long_help: Option<StyledStr>,
     pub(crate) action: Option<ArgAction>,
     pub(crate) value_parser: Option<super::ValueParser>,
-    pub(crate) blacklist: Vec<Id>,
+    pub(crate) conflicts: Vec<Id>,
     pub(crate) settings: ArgFlags,
     pub(crate) overrides: Vec<Id>,
     pub(crate) groups: Vec<Id>,
@@ -4006,9 +4006,9 @@ impl Arg {
     #[must_use]
     pub fn conflicts_with(mut self, arg_id: impl IntoResettable<Id>) -> Self {
         if let Some(arg_id) = arg_id.into_resettable().into_option() {
-            self.blacklist.push(arg_id);
+            self.conflicts.push(arg_id);
         } else {
-            self.blacklist.clear();
+            self.conflicts.clear();
         }
         self
     }
@@ -4073,7 +4073,7 @@ impl Arg {
     /// [`Arg::exclusive(true)`]: Arg::exclusive()
     #[must_use]
     pub fn conflicts_with_all(mut self, names: impl IntoIterator<Item = impl Into<Id>>) -> Self {
-        self.blacklist.extend(names.into_iter().map(Into::into));
+        self.conflicts.extend(names.into_iter().map(Into::into));
         self
     }
 
@@ -4805,7 +4805,7 @@ impl fmt::Debug for Arg {
             .field("long_help", &self.long_help)
             .field("action", &self.action)
             .field("value_parser", &self.value_parser)
-            .field("blacklist", &self.blacklist)
+            .field("conflicts", &self.conflicts)
             .field("settings", &self.settings)
             .field("overrides", &self.overrides)
             .field("groups", &self.groups)

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -4034,7 +4034,7 @@ impl Command {
             self.get_global_arg_conflicts_with(arg)
         } else {
             let mut result = Vec::new();
-            for id in arg.blacklist.iter() {
+            for id in arg.conflicts.iter() {
                 if let Some(arg) = self.find(id) {
                     result.push(arg);
                 } else if let Some(group) = self.find_group(id) {
@@ -4064,7 +4064,7 @@ impl Command {
     /// this `Command`.
     fn get_global_arg_conflicts_with(&self, arg: &Arg) -> Vec<&Arg> // FIXME: This could probably have been an iterator
     {
-        arg.blacklist
+        arg.conflicts
             .iter()
             .map(|id| {
                 self.args

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -228,8 +228,8 @@ pub(crate) fn assert_app(cmd: &Command) {
             );
         }
 
-        // blacklist
-        for req in &arg.blacklist {
+        // conflicts
+        for req in &arg.conflicts {
             assert!(
                 cmd.id_exists(req),
                 "Command {}: Argument or group '{}' specified in 'conflicts_with*' for '{}' does not exist",
@@ -697,7 +697,7 @@ fn assert_arg(arg: &Arg) {
     // Self conflict
     // TODO: this check should be recursive
     assert!(
-        !arg.blacklist.iter().any(|x| x == arg.get_id()),
+        !arg.conflicts.iter().any(|x| x == arg.get_id()),
         "Argument '{}' cannot conflict with itself",
         arg.get_id(),
     );

--- a/clap_builder/src/parser/validator.rs
+++ b/clap_builder/src/parser/validator.rs
@@ -502,7 +502,7 @@ fn gather_direct_conflicts(cmd: &Command, id: &Id) -> Vec<Id> {
 }
 
 fn gather_arg_direct_conflicts(cmd: &Command, arg: &Arg) -> Vec<Id> {
-    let mut conf = arg.blacklist.clone();
+    let mut conf = arg.conflicts.clone();
     for group_id in cmd.groups_for_arg(arg.get_id()) {
         let group = cmd.find_group(&group_id).expect(INTERNAL_ERROR_MSG);
         conf.extend(group.conflicts.iter().cloned());


### PR DESCRIPTION
### What

Renames the internal `Arg::blacklist` field to `conflicts`. 11 occurrences across 4 files, no logic changes.

### Why

`conflicts` says what the field holds, matches the public `conflicts_with` / `conflicts_with_all` API it backs, and lines up with the neighbouring `overrides`, `groups`, and `requires` fields. `blacklist` is the odd one out in that group and carries baggage a lot of projects have since moved away from.

I came at this from the other end: the literal shows up in the string pool of any binary that links clap, because of the `Debug` impl. That is a small thing, but it is the sort of thing that ends up in someone's terminology audit, and the fix here is cheap.

### Compatibility

The field is `pub(crate)`, so no public API changes.

One externally visible effect: the `Arg` `Debug` output prints `conflicts` instead of `blacklist`. Per CONTRIBUTING that reads like a minor-release-level output change rather than a breaking one, but you know better than I do whether it needs to wait for a particular release train, and I am happy to hold it.

### Verification

Run locally on this branch:

- `cargo build --workspace` — clean
- `cargo test --workspace` — all suites pass, 0 failures
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets` — no new warnings

### Note

CONTRIBUTING says PRs suit changes with "little to no discussion" and points larger ones at an Issue first. I read a mechanical internal rename as falling on the PR side, but if you would rather discuss the naming or the timing first, say the word and I will move it to an Issue or close it. No hard feelings either way, and `conflicts` is just the name that seemed most consistent — happy to use whatever you prefer.
