### PR TITLE
fix(doctest): Use string predicate in example 1

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -2965,14 +2965,13 @@ impl Arg {
     /// ```rust
     /// # use clap_builder as clap;
     /// # use clap::{Command, Arg, ArgAction};
-    /// # use clap::builder::{ArgPredicate};
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("flag")
     ///         .long("flag")
     ///         .action(ArgAction::SetTrue))
     ///     .arg(Arg::new("other")
     ///         .long("other")
-    ///         .default_value_if("flag", ArgPredicate::IsPresent, Some("default")))
+    ///         .default_value_if("flag", "true", Some("default")))
     ///     .get_matches_from(vec![
     ///         "prog", "--flag"
     ///     ]);


### PR DESCRIPTION
Closes #4904

The first example in `Arg::default_value_if` (the doctest right after
"First we use the default value only if another arg is present at runtime")
used `ArgPredicate::IsPresent` as the predicate. As called out in the
issue, due to the underlying behavior bug tracked in #4918,
`IsPresent` currently sets the default value regardless of whether the
flag is actually passed, so this example does not actually demonstrate
"only if present at runtime". The next four examples all use a string
predicate for the same scenario.

The same workaround used by the second example (the predicate string
`"true"`) works for the first example too: `--flag` is
`ArgAction::SetTrue`, so its value is the string `"true"`, which
matches the `"true"` predicate, and the default value is set. The
follow-up example (no `--flag` passed, no default) is also unchanged
and still demonstrates the negative case.

I also dropped the now-unused `use clap::builder::{ArgPredicate};` line
in the first example.

Verified locally:

    cargo test --doc -p clap_builder --no-default-features --features=std
    # 342 passed; 0 failed; 3 ignored

If #4918 lands first and maintainers would prefer the example use
`ArgPredicate::IsPresent` again to highlight the higher-level intent,
this PR can be reverted in favor of the underlying fix. Happy to adjust
either way.