### PR TITLE
feat(derive): Support #[command(flatten = "prefix-")] for namespaced flattening

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4841,7 +4841,80 @@ impl fmt::Debug for Arg {
 #[cfg(feature = "unstable-ext")]
 pub trait ArgExt: Extension {}
 
+#[cfg(feature = "string")]
+impl Arg {
+    /// Remaps this arg onto `prefix`: the id, the `--long` name and its
+    /// aliases, and every id reference (group membership, conflicts,
+    /// overrides, requires, conditional requirements and conditional
+    /// defaults) gain the prefix verbatim, and the env name gains the prefix
+    /// uppercased with `-` mapped to `_`.
+    ///
+    /// Panics if the arg carries a short flag or short alias, or is
+    /// positional: neither can be prefixed.
+    pub(crate) fn prefix(mut self, prefix: &str) -> Self {
+        if self.short.is_some() || !self.short_aliases.is_empty() {
+            panic!(
+                "cannot prefix argument `{}`: short flags cannot be prefixed",
+                self.id
+            );
+        }
+        if self.long.is_none() {
+            panic!(
+                "cannot prefix argument `{}`: positional arguments cannot be prefixed",
+                self.id
+            );
+        }
+        self.id = self.id.prefixed(prefix);
+        if let Some(long) = self.long.take() {
+            self.long = Some(format!("{prefix}{long}").into());
+        }
+        for (alias, _visible) in &mut self.aliases {
+            *alias = format!("{prefix}{alias}").into();
+        }
+        #[cfg(feature = "env")]
+        if let Some((env, value)) = &mut self.env {
+            let mut name = OsString::from(prefix.to_uppercase().replace('-', "_"));
+            name.push(env.as_os_str());
+            // `Arg::env` caches the looked-up value, so re-resolve it under
+            // the prefixed name.
+            *value = env::var_os(&name);
+            *env = name.into();
+        }
+        self.groups = self.groups.iter().map(|g| g.prefixed(prefix)).collect();
+        self.conflicts = self.conflicts.iter().map(|c| c.prefixed(prefix)).collect();
+        self.overrides = self.overrides.iter().map(|o| o.prefixed(prefix)).collect();
+        self.requires = self
+            .requires
+            .iter()
+            .map(|(predicate, id)| (predicate.clone(), id.prefixed(prefix)))
+            .collect();
+        self.r_ifs = self
+            .r_ifs
+            .iter()
+            .map(|(id, value)| (id.prefixed(prefix), value.clone()))
+            .collect();
+        self.r_ifs_all = self
+            .r_ifs_all
+            .iter()
+            .map(|(id, value)| (id.prefixed(prefix), value.clone()))
+            .collect();
+        self.r_unless = self.r_unless.iter().map(|id| id.prefixed(prefix)).collect();
+        self.r_unless_all = self
+            .r_unless_all
+            .iter()
+            .map(|id| id.prefixed(prefix))
+            .collect();
+        self.default_vals_ifs = self
+            .default_vals_ifs
+            .iter()
+            .map(|(id, predicate, value)| (id.prefixed(prefix), predicate.clone(), value.clone()))
+            .collect();
+        self
+    }
+}
+
 // Flags
+
 #[cfg(test)]
 mod test {
     use super::Arg;

--- a/clap_builder/src/builder/arg_group.rs
+++ b/clap_builder/src/builder/arg_group.rs
@@ -534,6 +534,19 @@ impl From<&'_ ArgGroup> for ArgGroup {
     }
 }
 
