### PR TITLE
docs: fix broken derive reference link in clap_derive CONTRIBUTING

### DIFF
--- a/clap_derive/CONTRIBUTING.md
+++ b/clap_derive/CONTRIBUTING.md
@@ -9,5 +9,5 @@ See the [clap-wide CONTRIBUTING.md](../CONTRIBUTING.md).  This will contain `cla
 - Prefer substituting variable names to avoid problems with `macro_rules`, see [#2823](https://github.com/clap-rs/clap/pull/2823).
 - Prefer `::std::result::Result` and `::std::option::Option`, see [#3092](https://github.com/clap-rs/clap/pull/3092).
 - Put whitespace between `#quoted #variables`.
-- New "magic" attributes must be documented in the [derive reference](../src/_derive.rs)
+- New "magic" attributes must be documented in the [derive reference](../src/_derive/mod.rs)
   - If there is no related builder method, a `#![doc(alias = "")]` should also be added, see [#4984](https://github.com/clap-rs/clap/pull/4984)


### PR DESCRIPTION
`clap_derive/CONTRIBUTING.md` links the derive reference:

> New "magic" attributes must be documented in the [derive reference](../src/_derive.rs)

`src/_derive.rs` no longer exists, so the link 404s: the derive reference was moved into a module directory and now lives at `src/_derive/mod.rs`. This repoints the link.
