### PR TITLE
fix(builder): enforce exclusive global groups across subcommands

### DIFF
--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -4378,6 +4378,19 @@ impl Command {
 
         matcher.propagate_globals(&global_arg_vec);
 
+        // Re-check conflicts now that globals are merged across the subcommand boundary.
+        // Per-command validation runs before propagate_globals, so exclusive global
+        // groups split around a subcommand would otherwise be missed (#6379).
+        if let Err(error) =
+            crate::parser::Validator::new(self).validate_propagated_globals(&mut matcher)
+        {
+            if self.is_set(AppSettings::IgnoreErrors) && error.use_stderr() {
+                debug!("Command::_do_parse: ignoring error: {error}");
+            } else {
+                return Err(error);
+            }
+        }
+
         Ok(matcher.into_inner())
     }
 
@@ -4770,6 +4783,29 @@ impl Command {
                     sc.get_name(),
                 );
                 sc.args.push(a.clone());
+            }
+
+            // Global args take their exclusive ArgGroups with them. Without this,
+            // two globals that share a non-multiple group conflict at the root but
+            // silently coexist once they only appear on a subcommand matcher (#6379).
+            for group in &self.groups {
+                let involves_global = group.args.iter().any(|id| {
+                    self.args
+                        .args()
+                        .any(|a| a.get_id() == id && a.is_global_set())
+                });
+                if !involves_global {
+                    continue;
+                }
+                if sc.find_group(&group.id).is_some() {
+                    continue;
+                }
+                debug!(
+                    "Command::_propagate pushing group {:?} to {}",
+                    group.id,
+                    sc.get_name(),
+                );
+                sc.groups.push(group.clone());
             }
         }
     }

--- a/clap_builder/src/parser/validator.rs
+++ b/clap_builder/src/parser/validator.rs
@@ -59,6 +59,21 @@ impl<'cmd> Validator<'cmd> {
         Ok(())
     }
 
+    /// Re-check conflicts once global args have been merged across subcommand boundaries.
+    ///
+    /// Each command validates its own matcher before globals are propagated, so two conflicting
+    /// globals used on either side of a subcommand never meet during that pass. Only conflicts are
+    /// revisited here: requirements were already resolved against the pre-propagation matcher, and
+    /// propagation only ever adds args, so it cannot leave a requirement unmet.
+    pub(crate) fn validate_propagated_globals(
+        &mut self,
+        matcher: &mut ArgMatcher,
+    ) -> ClapResult<()> {
+        debug!("Validator::validate_propagated_globals");
+        let conflicts = Conflicts::with_args(self.cmd, matcher);
+        self.validate_conflicts(matcher, &conflicts)
+    }
+
     fn validate_conflicts(
         &mut self,
         matcher: &ArgMatcher,
@@ -446,6 +461,9 @@ impl Conflicts {
             matcher
                 .args()
                 .filter(|(_, matched)| matched.check_explicit(&ArgPredicate::IsPresent))
+                // Once globals have been propagated a matcher can hold ids belonging to another
+                // command in the tree; those have no conflicts to contribute here.
+                .filter(|(id, _)| cmd.find(id).is_some() || cmd.find_group(id).is_some())
                 .map(|(id, _)| {
                     let conf = gather_direct_conflicts(cmd, id);
                     (id.clone(), conf)

--- a/tests/builder/conflicts.rs
+++ b/tests/builder/conflicts.rs
@@ -1002,3 +1002,68 @@ fn group_conrflicts_with_subcommands() {
     let err = res.err().unwrap();
     assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
 }
+
+#[test]
+fn global_args_in_exclusive_group_conflict() {
+    let cmd = || {
+        Command::new("globals_conflict")
+            .group(ArgGroup::new("gr").arg("some").arg("other").multiple(false))
+            .arg(arg!(--some "some arg").global(true))
+            .arg(arg!(--other "other arg").global(true))
+            .subcommand(Command::new("cmd"))
+    };
+
+    // Baseline: exclusive group works without subcommand involvement
+    let result = cmd().try_get_matches_from(vec!["myprog", "--some", "--other"]);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+
+    // Together before subcommand: currently correctly fails
+    let result = cmd().try_get_matches_from(vec!["myprog", "--some", "--other", "cmd"]);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+
+    // Together after subcommand: MUST FAIL (bug: currently Ok)
+    let result = cmd().try_get_matches_from(vec!["myprog", "cmd", "--some", "--other"]);
+    assert!(
+        result.is_err(),
+        "expected ArgumentConflict when both exclusive globals appear after subcommand, got Ok: {result:?}"
+    );
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+
+    // Split across subcommand boundary: MUST FAIL (bug: currently Ok)
+    let result = cmd().try_get_matches_from(vec!["myprog", "--some", "cmd", "--other"]);
+    assert!(
+        result.is_err(),
+        "expected ArgumentConflict when exclusive globals are split around subcommand, got Ok: {result:?}"
+    );
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn global_exclusive_arg_conflict_across_subcommand() {
+    let cmd = || {
+        Command::new("globals_exclusive")
+            .arg(arg!(--some "some arg").global(true).exclusive(true))
+            .arg(arg!(--other "other arg").global(true))
+            .subcommand(Command::new("cmd"))
+    };
+
+    let result = cmd().try_get_matches_from(vec!["myprog", "--some", "--other"]);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+
+    let result = cmd().try_get_matches_from(vec!["myprog", "--some", "--other", "cmd"]);
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+
+    let result = cmd().try_get_matches_from(vec!["myprog", "cmd", "--some", "--other"]);
+    assert!(
+        result.is_err(),
+        "expected ArgumentConflict for exclusive global after subcommand, got Ok: {result:?}"
+    );
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+
+    let result = cmd().try_get_matches_from(vec!["myprog", "--some", "cmd", "--other"]);
+    assert!(
+        result.is_err(),
+        "expected ArgumentConflict for exclusive global split around subcommand, got Ok: {result:?}"
+    );
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+}


### PR DESCRIPTION
## Summary

Global args are copied onto subcommands, but exclusive `ArgGroup`s that
contained those globals were not. Validation also ran before
`propagate_globals`, so two exclusive globals split around a subcommand
never appeared together in one matcher and the conflict was missed.

- Propagate `ArgGroup`s that include any global member along with the globals
- Re-validate after globals are merged across the subcommand boundary

## Test plan

- `cargo test -p clap --test builder global_args_in_exclusive`
- `cargo test -p clap --test builder global_exclusive_arg_conflict`
- `cargo test -p clap --test builder conflicts`

Fixes #6379
