### PR TITLE
feat(builder): expose argument relationship reflection

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4424,24 +4424,27 @@ impl Arg {
     /// Get the conditional default-value rules in evaluation order.
     ///
     /// Each entry contains the argument to inspect, the predicate to match, and the
-    /// default values to apply. `None` clears any unconditional default value when
-    /// the predicate matches.
+    /// optional default values for a matching rule. `None` represents a matching rule
+    /// that suppresses the unconditional default.
     #[inline]
     pub fn get_default_values_ifs(&self) -> &[(Id, ArgPredicate, Option<Vec<OsStr>>)] {
         &self.default_vals_ifs
     }
 
-    /// Get the arguments overridden by this argument.
+    /// Get the argument and group IDs configured to be overridden by this argument.
+    ///
+    /// Override behavior is mutual at runtime, so this does not include relationships
+    /// configured only from the other side.
     #[inline]
     pub fn get_overrides(&self) -> &[Id] {
         &self.overrides
     }
 
-    /// Get the arguments conditionally required by this argument.
+    /// Get the direct requirement rules configured on this argument.
     ///
-    /// Each entry contains the predicate applied to this argument and the argument
-    /// that becomes required when the predicate matches. Unconditional requirements
-    /// are represented by [`ArgPredicate::IsPresent`].
+    /// Each entry contains the predicate applied to this argument and the argument or
+    /// group that becomes required when the predicate matches. Rules configured with
+    /// [`Arg::requires`] use [`ArgPredicate::IsPresent`].
     #[inline]
     pub fn get_requires(&self) -> &[(ArgPredicate, Id)] {
         &self.requires
@@ -4449,6 +4452,7 @@ impl Arg {
 
     /// Get the conditions that make this argument required when any condition matches.
     ///
+    /// Each entry contains the argument or group to inspect and the value it must equal.
     /// This includes conditions configured with [`Arg::required_if_eq`] and
     /// [`Arg::required_if_eq_any`].
     #[inline]
@@ -4457,12 +4461,14 @@ impl Arg {
     }
 
     /// Get the conditions that make this argument required when all conditions match.
+    ///
+    /// Each entry contains the argument or group to inspect and the value it must equal.
     #[inline]
     pub fn get_required_if_eq_all(&self) -> &[(Id, OsStr)] {
         &self.r_ifs_all
     }
 
-    /// Get the arguments whose presence makes this argument optional when any is present.
+    /// Get the argument and group IDs used by the "required unless any are present" rules.
     ///
     /// This includes rules configured with [`Arg::required_unless_present`] and
     /// [`Arg::required_unless_present_any`].
@@ -4471,7 +4477,7 @@ impl Arg {
         &self.r_unless
     }
 
-    /// Get the arguments whose presence makes this argument optional when all are present.
+    /// Get the argument and group IDs used by the "required unless all are present" rule.
     #[inline]
     pub fn get_required_unless_present_all(&self) -> &[Id] {
         &self.r_unless_all

--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -4415,6 +4415,68 @@ impl Arg {
         &self.default_vals
     }
 
+    /// Get the values used when the argument is present without an explicit value.
+    #[inline]
+    pub fn get_default_missing_values(&self) -> &[OsStr] {
+        &self.default_missing_vals
+    }
+
+    /// Get the conditional default-value rules in evaluation order.
+    ///
+    /// Each entry contains the argument to inspect, the predicate to match, and the
+    /// default values to apply. `None` clears any unconditional default value when
+    /// the predicate matches.
+    #[inline]
+    pub fn get_default_values_ifs(&self) -> &[(Id, ArgPredicate, Option<Vec<OsStr>>)] {
+        &self.default_vals_ifs
+    }
+
+    /// Get the arguments overridden by this argument.
+    #[inline]
+    pub fn get_overrides(&self) -> &[Id] {
+        &self.overrides
+    }
+
+    /// Get the arguments conditionally required by this argument.
+    ///
+    /// Each entry contains the predicate applied to this argument and the argument
+    /// that becomes required when the predicate matches. Unconditional requirements
+    /// are represented by [`ArgPredicate::IsPresent`].
+    #[inline]
+    pub fn get_requires(&self) -> &[(ArgPredicate, Id)] {
+        &self.requires
+    }
+
+    /// Get the conditions that make this argument required when any condition matches.
+    ///
+    /// This includes conditions configured with [`Arg::required_if_eq`] and
+    /// [`Arg::required_if_eq_any`].
+    #[inline]
+    pub fn get_required_if_eq_any(&self) -> &[(Id, OsStr)] {
+        &self.r_ifs
+    }
+
+    /// Get the conditions that make this argument required when all conditions match.
+    #[inline]
+    pub fn get_required_if_eq_all(&self) -> &[(Id, OsStr)] {
+        &self.r_ifs_all
+    }
+
+    /// Get the arguments whose presence makes this argument optional when any is present.
+    ///
+    /// This includes rules configured with [`Arg::required_unless_present`] and
+    /// [`Arg::required_unless_present_any`].
+    #[inline]
+    pub fn get_required_unless_present_any(&self) -> &[Id] {
+        &self.r_unless
+    }
+
+    /// Get the arguments whose presence makes this argument optional when all are present.
+    #[inline]
+    pub fn get_required_unless_present_all(&self) -> &[Id] {
+        &self.r_unless_all
+    }
+
     /// Checks whether this argument is a positional or not.
     ///
     /// # Examples
@@ -4846,6 +4908,47 @@ pub trait ArgExt: Extension {}
 mod test {
     use super::Arg;
     use super::ArgAction;
+    use super::Id;
+
+    #[test]
+    fn relationship_reflection() {
+        let arg = Arg::new("config")
+            .default_missing_value("default-missing")
+            .default_value_if("mode", "auto", Some("default"))
+            .overrides_with("old-config")
+            .requires_if("special", "input")
+            .required_if_eq_any([("format", "json"), ("mode", "strict")])
+            .required_if_eq_all([("source", "remote"), ("auth", "token")])
+            .required_unless_present_any(["stdin", "file"])
+            .required_unless_present_all(["host", "port"]);
+
+        assert_eq!(arg.get_default_missing_values(), &["default-missing"]);
+        assert_eq!(arg.get_default_values_ifs().len(), 1);
+        assert_eq!(
+            arg.get_overrides()
+                .iter()
+                .map(Id::as_str)
+                .collect::<Vec<_>>(),
+            ["old-config"]
+        );
+        assert_eq!(arg.get_requires().len(), 1);
+        assert_eq!(arg.get_required_if_eq_any().len(), 2);
+        assert_eq!(arg.get_required_if_eq_all().len(), 2);
+        assert_eq!(
+            arg.get_required_unless_present_any()
+                .iter()
+                .map(Id::as_str)
+                .collect::<Vec<_>>(),
+            ["stdin", "file"]
+        );
+        assert_eq!(
+            arg.get_required_unless_present_all()
+                .iter()
+                .map(Id::as_str)
+                .collect::<Vec<_>>(),
+            ["host", "port"]
+        );
+    }
 
     #[test]
     fn flag_display_long() {

--- a/clap_builder/src/builder/arg_group.rs
+++ b/clap_builder/src/builder/arg_group.rs
@@ -521,6 +521,18 @@ impl ArgGroup {
         &self.id
     }
 
+    /// Get the arguments and groups required when this group is present.
+    #[inline]
+    pub fn get_requires(&self) -> impl Iterator<Item = &Id> {
+        self.requires.iter()
+    }
+
+    /// Get the arguments and groups that conflict with this group.
+    #[inline]
+    pub fn get_conflicts(&self) -> impl Iterator<Item = &Id> {
+        self.conflicts.iter()
+    }
+
     /// Reports whether [`ArgGroup::required`] is set
     #[inline]
     pub fn is_required_set(&self) -> bool {
@@ -611,5 +623,21 @@ mod test {
         for (pos, arg) in grp.get_args().enumerate() {
             assert_eq!(*arg, args[pos]);
         }
+    }
+
+    #[test]
+    fn arg_group_relationship_reflection() {
+        let grp = ArgGroup::new("program")
+            .requires_all(["input", "output"])
+            .conflicts_with_all(["quiet", "verbose"]);
+
+        assert_eq!(
+            grp.get_requires().map(Id::as_str).collect::<Vec<_>>(),
+            ["input", "output"]
+        );
+        assert_eq!(
+            grp.get_conflicts().map(Id::as_str).collect::<Vec<_>>(),
+            ["quiet", "verbose"]
+        );
     }
 }

--- a/clap_builder/src/builder/arg_group.rs
+++ b/clap_builder/src/builder/arg_group.rs
@@ -521,13 +521,16 @@ impl ArgGroup {
         &self.id
     }
 
-    /// Get the arguments and groups required when this group is present.
+    /// Get the argument and group IDs configured as requirements for this group.
     #[inline]
     pub fn get_requires(&self) -> impl Iterator<Item = &Id> {
         self.requires.iter()
     }
 
-    /// Get the arguments and groups that conflict with this group.
+    /// Get the argument and group IDs configured to conflict with this group.
+    ///
+    /// Conflict behavior is mutual at runtime, so this does not include relationships
+    /// configured only from the other side.
     #[inline]
     pub fn get_conflicts(&self) -> impl Iterator<Item = &Id> {
         self.conflicts.iter()


### PR DESCRIPTION
<!-- Thanks for helping out! -->

### What does this PR try to solve?

Clap already tracks conditional defaults, overrides, requirements, conditional requiredness, required-unless relationships, and argument-group requirements and conflicts internally, but does not expose these through the public builder reflection API.

This makes it difficult for consumers that inspect a built `Command` to reconstruct the effective argument contract without relying on implementation details.

This PR adds read-only getters for that existing state. It does not change parsing or validation behavior.

### Notes to reviewers

This PR only adds read-only accessors for state Clap already stores internally. It does not change parsing or validation behavior.

The motivation is to support tooling that reflects over built Command definitions, such as schema generation and other machine-readable command introspection.

Tests cover each newly exposed category of state.