### PR TITLE
fix(mangen): Hide hidden positionals from the SYNOPSIS

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -78,7 +78,7 @@ pub(crate) fn synopsis(roff: &mut Roff, cmd: &clap::Command) {
         line.push(roman(" "));
     }
 
-    for arg in cmd.get_positionals() {
+    for arg in cmd.get_positionals().filter(|arg| !arg.is_hide_set()) {
         if group_members.iter().any(|gm| gm.get_id() == arg.get_id()) {
             continue;
         }

--- a/clap_mangen/tests/snapshots/hidden_positional.bash.roff
+++ b/clap_mangen/tests/snapshots/hidden_positional.bash.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] [\fIvisible\fR] [\fIsecret\fR] 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+[\fIvisible\fR]
+A visible positional

--- a/clap_mangen/tests/snapshots/hidden_positional.bash.roff
+++ b/clap_mangen/tests/snapshots/hidden_positional.bash.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] [\fIvisible\fR] [\fIsecret\fR] 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] [\fIvisible\fR] 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -261,6 +261,16 @@ pub(crate) fn hidden_option_command(name: &'static str) -> clap::Command {
         )
 }
 
+pub(crate) fn hidden_positional_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(clap::Arg::new("visible").help("A visible positional"))
+        .arg(
+            clap::Arg::new("secret")
+                .hide(true)
+                .help("An internal positional"),
+        )
+}
+
 #[cfg(feature = "env")]
 pub(crate) fn env_value_command(name: &'static str) -> clap::Command {
     clap::Command::new(name).arg(

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -63,6 +63,16 @@ fn hidden_options() {
 }
 
 #[test]
+fn hidden_positionals() {
+    let name = "my-app";
+    let cmd = common::hidden_positional_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/hidden_positional.bash.roff"],
+        cmd,
+    );
+}
+
+#[test]
 fn override_usage() {
     let name = "my-app";
     let cmd = common::override_usage_command(name);


### PR DESCRIPTION
### What does this PR try to solve?

Fixes #6481

`clap_mangen`'s SYNOPSIS rendered positional arguments marked with `Arg::hide(true)`, while

- clap's own usage line skips hidden positionals ([`usage.rs`](https://github.com/clap-rs/clap/blob/8e50ec891e30cd2af4f9a62a405a5b7ee31aac4f/clap_builder/src/output/usage.rs#L324-L327)),
- the SYNOPSIS already filters hidden short/long arguments (#3605),
- and the OPTIONS / SUBCOMMANDS sections filter hidden items too.

So a man page could advertise a positional in the SYNOPSIS that is documented nowhere else on the page. This applies the same `is_hide_set()` filter to the positionals loop in `synopsis()`.

### Notes to reviewers

- Follows the "test commit first, then fix commit" convention: the first commit snapshots the current behavior (`[secret]` present in SYNOPSIS), the second commit's snapshot diff shows exactly what changed.
- Test evidence (`cargo test -p clap_mangen`):

  ```console
  $ cargo test -p clap_mangen
  test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
  ```

  Regenerating all snapshots with `SNAPSHOTS=overwrite` only changed `hidden_positional.bash.roff`, so no other rendering scenario is affected. Other workspace crates were not run.
- This PR was prepared with AI assistance; I reproduced the issue locally and reviewed every change.