+#[cfg(feature = "string")]
+impl ArgGroup {
+    /// Remaps this group onto `prefix`: the id, the membership, and the
+    /// requires/conflicts references, preserving every other setting.
+    pub(crate) fn prefixed(mut self, prefix: &str) -> Self {
+        self.id = self.id.prefixed(prefix);
+        self.args = self.args.iter().map(|a| a.prefixed(prefix)).collect();
+        self.requires = self.requires.iter().map(|r| r.prefixed(prefix)).collect();
+        self.conflicts = self.conflicts.iter().map(|c| c.prefixed(prefix)).collect();
+        self
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -301,6 +301,47 @@ impl Command {
         self
     }
 
+    /// Prefixes every argument and group of this `Command` with `prefix`:
+    /// argument ids, `--long` names and aliases, and every id reference gain
+    /// the prefix verbatim, env names gain the prefix uppercased with `-`
+    /// mapped to `_`, and group ids and memberships are remapped to match.
+    ///
+    /// This namespaces a flattened child `Args` struct so the same struct can
+    /// be flattened more than once (derive: `#[command(flatten = "prefix-")]`).
+    ///
+    /// Requires the `string` feature.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any argument carries a short flag or short alias, or is
+    /// positional: neither can be prefixed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, Arg};
+    /// let cmd = Command::new("prog")
+    ///     .arg(Arg::new("host").long("host"))
+    ///     .prefix_args("source-");
+    ///
+    /// let matches = cmd.get_matches_from(["prog", "--source-host", "example.com"]);
+    /// assert_eq!(
+    ///     matches.get_one::<String>("source-host").map(String::as_str),
+    ///     Some("example.com")
+    /// );
+    /// ```
+    #[must_use]
+    #[cfg(feature = "string")]
+    pub fn prefix_args(self, prefix: &str) -> Self {
+        let mut cmd = self.mut_args(|arg| arg.prefix(prefix));
+        let group_ids: Vec<Id> = cmd.get_groups().map(|g| g.get_id().clone()).collect();
+        for group_id in group_ids {
+            cmd = cmd.mut_group(group_id.as_str(), |group| group.prefixed(prefix));
+        }
+        cmd
+    }
+
     /// Allows one to mutate an [`ArgGroup`] after it's been added to a [`Command`].
     ///
     /// # Panics

--- a/clap_builder/src/derive.rs
+++ b/clap_builder/src/derive.rs
@@ -217,6 +217,12 @@ pub trait FromArgMatches: Sized {
 /// with:
 /// - `#[command(flatten)] args: ChildArgs`: Attribute can only be used with struct fields that impl
 ///   `Args`.
+/// - `#[command(flatten = "prefix-")] args: ChildArgs`: Like `flatten`, but prepends `"prefix-"`
+///   to each argument's id, `--long` name, and env name (as the prefix uppercased with `-` mapped
+///   to `_`), allowing the same `Args` type to be flattened multiple times with different prefixes
+///   (e.g. `--source-host` and `--dest-host` from one struct). Requires the `string` feature.
+///   Short flags and positional arguments cannot be prefixed and panic at command construction
+///   time.
 /// - `Variant(ChildArgs)`: No attribute is used with enum variants that impl `Args`.
 ///
 /// <div class="warning">

--- a/clap_builder/src/parser/matches/arg_matches.rs
+++ b/clap_builder/src/parser/matches/arg_matches.rs
@@ -1235,6 +1235,76 @@ impl ArgMatches {
         ok!(self.verify_arg(id));
         Ok(self.args.remove_entry(id).is_some())
     }
+
+    /// Extracts all arguments whose ids start with `prefix` into a new
+    /// [`ArgMatches`], stripping the prefix from each id.
+    ///
+    /// This backs `#[command(flatten = "prefix")]` in the derive: a flattened
+    /// struct's [`FromArgMatches`][crate::FromArgMatches] implementation finds
+    /// its arguments under their unprefixed names.
+    ///
+    /// Entries are moved out of `self` into the returned [`ArgMatches`].
+    /// Matching is a plain string comparison on the id: every entry whose id
+    /// starts with `prefix` is moved, so overlapping prefixes are the
+    /// caller's responsibility.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Command, Arg};
+    /// let mut matches = Command::new("prog")
+    ///     .arg(Arg::new("source-host").long("source-host"))
+    ///     .get_matches_from(["prog", "--source-host", "example.com"]);
+    ///
+    /// let child = matches.remove_prefixed("source-");
+    /// assert_eq!(
+    ///     child.get_one::<String>("host").map(String::as_str),
+    ///     Some("example.com")
+    /// );
+    /// ```
+    #[cfg(feature = "string")]
+    pub fn remove_prefixed(&mut self, prefix: &str) -> ArgMatches {
+        let mut new_args = FlatMap::new();
+        #[cfg(debug_assertions)]
+        let mut new_valid = Vec::new();
+
+        let matching_keys: Vec<Id> = self
+            .args
+            .keys()
+            .filter(|k| k.as_str().starts_with(prefix))
+            .cloned()
+            .collect();
+
+        for key in matching_keys {
+            if let Some((_id, matched)) = self.args.remove_entry(key.as_str()) {
+                let stripped = &key.as_str()[prefix.len()..];
+                new_args.insert(Id::from(stripped.to_owned()), matched);
+            }
+        }
+
+        #[cfg(debug_assertions)]
+        {
+            self.valid_args.retain(|id| {
+                if id.as_str().starts_with(prefix) {
+                    let stripped = &id.as_str()[prefix.len()..];
+                    new_valid.push(Id::from(stripped.to_owned()));
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+
+        ArgMatches {
+            #[cfg(debug_assertions)]
+            valid_args: new_valid,
+            #[cfg(debug_assertions)]
+            valid_subcommands: Default::default(),
+            args: new_args,
+            subcommand: None,
+        }
+    }
 }
 
 // Private methods

--- a/clap_builder/src/util/id.rs
+++ b/clap_builder/src/util/id.rs
@@ -27,6 +27,12 @@ impl Id {
     pub(crate) fn as_internal_str(&self) -> &Str {
         &self.0
     }
+
+    /// Returns a new `Id` with `prefix` prepended verbatim
+    #[cfg(feature = "string")]
+    pub(crate) fn prefixed(&self, prefix: &str) -> Self {
+        Self::from(format!("{prefix}{}", self.as_str()))
+    }
 }
 
 impl From<&'_ Id> for Id {

--- a/clap_derive/src/derives/args.rs
+++ b/clap_derive/src/derives/args.rs
@@ -235,7 +235,30 @@ pub(crate) fn gen_augment(
                 } else {
                     quote! {}
                 };
-                if override_required {
+                if let Some(prefix_lit) = item.flatten_prefix() {
+                    let augment_call = if override_required {
+                        quote_spanned! { kind.span()=>
+                            <#inner_type as clap::Args>::augment_args_for_update
+                        }
+                    } else {
+                        quote_spanned! { kind.span()=>
+                            <#inner_type as clap::Args>::augment_args
+                        }
+                    };
+                    Some(quote_spanned! { kind.span()=>
+                        #flatten_group_assert
+                        let #app_var = #app_var
+                            #next_help_heading
+                            #next_display_order;
+                        let #app_var = {
+                            let __clap_child = #augment_call(clap::Command::new("__flatten_prefix"))
+                                .prefix_args(#prefix_lit);
+                            #app_var
+                                .args(__clap_child.get_arguments().cloned())
+                                .groups(__clap_child.get_groups().cloned())
+                        };
+                    })
+                } else if override_required {
                     Some(quote_spanned! { kind.span()=>
                         #flatten_group_assert
                         let #app_var = #app_var
@@ -498,10 +521,38 @@ pub(crate) fn gen_constructor(fields: &[(&Field, Item)]) -> Result<TokenStream, 
                     (Ty::Option, Some(sub_type)) => sub_type,
                     _ => &field.ty,
                 };
+                let prefix_lit = item.flatten_prefix();
                 match **ty {
+                    Ty::Other if prefix_lit.is_some() => {
+                        let prefix_lit = prefix_lit.unwrap();
+                        quote_spanned! { kind.span()=>
+                            #field_name: {
+                                let mut __clap_prefixed = #arg_matches.remove_prefixed(#prefix_lit);
+                                <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(&mut __clap_prefixed)?
+                            }
+                        }
+                    },
                     Ty::Other => {
                         quote_spanned! { kind.span()=>
                             #field_name: <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(#arg_matches)?
+                        }
+                    },
+                    Ty::Option if prefix_lit.is_some() => {
+                        let prefix_lit = prefix_lit.unwrap();
+                        quote_spanned! { kind.span()=>
+                            #field_name: {
+                                let group_id = <#inner_type as clap::Args>::group_id()
+                                    .expect("asserted during `Arg` creation");
+                                let prefixed_group_id = format!("{}{}", #prefix_lit, group_id.as_str());
+                                if #arg_matches.contains_id(prefixed_group_id.as_str()) {
+                                    let mut __clap_prefixed = #arg_matches.remove_prefixed(#prefix_lit);
+                                    Some(
+                                        <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(&mut __clap_prefixed)?
+                                    )
+                                } else {
+                                    None
+                                }
+                            }
                         }
                     },
                     Ty::Option => {
@@ -616,8 +667,30 @@ pub(crate) fn gen_updater(
                     _ => &field.ty,
                 };
 
-                let updater = quote_spanned! { ty.span()=>
-                    <#inner_type as clap::FromArgMatches>::update_from_arg_matches_mut(#field_name, #arg_matches)?;
+                let updater = if let Some(prefix_lit) = item.flatten_prefix() {
+                    quote_spanned! { ty.span()=>
+                        let mut __clap_prefixed = #arg_matches.remove_prefixed(#prefix_lit);
+                        <#inner_type as clap::FromArgMatches>::update_from_arg_matches_mut(#field_name, &mut __clap_prefixed)?;
+                    }
+                } else {
+                    quote_spanned! { ty.span()=>
+                        <#inner_type as clap::FromArgMatches>::update_from_arg_matches_mut(#field_name, #arg_matches)?;
+                    }
+                };
+
+                let constructor = if let Some(prefix_lit) = item.flatten_prefix() {
+                    quote_spanned! { kind.span()=>
+                        {
+                            let mut __clap_prefixed = #arg_matches.remove_prefixed(#prefix_lit);
+                            <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(&mut __clap_prefixed)?
+                        }
+                    }
+                } else {
+                    quote_spanned! { kind.span()=>
+                        <#inner_type as clap::FromArgMatches>::from_arg_matches_mut(
+                            #arg_matches
+                        )?
+                    }
                 };
 
                 let updater = match **ty {
@@ -625,9 +698,7 @@ pub(crate) fn gen_updater(
                         if let Some(#field_name) = #field_name.as_mut() {
                             #updater
                         } else {
-                            *#field_name = Some(<#inner_type as clap::FromArgMatches>::from_arg_matches_mut(
-                                #arg_matches
-                            )?);
+                            *#field_name = Some(#constructor);
                         }
                     },
                     _ => quote_spanned! { kind.span()=>

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -181,6 +181,12 @@ fn gen_augment(
 
             Kind::Flatten(_) => match variant.fields {
                 Unnamed(FieldsUnnamed { ref unnamed, .. }) if unnamed.len() == 1 => {
+                    if let Some(prefix) = item.flatten_prefix() {
+                        abort!(
+                            prefix,
+                            "`flatten` prefixes are only supported on `Args` fields"
+                        );
+                    }
                     let ty = &unnamed[0].ty;
                     let deprecations = if !override_required {
                         item.deprecations()

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -50,6 +50,7 @@ pub(crate) struct Item {
     group_id: Name,
     group_methods: Vec<Method>,
     kind: Sp<Kind>,
+    flatten_prefix: Option<LitStr>,
 }
 
 impl Item {
@@ -279,6 +280,7 @@ impl Item {
             group_id,
             group_methods: vec![],
             kind,
+            flatten_prefix: None,
         }
     }
 
@@ -387,10 +389,13 @@ impl Item {
                     let kind = Sp::new(Kind::ExternalSubcommand, attr.name.span());
                     Some(kind)
                 }
-                Some(MagicAttrName::Flatten) if attr.value.is_none() => {
+                Some(MagicAttrName::Flatten) => {
                     if attr.value.is_some() {
-                        let expr = attr.value_or_abort()?;
-                        abort!(expr, "attribute `{}` does not accept a value", attr.name);
+                        let lit = attr.lit_str_or_abort()?;
+                        if lit.value().is_empty() {
+                            abort!(lit, "`flatten` prefix must not be empty");
+                        }
+                        self.flatten_prefix = Some(lit.clone());
                     }
                     let ty = self
                         .kind()
@@ -1067,6 +1072,10 @@ impl Item {
 
     pub(crate) fn kind(&self) -> Sp<Kind> {
         self.kind.clone()
+    }
+
+    pub(crate) fn flatten_prefix(&self) -> Option<&LitStr> {
+        self.flatten_prefix.as_ref()
     }
 
     pub(crate) fn is_positional(&self) -> bool {

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -188,6 +188,18 @@
 //!   - **Tip:** Though we do apply a flattened [`Args`][crate::Args]'s Parent Command Attributes, this
 //!     makes reuse harder. Generally prefer putting the cmd attributes on the
 //!     [`Parser`][crate::Parser] or on the flattened field.
+//! - `flatten = "prefix-"`: Like `flatten`, but prepends `prefix-` to each argument's id and
+//!   `--long` name, allowing the same [`Args`][crate::Args] type to be flattened multiple times
+//!   with different prefixes.
+//!   Env names are prepended with the prefix uppercased and `-` mapped to `_`
+//!   (`env = "HOST"` becomes `SOURCE_HOST` for the prefix `source-`).
+//!   - Requires the [`string` feature][crate::_features].
+//!   - Short flags and positional arguments cannot be prefixed; a runtime panic is raised at
+//!     command construction time if the flattened type contains any.
+//!   - Unlike plain `flatten`, the child's Parent Command Attributes (including
+//!     [`next_help_heading`][crate::Command::next_help_heading] on the child struct) are not
+//!     applied to the parent command.
+//!   - Example: `#[command(flatten = "source-")] source: Opts` turns `--host` into `--source-host`.
 //! - `subcommand`: Delegates definition of subcommands to the field (must implement
 //!   [`Subcommand`][crate::Subcommand])
 //!   - When `Option<T>`, the subcommand becomes optional

--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -303,3 +303,428 @@ fn flatten_skipped_group() {
 
     Cli::try_parse_from(["test"]).unwrap();
 }
+
+#[cfg(feature = "string")]
+mod flatten_prefix {
+    use clap::error::ErrorKind;
+    use snapbox::assert_data_eq;
+    use snapbox::str;
+
+    use super::*;
+    use crate::utils;
+
+    #[test]
+    fn basic_prefix() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: String,
+            #[arg(long)]
+            username: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+        }
+
+        assert_eq!(
+            Cli {
+                source: StorageOptions {
+                    host: "localhost".into(),
+                    username: "admin".into(),
+                }
+            },
+            Cli::try_parse_from([
+                "test",
+                "--source-host",
+                "localhost",
+                "--source-username",
+                "admin"
+            ])
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn duplicate_flatten_with_different_prefixes() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: String,
+            #[arg(long)]
+            username: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+            #[command(flatten = "dest-")]
+            dest: StorageOptions,
+        }
+
+        assert_eq!(
+            Cli {
+                source: StorageOptions {
+                    host: "src.example.com".into(),
+                    username: "reader".into(),
+                },
+                dest: StorageOptions {
+                    host: "dst.example.com".into(),
+                    username: "writer".into(),
+                },
+            },
+            Cli::try_parse_from([
+                "test",
+                "--source-host",
+                "src.example.com",
+                "--source-username",
+                "reader",
+                "--dest-host",
+                "dst.example.com",
+                "--dest-username",
+                "writer",
+            ])
+            .unwrap()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "short flags cannot be prefixed")]
+    fn prefix_with_short_flag_panics() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Opts {
+            #[arg(short, long)]
+            verbose: bool,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            opts: Opts,
+        }
+
+        // The panic happens during command construction (augment_args).
+        let _ = Cli::try_parse_from(["test"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "positional arguments cannot be prefixed")]
+    fn prefix_with_positional_panics() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Opts {
+            path: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            opts: Opts,
+        }
+
+        // The panic happens during command construction (augment_args).
+        let _ = Cli::try_parse_from(["test"]);
+    }
+
+    #[test]
+    fn prefix_help_shows_prefixed_flags() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: String,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+        }
+
+        let help = utils::get_help::<Cli>();
+        assert_data_eq!(help, str![[r#"
+Usage: clap --source-host <HOST>
+
+Options:
+      --source-host <HOST>  
+  -h, --help                Print help
+
+"#]]);
+    }
+
+    #[test]
+    fn prefix_with_optional_flatten() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            source: Option<StorageOptions>,
+        }
+
+        // Without args, the optional should be None.
+        let cli = Cli::try_parse_from(["test"]).unwrap();
+        assert_eq!(cli.source, None);
+
+        // With args, the optional should be Some.
+        let cli = Cli::try_parse_from(["test", "--src-host", "localhost"]).unwrap();
+        assert_eq!(
+            cli.source,
+            Some(StorageOptions {
+                host: Some("localhost".into())
+            })
+        );
+    }
+
+    #[test]
+    fn prefix_preserves_groups() {
+        #[derive(Args, PartialEq, Debug)]
+        struct AuthOptions {
+            #[arg(long, group = "auth")]
+            token: Option<String>,
+            #[arg(long, group = "auth")]
+            api_key: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: AuthOptions,
+            #[command(flatten = "dest-")]
+            dest: AuthOptions,
+        }
+
+        // One member of each group parses.
+        let cli =
+            Cli::try_parse_from(["test", "--source-token", "a", "--dest-api-key", "b"]).unwrap();
+        assert_eq!(cli.source.token.as_deref(), Some("a"));
+        assert_eq!(cli.dest.api_key.as_deref(), Some("b"));
+
+        // Group exclusivity survives the remapping: two members of one
+        // prefixed group still conflict.
+        let res = Cli::try_parse_from(["test", "--source-token", "a", "--source-api-key", "b"]);
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn prefix_remaps_conflicts() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Opts {
+            #[arg(long)]
+            token: Option<String>,
+            #[arg(long, conflicts_with = "token")]
+            password: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            src: Opts,
+            #[command(flatten = "dst-")]
+            dst: Opts,
+        }
+
+        // The remapped conflict still fires within one prefix.
+        let res = Cli::try_parse_from(["test", "--src-token", "a", "--src-password", "b"]);
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::ArgumentConflict);
+
+        // No bleed across prefixes.
+        let cli =
+            Cli::try_parse_from(["test", "--src-token", "a", "--dst-password", "b"]).unwrap();
+        assert_eq!(cli.src.token.as_deref(), Some("a"));
+        assert_eq!(cli.dst.password.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn prefix_remaps_requires() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Opts {
+            #[arg(long, requires = "cert")]
+            key: Option<String>,
+            #[arg(long)]
+            cert: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            src: Opts,
+        }
+
+        let res = Cli::try_parse_from(["test", "--src-key", "k"]);
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::MissingRequiredArgument);
+
+        let cli = Cli::try_parse_from(["test", "--src-key", "k", "--src-cert", "c"]).unwrap();
+        assert_eq!(cli.src.key.as_deref(), Some("k"));
+        assert_eq!(cli.src.cert.as_deref(), Some("c"));
+    }
+
+    #[test]
+    fn prefix_remaps_default_value_if() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Opts {
+            #[arg(long)]
+            mode: Option<String>,
+            #[arg(long, default_value_if("mode", "fast", "8"))]
+            threads: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            opts: Opts,
+        }
+
+        let cli = Cli::try_parse_from(["test", "--src-mode", "fast"]).unwrap();
+        assert_eq!(cli.opts.threads.as_deref(), Some("8"));
+
+        let cli = Cli::try_parse_from(["test"]).unwrap();
+        assert_eq!(cli.opts.threads, None);
+    }
+
+    #[test]
+    fn prefix_remaps_long_aliases() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Opts {
+            #[arg(long, alias = "hostname")]
+            host: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            src: Opts,
+        }
+
+        let cli = Cli::try_parse_from(["test", "--src-hostname", "h"]).unwrap();
+        assert_eq!(cli.src.host.as_deref(), Some("h"));
+    }
+
+    #[test]
+    fn prefix_update_from() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: Option<String>,
+            #[arg(long)]
+            username: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            source: StorageOptions,
+        }
+
+        let mut cli =
+            Cli::try_parse_from(["test", "--src-host", "a", "--src-username", "u"]).unwrap();
+        cli.try_update_from(["test", "--src-host", "b"]).unwrap();
+        assert_eq!(cli.source.host.as_deref(), Some("b"));
+        assert_eq!(cli.source.username.as_deref(), Some("u"));
+    }
+
+    #[test]
+    fn prefix_update_from_optional() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long)]
+            host: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "src-")]
+            source: Option<StorageOptions>,
+        }
+
+        // Updating a `None` constructs the child from the prefixed matches.
+        let mut cli = Cli::try_parse_from(["test"]).unwrap();
+        assert_eq!(cli.source, None);
+        cli.try_update_from(["test", "--src-host", "example.com"])
+            .unwrap();
+        assert_eq!(
+            cli.source,
+            Some(StorageOptions {
+                host: Some("example.com".into())
+            })
+        );
+
+        // Updating a `Some` updates it in place.
+        cli.try_update_from(["test", "--src-host", "other.example.com"])
+            .unwrap();
+        assert_eq!(
+            cli.source,
+            Some(StorageOptions {
+                host: Some("other.example.com".into())
+            })
+        );
+    }
+
+    #[test]
+    fn prefix_nested_flatten() {
+        #[derive(Args, PartialEq, Debug)]
+        struct Inner {
+            #[arg(long)]
+            value: Option<String>,
+        }
+
+        #[derive(Args, PartialEq, Debug)]
+        struct Middle {
+            #[command(flatten = "in-")]
+            inner: Inner,
+            #[arg(long)]
+            direct: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "out-")]
+            middle: Middle,
+        }
+
+        let cli =
+            Cli::try_parse_from(["test", "--out-in-value", "v", "--out-direct", "d"]).unwrap();
+        assert_eq!(cli.middle.inner.value.as_deref(), Some("v"));
+        assert_eq!(cli.middle.direct.as_deref(), Some("d"));
+    }
+
+    #[cfg(feature = "env")]
+    #[test]
+    fn prefix_env_variables() {
+        #[derive(Args, PartialEq, Debug)]
+        struct StorageOptions {
+            #[arg(long, env = "CLP_TEST_FLATTEN_PREFIX_HOST")]
+            host: Option<String>,
+        }
+
+        #[derive(Parser, PartialEq, Debug)]
+        struct Cli {
+            #[command(flatten = "source-")]
+            source: StorageOptions,
+        }
+
+        unsafe {
+            std::env::set_var("CLP_TEST_FLATTEN_PREFIX_HOST", "unprefixed");
+            std::env::set_var("SOURCE_CLP_TEST_FLATTEN_PREFIX_HOST", "prefixed");
+        }
+        // Only the prefixed name is consulted.
+        let cli = Cli::try_parse_from(["test"]).unwrap();
+        assert_eq!(cli.source.host.as_deref(), Some("prefixed"));
+
+        // The unprefixed name is ignored.
+        unsafe {
+            std::env::remove_var("SOURCE_CLP_TEST_FLATTEN_PREFIX_HOST");
+        }
+        let cli = Cli::try_parse_from(["test"]).unwrap();
+        assert_eq!(cli.source.host, None);
+
+        unsafe {
+            std::env::remove_var("CLP_TEST_FLATTEN_PREFIX_HOST");
+        }
+    }
+}


