### PR TITLE
fix(docs): use correct predicate in default_value_if example

### DIFF
--- a/clap_builder/src/builder/arg.rs
+++ b/clap_builder/src/builder/arg.rs
@@ -2965,14 +2965,13 @@ impl Arg {
     /// ```rust
     /// # use clap_builder as clap;
     /// # use clap::{Command, Arg, ArgAction};
-    /// # use clap::builder::{ArgPredicate};
     /// let m = Command::new("prog")
     ///     .arg(Arg::new("flag")
     ///         .long("flag")
     ///         .action(ArgAction::SetTrue))
     ///     .arg(Arg::new("other")
     ///         .long("other")
-    ///         .default_value_if("flag", ArgPredicate::IsPresent, Some("default")))
+    ///         .default_value_if("flag", "true", Some("default")))
     ///     .get_matches_from(vec![
     ///         "prog", "--flag"
     ///     ]);


### PR DESCRIPTION
## Summary

Fixes #4904

The first doc example for `Arg::default_value_if` used `ArgPredicate::IsPresent` as the predicate. When paired with `ArgAction::SetTrue`, this doesn't meaningfully test the flag's value. The example also claimed 'Next we run the same test' but used a different predicate.

## Fix

- Changed `ArgPredicate::IsPresent` → `"true"` in the first example, matching the second example
- Removed the now-unused `ArgPredicate` import

## Verification

All 8 doc tests pass: `cargo test --doc -p clap_builder default_value_if`