### PR TITLE
feat: Add requires_any

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -68,6 +68,7 @@ pub struct Arg {
     pub(crate) overrides: Vec<Id>,
     pub(crate) groups: Vec<Id>,
     pub(crate) requires: Vec<(ArgPredicate, Id)>,
+    pub(crate) requires_any: Vec<Id>,
     pub(crate) r_ifs: Vec<(Id, OsStr)>,
     pub(crate) r_ifs_all: Vec<(Id, OsStr)>,
     pub(crate) r_unless: Vec<Id>,
@@ -828,6 +829,33 @@ impl Arg {
         } else {
             self.requires.clear();
         }
+        self
+    }
+
+    /// Sets arguments where at least one is required when this one is present.
+    ///
+    /// The requirement is satisfied when any listed argument or argument group is present.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use clap_builder as clap;
+    /// # use clap::{Arg, ArgAction, Command};
+    /// let result = Command::new("prog")
+    ///     .arg(
+    ///         Arg::new("config")
+    ///             .long("config")
+    ///             .action(ArgAction::SetTrue)
+    ///             .requires_any(["input", "stdin"]),
+    ///     )
+    ///     .arg(Arg::new("input").long("input").action(ArgAction::SetTrue))
+    ///     .arg(Arg::new("stdin").long("stdin").action(ArgAction::SetTrue))
+    ///     .try_get_matches_from(["prog", "--config", "--stdin"]);
+    /// assert!(result.is_ok());
+    /// ```
+    #[must_use]
+    pub fn requires_any(mut self, ids: impl IntoIterator<Item = impl Into<Id>>) -> Self {
+        self.requires_any.extend(ids.into_iter().map(Into::into));
         self
     }
 
@@ -4810,6 +4838,7 @@ impl fmt::Debug for Arg {
             .field("overrides", &self.overrides)
             .field("groups", &self.groups)
             .field("requires", &self.requires)
+            .field("requires_any", &self.requires_any)
             .field("r_ifs", &self.r_ifs)
             .field("r_unless", &self.r_unless)
             .field("short", &self.short)

--- a/clap_builder/src/builder/debug_asserts.rs
+++ b/clap_builder/src/builder/debug_asserts.rs
@@ -168,6 +168,22 @@ pub(crate) fn assert_app(cmd: &Command) {
             );
         }
 
