### PR TITLE
feat(derive): Defer enum subcommand initialization

### DIFF
--- a/clap_derive/src/attr.rs
+++ b/clap_derive/src/attr.rs
@@ -84,6 +84,21 @@ impl ClapAttr {
             }
         }
     }
+
+    pub(crate) fn lit_bool_or_abort(&self) -> Result<bool, syn::Error> {
+        let value = self.value_or_abort()?;
+        match value {
+            AttrValue::Expr(Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Bool(lit),
+                ..
+            })) => Ok(lit.value()),
+            _ => abort!(
+                self.name,
+                "attribute `{}` can only accept bool literals",
+                self.name
+            ),
+        }
+    }
 }
 
 impl Parse for ClapAttr {
@@ -117,6 +132,7 @@ impl Parse for ClapAttr {
             "long_help" => Some(MagicAttrName::LongHelp),
             "author" => Some(MagicAttrName::Author),
             "version" => Some(MagicAttrName::Version),
+            "defer" => Some(MagicAttrName::Defer),
             _ => None,
         };
 
@@ -178,6 +194,7 @@ pub(crate) enum MagicAttrName {
     DefaultValuesOsT,
     NextDisplayOrder,
     NextHelpHeading,
+    Defer,
 }
 
 #[derive(Clone)]

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -287,29 +287,22 @@ fn gen_augment(
 
             Kind::Command(_) => {
                 let subcommand_var = Ident::new("__clap_subcommand", Span::call_site());
-                let sub_augment = match variant.fields {
+                let (sub_augment, initial_app_methods, final_from_attrs) = match variant.fields {
                     Named(ref fields) => {
                         let fields = collect_args_fields(item, fields)?;
-                        let arg_block =
+                        let sub_augment =
                             args::gen_augment(&fields, &subcommand_var, item, override_required)?;
-                        let initial_app_methods = item.initial_top_level_methods();
-                        let final_from_attrs = item.final_top_level_methods();
-                        quote! {
-                            let #subcommand_var = #subcommand_var #initial_app_methods;
-                            let #subcommand_var = #arg_block;
-                            #subcommand_var #final_from_attrs
-                        }
+                        (
+                            sub_augment,
+                            item.initial_top_level_methods(),
+                            item.final_top_level_methods(),
+                        )
                     }
-                    Unit => {
-                        let arg_block = quote!( #subcommand_var );
-                        let initial_app_methods = item.initial_top_level_methods();
-                        let final_from_attrs = item.final_top_level_methods();
-                        quote! {
-                            let #subcommand_var = #subcommand_var #initial_app_methods;
-                            let #subcommand_var = #arg_block;
-                            #subcommand_var #final_from_attrs
-                        }
-                    }
+                    Unit => (
+                        quote! { #subcommand_var },
+                        item.initial_top_level_methods(),
+                        item.final_top_level_methods(),
+                    ),
                     Unnamed(FieldsUnnamed { ref unnamed, .. }) if unnamed.len() == 1 => {
                         let ty = &unnamed[0].ty;
                         let arg_block = if override_required {
@@ -325,13 +318,11 @@ fn gen_augment(
                                 }
                             }
                         };
-                        let initial_app_methods = item.initial_top_level_methods();
-                        let final_from_attrs = item.final_top_level_methods();
-                        quote! {
-                            let #subcommand_var = #subcommand_var #initial_app_methods;
-                            let #subcommand_var = #arg_block;
-                            #subcommand_var #final_from_attrs
-                        }
+                        (
+                            arg_block,
+                            item.initial_top_level_methods(),
+                            item.final_top_level_methods(),
+                        )
                     }
                     Unnamed(..) => {
                         abort!(
@@ -350,8 +341,10 @@ fn gen_augment(
                 let subcommand = quote! {
                     let #app_var = #app_var.subcommand({
                         #deprecations
-                        let #subcommand_var = clap::Command::new(#name);
-                        #sub_augment
+                        let #subcommand_var = clap::Command::new(#name)
+                            #initial_app_methods;
+                        let #subcommand_var = #sub_augment;
+                        #subcommand_var #final_from_attrs
                     });
                 };
                 Some(subcommand)

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -64,6 +64,8 @@ pub(crate) fn gen_for_enum(
     let augmentation = gen_augment(variants, item, false)?;
     let augmentation_update = gen_augment(variants, item, true)?;
     let has_subcommand = gen_has_subcommand(variants)?;
+    let initial_app_methods = item.initial_top_level_methods();
+    let final_app_methods = item.final_top_level_methods();
 
     Ok(quote! {
         #[allow(
@@ -123,10 +125,14 @@ pub(crate) fn gen_for_enum(
         #[automatically_derived]
         impl #impl_generics clap::Subcommand for #item_name #ty_generics #where_clause {
             fn augment_subcommands <'b>(__clap_app: clap::Command) -> clap::Command {
-                #augmentation
+                let __clap_app = __clap_app #initial_app_methods;
+                let __clap_app = #augmentation;
+                __clap_app #final_app_methods
             }
             fn augment_subcommands_for_update <'b>(__clap_app: clap::Command) -> clap::Command {
-                #augmentation_update
+                let __clap_app = __clap_app #initial_app_methods;
+                let __clap_app = #augmentation_update;
+                __clap_app #final_app_methods
             }
             fn has_subcommand(__clap_name: &str) -> bool {
                 #has_subcommand
@@ -283,9 +289,16 @@ fn gen_augment(
                 let subcommand_var = Ident::new("__clap_subcommand", Span::call_site());
                 let sub_augment = match variant.fields {
                     Named(ref fields) => {
-                        // Defer to `gen_augment` for adding cmd methods
                         let fields = collect_args_fields(item, fields)?;
-                        args::gen_augment(&fields, &subcommand_var, item, override_required)?
+                        let arg_block =
+                            args::gen_augment(&fields, &subcommand_var, item, override_required)?;
+                        let initial_app_methods = item.initial_top_level_methods();
+                        let final_from_attrs = item.final_top_level_methods();
+                        quote! {
+                            let #subcommand_var = #subcommand_var #initial_app_methods;
+                            let #subcommand_var = #arg_block;
+                            #subcommand_var #final_from_attrs
+                        }
                     }
                     Unit => {
                         let arg_block = quote!( #subcommand_var );
@@ -352,14 +365,11 @@ fn gen_augment(
     } else {
         quote!()
     };
-    let initial_app_methods = parent_item.initial_top_level_methods();
-    let final_app_methods = parent_item.final_top_level_methods();
-    Ok(quote! {
+    Ok(quote! {{
         #deprecations;
-        let #app_var = #app_var #initial_app_methods;
         #( #subcommands )*;
-        #app_var #final_app_methods
-    })
+        #app_var
+    }})
 }
 
 fn gen_has_subcommand(variants: &[(&Variant, Item)]) -> Result<TokenStream, syn::Error> {

--- a/clap_derive/src/derives/subcommand.rs
+++ b/clap_derive/src/derives/subcommand.rs
@@ -332,6 +332,14 @@ fn gen_augment(
                     }
                 };
 
+                let sub_augment = if parent_item.defer() {
+                    quote! {
+                        #subcommand_var.defer(|#subcommand_var| { #sub_augment })
+                    }
+                } else {
+                    sub_augment
+                };
+
                 let deprecations = if !override_required {
                     item.deprecations()
                 } else {

--- a/clap_derive/src/item.rs
+++ b/clap_derive/src/item.rs
@@ -50,6 +50,7 @@ pub(crate) struct Item {
     group_id: Name,
     group_methods: Vec<Method>,
     kind: Sp<Kind>,
+    defer: Option<Sp<bool>>,
 }
 
 impl Item {
@@ -65,6 +66,7 @@ impl Item {
         let parsed_attrs = ClapAttr::parse_all(attrs)?;
         res.infer_kind(&parsed_attrs)?;
         res.push_attrs(&parsed_attrs)?;
+        res.assert_no_defer()?;
         res.push_doc_comment(attrs, "about", Some("long_about"));
 
         Ok(res)
@@ -102,6 +104,7 @@ impl Item {
         let parsed_attrs = ClapAttr::parse_all(attrs)?;
         res.infer_kind(&parsed_attrs)?;
         res.push_attrs(&parsed_attrs)?;
+        res.assert_no_defer()?;
         // Ignoring `push_doc_comment` as there is no top-level clap builder to add documentation
         // to
 
@@ -144,6 +147,7 @@ impl Item {
         let parsed_attrs = ClapAttr::parse_all(&variant.attrs)?;
         res.infer_kind(&parsed_attrs)?;
         res.push_attrs(&parsed_attrs)?;
+        res.assert_no_defer()?;
         if matches!(&*res.kind, Kind::Command(_) | Kind::Subcommand(_)) {
             res.push_doc_comment(&variant.attrs, "about", Some("long_about"));
         }
@@ -189,6 +193,7 @@ impl Item {
         let parsed_attrs = ClapAttr::parse_all(&variant.attrs)?;
         res.infer_kind(&parsed_attrs)?;
         res.push_attrs(&parsed_attrs)?;
+        res.assert_no_defer()?;
         if matches!(&*res.kind, Kind::Value) {
             res.push_doc_comment(&variant.attrs, "help", None);
         }
@@ -217,6 +222,7 @@ impl Item {
         let parsed_attrs = ClapAttr::parse_all(&field.attrs)?;
         res.infer_kind(&parsed_attrs)?;
         res.push_attrs(&parsed_attrs)?;
+        res.assert_no_defer()?;
         if matches!(&*res.kind, Kind::Arg(_)) {
             res.push_doc_comment(&field.attrs, "help", Some("long_help"));
         }
@@ -279,6 +285,7 @@ impl Item {
             group_id,
             group_methods: vec![],
             kind,
+            defer: None,
         }
     }
 
@@ -835,6 +842,11 @@ impl Item {
                     self.skip_group = true;
                 }
 
+                Some(MagicAttrName::Defer) => {
+                    assert_attr_kind(attr, &[AttrKind::Command])?;
+                    self.defer = Some(Sp::new(attr.lit_bool_or_abort()?, attr.name.span()));
+                }
+
                 None
                 // Magic only for the default, otherwise just forward to the builder
                 | Some(MagicAttrName::Short)
@@ -1089,6 +1101,23 @@ impl Item {
 
     pub(crate) fn skip_group(&self) -> bool {
         self.skip_group
+    }
+
+    pub(crate) fn defer(&self) -> bool {
+        self.defer
+            .as_ref()
+            .map(|defer| **defer)
+            .unwrap_or(cfg!(feature = "unstable-v5"))
+    }
+
+    fn assert_no_defer(&self) -> Result<(), syn::Error> {
+        if let Some(defer) = &self.defer {
+            abort!(
+                defer.span(),
+                "`defer` is only supported on `Parser` and `Subcommand` enums"
+            );
+        }
+        Ok(())
     }
 }
 

--- a/src/_derive/mod.rs
+++ b/src/_derive/mod.rs
@@ -161,6 +161,20 @@
 //!   - When not present: [Doc comment](#doc-comments) if there is a blank line, else nothing
 //!   - When present without a value: [Doc comment](#doc-comments)
 //! - `verbatim_doc_comment`: Minimizes pre-processing when converting doc comments to [`about`][crate::Command::about] / [`long_about`][crate::Command::long_about]
+//! - `defer = <bool_literal>`: Delay argument construction for an enum's subcommands with
+//!   [`Command::defer`][crate::Command::defer]. Available on [`Parser`][crate::Parser] and
+//!   [`Subcommand`][crate::Subcommand] enum containers.
+//!   - When not present: `false`, or `true` with the `unstable-v5` feature.
+//!   - Subcommand names and attributes on the variants are applied eagerly, so their descriptions
+//!     are available in the parent's help. Arguments and groups in named variants, and the entire
+//!     [`Args::augment_args`][crate::Args::augment_args] call for newtype variants, are deferred.
+//!   - Put metadata needed by the parent's help on the enum variants. Metadata from an `Args`
+//!     container or its flattened fields is applied when the subcommand is built, and can then
+//!     override metadata on the variant.
+//!   - Flattened and nested `Subcommand` enums use their own `defer` setting. The setting is not
+//!     inherited by those enums and does not defer their registration in the parent.
+//!   - Call [`Command::build`][crate::Command::build] before inspecting deferred arguments or
+//!     nested commands. Parsing builds the selected commands automatically.
 //! - `next_display_order`: [`Command::next_display_order`][crate::Command::next_display_order]
 //! - `next_help_heading`: [`Command::next_help_heading`][crate::Command::next_help_heading]
 //!   - When `flatten`ing [`Args`][crate::Args], this is scoped to just the args in this struct and any struct `flatten`ed into it

--- a/tests/derive/defer.rs
+++ b/tests/derive/defer.rs
@@ -1,0 +1,218 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use clap::{Args, CommandFactory, Parser, Subcommand};
+
+#[test]
+fn named_fields() {
+    #[derive(Parser)]
+    enum Cli {
+        /// Add a file
+        #[command(visible_alias = "a", version = "1.0")]
+        Add {
+            #[arg(long)]
+            file: String,
+        },
+    }
+
+    for (mut cmd, required) in [(Cli::command(), true), (Cli::command_for_update(), false)] {
+        let add = cmd.find_subcommand("add").unwrap();
+        assert_eq!(add.get_about().unwrap().to_string(), "Add a file");
+        assert_eq!(add.get_version(), Some("1.0"));
+        assert_eq!(add.get_visible_aliases().collect::<Vec<_>>(), ["a"]);
+        assert_eq!(add.get_arguments().count(), 1);
+        cmd.build();
+        let file = cmd
+            .find_subcommand("add")
+            .unwrap()
+            .get_arguments()
+            .find(|arg| arg.get_id() == "file")
+            .unwrap();
+        assert_eq!(file.is_required_set(), required);
+    }
+}
+
+#[test]
+fn newtype_with_flattened_args() {
+    #[derive(Parser)]
+    enum Cli {
+        Account(Account),
+    }
+
+    #[derive(Args)]
+    struct Account {
+        account_id: String,
+        #[command(flatten)]
+        common: Common,
+        #[command(subcommand)]
+        action: Action,
+    }
+
+    #[derive(Args)]
+    struct Common {
+        #[arg(long)]
+        verbose: bool,
+    }
+
+    #[derive(Subcommand)]
+    enum Action {
+        View,
+    }
+
+    for (mut cmd, required) in [(Cli::command(), true), (Cli::command_for_update(), false)] {
+        let account = cmd.find_subcommand("account").unwrap();
+        assert_eq!(account.get_arguments().count(), 2);
+        assert_eq!(account.get_subcommands().count(), 1);
+        cmd.build();
+        let account = cmd.find_subcommand("account").unwrap();
+        let account_id = account
+            .get_arguments()
+            .find(|arg| arg.get_id() == "account_id")
+            .unwrap();
+        assert_eq!(account_id.is_required_set(), required);
+        assert!(account.get_arguments().any(|arg| arg.get_id() == "verbose"));
+        assert!(account.find_subcommand("view").is_some());
+    }
+}
+
+#[test]
+fn initialization_runs_once() {
+    static ARGS: AtomicUsize = AtomicUsize::new(0);
+    static METADATA: AtomicUsize = AtomicUsize::new(0);
+
+    fn value() -> &'static str {
+        ARGS.fetch_add(1, Ordering::SeqCst);
+        "value"
+    }
+
+    fn about() -> &'static str {
+        METADATA.fetch_add(1, Ordering::SeqCst);
+        "Selected command"
+    }
+
+    #[derive(Parser)]
+    enum Cli {
+        #[command(about = about())]
+        Selected {
+            #[arg(long, default_value = value())]
+            value: String,
+        },
+        Unselected {
+            #[arg(long, default_value = value())]
+            value: String,
+        },
+    }
+
+    let cmd = Cli::command();
+    assert_eq!(ARGS.load(Ordering::SeqCst), 2);
+    assert_eq!(METADATA.load(Ordering::SeqCst), 1);
+    cmd.try_get_matches_from(["test", "selected"]).unwrap();
+    assert_eq!(ARGS.load(Ordering::SeqCst), 2);
+    assert_eq!(METADATA.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn flattened_and_nested_subcommands() {
+    #[derive(Parser)]
+    enum Cli {
+        #[command(flatten)]
+        Flat(Commands),
+        #[command(subcommand)]
+        Nested(Commands),
+    }
+
+    #[derive(Subcommand)]
+    enum Commands {
+        Run {
+            #[arg(long)]
+            flag: bool,
+        },
+    }
+
+    let cmd = Cli::command();
+    let flat = cmd.find_subcommand("run").unwrap();
+    let nested = cmd
+        .find_subcommand("nested")
+        .unwrap()
+        .find_subcommand("run")
+        .unwrap();
+    assert_eq!(flat.get_arguments().count(), 1);
+    assert_eq!(nested.get_arguments().count(), 1);
+}
+
+#[test]
+fn args_metadata() {
+    #[derive(Parser)]
+    enum Cli {
+        Run(Options),
+    }
+
+    #[derive(Args)]
+    #[command(about = "From Args")]
+    struct Options {
+        #[arg(long)]
+        flag: bool,
+    }
+
+    let mut cmd = Cli::command();
+    assert_eq!(
+        cmd.find_subcommand("run")
+            .unwrap()
+            .get_about()
+            .map(ToString::to_string),
+        Some("From Args".into())
+    );
+    cmd.build();
+    assert_eq!(
+        cmd.find_subcommand("run")
+            .unwrap()
+            .get_about()
+            .map(ToString::to_string),
+        Some("From Args".into())
+    );
+}
+
+#[test]
+fn eager_subcommands() {
+    #[derive(Parser)]
+    enum Cli {
+        Run {
+            #[arg(long)]
+            flag: bool,
+        },
+    }
+
+    let cmd = Cli::command();
+    assert_eq!(
+        cmd.find_subcommand("run").unwrap().get_arguments().count(),
+        1
+    );
+}
+
+#[test]
+fn default_initialization() {
+    #[derive(Parser)]
+    enum Cli {
+        Run {
+            #[arg(long)]
+            flag: bool,
+        },
+    }
+
+    let cmd = Cli::command();
+    assert_eq!(
+        cmd.find_subcommand("run").unwrap().get_arguments().count(),
+        1
+    );
+}
+
+#[test]
+fn raw_defer() {
+    #[derive(Parser)]
+    #[command(defer(|cmd| cmd.about("From callback")))]
+    struct Cli {}
+
+    let mut cmd = Cli::command();
+    assert_eq!(cmd.get_about(), None);
+    cmd.build();
+    assert_eq!(cmd.get_about().unwrap().to_string(), "From callback");
+}

--- a/tests/derive/defer.rs
+++ b/tests/derive/defer.rs
@@ -5,6 +5,7 @@ use clap::{Args, CommandFactory, Parser, Subcommand};
 #[test]
 fn named_fields() {
     #[derive(Parser)]
+    #[command(defer = true)]
     enum Cli {
         /// Add a file
         #[command(visible_alias = "a", version = "1.0")]
@@ -19,7 +20,7 @@ fn named_fields() {
         assert_eq!(add.get_about().unwrap().to_string(), "Add a file");
         assert_eq!(add.get_version(), Some("1.0"));
         assert_eq!(add.get_visible_aliases().collect::<Vec<_>>(), ["a"]);
-        assert_eq!(add.get_arguments().count(), 1);
+        assert_eq!(add.get_arguments().count(), 0);
         cmd.build();
         let file = cmd
             .find_subcommand("add")
@@ -34,6 +35,7 @@ fn named_fields() {
 #[test]
 fn newtype_with_flattened_args() {
     #[derive(Parser)]
+    #[command(defer = true)]
     enum Cli {
         Account(Account),
     }
@@ -60,8 +62,8 @@ fn newtype_with_flattened_args() {
 
     for (mut cmd, required) in [(Cli::command(), true), (Cli::command_for_update(), false)] {
         let account = cmd.find_subcommand("account").unwrap();
-        assert_eq!(account.get_arguments().count(), 2);
-        assert_eq!(account.get_subcommands().count(), 1);
+        assert_eq!(account.get_arguments().count(), 0);
+        assert_eq!(account.get_subcommands().count(), 0);
         cmd.build();
         let account = cmd.find_subcommand("account").unwrap();
         let account_id = account
@@ -90,6 +92,7 @@ fn initialization_runs_once() {
     }
 
     #[derive(Parser)]
+    #[command(defer = true)]
     enum Cli {
         #[command(about = about())]
         Selected {
@@ -103,16 +106,17 @@ fn initialization_runs_once() {
     }
 
     let cmd = Cli::command();
-    assert_eq!(ARGS.load(Ordering::SeqCst), 2);
+    assert_eq!(ARGS.load(Ordering::SeqCst), 0);
     assert_eq!(METADATA.load(Ordering::SeqCst), 1);
     cmd.try_get_matches_from(["test", "selected"]).unwrap();
-    assert_eq!(ARGS.load(Ordering::SeqCst), 2);
+    assert_eq!(ARGS.load(Ordering::SeqCst), 1);
     assert_eq!(METADATA.load(Ordering::SeqCst), 1);
 }
 
 #[test]
 fn flattened_and_nested_subcommands() {
     #[derive(Parser)]
+    #[command(defer = true)]
     enum Cli {
         #[command(flatten)]
         Flat(Commands),
@@ -121,6 +125,7 @@ fn flattened_and_nested_subcommands() {
     }
 
     #[derive(Subcommand)]
+    #[command(defer = true)]
     enum Commands {
         Run {
             #[arg(long)]
@@ -135,13 +140,14 @@ fn flattened_and_nested_subcommands() {
         .unwrap()
         .find_subcommand("run")
         .unwrap();
-    assert_eq!(flat.get_arguments().count(), 1);
-    assert_eq!(nested.get_arguments().count(), 1);
+    assert_eq!(flat.get_arguments().count(), 0);
+    assert_eq!(nested.get_arguments().count(), 0);
 }
 
 #[test]
 fn args_metadata() {
     #[derive(Parser)]
+    #[command(defer = true)]
     enum Cli {
         Run(Options),
     }
@@ -159,7 +165,7 @@ fn args_metadata() {
             .unwrap()
             .get_about()
             .map(ToString::to_string),
-        Some("From Args".into())
+        None
     );
     cmd.build();
     assert_eq!(
@@ -174,6 +180,7 @@ fn args_metadata() {
 #[test]
 fn eager_subcommands() {
     #[derive(Parser)]
+    #[command(defer = false)]
     enum Cli {
         Run {
             #[arg(long)]
@@ -201,7 +208,7 @@ fn default_initialization() {
     let cmd = Cli::command();
     assert_eq!(
         cmd.find_subcommand("run").unwrap().get_arguments().count(),
-        1
+        usize::from(!cfg!(feature = "unstable-v5"))
     );
 }
 

--- a/tests/derive/flatten.rs
+++ b/tests/derive/flatten.rs
@@ -257,6 +257,44 @@ Options:
 }
 
 #[test]
+fn flattened_enum_parent_doc_comments() {
+    use clap::CommandFactory;
+
+    /// Parent summary
+    ///
+    /// Parent details.
+    #[derive(Parser)]
+    enum Parent {
+        #[command(flatten)]
+        Child(Child),
+    }
+
+    /// Child summary
+    ///
+    /// Child details.
+    #[derive(Subcommand)]
+    enum Child {
+        Run {
+            #[arg(long)]
+            flag: bool,
+        },
+    }
+
+    for mut cmd in [Parent::command(), Parent::command_for_update()] {
+        for build in [false, true] {
+            if build {
+                cmd.build();
+            }
+            assert_eq!(cmd.get_about().unwrap().to_string(), "Parent summary");
+            assert_eq!(
+                cmd.get_long_about().unwrap().to_string(),
+                "Parent summary\n\nParent details."
+            );
+        }
+    }
+}
+
+#[test]
 fn docstrings_ordering_with_multiple_clap_partial() {
     /// This is the docstring for Flattened
     #[derive(Args)]

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -139,6 +139,13 @@ fn app_help_heading_flattened() {
         .unwrap();
     assert_eq!(should_be_in_section_b.get_help_heading(), Some("HEADING B"));
 
+    #[cfg(feature = "unstable-v5")]
+    let cmd = {
+        let mut cmd = cmd;
+        cmd.build();
+        cmd
+    };
+
     let sub_a_two = cmd.find_subcommand("sub-a-two").unwrap();
 
     let should_be_in_sub_a = sub_a_two

--- a/tests/derive/help.rs
+++ b/tests/derive/help.rs
@@ -348,6 +348,57 @@ Options:
 }
 
 #[test]
+fn flattened_enum_display_order() {
+    #[derive(Parser)]
+    #[command(next_display_order = 100)]
+    enum Parent {
+        First,
+        #[command(flatten, next_display_order = 20)]
+        Child(Child),
+        AfterChild,
+        #[command(flatten, next_display_order = 50)]
+        Other(Other),
+        Last,
+    }
+
+    #[derive(Subcommand)]
+    enum Child {
+        Zebra {
+            #[arg(long)]
+            flag: bool,
+        },
+        Alpha,
+    }
+
+    #[derive(Subcommand)]
+    #[command(next_display_order = 10)]
+    enum Other {
+        Run,
+    }
+
+    for mut cmd in [Parent::command(), Parent::command_for_update()] {
+        for build in [false, true] {
+            if build {
+                cmd.build();
+            }
+            for (name, order) in [
+                ("first", 100),
+                ("zebra", 20),
+                ("alpha", 21),
+                ("after-child", 22),
+                ("run", 10),
+                ("last", 11),
+            ] {
+                assert_eq!(
+                    cmd.find_subcommand(name).unwrap().get_display_order(),
+                    order
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn derive_order_no_next_order() {
     #[derive(Parser, Debug)]
     #[command(name = "test", version = "1.2")]

--- a/tests/derive_ui/defer_field.rs
+++ b/tests/derive_ui/defer_field.rs
@@ -1,0 +1,7 @@
+#[derive(clap::Parser)]
+struct Cli {
+    #[arg(defer = true)]
+    flag: bool,
+}
+
+fn main() {}

--- a/tests/derive_ui/defer_field.stderr
+++ b/tests/derive_ui/defer_field.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `defer` found for struct `Arg` in the current scope
+ --> tests/derive_ui/defer_field.rs:3:11
+  |
+3 |     #[arg(defer = true)]
+  |           ^^^^^ method not found in `Arg`

--- a/tests/derive_ui/defer_field.stderr
+++ b/tests/derive_ui/defer_field.stderr
@@ -1,5 +1,5 @@
-error[E0599]: no method named `defer` found for struct `Arg` in the current scope
+error: unknown `#[arg(defer)]` attribute (`#[command(defer)]` exists)
  --> tests/derive_ui/defer_field.rs:3:11
   |
 3 |     #[arg(defer = true)]
-  |           ^^^^^ method not found in `Arg`
+  |           ^^^^^

--- a/tests/derive_ui/defer_flatten.rs
+++ b/tests/derive_ui/defer_flatten.rs
@@ -1,0 +1,12 @@
+#[derive(clap::Parser)]
+struct Cli {
+    #[command(flatten, defer = true)]
+    options: Options,
+}
+
+#[derive(clap::Args)]
+struct Options {
+    flag: bool,
+}
+
+fn main() {}

--- a/tests/derive_ui/defer_flatten.stderr
+++ b/tests/derive_ui/defer_flatten.stderr
@@ -1,0 +1,5 @@
+error: methods are not allowed for flattened entry
+ --> tests/derive_ui/defer_flatten.rs:3:15
+  |
+3 |     #[command(flatten, defer = true)]
+  |               ^^^^^^^

--- a/tests/derive_ui/defer_flatten.stderr
+++ b/tests/derive_ui/defer_flatten.stderr
@@ -1,5 +1,5 @@
-error: methods are not allowed for flattened entry
- --> tests/derive_ui/defer_flatten.rs:3:15
+error: `defer` is only supported on `Parser` and `Subcommand` enums
+ --> tests/derive_ui/defer_flatten.rs:3:24
   |
 3 |     #[command(flatten, defer = true)]
-  |               ^^^^^^^
+  |                        ^^^^^

--- a/tests/derive_ui/defer_missing_value.rs
+++ b/tests/derive_ui/defer_missing_value.rs
@@ -1,0 +1,7 @@
+#[derive(clap::Parser)]
+#[command(defer)]
+enum Cli {
+    Run,
+}
+
+fn main() {}

--- a/tests/derive_ui/defer_missing_value.stderr
+++ b/tests/derive_ui/defer_missing_value.stderr
@@ -1,0 +1,5 @@
+error: attribute `defer` requires a value
+ --> tests/derive_ui/defer_missing_value.rs:2:11
+  |
+2 | #[command(defer)]
+  |           ^^^^^

--- a/tests/derive_ui/defer_struct.rs
+++ b/tests/derive_ui/defer_struct.rs
@@ -1,0 +1,7 @@
+#[derive(clap::Args)]
+#[command(defer = true)]
+struct Options {
+    flag: bool,
+}
+
+fn main() {}

--- a/tests/derive_ui/defer_struct.stderr
+++ b/tests/derive_ui/defer_struct.stderr
@@ -1,15 +1,5 @@
-error[E0308]: mismatched types
- --> tests/derive_ui/defer_struct.rs:2:19
+error: `defer` is only supported on `Parser` and `Subcommand` enums
+ --> tests/derive_ui/defer_struct.rs:2:11
   |
 2 | #[command(defer = true)]
-  |           -----   ^^^^ expected fn pointer, found `bool`
-  |           |
-  |           arguments to this method are incorrect
-  |
-  = note: expected fn pointer `fn(clap::Command) -> clap::Command`
-                   found type `bool`
-note: method defined here
- --> clap_builder/src/builder/command.rs
-  |
-  |     pub fn defer(mut self, deferred: fn(Command) -> Command) -> Self {
-  |            ^^^^^
+  |           ^^^^^

--- a/tests/derive_ui/defer_struct.stderr
+++ b/tests/derive_ui/defer_struct.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+ --> tests/derive_ui/defer_struct.rs:2:19
+  |
+2 | #[command(defer = true)]
+  |           -----   ^^^^ expected fn pointer, found `bool`
+  |           |
+  |           arguments to this method are incorrect
+  |
+  = note: expected fn pointer `fn(clap::Command) -> clap::Command`
+                   found type `bool`
+note: method defined here
+ --> clap_builder/src/builder/command.rs
+  |
+  |     pub fn defer(mut self, deferred: fn(Command) -> Command) -> Self {
+  |            ^^^^^

--- a/tests/derive_ui/defer_value.rs
+++ b/tests/derive_ui/defer_value.rs
@@ -1,0 +1,7 @@
+#[derive(clap::Parser)]
+#[command(defer = "true")]
+enum Cli {
+    Run,
+}
+
+fn main() {}

--- a/tests/derive_ui/defer_value.stderr
+++ b/tests/derive_ui/defer_value.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+ --> tests/derive_ui/defer_value.rs:2:19
+  |
+2 | #[command(defer = "true")]
+  |           -----   ^^^^^^ expected fn pointer, found `&str`
+  |           |
+  |           arguments to this method are incorrect
+  |
+  = note: expected fn pointer `fn(clap::Command) -> clap::Command`
+              found reference `&'static str`
+note: method defined here
+ --> clap_builder/src/builder/command.rs
+  |
+  |     pub fn defer(mut self, deferred: fn(Command) -> Command) -> Self {
+  |            ^^^^^

--- a/tests/derive_ui/defer_value.stderr
+++ b/tests/derive_ui/defer_value.stderr
@@ -1,15 +1,5 @@
-error[E0308]: mismatched types
- --> tests/derive_ui/defer_value.rs:2:19
+error: attribute `defer` can only accept bool literals
+ --> tests/derive_ui/defer_value.rs:2:11
   |
 2 | #[command(defer = "true")]
-  |           -----   ^^^^^^ expected fn pointer, found `&str`
-  |           |
-  |           arguments to this method are incorrect
-  |
-  = note: expected fn pointer `fn(clap::Command) -> clap::Command`
-              found reference `&'static str`
-note: method defined here
- --> clap_builder/src/builder/command.rs
-  |
-  |     pub fn defer(mut self, deferred: fn(Command) -> Command) -> Self {
-  |            ^^^^^
+  |           ^^^^^

--- a/tests/derive_ui/defer_variant.rs
+++ b/tests/derive_ui/defer_variant.rs
@@ -1,0 +1,7 @@
+#[derive(clap::Parser)]
+enum Cli {
+    #[command(defer = true)]
+    Run,
+}
+
+fn main() {}

--- a/tests/derive_ui/defer_variant.stderr
+++ b/tests/derive_ui/defer_variant.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+ --> tests/derive_ui/defer_variant.rs:3:23
+  |
+3 |     #[command(defer = true)]
+  |               -----   ^^^^ expected fn pointer, found `bool`
+  |               |
+  |               arguments to this method are incorrect
+  |
+  = note: expected fn pointer `fn(clap::Command) -> clap::Command`
+                   found type `bool`
+note: method defined here
+ --> clap_builder/src/builder/command.rs
+  |
+  |     pub fn defer(mut self, deferred: fn(Command) -> Command) -> Self {
+  |            ^^^^^

--- a/tests/derive_ui/defer_variant.stderr
+++ b/tests/derive_ui/defer_variant.stderr
@@ -1,15 +1,5 @@
-error[E0308]: mismatched types
- --> tests/derive_ui/defer_variant.rs:3:23
+error: `defer` is only supported on `Parser` and `Subcommand` enums
+ --> tests/derive_ui/defer_variant.rs:3:15
   |
 3 |     #[command(defer = true)]
-  |               -----   ^^^^ expected fn pointer, found `bool`
-  |               |
-  |               arguments to this method are incorrect
-  |
-  = note: expected fn pointer `fn(clap::Command) -> clap::Command`
-                   found type `bool`
-note: method defined here
- --> clap_builder/src/builder/command.rs
-  |
-  |     pub fn defer(mut self, deferred: fn(Command) -> Command) -> Self {
-  |            ^^^^^
+  |               ^^^^^


### PR DESCRIPTION
### What does this PR try to solve?

Derived CLIs build arguments for every subcommand, even when only one is used. This adds `#[command(defer = true)]` to `Parser` and `Subcommand` enums so argument construction can wait until a subcommand is needed.

Deferral is opt-in in v4 and enabled by default with `unstable-v5`. Use `defer = false` to keep eager initialization.

Part of #4959.
