### PR TITLE
docs(error): teach Error::render() via .ansi(), not Display (#6471)

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -281,6 +281,12 @@ impl<F: ErrorFormatter> Error<F> {
 
     /// Render the error message to a [`StyledStr`].
     ///
+    /// The returned `StyledStr` carries any ANSI styling that was active
+    /// when the error was formatted. To print those styles to a terminal
+    /// (or any stream), use [`StyledStr::ansi`] — formatting via
+    /// `Display` (e.g. `println!("{err}")`) is documented as
+    /// color-unaware and will silently strip the styling. See #6471.
+    ///
     /// # Example
     /// ```no_run
     /// # use clap_builder as clap;
@@ -292,7 +298,7 @@ impl<F: ErrorFormatter> Error<F> {
     ///     },
     ///     Err(err) => {
     ///         let err = err.render();
-    ///         println!("{err}");
+    ///         print!("{}", err.ansi());
     ///         // do_something
     ///     },
     /// };


### PR DESCRIPTION
## Summary

The doc example on `Error::render()` used `println!("{err}")`, which
goes through `StyledStr`'s `Display` impl. `Display` is documented as
"Color-unaware printing. Never uses coloring" and calls `iter_text`
which calls `anstream::adapter::strip_str`, unconditionally stripping
ANSI codes — even on a TTY. The same data, returned from `render()`,
loses its styling the moment the documented example prints it.

## Fix

Switch the example to use `StyledStr::ansi()`, which returns the
underlying ANSI-carrying string. Add a short note pointing at #6471 so
the next reader understands why `Display` strips styling here.

## Verification

`cargo test --doc -p clap_builder` — `error::Error<F>::render` doc test
still compiles and passes.

`cargo test -p clap_builder --lib` — 83/83 unit tests pass.

## AI assistance disclosure

Code and docstring written with AI assistance (Claude / Anthropic).
Reviewed and tested by the human submitter before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)