### PR TITLE
fix(nushell): skip dotted long options

### DIFF
--- a/clap_complete_nushell/src/lib.rs
+++ b/clap_complete_nushell/src/lib.rs
@@ -157,7 +157,11 @@ fn append_argument(arg: &Arg, name: &str, s: &mut String) {
     }
 
     let shorts = arg.get_short_and_visible_aliases();
-    let longs = arg.get_long_and_visible_aliases();
+    let longs = arg.get_long_and_visible_aliases().and_then(|mut longs| {
+        // Nushell extern signatures cannot represent long options containing dots.
+        longs.retain(|long| !long.contains('.'));
+        (!longs.is_empty()).then_some(longs)
+    });
 
     match shorts {
         Some(shorts) => match longs {
@@ -193,16 +197,15 @@ fn append_argument(arg: &Arg, name: &str, s: &mut String) {
                 }
             }
         },
-        None => match longs {
-            Some(longs) => {
+        None => {
+            if let Some(longs) = longs {
                 // long options only
                 for long in longs {
                     s.push_str(format!("    --{long}").as_str());
                     append_value_completion_and_help(arg, name, &possible_values, s);
                 }
             }
-            None => unreachable!("No short or long options found"),
-        },
+        }
     }
 }
 

--- a/clap_complete_nushell/tests/common.rs
+++ b/clap_complete_nushell/tests/common.rs
@@ -17,6 +17,12 @@ pub(crate) fn basic_command(name: &'static str) -> Command {
                 .conflicts_with("config")
                 .action(ArgAction::SetTrue),
         )
+        .arg(Arg::new("nested.option").long("nested.option"))
+        .arg(
+            Arg::new("nested.short-option")
+                .short('n')
+                .long("nested.short-option"),
+        )
         .subcommand(
             Command::new("test")
                 .about("Subcommand\nwith a second line")

--- a/clap_complete_nushell/tests/snapshots/basic.nu
+++ b/clap_complete_nushell/tests/snapshots/basic.nu
@@ -3,6 +3,7 @@ module completions {
   export extern my-app [
     -c
     -v
+    -n: string
     --help(-h)                # Print help
   ]
 


### PR DESCRIPTION
### What does this PR try to solve?

Closes #6112

Nushell extern signatures reject dotted long options. Omit dotted long names from generated signatures while retaining a valid short name when one exists.

### Notes to reviewers

- The snapshot covers a dotted-only long option and a short-plus-dotted-long option. The generated completion omits the invalid dotted names and retains `-n` for the latter.
- `cargo test -p clap_complete_nushell --locked` — snapshot tests 9/9 and doctests 2/2 passed.
- `cargo test -p clap_complete_nushell --features unstable-shell-tests --locked` — Nushell integration 4/4, snapshot tests 9/9, and doctests 2/2 passed.
- `cargo check -p clap_complete_nushell --all-targets --all-features --locked`, `cargo clippy -p clap_complete_nushell --all-targets --all-features --locked -- -D warnings -A deprecated`, and `cargo fmt --check` passed.
- Not run: workspace-wide test/check/clippy commands and the MSRV 1.85 boundary; the local toolchain set does not include Rust 1.85.