+        for req_id in &arg.requires_any {
+            assert!(
+                &arg.id != req_id,
+                "Argument {} cannot require itself",
+                arg.get_id()
+            );
+
+            assert!(
+                cmd.id_exists(req_id),
+                "Command {}: Argument or group '{}' specified in 'requires_any' for '{}' does not exist",
+                cmd.get_name(),
+                req_id,
+                arg.get_id(),
+            );
+        }
+
         for req in &arg.r_ifs {
             assert!(
                 !arg.is_required_set(),

--- a/clap_builder/src/parser/validator.rs
+++ b/clap_builder/src/parser/validator.rs
@@ -218,9 +218,33 @@ impl<'cmd> Validator<'cmd> {
         }
     }
 
+    fn gather_requires_any(&self, matcher: &ArgMatcher) -> Vec<Vec<Id>> {
+        debug!("Validator::gather_requires_any");
+        let is_present = |id: &Id| {
+            if let Some(group) = self.cmd.find_group(id) {
+                self.cmd
+                    .unroll_args_in_group(group.get_id())
+                    .iter()
+                    .any(|arg| matcher.check_explicit(arg, &ArgPredicate::IsPresent))
+            } else {
+                matcher.check_explicit(id, &ArgPredicate::IsPresent)
+            }
+        };
+
+        matcher
+            .args()
+            .filter(|(_, matched)| matched.check_explicit(&ArgPredicate::IsPresent))
+            .filter_map(|(name, _)| self.cmd.find(name))
+            .filter(|arg| !arg.requires_any.is_empty())
+            .filter(|arg| !arg.requires_any.iter().any(&is_present))
+            .map(|arg| arg.requires_any.clone())
+            .collect()
+    }
+
     fn validate_required(&mut self, matcher: &ArgMatcher, conflicts: &Conflicts) -> ClapResult<()> {
         debug!("Validator::validate_required: required={:?}", self.required);
         self.gather_requires(matcher);
+        let missing_required_any = self.gather_requires_any(matcher);
 
         let mut missing_required = Vec::new();
         let mut highest_index = 0;
@@ -335,8 +359,8 @@ impl<'cmd> Validator<'cmd> {
             }
         }
 
-        if !missing_required.is_empty() {
-            ok!(self.missing_required_error(matcher, missing_required));
+        if !missing_required.is_empty() || !missing_required_any.is_empty() {
+            ok!(self.missing_required_error(matcher, missing_required, missing_required_any));
         }
 
         Ok(())
@@ -371,6 +395,7 @@ impl<'cmd> Validator<'cmd> {
         &self,
         matcher: &ArgMatcher,
         raw_req_args: Vec<Id>,
+        raw_req_any: Vec<Vec<Id>>,
     ) -> ClapResult<()> {
         debug!("Validator::missing_required_error; incl={raw_req_args:?}");
         debug!(
@@ -380,7 +405,7 @@ impl<'cmd> Validator<'cmd> {
 
         let usg = Usage::new(self.cmd).required(&self.required);
 
-        let req_args = {
+        let mut req_args = {
             #[cfg(feature = "usage")]
             {
                 usg.get_required_usage_from(&raw_req_args, Some(matcher), true)
@@ -408,6 +433,11 @@ impl<'cmd> Validator<'cmd> {
                     .collect::<Vec<_>>()
             }
         };
+        req_args.extend(
+            raw_req_any
+                .iter()
+                .map(|ids| self.format_required_any(ids).to_string()),
+        );
 
         debug!("Validator::missing_required_error: req_args={req_args:#?}");
 
@@ -426,11 +456,45 @@ impl<'cmd> Validator<'cmd> {
             .chain(raw_req_args)
             .collect();
 
-        Err(Error::missing_required_argument(
-            self.cmd,
-            req_args,
-            usg.create_usage_with_title(&used),
-        ))
+        let mut usage = usg.create_usage_with_title(&used);
+        if let Some(usage) = usage.as_mut() {
+            for ids in &raw_req_any {
+                usage.push_str(" ");
+                usage.push_styled(&self.format_required_any(ids));
+            }
+        }
+
+        Err(Error::missing_required_argument(self.cmd, req_args, usage))
+    }
+
+    fn format_required_any(&self, ids: &[Id]) -> StyledStr {
+        use std::fmt::Write as _;
+
+        let mut args = FlatSet::new();
+        for id in ids {
+            if let Some(group) = self.cmd.find_group(id) {
+                args.extend(self.cmd.unroll_args_in_group(group.get_id()));
+            } else {
+                args.insert(id.clone());
+            }
+        }
+
+        let group = args
+            .iter()
+            .filter_map(|id| self.cmd.find(id))
+            .map(|arg| {
+                if arg.is_positional() {
+                    arg.name_no_brackets()
+                } else {
+                    arg.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("|");
+        let placeholder = self.cmd.get_styles().get_placeholder();
+        let mut styled = StyledStr::new();
+        write!(&mut styled, "{placeholder}<{group}>{placeholder:#}").unwrap();
+        styled
     }
 }
 

--- a/tests/builder/require.rs
+++ b/tests/builder/require.rs
@@ -1486,3 +1486,130 @@ fn requires_self() {
         .arg(arg!(-f --flag "some flag").requires("flag"))
         .try_get_matches_from(vec![""]);
 }
+
+
+#[test]
+fn requires_any_group() {
+    fn cmd() -> Command {
+        Command::new("my-app")
+            .arg(
+                Arg::new("special")
+                    .long("special")
+                    .action(ArgAction::SetTrue)
+                    .requires_any(["special-and-opt-a", "special-and-opt-b"]),
+            )
+            .arg(Arg::new("opt-a1").long("opt-a1").action(ArgAction::SetTrue))
+            .arg(Arg::new("opt-a2").long("opt-a2").action(ArgAction::SetTrue))
+            .arg(Arg::new("opt-b1").long("opt-b1").action(ArgAction::SetTrue))
+            .arg(Arg::new("opt-b2").long("opt-b2").action(ArgAction::SetTrue))
+            .group(
+                ArgGroup::new("special-and-opt-a")
+                    .args(["opt-a1", "opt-a2"])
+                    .requires_all(["special", "opt-a1", "opt-a2"])
+                    .conflicts_with("special-and-opt-b")
+                    .multiple(true),
+            )
+            .group(
+                ArgGroup::new("special-and-opt-b")
+                    .args(["opt-b1", "opt-b2"])
+                    .requires_all(["special", "opt-b1", "opt-b2"])
+                    .conflicts_with("special-and-opt-a")
+                    .multiple(true),
+            )
+    }
+
+    for args in [
+        vec!["my-app"],
+        vec!["my-app", "--special", "--opt-a1", "--opt-a2"],
+        vec!["my-app", "--special", "--opt-b1", "--opt-b2"],
+    ] {
+        let result = cmd().try_get_matches_from(args.clone());
+        assert!(result.is_ok(), "expected {args:?} to be valid: {result:?}");
+    }
+
+    for args in [
+        vec!["my-app", "--opt-a1", "--opt-a2"],
+        vec!["my-app", "--opt-b1", "--opt-b2"],
+        vec!["my-app", "--special"],
+        vec!["my-app", "--special", "--opt-a1"],
+        vec!["my-app", "--special", "--opt-b1"],
+        vec!["my-app", "--special", "--opt-a1", "--opt-a2", "--opt-b1"],
+        vec!["my-app", "--special", "--opt-b1", "--opt-b2", "--opt-a1"],
+        vec![
+            "my-app",
+            "--special",
+            "--opt-a1",
+            "--opt-a2",
+            "--opt-b1",
+            "--opt-b2",
+        ],
+    ] {
+        let result = cmd().try_get_matches_from(args.clone());
+        assert!(result.is_err(), "expected {args:?} to be invalid");
+    }
+}
+
+#[test]
+fn requires_any_arg() {
+    let result = Command::new("prog")
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .action(ArgAction::SetTrue)
+                .requires_any(["input", "stdin"]),
+        )
+        .arg(Arg::new("input").long("input").action(ArgAction::SetTrue))
+        .arg(Arg::new("stdin").long("stdin").action(ArgAction::SetTrue))
+        .try_get_matches_from(["prog", "--config", "--stdin"]);
+    assert!(result.is_ok());
+}
+
+
+#[test]
+#[cfg(feature = "error-context")]
+fn requires_any_error_output() {
+    let cmd = Command::new("prog")
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .action(ArgAction::SetTrue)
+                .requires_any(["input", "stdin"]),
+        )
+        .arg(Arg::new("input").long("input").action(ArgAction::SetTrue))
+        .arg(Arg::new("stdin").long("stdin").action(ArgAction::SetTrue));
+    const EXPECTED: &str = "\
+error: the following required arguments were not provided:
+  <--input|--stdin>
+
+Usage: prog --config <--input|--stdin>
+
+For more information, try '--help'.
+";
+    utils::assert_output(cmd, "prog --config", EXPECTED, true);
+}
+
+#[test]
+#[should_panic = "Argument config cannot require itself"]
+fn requires_any_self() {
+    let _ = Command::new("prog")
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .action(ArgAction::SetTrue)
+                .requires_any(["config"]),
+        )
+        .try_get_matches_from(["prog"]);
+}
+
+#[test]
+#[should_panic = "Argument or group 'missing' specified in 'requires_any' for 'config' does not exist"]
+fn requires_any_invalid_arg() {
+    let _ = Command::new("prog")
+        .arg(
+            Arg::new("config")
+                .long("config")
+                .action(ArgAction::SetTrue)
+                .requires_any(["missing"]),
+        )
+        .try_get_matches_from(["prog"]);
+}


### PR DESCRIPTION
### What does this PR try to solve?

Adds `Arg::requires_any` so an argument can require at least one of several arguments or argument groups. A listed group is satisfied when any of its members is explicitly present, and missing-argument output renders the alternatives as a single OR requirement.

Closes #1537

### Notes to reviewers

This keeps existing `requires` behavior unchanged and adds the OR requirement explicitly rather than allowing nested `ArgGroup`s, which remain outside the current group contract.