### PR TITLE
fix(clap_complete_nushell): Set argument type to `directory` for `ValueHint::DirPath`

### DIFF
--- a/clap_complete_nushell/src/lib.rs
+++ b/clap_complete_nushell/src/lib.rs
@@ -79,7 +79,7 @@ fn append_value_completion_and_help(
             ValueHint::Other => "string",
             ValueHint::AnyPath => "path",
             ValueHint::FilePath => "path",
-            ValueHint::DirPath => "path",
+            ValueHint::DirPath => "directory",
             ValueHint::ExecutablePath => "path",
             ValueHint::CommandName => "string",
             ValueHint::CommandString => "string",

--- a/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
+++ b/clap_complete_nushell/tests/snapshots/home/static/test/nu/.config/nushell/completions/test.nu
@@ -190,7 +190,7 @@ module completions {
     --other: string
     --path(-p): path
     --file(-f): path
-    --dir(-d): path
+    --dir(-d): directory
     --exe(-e): path
     --cmd-name: string
     --cmd(-c): string

--- a/clap_complete_nushell/tests/snapshots/value_hint.nu
+++ b/clap_complete_nushell/tests/snapshots/value_hint.nu
@@ -10,7 +10,7 @@ module completions {
     --other: string
     --path(-p): path
     --file(-f): path
-    --dir(-d): path
+    --dir(-d): directory
     --exe(-e): path
     --cmd-name: string
     --cmd(-c): string


### PR DESCRIPTION
### What does this PR try to solve?

The current implementation incorrectly maps `ValueHint::DirPath` to the `path` type, when according to the [Nushell documentation](https://www.nushell.sh/book/custom_commands.html#parameter-types) in the "List of Type Annotations" section, there is a dedicated `directory` type that provides more accurate completions by restricting suggestions to directories only.

### Notes to reviewers

- I updated the existing snapshot test.
- I ran `make test-full` to verify the change doesn't introduce regressions.
- In my opinion, this is a trivial change, so I didn't create an issue. However, I can do so if preferred, per the [PR style guidelines](https://epage.github.io/dev/pr-style/#d-issue).