### PR TITLE
docs(error): show the color-aware path in the Error::render() example

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -281,6 +281,12 @@ impl<F: ErrorFormatter> Error<F> {
 
     /// Render the error message to a [`StyledStr`].
     ///
+    /// The `Display` implementation of [`StyledStr`] is
+    /// color-unaware and strips any styling, so formatting it directly (e.g.
+    /// `println!("{err}")`) always emits plain text — even on a terminal. To
+    /// keep the styling that `render()` produced, render with [`StyledStr::ansi`]
+    /// instead, or call [`Error::print`], which is terminal-aware.
+    ///
     /// # Example
     /// ```no_run
     /// # use clap_builder as clap;
@@ -292,7 +298,7 @@ impl<F: ErrorFormatter> Error<F> {
     ///     },
     ///     Err(err) => {
     ///         let err = err.render();
-    ///         println!("{err}");
+    ///         println!("{}", err.ansi());
     ///         // do_something
     ///     },
     /// };


### PR DESCRIPTION
Closes #6471.

The doc example for `Error::render()` printed the returned `StyledStr` via `println!("{err}")`. However, `StyledStr`'s `Display` impl is documented as "Color-unaware printing. Never uses coloring" and strips styling unconditionally (`iter_text` → `anstream::adapter::strip_str`), so the path the example teaches always emits plain text — even on a terminal — silently discarding the styling `render()` just produced.

This updates the example to use the color-aware path (`StyledStr::ansi`) and adds a note that `Display` strips styling, pointing readers who want terminal-aware output at `Error::print`.

Both options suggested in the issue are covered: the example uses `.render().ansi()`, and the prose explicitly notes that `Display` strips styling.

### Verification
- `cargo build -p clap_builder` — clean
- `cargo test --doc -p clap_builder render` — the `Error::render` doctest (line 291) compiles and passes (`.ansi()` resolves under clap_builder's default features, which include `color`)
- `cargo fmt --check` — clean
- `cargo clippy -p clap_builder` — clean
- `cargo doc -p clap_builder --no-deps` — no new intra-doc-link warnings on the edited lines