### PR TITLE
fix(mangen): Hide hidden args in required ArgGroups

### DIFF
--- a/clap_mangen/src/render.rs
+++ b/clap_mangen/src/render.rs
@@ -150,6 +150,9 @@ fn unroll_group_args<'a>(cmd: &'a clap::Command, group: &clap::Id) -> Vec<&'a Ar
                 continue;
             }
             if let Some(arg) = cmd.get_arguments().find(|a| a.get_id() == n) {
+                if arg.is_hide_set() {
+                    continue;
+                }
                 args.push(arg);
             } else {
                 g_vec.push(n);

--- a/clap_mangen/tests/snapshots/required_group_with_hidden_arg.roff
+++ b/clap_mangen/tests/snapshots/required_group_with_hidden_arg.roff
@@ -1,0 +1,15 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH my-app 1  "my-app " 
+.SH NAME
+my\-app
+.SH SYNOPSIS
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-outfile\fR|\fB\-\-secret\fR> 
+.SH DESCRIPTION
+.SH OPTIONS
+.TP
+\fB\-\-outfile\fR
+
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help

--- a/clap_mangen/tests/snapshots/required_group_with_hidden_arg.roff
+++ b/clap_mangen/tests/snapshots/required_group_with_hidden_arg.roff
@@ -4,7 +4,7 @@
 .SH NAME
 my\-app
 .SH SYNOPSIS
-\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-outfile\fR|\fB\-\-secret\fR> 
+\fBmy\-app\fR [\fB\-h\fR|\fB\-\-help\fR] <\fB\-\-outfile\fR> 
 .SH DESCRIPTION
 .SH OPTIONS
 .TP

--- a/clap_mangen/tests/testsuite/common.rs
+++ b/clap_mangen/tests/testsuite/common.rs
@@ -556,6 +556,27 @@ pub(crate) fn required_group_with_required_option_command(name: &'static str) ->
         )
 }
 
+pub(crate) fn required_group_with_hidden_arg_command(name: &'static str) -> clap::Command {
+    clap::Command::new(name)
+        .arg(
+            clap::Arg::new("outfile")
+                .long("outfile")
+                .action(clap::ArgAction::Set),
+        )
+        .arg(
+            clap::Arg::new("secret")
+                .long("secret")
+                .hide(true)
+                .action(clap::ArgAction::Set),
+        )
+        .group(
+            clap::ArgGroup::new("output")
+                .required(true)
+                .arg("outfile")
+                .arg("secret"),
+        )
+}
+
 pub(crate) fn single_required_group_command(name: &'static str) -> clap::Command {
     clap::Command::new(name)
         .arg(

--- a/clap_mangen/tests/testsuite/roff.rs
+++ b/clap_mangen/tests/testsuite/roff.rs
@@ -239,6 +239,16 @@ fn required_group_with_required_option() {
 }
 
 #[test]
+fn required_group_with_hidden_arg() {
+    let name = "my-app";
+    let cmd = common::required_group_with_hidden_arg_command(name);
+    common::assert_matches(
+        snapbox::file!["../snapshots/required_group_with_hidden_arg.roff"],
+        cmd,
+    );
+}
+
+#[test]
 fn single_required_group() {
     let name = "my-app";
     let cmd = common::single_required_group_command(name);


### PR DESCRIPTION
### What does this PR try to solve?

Hidden `Arg`s that are members of a required `ArgGroup` are rendered into the
man page SYNOPSIS.

```rust
Command::new("my-app")
    .arg(Arg::new("outfile").long("outfile").action(ArgAction::Set))
    .arg(Arg::new("secret").long("secret").hide(true).action(ArgAction::Set))
    .group(ArgGroup::new("output").required(true).args(["outfile", "secret"]))
```

generates `my-app [-h|--help] <--outfile|--secret>`, leaking `--secret` even
though it is correctly omitted from OPTIONS.

`unroll_group_args` collects every member of the group without checking
`Arg::is_hide_set`, so the required-group rendering loop added in "Render
required ArgGroups" never filtered hidden members. #6482 fixed the same class
of bug for plain positionals but did not touch this path. The fix mirrors the
filtering `clap_builder`'s usage generation already applies.

No linked issue — filing this directly as an obvious bug fix, same as #6482.

### Notes to reviewers

Split into two commits per CONTRIBUTING: the first adds the test showing the
current (incorrect) output, the second contains the one-line fix and the
resulting snapshot change, so the behavior change is visible in the diff.

A required group whose members are *all* hidden now unrolls to an empty vec and
is dropped by the existing `!members.is_empty()` filter, so no empty `<>` is
emitted.

`cargo test -p clap_mangen`, `cargo clippy -p clap_mangen --all-targets`, and
`cargo fmt --all --check` all pass; no other snapshot changed.

Disclosure: written with assistance from Claude (Opus 5); noted via
`Co-Authored-By` trailers on both commits. I have reviewed and verified the
change.
