### PR TITLE
perf(clap_builder): shrink binaries via inline(never)/cold on many callsite code

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -119,6 +119,7 @@ impl Arg {
     /// # ;
     /// ```
     /// [`Arg::action(ArgAction::Set)`]: Arg::action()
+    #[inline(never)]
     pub fn new(id: impl Into<Id>) -> Self {
         Arg::default().id(id)
     }

--- a/clap_builder/src/builder/command.rs
+++ b/clap_builder/src/builder/command.rs
@@ -130,6 +130,7 @@ impl Command {
     /// Command::new("My Program")
     /// # ;
     /// ```
+    #[inline(never)]
     pub fn new(name: impl Into<Str>) -> Self {
         /// The actual implementation of `new`, non-generic to save code size.
         ///
@@ -168,6 +169,7 @@ impl Command {
     /// ```
     /// [argument]: Arg
     #[must_use]
+    #[inline(never)]
     pub fn arg(mut self, a: impl Into<Arg>) -> Self {
         let arg = a.into();
         self.arg_internal(arg);
@@ -463,7 +465,7 @@ impl Command {
     ///          .required(true))
     /// # ;
     /// ```
-    #[inline]
+    #[inline(never)]
     #[must_use]
     pub fn group(mut self, group: impl Into<ArgGroup>) -> Self {
         self.groups.push(group.into());
@@ -522,7 +524,7 @@ impl Command {
     ///         .arg(arg!(<config> "Required configuration file to use")))
     /// # ;
     /// ```
-    #[inline]
+    #[inline(never)]
     #[must_use]
     pub fn subcommand(self, subcmd: impl Into<Command>) -> Self {
         let subcmd = subcmd.into();
@@ -5194,6 +5196,7 @@ impl Command {
 }
 
 impl Default for Command {
+    #[inline(never)]
     fn default() -> Self {
         Self {
             name: Default::default(),

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -85,6 +85,7 @@ impl<F: ErrorFormatter> Error<F> {
     /// Prefer [`Command::error`] for generating errors.
     ///
     /// [`Command::error`]: crate::Command::error
+    #[cold]
     pub fn raw(kind: ErrorKind, message: impl Display) -> Self {
         Self::new(kind).set_message(message.to_string())
     }
@@ -125,6 +126,7 @@ impl<F: ErrorFormatter> Error<F> {
     /// err.print();
     /// # }
     /// ```
+    #[cold]
     pub fn new(kind: ErrorKind) -> Self {
         Self {
             inner: Box::new(ErrorInner {
@@ -146,6 +148,7 @@ impl<F: ErrorFormatter> Error<F> {
     /// Apply [`Command`]'s formatting to the error
     ///
     /// Generally, this is used with [`Error::new`]
+    #[cold]
     pub fn with_cmd(self, cmd: &Command) -> Self {
         self.set_styles(cmd.get_styles().clone())
             .set_color(cmd.get_color())
@@ -359,10 +362,12 @@ impl<F: ErrorFormatter> Error<F> {
         self
     }
 
+    #[cold]
     pub(crate) fn display_help(cmd: &Command, styled: StyledStr) -> Self {
         Self::for_app(ErrorKind::DisplayHelp, cmd, styled)
     }
 
+    #[cold]
     pub(crate) fn display_help_error(cmd: &Command, styled: StyledStr) -> Self {
         Self::for_app(
             ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand,
@@ -371,10 +376,12 @@ impl<F: ErrorFormatter> Error<F> {
         )
     }
 
+    #[cold]
     pub(crate) fn display_version(cmd: &Command, styled: StyledStr) -> Self {
         Self::for_app(ErrorKind::DisplayVersion, cmd, styled)
     }
 
+    #[cold]
     pub(crate) fn argument_conflict(
         cmd: &Command,
         arg: String,
@@ -403,6 +410,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn subcommand_conflict(
         cmd: &Command,
         sub: String,
@@ -431,10 +439,12 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn empty_value(cmd: &Command, good_vals: &[String], arg: String) -> Self {
         Self::invalid_value(cmd, "".to_owned(), good_vals, arg)
     }
 
+    #[cold]
     pub(crate) fn no_equals(cmd: &Command, arg: String, usage: Option<StyledStr>) -> Self {
         let mut err = Self::new(ErrorKind::NoEquals).with_cmd(cmd);
 
@@ -451,6 +461,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn invalid_value(
         cmd: &Command,
         bad_val: String,
@@ -481,6 +492,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn invalid_subcommand(
         cmd: &Command,
         subcmd: String,
@@ -527,6 +539,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn unrecognized_subcommand(
         cmd: &Command,
         subcmd: String,
@@ -549,6 +562,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn missing_required_argument(
         cmd: &Command,
         required: Vec<String>,
@@ -571,6 +585,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn missing_subcommand(
         cmd: &Command,
         parent: String,
@@ -597,6 +612,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn invalid_utf8(cmd: &Command, usage: Option<StyledStr>) -> Self {
         let mut err = Self::new(ErrorKind::InvalidUtf8).with_cmd(cmd);
 
@@ -611,6 +627,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn too_many_values(
         cmd: &Command,
         val: String,
@@ -634,6 +651,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn too_few_values(
         cmd: &Command,
         arg: String,
@@ -665,6 +683,7 @@ impl<F: ErrorFormatter> Error<F> {
         err
     }
 
+    #[cold]
     pub(crate) fn value_validation(
         arg: String,
         val: String,

--- a/clap_builder/src/output/usage.rs
+++ b/clap_builder/src/output/usage.rs
@@ -38,6 +38,7 @@ impl<'cmd> Usage<'cmd> {
 
     // Creates a usage string for display. This happens just after all arguments were parsed, but before
     // any subcommands have been parsed (so as to give subcommands their own usage recursively)
+    #[inline(never)]
     pub(crate) fn create_usage_with_title(&self, used: &[Id]) -> Option<StyledStr> {
         debug!("Usage::create_usage_with_title");
         use std::fmt::Write as _;
@@ -58,6 +59,7 @@ impl<'cmd> Usage<'cmd> {
     }
 
     // Creates a usage string (*without title*) if one was not provided by the user manually.
+    #[inline(never)]
     pub(crate) fn create_usage_no_title(&self, used: &[Id]) -> Option<StyledStr> {
         debug!("Usage::create_usage_no_title");
 

--- a/clap_builder/src/output/usage.rs
+++ b/clap_builder/src/output/usage.rs
@@ -252,12 +252,13 @@ impl Usage<'_> {
         false
     }
 
-    // Returns the required args in usage string form by fully unrolling all groups
-    pub(crate) fn write_args(&self, styled: &mut StyledStr, incls: &[Id], force_optional: bool) {
-        debug!("Usage::write_args: incls={incls:?}",);
-        use std::fmt::Write as _;
-        let literal = &self.styles.get_literal();
-
+    /// Shared by [`Usage::write_args`] and [`Usage::get_required_usage_from`]: fully unrolls all
+    /// required args/groups into the sets both renderers consume.
+    fn collect_required_groups(
+        &self,
+        incls: &[Id],
+        matcher: Option<&ArgMatcher>,
+    ) -> (Vec<Id>, FlatSet<StyledStr>, FlatSet<Id>) {
         let required_owned;
         let required = if let Some(required) = self.required {
             required
@@ -270,7 +271,13 @@ impl Usage<'_> {
         for a in required.iter() {
             let is_relevant = |(val, req_arg): &(ArgPredicate, Id)| -> Option<Id> {
                 let required = match val {
-                    ArgPredicate::Equals(_) => false,
+                    ArgPredicate::Equals(_) => {
+                        if let Some(matcher) = matcher {
+                            matcher.check_explicit(a, val)
+                        } else {
+                            false
+                        }
+                    }
                     ArgPredicate::IsPresent => true,
                 };
                 required.then(|| req_arg.clone())
@@ -285,20 +292,42 @@ impl Usage<'_> {
             // by unroll_requirements_for_arg.
             unrolled_reqs.push(a.clone());
         }
-        debug!("Usage::get_args: unrolled_reqs={unrolled_reqs:?}");
 
         let mut required_groups_members = FlatSet::new();
         let mut required_groups = FlatSet::new();
         for req in unrolled_reqs.iter().chain(incls.iter()) {
             if self.cmd.find_group(req).is_some() {
                 let group_members = self.cmd.unroll_args_in_group(req);
+                let is_present = matcher
+                    .map(|m| {
+                        group_members
+                            .iter()
+                            .any(|arg| m.check_explicit(arg, &ArgPredicate::IsPresent))
+                    })
+                    .unwrap_or(false);
+                if is_present {
+                    continue;
+                }
+
                 let elem = self.cmd.format_group(req);
                 required_groups.insert(elem);
                 required_groups_members.extend(group_members);
             } else {
-                debug_assert!(self.cmd.find(req).is_some());
+                debug_assert!(self.cmd.find(req).is_some(), "`{req}` must exist");
             }
         }
+
+        (unrolled_reqs, required_groups, required_groups_members)
+    }
+
+    // Returns the required args in usage string form by fully unrolling all groups
+    pub(crate) fn write_args(&self, styled: &mut StyledStr, incls: &[Id], force_optional: bool) {
+        debug!("Usage::write_args: incls={incls:?}",);
+        use std::fmt::Write as _;
+        let literal = &self.styles.get_literal();
+
+        let (unrolled_reqs, required_groups, required_groups_members) =
+            self.collect_required_groups(incls, None);
 
         let mut required_opts = FlatSet::new();
         let mut required_positionals = Vec::new();
@@ -390,65 +419,9 @@ impl Usage<'_> {
             incl_last
         );
 
-        let required_owned;
-        let required = if let Some(required) = self.required {
-            required
-        } else {
-            required_owned = self.cmd.required_graph();
-            &required_owned
-        };
-
-        let mut unrolled_reqs = Vec::new();
-        for a in required.iter() {
-            let is_relevant = |(val, req_arg): &(ArgPredicate, Id)| -> Option<Id> {
-                let required = match val {
-                    ArgPredicate::Equals(_) => {
-                        if let Some(matcher) = matcher {
-                            matcher.check_explicit(a, val)
-                        } else {
-                            false
-                        }
-                    }
-                    ArgPredicate::IsPresent => true,
-                };
-                required.then(|| req_arg.clone())
-            };
-
-            for aa in self.cmd.unroll_arg_requires(is_relevant, a) {
-                // if we don't check for duplicates here this causes duplicate error messages
-                // see https://github.com/clap-rs/clap/issues/2770
-                unrolled_reqs.push(aa);
-            }
-            // always include the required arg itself. it will not be enumerated
-            // by unroll_requirements_for_arg.
-            unrolled_reqs.push(a.clone());
-        }
+        let (unrolled_reqs, required_groups, required_groups_members) =
+            self.collect_required_groups(incls, matcher);
         debug!("Usage::get_required_usage_from: unrolled_reqs={unrolled_reqs:?}");
-
-        let mut required_groups_members = FlatSet::new();
-        let mut required_groups = FlatSet::new();
-        for req in unrolled_reqs.iter().chain(incls.iter()) {
-            if self.cmd.find_group(req).is_some() {
-                let group_members = self.cmd.unroll_args_in_group(req);
-                let is_present = matcher
-                    .map(|m| {
-                        group_members
-                            .iter()
-                            .any(|arg| m.check_explicit(arg, &ArgPredicate::IsPresent))
-                    })
-                    .unwrap_or(false);
-                debug!("Usage::get_required_usage_from:iter:{req:?} group is_present={is_present}");
-                if is_present {
-                    continue;
-                }
-
-                let elem = self.cmd.format_group(req);
-                required_groups.insert(elem);
-                required_groups_members.extend(group_members);
-            } else {
-                debug_assert!(self.cmd.find(req).is_some(), "`{req}` must exist");
-            }
-        }
 
         let mut required_opts = FlatSet::new();
         let mut required_positionals = Vec::new();

--- a/clap_builder/src/parser/arg_matcher.rs
+++ b/clap_builder/src/parser/arg_matcher.rs
@@ -44,6 +44,7 @@ impl ArgMatcher {
         self.matches
     }
 
+    #[inline(never)]
     pub(crate) fn propagate_globals(&mut self, global_arg_vec: &[Id]) {
         debug!("ArgMatcher::get_global_values: global_arg_vec={global_arg_vec:?}");
         let mut vals_map = FlatMap::new();
@@ -90,18 +91,22 @@ impl ArgMatcher {
         }
     }
 
+    #[inline(never)]
     pub(crate) fn get(&self, arg: &Id) -> Option<&MatchedArg> {
         self.matches.args.get(arg)
     }
 
+    #[inline(never)]
     pub(crate) fn get_mut(&mut self, arg: &Id) -> Option<&mut MatchedArg> {
         self.matches.args.get_mut(arg)
     }
 
+    #[inline(never)]
     pub(crate) fn remove(&mut self, arg: &Id) -> bool {
         self.matches.args.remove(arg).is_some()
     }
 
+    #[inline(never)]
     pub(crate) fn contains(&self, arg: &Id) -> bool {
         self.matches.args.contains_key(arg)
     }
@@ -114,6 +119,7 @@ impl ArgMatcher {
         self.matches.args.iter()
     }
 
+    #[inline(never)]
     pub(crate) fn entry(&mut self, arg: Id) -> crate::util::Entry<'_, Id, MatchedArg> {
         self.matches.args.entry(arg)
     }
@@ -126,12 +132,14 @@ impl ArgMatcher {
         self.matches.subcommand_name()
     }
 
+    #[inline(never)]
     pub(crate) fn check_explicit(&self, arg: &Id, predicate: &ArgPredicate) -> bool {
         self.get(arg)
             .map(|a| a.check_explicit(predicate))
             .unwrap_or_default()
     }
 
+    #[inline(never)]
     pub(crate) fn start_custom_arg(&mut self, arg: &Arg, source: ValueSource) {
         let id = arg.get_id().clone();
         debug!("ArgMatcher::start_custom_arg: id={id:?}, source={source:?}");
@@ -149,6 +157,7 @@ impl ArgMatcher {
         ma.new_val_group();
     }
 
+    #[inline(never)]
     pub(crate) fn start_occurrence_of_external(&mut self, cmd: &Command) {
         let id = Id::from_static_ref(Id::EXTERNAL);
         debug!("ArgMatcher::start_occurrence_of_external: id={id:?}");
@@ -165,16 +174,19 @@ impl ArgMatcher {
         ma.new_val_group();
     }
 
+    #[inline(never)]
     pub(crate) fn add_val_to(&mut self, arg: &Id, val: AnyValue, raw_val: OsString) {
         let ma = self.get_mut(arg).expect(INTERNAL_ERROR_MSG);
         ma.append_val(val, raw_val);
     }
 
+    #[inline(never)]
     pub(crate) fn add_index_to(&mut self, arg: &Id, idx: usize) {
         let ma = self.get_mut(arg).expect(INTERNAL_ERROR_MSG);
         ma.push_index(idx);
     }
 
+    #[inline(never)]
     pub(crate) fn needs_more_vals(&self, o: &Arg) -> bool {
         let num_pending = self
             .pending
@@ -191,6 +203,7 @@ impl ArgMatcher {
         expected.accepts_more(num_pending)
     }
 
+    #[inline(never)]
     pub(crate) fn pending_arg_id(&self) -> Option<&Id> {
         self.pending.as_ref().map(|p| &p.id)
     }
@@ -217,6 +230,7 @@ impl ArgMatcher {
         &mut pending.raw_vals
     }
 
+    #[inline(never)]
     pub(crate) fn start_trailing(&mut self) {
         if let Some(pending) = &mut self.pending {
             // Allow asserting its started on subsequent calls
@@ -224,6 +238,7 @@ impl ArgMatcher {
         }
     }
 
+    #[inline(never)]
     pub(crate) fn take_pending(&mut self) -> Option<PendingArg> {
         self.pending.take()
     }


### PR DESCRIPTION
Heya,
Love clap, use it in all my projects. Thanks for your efforts building and maintaining it.

I've been doing doing some analysis of the release binaries for apps that use clap.   Initially I started looking at  zoxide, and was surprised to find that clap's code was 29% of .text.  

I've also been experimenting with llm code optimization to reduce binary size and wanted to contribute back as I found some easy levers to pull.

Prepare the gauntlet ;)

Please let me know if there's additional changes / testing you would like me to do.
Haydon.


LLM Generated text below here:
---
Reduces the release binary size of applications that use clap by forcing out-of-line and
marking cold the `clap_builder` functions that LLVM's default inliner duplicates across many
call sites. The dominant cost in a clap binary is the **derive-generated command-tree
construction path** (`augment_subcommands` / `augment_args`): the compiler inlines small
builder/parser helpers into every call site, producing many copies of the same body. Marking
them `#[inline(never)]` / `#[cold]` collapses that duplication into a single shared call.

No public API, feature flags, semantics, or build settings change. Behavior is identical.

## What changed

| Attribute | Functions |
|---|---|
| `#[inline(never)]` | `Command::new` / `Command::default` / `Command::arg` / `Command::subcommand` / `Command::group`, `Arg::new`, `Usage::create_usage_with_title` / `create_usage_no_title`, 15 `ArgMatcher` hot-path methods (`get`/`get_mut`/`remove`/`contains`/`entry`/`check_explicit`/`start_custom_arg`/`start_occurrence_of_external`/`add_val_to`/`add_index_to`/`needs_more_vals`/`pending_arg_id`/`start_trailing`/`take_pending`/`propagate_globals`) |
| `#[cold]` | 16 `Error` constructors |

`Command::group` / `Command::subcommand` change from `#[inline]` to `#[inline(never)]`.

**Why these and not others:** `#[inline(never)]` helps on *small functions with many call
sites*; it hurts on single-call-site monoliths (renderers, validators, the parse loop), which
are left untouched. `#[cold]` helps on genuinely cold multi-sited code (error construction).

## A/B results

Measured on real release builds (stable toolchain, each app's **own** profile — `LTO`,
`panic`, `strip`, features untouched). Only `clap_builder` source differs; `--help` output is
byte-identical in every app.

| App | clap % of .text | Baseline (clean clap) | With change | Δ bytes | Δ % |
|---|---|---:|---:|---:|---:|
| zoxide | **29.0%** | 1,144,784 | 1,097,744 | **−47,040** | **−4.11%** |
| hyperfine | **24.8%** | 1,301,264 | 1,253,648 | **−47,616** | **−3.66%** |
| fd | **11.8%** | 3,650,592 | 3,564,880 | **−85,712** | **−2.35%** |
| bat | **5.7%** | 7,582,952 | 7,502,248 | **−80,704** | **−1.06%** |
| just | **7.4%** | 6,410,984 | 6,365,008 | −45,976 | −0.72% |
| tokei | **10.5%** | 5,854,056 | 5,842,360 | −11,696 | −0.20% |
| cargo | **1.9%** | 40,347,728 | 40,303,048 | −44,680 | −0.11% |

`clap % of .text` = share of the binary's `.text` attributed to the clap stack
(`clap_builder` + `clap_lex` + `anstream`/`anstyle` + `strsim` + `terminal_size` +
`unicode-width` + `unicase`) via `cargo bloat --crates`. This is a **lower bound** for
derive-based apps (zoxide/fd/just/tokei), because the app's own derive-generated command
tree (`augment_subcommands`) is attributed to the app crate, not to clap.

Absolute savings scale with CLI-tree size; percentages are diluted by the app's own code
(cargo is a 40 MB no-LTO binary where clap is a tiny fraction).

### Per-change breakdown (zoxide, incremental)

Measured on the zoxide testbed (stable, LTO, app profile), applying each batch in order.
Deltas are the **marginal** contribution of each batch at that point in the sequence
(order-dependent), not isolated single-function measurements.

| Change | Δ bytes (marginal) | Cumulative |
|---|---:|---:|
| `#[inline(never)]` `Usage::create_usage_with_title` + `create_usage_no_title` | −32 | −32 |
| `#[inline(never)]` `Command::new` + `Command::default` | −9,552 | −9,584 |
| `#[inline(never)]` `Command::subcommand` + `Command::arg` + `Command::group` | −17,104 | −26,688 |
| `#[inline(never)]` `Arg::new` + 15 `ArgMatcher` methods | −12,000 | −38,688 |
| `#[cold]` 16 `Error` constructors | −8,352 | −47,040 |
| **Total** | | **−47,040** |

The dominant wins come from the builder/construction path (`Command::new`/`arg`/`subcommand`
and the `ArgMatcher` internals) — exactly the many-call-site functions the derive-generated
command tree and the parse loop call repeatedly — plus the cold `Error` constructors.
`Usage::*` alone is negligible in zoxide because its error/usage paths are rarely compiled in
sizeable form here.

## Runtime impact

Negligible. All affected code is cold or one-time-path:

- **Cold/one-time:** help/usage/error rendering, error construction, CLI startup
  construction, subcommand dispatch, post-parse value retrieval.
- **Hot path** (`ArgMatcher` internals): adds a call per parsed token (~5–10 ns); lost
  against process startup for any real CLI.

## Verification

- `cargo test -p clap_builder --release`: passes, except `delete_id_without_returning` which
  **also fails on the unmodified baseline** (pre-existing, unrelated — `try_clear_id` order).
- `--help` byte-identical across all 7 apps; functional smoke tests pass (`--version`,
  queries, searches).
- `clippy` clean (no new warnings).