### PR DESCRIPTION
Implements "Flatten with prefix" (#2293, folded into #3117) using the child-as-`Command` → mutate → merge mechanism proposed in #5050.

```rust
#[derive(Args)]
struct StorageOptions {
    #[arg(long)]
    host: String,
}

#[derive(Parser)]
struct Cli {
    #[command(flatten = "source-")]
    source: StorageOptions,
    #[command(flatten = "dest-")]
    dest: StorageOptions,
}
// --source-host and --dest-host, one struct.
```

The child struct is built into its own `Command`, prefixed there, and only then merged into the parent, so nothing collides mid-merge. This picks up where #6316 by @xfbs left off, with these correctness additions:

- Groups keep their settings: membership and group ids are remapped in place, so `required`, `multiple`, `requires`, and `conflicts` survive.
- Every id reference is remapped (`conflicts_with`, `overrides`, `requires`, `required_if_eq*`, `required_unless_present*`, `default_value_if*`), along with long aliases.
- Env names are prepended with the prefix uppercased and `-` mapped to `_`, and the cached env value is re-resolved under the new name (`Arg::env` captures `var_os` at setter time).

## How it works

- New `Command::prefix_args(prefix)` (`string` feature): prefixes every argument id, `--long` name and alias, env name, and id reference, plus group ids, membership, and group relations. Hand-rolled builder users get the same capability the derive uses.
- New `ArgMatches::remove_prefixed(prefix)`: moves the prefixed entries into a fresh `ArgMatches` with the prefix stripped, so the child's `FromArgMatches` finds its fields under their own names.
- The derive accepts an optional string on the flatten attribute and emits build → prefix → merge in `augment_args` / `augment_args_for_update`.

## Limits

- Short flags and positional arguments cannot be prefixed and panic at command construction time. Relaxing this later is non-breaking; the reverse would not be.
- Requires the `string` feature (runtime-generated ids and longs).
- Empty prefixes, and prefixes on `Subcommand` flatten variants, are compile errors.
- Unlike plain `flatten`, the child's parent command attributes (e.g. `next_help_heading` on the child struct) are not applied to the parent.
- `remove_prefixed` matches ids by plain `starts_with`; overlapping prefixes are the caller's responsibility.
- Value names stay unprefixed, so help renders `--source-host <HOST>`.

## Tests

15 cases in `tests/derive/flatten.rs`: basics, the same struct flattened twice, remapped relationships (`conflicts_with`, `requires`, `default_value_if`, long aliases), group exclusivity, optional flattens, `update_from` for plain and optional flattens, nested prefixes, env prefixing with isolation from the unprefixed name, a snapbox help snapshot, and the short-flag/positional panics.

## Notes for the reviewer

- Please find further discussion in #5050.
- Towards #5050; covers the use cases of #2293 and #3117.