### PR TITLE
fix(complete): Name the bash completion function after fn_name

### DIFF
--- a/clap_complete/src/aot/shells/bash.rs
+++ b/clap_complete/src/aot/shells/bash.rs
@@ -30,7 +30,7 @@ impl Generator for Bash {
 
         write!(
             buf,
-            "_{name}() {{
+            "_{fn_name}() {{
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ \"${{BASH_VERSINFO[0]}}\" -ge 4 ]]; then
@@ -72,12 +72,13 @@ impl Generator for Bash {
 }}
 
 if [[ \"${{BASH_VERSINFO[0]}}\" -eq 4 && \"${{BASH_VERSINFO[1]}}\" -ge 4 || \"${{BASH_VERSINFO[0]}}\" -gt 4 ]]; then
-    complete -F _{name} -o nosort -o bashdefault -o default {name}
+    complete -F _{fn_name} -o nosort -o bashdefault -o default {name}
 else
-    complete -F _{name} -o bashdefault -o default {name}
+    complete -F _{fn_name} -o bashdefault -o default {name}
 fi
 ",
             name = bin_name,
+            fn_name = fn_name,
             cmd = fn_name,
             name_opts = all_options_for_path(cmd, bin_name),
             name_opts_details = option_details_for_path(cmd, bin_name),

--- a/clap_complete/tests/snapshots/aliases.bash
+++ b/clap_complete/tests/snapshots/aliases.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -56,7 +56,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/basic.bash
+++ b/clap_complete/tests/snapshots/basic.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -108,7 +108,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/custom_bin_name.bash
+++ b/clap_complete/tests/snapshots/custom_bin_name.bash
@@ -1,4 +1,4 @@
-_bin-name() {
+_bin__name() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -108,7 +108,7 @@ _bin-name() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _bin-name -o nosort -o bashdefault -o default bin-name
+    complete -F _bin__name -o nosort -o bashdefault -o default bin-name
 else
-    complete -F _bin-name -o bashdefault -o default bin-name
+    complete -F _bin__name -o bashdefault -o default bin-name
 fi

--- a/clap_complete/tests/snapshots/external_subcommands.bash
+++ b/clap_complete/tests/snapshots/external_subcommands.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -108,7 +108,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/feature_sample.bash
+++ b/clap_complete/tests/snapshots/feature_sample.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -112,7 +112,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/multi_value_option.bash
+++ b/clap_complete/tests/snapshots/multi_value_option.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -44,7 +44,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/optional_multi_value_option.bash
+++ b/clap_complete/tests/snapshots/optional_multi_value_option.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -44,7 +44,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/optional_value_option.bash
+++ b/clap_complete/tests/snapshots/optional_value_option.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -44,7 +44,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/quoting.bash
+++ b/clap_complete/tests/snapshots/quoting.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -278,7 +278,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/special_commands.bash
+++ b/clap_complete/tests/snapshots/special_commands.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -218,7 +218,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/sub_subcommands.bash
+++ b/clap_complete/tests/snapshots/sub_subcommands.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -238,7 +238,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/subcommand_last.bash
+++ b/clap_complete/tests/snapshots/subcommand_last.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -142,7 +142,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
+++ b/clap_complete/tests/snapshots/two_multi_valued_arguments.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -40,7 +40,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/value_hint.bash
+++ b/clap_complete/tests/snapshots/value_hint.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -151,7 +151,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/snapshots/value_terminator.bash
+++ b/clap_complete/tests/snapshots/value_terminator.bash
@@ -1,4 +1,4 @@
-_my-app() {
+_my__app() {
     local i cur prev opts cmd
     COMPREPLY=()
     if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
@@ -40,7 +40,7 @@ _my-app() {
 }
 
 if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
-    complete -F _my-app -o nosort -o bashdefault -o default my-app
+    complete -F _my__app -o nosort -o bashdefault -o default my-app
 else
-    complete -F _my-app -o bashdefault -o default my-app
+    complete -F _my__app -o bashdefault -o default my-app
 fi

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -210,7 +210,7 @@ fn sources_under_posix_mode_bash() {
 
     assert_data_eq!(
         complaint,
-        snapbox::str!["`_my-app\': not a valid identifier"]
+        snapbox::str![""]
     );
 }
 

--- a/clap_complete/tests/testsuite/bash.rs
+++ b/clap_complete/tests/testsuite/bash.rs
@@ -193,6 +193,62 @@ fn subcommand_last() {
 
 #[test]
 #[cfg(unix)]
+fn sources_under_posix_mode_bash() {
+    let name = "my-app";
+    let mut cmd = clap::Command::new(name);
+
+    let mut script = vec![];
+    clap_complete::generate(clap_complete::shells::Bash, &mut cmd, name, &mut script);
+
+    let testdir = snapbox::dir::DirRoot::mutable_temp().unwrap();
+    let script_path = testdir.path().unwrap().join("my-app.bash");
+    std::fs::write(&script_path, script).unwrap();
+
+    let Some(complaint) = source_under_posix_mode(&script_path) else {
+        return;
+    };
+
+    assert_data_eq!(
+        complaint,
+        snapbox::str!["`_my-app\': not a valid identifier"]
+    );
+}
+
+/// Source `script` in POSIX-mode bash and report what it complained about.
+///
+/// The file name and line number are stripped so the snapshot is about the
+/// complaint rather than the temp directory. Returns `None` when bash is not
+/// installed, matching how the other tests here skip rather than fail.
+#[cfg(unix)]
+fn source_under_posix_mode(script: &std::path::Path) -> Option<String> {
+    let probe = std::process::Command::new("bash")
+        .arg("--version")
+        .output()
+        .ok()?;
+    if !probe.status.success() {
+        return None;
+    }
+
+    let output = std::process::Command::new("bash")
+        .arg("--posix")
+        .arg("-c")
+        .arg(r#"source "$1""#)
+        .arg("bash")
+        .arg(script)
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let complaint = stderr
+        .rsplit_once("line ")
+        .and_then(|(_, rest)| rest.split_once(": "))
+        .map(|(_, message)| message)
+        .unwrap_or(&stderr);
+    Some(complaint.trim_end().to_owned())
+}
+
+#[test]
+#[cfg(unix)]
 #[cfg(feature = "unstable-shell-tests")]
 fn register_completion() {
     common::register_example::<RuntimeBuilder>("static", "exhaustive");


### PR DESCRIPTION
A hyphenated bin name produces `_my-app()`, which POSIX-mode bash refuses to load:

```console
$ bash --posix -c 'source my-app.bash'
my-app.bash: line 40: `_my-app': not a valid identifier
```

That is the mode you get when `/bin/sh` is a symlink to bash, so on those systems the completions are simply unavailable.

`fn_name` already holds the bin name with hyphens replaced, and the dispatch loop has been keyed on it all along. The function definition and the two `complete -F` references were the only places still using the raw bin name. The command being completed does not change, only the identifier of the function behind it.

Split out of #6428 at your suggestion.

<sub>Drafted with Claude Code; reviewed and verified by me.</sub>
