### PR TITLE
docs: Scrape the git example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,10 @@ required-features = ["cargo"]
 doc-scrape-examples = true
 
 [[example]]
+name = "git"
+doc-scrape-examples = true
+
+[[example]]
 name = "git-derive"
 required-features = ["derive"]
 doc-scrape-examples = true


### PR DESCRIPTION
### What does this PR try to solve?

`examples/git.rs` is the only example without an `[[example]]` entry in `Cargo.toml`. Cargo still auto-discovers it, so it builds and `examples/git.md` still runs under trycmd, which is why nothing ever failed. But #5710 worked by adding `doc-scrape-examples = true` to each existing entry, and `git` had no entry to add it to, so it silently sat out that sweep.

Counting the example targets that `cargo metadata` reports for the `clap` package, there are 58, and 57 of them opt into scraping. `git` is the odd one out, so its usage of `Command`, `arg!` and `ArgMatches` never shows up under "Examples found in repository" on docs.rs while every other example's does.

`src/_cookbook/mod.rs` also asks that new examples be added to `Cargo.toml`, and `git` is already linked from the cookbook via `src/_cookbook/git.rs`.

### Notes to reviewers

The entry carries only the scrape flag. `git.rs` uses `clap::{ArgMatches, Command, arg}` and nothing feature gated, and `cargo metadata` lists it alongside `pacman`, `busybox` and `hostname` as an example with no required features, so adding `required-features` here would narrow when it builds rather than keep things as they are.

Checked locally with `cargo check --example git`, which passes, and `cargo metadata --no-deps`, which still reports 58 example targets afterwards. The `[[example]]` block count and the `doc-scrape-examples = true` line count now match at 58 each.

I could not run the full test suite on this machine: it is Windows with the `x86_64-pc-windows-gnu` toolchain, and linking the dev-dependencies needs an assembler that the bundled `dlltool` does not ship with. That is unrelated to this change, which only adds manifest metadata.