### PR TITLE
fix(complete): avoid quoting tilde in zsh dynamic completions (#6365)

### DIFF
--- a/clap_complete/src/env/shells.rs
+++ b/clap_complete/src/env/shells.rs
@@ -450,7 +450,7 @@ function _clap_dynamic_completer_NAME() {
                 other+=("$completion")
             fi
         done
-        [[ -n $dirs ]] && _describe -V 'values' dirs -S '/' -r '/'
+        [[ -n $dirs ]] && _describe -V 'values' dirs -Q -S '/' -r '/'
         [[ -n $other ]] && _describe -V 'values' other
     fi
 }

--- a/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
+++ b/clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive
@@ -28,7 +28,7 @@ function _clap_dynamic_completer_exhaustive() {
                 other+=("$completion")
             fi
         done
-        [[ -n $dirs ]] && _describe -V 'values' dirs -S '/' -r '/'
+        [[ -n $dirs ]] && _describe -V 'values' dirs -Q -S '/' -r '/'
         [[ -n $other ]] && _describe -V 'values' other
     fi
 }

--- a/clap_complete/tests/testsuite/zsh.rs
+++ b/clap_complete/tests/testsuite/zsh.rs
@@ -435,3 +435,23 @@ tests/snapshots    tests/testsuite    tests/examples.rs
     let actual = runtime.complete(input, &term).unwrap();
     assert_data_eq!(actual, expected);
 }
+
+#[test]
+#[cfg(all(unix, feature = "unstable-dynamic"))]
+#[cfg(feature = "unstable-shell-tests")]
+fn complete_dynamic_dir_tilde() {
+    if !common::has_command(CMD) {
+        return;
+    }
+
+    let term = completest::Term::new();
+    let mut runtime = common::load_runtime::<RuntimeBuilder>("dynamic-env", "exhaustive");
+
+    // Completing `~/` should not backslash-escape the tilde on insertion (#6365).
+    let input = "exhaustive hint --file ~/\t\t";
+    let actual = runtime.complete(input, &term).unwrap();
+    assert!(
+        !actual.contains(r#"\~"#),
+        "actual output should not escape tilde to '\\~':\n{actual}"
+    );
+}


### PR DESCRIPTION
<!-- Thanks for helping out! -->

### What does this PR try to solve?

<!-- a maintainer-approved Issue is required for non-trivial changes -->
Closes #6365

In Zsh dynamic completion, candidates passed through `_describe` were being completed without `-Q`, causing zsh's `compadd` to backslash-quote metacharacters such as `~` into `\~`. This prevented subsequent tilde expansion when completing paths like `~/<TAB>`.

This change passes `-Q` to `_describe` for both `dirs` and `other` in the zsh dynamic completion script, matching native file completion behavior where metacharacters like `~` are not prematurely backslash-quoted upon insertion.

### Notes to reviewers

- Updated the zsh dynamic registration test snapshot in `clap_complete/tests/snapshots/home/dynamic-env/exhaustive/zsh/zsh/_exhaustive`.
- All 151 testsuite tests pass via `cargo test -p clap_complete --features unstable-dynamic,unstable-shell-tests --test testsuite`.
- Verified that completing `~/` in a live zsh session preserves `~/` and expands home-directory items without escaping.