### PR TITLE
fix(derive): Validate Count field types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Fixes
+
+- *(derive)* Report incompatible `ArgAction::Count` field types at compile time
+
 ## [4.6.6] - 2026-08-06
 
 ### Features

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -70,6 +70,7 @@ pub(crate) fn gen_for_struct(
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+    let action_type_assertions = gen_action_type_assertions(fields);
     let constructor = gen_constructor(fields)?;
     let updater = gen_updater(fields, true)?;
     let raw_deprecated = raw_deprecated();
@@ -114,6 +115,7 @@ pub(crate) fn gen_for_struct(
 
             fn from_arg_matches_mut(__clap_arg_matches: &mut clap::ArgMatches) -> ::std::result::Result<Self, clap::Error> {
                 #raw_deprecated
+                #action_type_assertions
                 let v = #item_name #constructor;
                 ::std::result::Result::Ok(v)
             }
@@ -438,6 +440,25 @@ pub(crate) fn gen_augment(
         #( #args )*
         #app_var #final_app_methods
     }})
+}
+
+fn gen_action_type_assertions(fields: &[(&Field, Item)]) -> TokenStream {
+    let assertions = fields
+        .iter()
+        .filter(|(_, item)| item.is_count_action())
+        .map(|(field, _)| {
+            let field_type = inner_type(&field.ty);
+            quote_spanned! { field.ty.span()=>
+                {
+                    trait __ClapCountActionRequiresU8 {}
+                    impl __ClapCountActionRequiresU8 for u8 {}
+                    fn __clap_assert_count_action_type<T: __ClapCountActionRequiresU8>() {}
+                    let _ = __clap_assert_count_action_type::<#field_type>;
+                }
+            }
+        });
+
+    quote!(#(#assertions)*)
 }
 
 pub(crate) fn gen_constructor(fields: &[(&Field, Item)]) -> Result<TokenStream, syn::Error> {

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -1065,6 +1065,10 @@ impl Item {
             })
     }
 
+    pub(crate) fn is_count_action(&self) -> bool {
+        self.action.as_ref().is_some_and(Action::is_count)
+    }
+
     pub(crate) fn kind(&self) -> Sp<Kind> {
         self.kind.clone()
     }
@@ -1143,6 +1147,24 @@ impl Action {
             Self::Explicit(method) => method.name.span(),
             Self::Implicit(ident) => ident.span(),
         }
+    }
+
+    fn is_count(&self) -> bool {
+        let Self::Explicit(method) = self else {
+            return false;
+        };
+        let Ok(path) = syn::parse2::<syn::Path>(method.args.clone()) else {
+            return false;
+        };
+        let mut segments = path.segments.iter().rev();
+        let Some(variant) = segments.next() else {
+            return false;
+        };
+        let Some(action) = segments.next() else {
+            return false;
+        };
+
+        action.ident == "ArgAction" && variant.ident == "Count"
     }
 }
 

--- a/tests/derive/flags.rs
+++ b/tests/derive/flags.rs
@@ -159,6 +159,22 @@ fn count() {
 }
 
 #[test]
+fn count_type_alias() {
+    type Count = u8;
+
+    #[derive(Parser, PartialEq, Eq, Debug)]
+    struct Opt {
+        #[arg(short, action = clap::ArgAction::Count)]
+        verbose: Count,
+    }
+
+    assert_eq!(
+        Opt { verbose: 2 },
+        Opt::try_parse_from(["test", "-vv"]).unwrap()
+    );
+}
+
+#[test]
 fn mixed_type_flags() {
     #[derive(Parser, PartialEq, Eq, Debug)]
     struct Opt {

--- a/tests/derive_ui/count_action_wrong_type.rs
+++ b/tests/derive_ui/count_action_wrong_type.rs
@@ -1,0 +1,9 @@
+use clap::Parser;
+
+#[derive(Parser)]
+struct Cli {
+    #[arg(short, action = clap::ArgAction::Count)]
+    verbose: i32,
+}
+
+fn main() {}

--- a/tests/derive_ui/count_action_wrong_type.stderr
+++ b/tests/derive_ui/count_action_wrong_type.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the trait bound `i32: __ClapCountActionRequiresU8` is not satisfied
+ --> tests/derive_ui/count_action_wrong_type.rs:6:14
+  |
+6 |     verbose: i32,
+  |              ^^^ the trait `__ClapCountActionRequiresU8` is not implemented for `i32`
+  |
+help: the trait `__ClapCountActionRequiresU8` is implemented for `u8`
+ --> tests/derive_ui/count_action_wrong_type.rs:6:14
+  |
+6 |     verbose: i32,
+  |              ^^^
+note: required by a bound in `__clap_assert_count_action_type`
+ --> tests/derive_ui/count_action_wrong_type.rs:6:14
+  |
+6 |     verbose: i32,
+  |              ^^^ required by this bound in `__clap_assert_count_action_type`


### PR DESCRIPTION
### What does this PR try to solve?

Closes #3864

`ArgAction::Count` currently allows incompatible derive field types and only fails when the generated command is built. This adds a generated `u8` type constraint for explicit `ArgAction::Count` paths, so an incompatible field is reported at compile time with the diagnostic pointing at that field.

The regression coverage includes a compile-fail case for `i32` and a positive case confirming that type aliases to `u8` remain supported.

### Notes to reviewers

Validated with:

- `make test-full`
- `make clippy-full`
- `make doc`
- `cargo test --features derive,unstable-derive-ui-tests --test derive_ui ui -- --exact`
- `cargo test --features derive --test derive flags::count_type_alias -- --exact`
- `cargo fmt --all -- --check`
