### PR TITLE
docs: Clarify color handling for StyledStr and Error::render

### DIFF
--- a/clap_builder/src/builder/styled_str.rs
+++ b/clap_builder/src/builder/styled_str.rs
@@ -31,6 +31,12 @@ impl StyledStr {
     }
 
     /// Display using [ANSI Escape Code](https://en.wikipedia.org/wiki/ANSI_escape_code) styling
+    ///
+    /// This always emits the escape codes, even when writing to a file or pipe. Only reach for it
+    /// once you've decided color is wanted, such as writing to a known terminal or a color-aware
+    /// stream like [`anstream`](https://docs.rs/anstream) that strips the codes when the
+    /// destination isn't a terminal. For color-unaware output, print the [`StyledStr`] directly
+    /// with `Display` instead.
     #[cfg(feature = "color")]
     pub fn ansi(&self) -> impl std::fmt::Display + '_ {
         self.0.as_str()

--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -291,6 +291,9 @@ impl<F: ErrorFormatter> Error<F> {
     ///         // do_something
     ///     },
     ///     Err(err) => {
+    ///         // `render` is color-unaware: printing the `StyledStr` through
+    ///         // `Display` (`println!`, `format!`, `to_string`) strips any styling.
+    ///         // Use `Error::print` for color-aware output to the terminal.
     ///         let err = err.render();
     ///         println!("{err}");
     ///         // do_something


### PR DESCRIPTION
Clarifies the color behavior of `StyledStr` so the doc examples stop implying that `render()` output keeps its styling when printed.

`Error::render()`'s example does `let err = err.render(); println!("{err}")`, but `StyledStr`'s `Display` is color-unaware and strips the styling, so that path silently produces plain text even on a terminal. Added a note there pointing at `Error::print` for the color-aware path.

Per epage's note on #6471 this is broader than errors: `.ansi()` unconditionally emits escape codes, so reaching for it with `println!` would force color even where it isn't wanted. Documented that on `StyledStr::ansi` so callers know it's only for output they've already decided should be colored (a terminal or a color-aware stream like anstream), and to use `Display` otherwise.

Docs only. `cargo test --doc -p clap_builder` passes.

Closes #6471
