### PR TITLE
docs: fix render() doc example to preserve colors

### DIFF
--- a/clap_builder/src/error/mod.rs
+++ b/clap_builder/src/error/mod.rs
@@ -281,6 +281,10 @@ impl<F: ErrorFormatter> Error<F> {
 
     /// Render the error message to a [`StyledStr`].
     ///
+    /// Use [`print`] instead if you want to automatically respect the
+    /// environment's (lack of) color preference, or [`render().ansi()`][StyledStr::ansi]
+    /// if you want to preserve styles in the output.
+    ///
     /// # Example
     /// ```no_run
     /// # use clap_builder as clap;
@@ -292,7 +296,7 @@ impl<F: ErrorFormatter> Error<F> {
     ///     },
     ///     Err(err) => {
     ///         let err = err.render();
-    ///         println!("{err}");
+    ///         println!("{}", err.ansi());
     ///         // do_something
     ///     },
     /// };


### PR DESCRIPTION
Error::render() doc example used println!("{err}") which goes through StyledStr's Display impl that strips all ANSI styling. Update to use .ansi() to preserve styling in the output, and add guidance about when to use print() vs render().ansi().

Closes #6471