### PR TITLE
docs(clap_builder): fix incorrect ArgPredicate in default_value_if example

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -2965,14 +2965,13 @@ impl Arg {
     /// ```rust
     /// # use clap_builder as clap;
     /// # use clap::{Command, Arg, ArgAction};
-    /// # use clap::builder::{ArgPredicate};
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("flag")
     ///         .long("flag")
     ///         .action(ArgAction::SetTrue))
     ///     .arg(Arg::new("other")
     ///         .long("other")
-    ///         .default_value_if("flag", ArgPredicate::IsPresent, Some("default")))
+    ///         .default_value_if("flag", "true", Some("default")))
     ///     .get_matches_from(vec![
     ///         "prog", "--flag"
     ///     ]);


### PR DESCRIPTION
Closes #4904

## Summary
- The first doc example for `Arg::default_value_if` used `ArgPredicate::IsPresent`, which is always true and contradicts the example's intent of 'use the default only when the flag is present'
- Switches to the literal predicate form `"true"` already used by the second example in the same doc comment
- Removes the now-unused `# use clap::builder::{ArgPredicate};` line in that example

## Test plan
- [x] `cargo build` passes
- [x] `cargo test --doc` passes (the modified example is a doc-test)
- [x] `cargo test` passes
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean